### PR TITLE
Support keywords in chv use

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ chv list                    # Installed versions
 chv list --available        # Available for download
 
 # Manage default version
-chv use 25.12.5.44          # Set default
+chv use 25.12.5.44          # Exact version
+chv use stable              # Latest stable (installs if needed)
+chv use lts                 # Latest LTS (installs if needed)
+chv use 25.12               # Latest 25.12.x.x (installs if needed)
 chv which                   # Show current default
 
 # Remove a version


### PR DESCRIPTION
## Summary

- `chv use stable`, `chv use lts`, and partial versions like `chv use 25.12` now resolve to actual installed version numbers via the GitHub API (same as `chv install`)
- If the resolved version isn't already installed, it is automatically downloaded before being set as default
- Updated README with new `chv use` examples

## Test plan

- [ ] `cargo build && cargo test` passes
- [ ] `chv use stable` resolves and sets (or installs then sets)
- [ ] `chv use lts` resolves and sets
- [ ] `chv use 25.8` matches latest 25.8.x.x
- [ ] `chv use 25.8.16.34` works for exact versions

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)