### PR TITLE
Add Linux install support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chv"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chv"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 
 [dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
     #[error("Failed to execute ClickHouse: {0}")]
     Exec(String),
 
+    #[error("Extraction failed: {0}")]
+    Extract(String),
+
     #[error("Cloud API error: {0}")]
     Cloud(String),
 }

--- a/src/version_manager/install.rs
+++ b/src/version_manager/install.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use crate::paths;
 use crate::version_manager::download::download_version;
+use crate::version_manager::resolve::is_tarball_download;
 use std::os::unix::fs::PermissionsExt;
 
 /// Installs a ClickHouse version
@@ -17,11 +18,21 @@ pub async fn install_version(version: &str, channel: &str) -> Result<()> {
     // Create the version directory
     std::fs::create_dir_all(&version_dir)?;
 
-    // Download the binary directly to the destination
     let binary_path = version_dir.join("clickhouse");
 
     println!("Downloading ClickHouse {}...", version);
-    download_version(version, channel, &binary_path).await?;
+
+    if is_tarball_download()? {
+        // Linux: download tarball, extract, move binary
+        let tarball_path = version_dir.join("clickhouse.tgz");
+        download_version(version, channel, &tarball_path).await?;
+
+        println!("Extracting...");
+        extract_tarball(&tarball_path, &version_dir, version)?;
+    } else {
+        // macOS: download binary directly
+        download_version(version, channel, &binary_path).await?;
+    }
 
     // Make the binary executable
     let mut perms = std::fs::metadata(&binary_path)?.permissions();
@@ -29,5 +40,49 @@ pub async fn install_version(version: &str, channel: &str) -> Result<()> {
     std::fs::set_permissions(&binary_path, perms)?;
 
     println!("ClickHouse {} installed successfully", version);
+    Ok(())
+}
+
+/// Extracts the ClickHouse binary from a Linux tarball
+fn extract_tarball(
+    tarball_path: &std::path::Path,
+    version_dir: &std::path::Path,
+    version: &str,
+) -> Result<()> {
+    // Extract the tarball
+    let status = std::process::Command::new("tar")
+        .args(["xzf", &tarball_path.to_string_lossy()])
+        .current_dir(version_dir)
+        .status()
+        .map_err(|e| Error::Extract(format!("Failed to run tar: {}", e)))?;
+
+    if !status.success() {
+        // Clean up tarball on failure
+        let _ = std::fs::remove_file(tarball_path);
+        return Err(Error::Extract("tar extraction failed".to_string()));
+    }
+
+    // Find the clickhouse binary inside the extracted directory
+    let extracted_dir = version_dir.join(format!("clickhouse-common-static-{}", version));
+    let extracted_binary = extracted_dir.join("usr/bin/clickhouse");
+
+    if !extracted_binary.exists() {
+        // Clean up on failure
+        let _ = std::fs::remove_file(tarball_path);
+        let _ = std::fs::remove_dir_all(&extracted_dir);
+        return Err(Error::Extract(format!(
+            "Binary not found at expected path: {}",
+            extracted_binary.display()
+        )));
+    }
+
+    // Move binary to final location
+    let final_binary = version_dir.join("clickhouse");
+    std::fs::rename(&extracted_binary, &final_binary)?;
+
+    // Clean up tarball and extracted directory
+    let _ = std::fs::remove_file(tarball_path);
+    let _ = std::fs::remove_dir_all(&extracted_dir);
+
     Ok(())
 }

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -81,14 +81,35 @@ pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
     }
 }
 
+/// Returns whether the current platform downloads a tarball (Linux) vs a bare binary (macOS)
+pub fn is_tarball_download() -> Result<bool> {
+    let (os, _) = detect_platform()?;
+    Ok(os == "linux")
+}
+
 /// Builds the download URL for a specific version from GitHub releases
-/// URL format: https://github.com/ClickHouse/ClickHouse/releases/download/v{version}-{channel}/clickhouse-{os}-{arch}
+/// macOS: .../clickhouse-macos-{arch}
+/// Linux: .../clickhouse-common-static-{version}-{arch}.tgz
 pub fn build_download_url(version: &str, channel: &str) -> Result<String> {
     let (os, arch) = detect_platform()?;
-    Ok(format!(
-        "https://github.com/ClickHouse/ClickHouse/releases/download/v{}-{}/clickhouse-{}-{}",
-        version, channel, os, arch
-    ))
+    let base = format!(
+        "https://github.com/ClickHouse/ClickHouse/releases/download/v{}-{}",
+        version, channel
+    );
+    match os {
+        "linux" => {
+            let linux_arch = match arch {
+                "x86_64" => "amd64",
+                "aarch64" => "arm64",
+                _ => arch,
+            };
+            Ok(format!(
+                "{}/clickhouse-common-static-{}-{}.tgz",
+                base, version, linux_arch
+            ))
+        }
+        _ => Ok(format!("{}/clickhouse-{}-{}", base, os, arch)),
+    }
 }
 
 #[cfg(test)]
@@ -116,5 +137,36 @@ mod tests {
         let url = build_download_url("25.8.16.34", "lts").unwrap();
         assert!(url.starts_with("https://github.com/ClickHouse/ClickHouse/releases/download/"));
         assert!(url.contains("v25.8.16.34-lts"));
+    }
+
+    #[test]
+    fn test_build_download_url_platform_specific() {
+        let url = build_download_url("25.12.5.44", "stable").unwrap();
+        let (os, arch) = detect_platform().unwrap();
+        match os {
+            "macos" => {
+                assert!(url.contains(&format!("clickhouse-macos-{}", arch)));
+                assert!(!url.ends_with(".tgz"));
+            }
+            "linux" => {
+                let expected_arch = match arch {
+                    "x86_64" => "amd64",
+                    "aarch64" => "arm64",
+                    _ => arch,
+                };
+                assert!(url.contains(&format!(
+                    "clickhouse-common-static-25.12.5.44-{}.tgz",
+                    expected_arch
+                )));
+            }
+            _ => panic!("unexpected os: {}", os),
+        }
+    }
+
+    #[test]
+    fn test_is_tarball_download() {
+        let is_tarball = is_tarball_download().unwrap();
+        let (os, _) = detect_platform().unwrap();
+        assert_eq!(is_tarball, os == "linux");
     }
 }


### PR DESCRIPTION
## Summary
- Linux ClickHouse releases are distributed as `.tgz` tarballs (`clickhouse-common-static-{version}-{arch}.tgz`), not bare binaries like macOS
- Updated `build_download_url()` to produce platform-appropriate URLs (Linux uses `amd64`/`arm64` naming)
- Added tarball extraction flow in `install_version()`: download `.tgz`, extract via `tar xzf`, move binary to final location, clean up
- macOS install flow is unchanged

Closes #12

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (5/5 tests, including 2 new platform-specific tests)
- [x] `cargo clippy` — no new warnings
- [ ] Manual test on Linux: `cargo run -- install stable` downloads `.tgz`, extracts, and installs correctly
- [ ] Manual test on macOS: `cargo run -- install stable` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)