### PR TITLE
Rename --available flag to --remote for list subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ chv install 25.12.5.44      # Exact version
 
 # List versions
 chv list                    # Installed versions
-chv list --available        # Available for download
+chv list --remote           # Available for download
 
 # Manage default version
 chv use 25.12.5.44          # Exact version

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ CONTEXT FOR AGENTS:
   Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
   Optionally set as default with `chv use <version>`.
   `chv use <version>` will auto-install if the version is missing and set as default.
-  Related: `chv list --available` to see downloadable versions.")]
+  Related: `chv list --remote` to see downloadable versions.")]
     Install {
         /// Version to install (e.g., 25.1.2.3, 25.1, stable, lts)
         version: String,
@@ -43,13 +43,13 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Without flags: shows locally installed versions (exact version strings).
-  With --available: shows versions available for download from GitHub releases.
+  With --remote: shows versions available for download from GitHub releases.
   Use the exact version strings from this output with `chv remove` or `chv use`.
   Related: `chv install <version>` to install, `chv which` to see current default.")]
     List {
         /// List versions available for download
         #[arg(long)]
-        available: bool,
+        remote: bool,
     },
 
     /// Set the default version

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,8 @@ async fn main() {
 async fn run(cmd: Commands) -> Result<()> {
     match cmd {
         Commands::Install { version } => install(&version).await,
-        Commands::List { available } => {
-            if available {
+        Commands::List { remote } => {
+            if remote {
                 list_available().await
             } else {
                 list_installed()


### PR DESCRIPTION
## Summary
- Renames `--available` flag to `--remote` on the `list` subcommand, similar to pnpm's convention
- Updates CLI definition, dispatch logic, help text, and README

Closes #5

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes
- [x] `chv list --help` shows `--remote` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)