### PR TITLE
Add opinionated project scaffold to chv init

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,26 +47,29 @@ chv remove 25.12.5.44
 ### Project Initialization
 
 ```bash
-# Initialize a project-local ClickHouse data directory
+# Initialize a project-local ClickHouse data directory and project scaffold
 chv init
 ```
 
-This creates a `.clickhouse/` directory in the current folder with a `.gitignore` so it won't be committed.
+This creates two directories:
 
-`chv run server` automatically runs `init` if needed, so you can skip this step.
+1. **`.clickhouse/`** — Runtime data directory (git-ignored). Data is scoped by version so switching versions with `chv use` won't cause compatibility issues. `chv run server` automatically creates this if needed.
 
-Data is scoped by version — each ClickHouse version gets its own subdirectory under `.clickhouse/`, so switching versions with `chv use` won't cause compatibility issues:
+2. **`clickhouse/`** — Project scaffold for organizing your SQL files (meant to be committed):
 
 ```
-.clickhouse/
-├── .gitignore
-├── 25.12.5.44/
-│   ├── data/
-│   └── ...
-└── 26.1.2.11/
-    ├── data/
-    └── ...
+clickhouse/
+├── tables/         # Table definitions (CREATE TABLE ...)
+│   └── .gitkeep
+├── materialized_views/  # Materialized view definitions
+│   └── .gitkeep
+├── queries/        # Saved queries
+│   └── .gitkeep
+└── seed/           # Seed data / INSERT statements
+    └── .gitkeep
 ```
+
+The `clickhouse/` scaffold is only created by `chv init`, not by `chv run server`.
 
 ### Running ClickHouse
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -87,9 +87,9 @@ CONTEXT FOR AGENTS:
     /// Initialize a project-local ClickHouse configuration
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Creates a .clickhouse/ directory in the current working directory.
-  Auto-called by `chv run server`, so rarely needed manually.
-  Project data is scoped by version in .clickhouse/{version}/.
+  Creates a .clickhouse/ directory (runtime data, git-ignored) and a clickhouse/ project
+  scaffold with subdirs: tables/, materialized_views/, queries/, seed/ (each with .gitkeep).
+  The clickhouse/ directory is meant to be committed — organize your SQL files there.
   Related: `chv run server` to start a server with project-local data.")]
     Init,
 


### PR DESCRIPTION
## Summary
- `chv init` now creates a `clickhouse/` project scaffold with subdirs: `tables/`, `materialized_views/`, `queries/`, `seed/` (each with `.gitkeep` so they're tracked by git)
- Decoupled `ensure_initialized()` from `init()` so `chv run server` only creates the `.clickhouse/` runtime dir, not the project scaffold
- Updated README and CLI help text to document the new structure

Closes #10

## Test plan
- [ ] `cargo build && cargo test` pass
- [ ] `rm -rf .clickhouse clickhouse && cargo run -- init` creates both dirs
- [ ] `ls clickhouse/` shows `tables/`, `materialized_views/`, `queries/`, `seed/`
- [ ] Each subdir contains `.gitkeep`
- [ ] Running `chv run server` does NOT create the `clickhouse/` scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)