### PR TITLE
Address code review feedback

### DIFF
--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -63,11 +63,12 @@ impl CloudClient {
         })
     }
 
-    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let url = format!("{}{}", BASE_URL, path);
-        let response = self
-            .client
-            .get(&url)
+    /// Send a request and parse the JSON response body.
+    async fn request<T: serde::de::DeserializeOwned>(
+        &self,
+        req: reqwest::RequestBuilder,
+    ) -> Result<T> {
+        let response = req
             .header("Authorization", &self.auth_header)
             .send()
             .await
@@ -81,7 +82,6 @@ impl CloudClient {
         })?;
 
         if !status.is_success() {
-            // Try to parse error response
             if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body) {
                 if let Some(err) = api_resp.error {
                     return Err(CloudError {
@@ -104,103 +104,9 @@ impl CloudClient {
         })
     }
 
-    async fn post<T: serde::de::DeserializeOwned, B: serde::Serialize>(
-        &self,
-        path: &str,
-        body: &B,
-    ) -> Result<T> {
-        let url = format!("{}{}", BASE_URL, path);
-        let response = self
-            .client
-            .post(&url)
-            .header("Authorization", &self.auth_header)
-            .header("Content-Type", "application/json")
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| CloudError {
-                message: format!("Request failed: {}", e),
-            })?;
-
-        let status = response.status();
-        let body_text = response.text().await.map_err(|e| CloudError {
-            message: format!("Failed to read response: {}", e),
-        })?;
-
-        if !status.is_success() {
-            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body_text) {
-                if let Some(err) = api_resp.error {
-                    return Err(CloudError {
-                        message: err.message,
-                    });
-                }
-            }
-            return Err(CloudError {
-                message: format!("API error ({}): {}", status, body_text),
-            });
-        }
-
-        let api_response: ApiResponse<T> =
-            serde_json::from_str(&body_text).map_err(|e| CloudError {
-                message: format!("Failed to parse response: {} - Body: {}", e, body_text),
-            })?;
-
-        api_response.result.ok_or_else(|| CloudError {
-            message: "Empty response from API".into(),
-        })
-    }
-
-    async fn patch<T: serde::de::DeserializeOwned, B: serde::Serialize>(
-        &self,
-        path: &str,
-        body: &B,
-    ) -> Result<T> {
-        let url = format!("{}{}", BASE_URL, path);
-        let response = self
-            .client
-            .patch(&url)
-            .header("Authorization", &self.auth_header)
-            .header("Content-Type", "application/json")
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| CloudError {
-                message: format!("Request failed: {}", e),
-            })?;
-
-        let status = response.status();
-        let body_text = response.text().await.map_err(|e| CloudError {
-            message: format!("Failed to read response: {}", e),
-        })?;
-
-        if !status.is_success() {
-            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body_text) {
-                if let Some(err) = api_resp.error {
-                    return Err(CloudError {
-                        message: err.message,
-                    });
-                }
-            }
-            return Err(CloudError {
-                message: format!("API error ({}): {}", status, body_text),
-            });
-        }
-
-        let api_response: ApiResponse<T> =
-            serde_json::from_str(&body_text).map_err(|e| CloudError {
-                message: format!("Failed to parse response: {} - Body: {}", e, body_text),
-            })?;
-
-        api_response.result.ok_or_else(|| CloudError {
-            message: "Empty response from API".into(),
-        })
-    }
-
-    async fn delete(&self, path: &str) -> Result<()> {
-        let url = format!("{}{}", BASE_URL, path);
-        let response = self
-            .client
-            .delete(&url)
+    /// Send a request expecting no response body.
+    async fn request_no_body(&self, req: reqwest::RequestBuilder) -> Result<()> {
+        let response = req
             .header("Authorization", &self.auth_header)
             .send()
             .await
@@ -224,6 +130,37 @@ impl CloudClient {
         }
 
         Ok(())
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", BASE_URL, path)
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
+        self.request(self.client.get(&self.url(path))).await
+    }
+
+    async fn post<T: serde::de::DeserializeOwned, B: serde::Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        self.request(self.client.post(&self.url(path)).json(body))
+            .await
+    }
+
+    async fn patch<T: serde::de::DeserializeOwned, B: serde::Serialize>(
+        &self,
+        path: &str,
+        body: &B,
+    ) -> Result<T> {
+        self.request(self.client.patch(&self.url(path)).json(body))
+            .await
+    }
+
+    async fn delete(&self, path: &str) -> Result<()> {
+        self.request_no_body(self.client.delete(&self.url(path)))
+            .await
     }
 
     // Organization endpoints

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,9 @@ fn start_server(
     if auto_assigned {
         eprintln!("Note: default ports in use, auto-assigned HTTP:{} TCP:{}", http_port, tcp_port);
     }
+    // Check if the user passed their own config in the trailing args (after --).
+    // If not, we inject our managed data directory and --path flag.
+    // If they did, we leave ClickHouse to use their config as-is.
     let has_config = args
         .iter()
         .any(|a| a.starts_with("--config-file") || a.starts_with("-C"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ async fn install(version_spec: &str) -> Result<()> {
     let entry = version_manager::resolve_version(version_spec).await?;
     println!("Resolved to version {} ({})", entry.version, entry.channel);
 
-    version_manager::install_version(&entry.version, &entry.channel).await?;
+    version_manager::install_version(&entry.version, entry.channel).await?;
     Ok(())
 }
 
@@ -118,7 +118,7 @@ async fn use_version(version_spec: &str) -> Result<()> {
     let installed = version_manager::list_installed_versions()?;
     if !installed.contains(version) {
         println!("Version {} not installed, installing...", version);
-        version_manager::install_version(version, &entry.channel).await?;
+        version_manager::install_version(version, entry.channel).await?;
     }
 
     version_manager::set_default_version(version)?;

--- a/src/version_manager/download.rs
+++ b/src/version_manager/download.rs
@@ -1,4 +1,5 @@
 use crate::error::{Error, Result};
+use crate::version_manager::list::Channel;
 use crate::version_manager::resolve::build_download_url;
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -6,7 +7,7 @@ use std::path::Path;
 use tokio::io::AsyncWriteExt;
 
 /// Downloads a ClickHouse version to the specified path
-pub async fn download_version(version: &str, channel: &str, dest_path: &Path) -> Result<()> {
+pub async fn download_version(version: &str, channel: Channel, dest_path: &Path) -> Result<()> {
     let url = build_download_url(version, channel)?;
 
     let client = reqwest::Client::new();

--- a/src/version_manager/install.rs
+++ b/src/version_manager/install.rs
@@ -1,11 +1,12 @@
 use crate::error::{Error, Result};
 use crate::paths;
 use crate::version_manager::download::download_version;
+use crate::version_manager::list::Channel;
 use crate::version_manager::resolve::is_tarball_download;
 use std::os::unix::fs::PermissionsExt;
 
 /// Installs a ClickHouse version
-pub async fn install_version(version: &str, channel: &str) -> Result<()> {
+pub async fn install_version(version: &str, channel: Channel) -> Result<()> {
     paths::ensure_dirs()?;
 
     let version_dir = paths::version_dir(version)?;

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -1,6 +1,33 @@
 use crate::error::{Error, Result};
 use crate::paths;
 use serde::Deserialize;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    Stable,
+    Lts,
+}
+
+impl fmt::Display for Channel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Channel::Stable => write!(f, "stable"),
+            Channel::Lts => write!(f, "lts"),
+        }
+    }
+}
+
+impl Channel {
+    /// Parse a channel from a release tag suffix (e.g. "stable", "lts")
+    pub fn from_tag_suffix(s: &str) -> Option<Self> {
+        match s {
+            "stable" => Some(Channel::Stable),
+            "lts" => Some(Channel::Lts),
+            _ => None,
+        }
+    }
+}
 
 /// Lists all installed ClickHouse versions
 pub fn list_installed_versions() -> Result<Vec<String>> {
@@ -34,11 +61,11 @@ struct GitHubRelease {
     tag_name: String,
 }
 
-/// A version with its release channel (stable or lts)
+/// A version with its release channel
 #[derive(Clone)]
 pub struct VersionEntry {
     pub version: String,
-    pub channel: String,
+    pub channel: Channel,
 }
 
 /// Fetches available versions from GitHub releases
@@ -58,10 +85,12 @@ pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
         // Tag format: v25.12.5.44-stable or v24.8.10.6-lts
         let tag = &release.tag_name;
         if let Some(version) = tag.strip_prefix('v') {
-            if let Some(v) = version.strip_suffix("-stable") {
-                versions.push(VersionEntry { version: v.to_string(), channel: "stable".to_string() });
-            } else if let Some(v) = version.strip_suffix("-lts") {
-                versions.push(VersionEntry { version: v.to_string(), channel: "lts".to_string() });
+            if let Some(dash_pos) = version.rfind('-') {
+                let v = &version[..dash_pos];
+                let suffix = &version[dash_pos + 1..];
+                if let Some(channel) = Channel::from_tag_suffix(suffix) {
+                    versions.push(VersionEntry { version: v.to_string(), channel });
+                }
             }
         }
     }

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -138,17 +138,79 @@ pub fn set_default_version(version: &str) -> Result<()> {
     Ok(())
 }
 
-/// Compares two version strings for sorting
-fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
-    let a_parts: Vec<u64> = a.split('.').filter_map(|s| s.parse().ok()).collect();
-    let b_parts: Vec<u64> = b.split('.').filter_map(|s| s.parse().ok()).collect();
+/// Compare a single version component. Numeric parts are compared numerically;
+/// non-numeric parts fall back to lexicographic comparison.
+fn compare_part(a: &str, b: &str) -> std::cmp::Ordering {
+    match (a.parse::<u64>(), b.parse::<u64>()) {
+        (Ok(a_num), Ok(b_num)) => a_num.cmp(&b_num),
+        _ => a.cmp(b),
+    }
+}
 
-    for (a_part, b_part) in a_parts.iter().zip(b_parts.iter()) {
-        match a_part.cmp(b_part) {
+/// Compares two version strings for sorting.
+/// Missing parts are treated as 0, so "20.3" < "20.3.1" and "20.3.0" == "20.3".
+fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let a_parts: Vec<&str> = a.split('.').collect();
+    let b_parts: Vec<&str> = b.split('.').collect();
+    let max_len = a_parts.len().max(b_parts.len());
+
+    for i in 0..max_len {
+        let a_part = a_parts.get(i).copied().unwrap_or("0");
+        let b_part = b_parts.get(i).copied().unwrap_or("0");
+        match compare_part(a_part, b_part) {
             std::cmp::Ordering::Equal => continue,
             other => return other,
         }
     }
 
-    a_parts.len().cmp(&b_parts.len())
+    std::cmp::Ordering::Equal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn test_equal_versions() {
+        assert_eq!(compare_versions("25.12.5.44", "25.12.5.44"), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_different_versions() {
+        assert_eq!(compare_versions("25.12.5.44", "25.12.5.43"), Ordering::Greater);
+        assert_eq!(compare_versions("25.12.5.43", "25.12.5.44"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_major_minor_difference() {
+        assert_eq!(compare_versions("25.12.5.44", "24.12.5.44"), Ordering::Greater);
+        assert_eq!(compare_versions("25.11.5.44", "25.12.5.44"), Ordering::Less);
+    }
+
+    #[test]
+    fn test_missing_parts_treated_as_zero() {
+        // 20.3 should be less than 20.3.1 (missing part = 0)
+        assert_eq!(compare_versions("20.3", "20.3.1"), Ordering::Less);
+        assert_eq!(compare_versions("20.3.1", "20.3"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_trailing_zero_equals_shorter() {
+        // 20.3.0 should equal 20.3 (missing part = 0)
+        assert_eq!(compare_versions("20.3.0", "20.3"), Ordering::Equal);
+        assert_eq!(compare_versions("20.3", "20.3.0"), Ordering::Equal);
+    }
+
+    #[test]
+    fn test_non_numeric_suffix() {
+        // 20.3.2-alpha1 should be greater than 20.3.1 (compare_part "2-alpha1" vs "1": lexicographic, "2" > "1")
+        assert_eq!(compare_versions("20.3.2-alpha1", "20.3.1"), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_single_component() {
+        assert_eq!(compare_versions("8", "8.0.1"), Ordering::Less);
+        assert_eq!(compare_versions("8.0.1", "8"), Ordering::Greater);
+    }
 }

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -68,8 +68,8 @@ pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
     // For all specifiers, fetch available versions to get accurate channel info
     let available = list_available_versions().await?;
 
-    // If it looks like an exact version (4 parts), find its channel from the list
-    if version_spec.split('.').count() == 4 {
+    // If it looks like an exact version (e.g. 25.12.5.44), find its channel from the list
+    if version_spec.matches('.').count() == 3 {
         let channel = available
             .iter()
             .find(|e| e.version == version_spec)

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::version_manager::list::{list_available_versions, VersionEntry};
+use crate::version_manager::list::{list_available_versions, Channel, VersionEntry};
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,8 +73,8 @@ pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
         let channel = available
             .iter()
             .find(|e| e.version == version_spec)
-            .map(|e| e.channel.clone())
-            .unwrap_or_else(|| "stable".to_string());
+            .map(|e| e.channel)
+            .unwrap_or(Channel::Stable);
         return Ok(VersionEntry {
             version: version_spec.to_string(),
             channel,
@@ -85,14 +85,14 @@ pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
         "stable" => {
             available
                 .iter()
-                .find(|e| e.channel == "stable")
+                .find(|e| e.channel == Channel::Stable)
                 .cloned()
                 .ok_or_else(|| Error::NoMatchingVersion(version_spec.to_string()))
         }
         "lts" => {
             available
                 .iter()
-                .find(|e| e.channel == "lts")
+                .find(|e| e.channel == Channel::Lts)
                 .cloned()
                 .ok_or_else(|| Error::NoMatchingVersion(version_spec.to_string()))
         }
@@ -117,7 +117,7 @@ pub fn is_tarball_download() -> Result<bool> {
 /// Builds the download URL for a specific version from GitHub releases
 /// macOS: .../clickhouse-macos-{arch}
 /// Linux: .../clickhouse-common-static-{version}-{arch}.tgz
-pub fn build_download_url(version: &str, channel: &str) -> Result<String> {
+pub fn build_download_url(version: &str, channel: Channel) -> Result<String> {
     let (os, arch) = detect_platform()?;
     let base = format!(
         "https://github.com/ClickHouse/ClickHouse/releases/download/v{}-{}",
@@ -153,21 +153,21 @@ mod tests {
 
     #[test]
     fn test_build_download_url_stable() {
-        let url = build_download_url("25.12.5.44", "stable").unwrap();
+        let url = build_download_url("25.12.5.44", Channel::Stable).unwrap();
         assert!(url.starts_with("https://github.com/ClickHouse/ClickHouse/releases/download/"));
         assert!(url.contains("v25.12.5.44-stable"));
     }
 
     #[test]
     fn test_build_download_url_lts() {
-        let url = build_download_url("25.8.16.34", "lts").unwrap();
+        let url = build_download_url("25.8.16.34", Channel::Lts).unwrap();
         assert!(url.starts_with("https://github.com/ClickHouse/ClickHouse/releases/download/"));
         assert!(url.contains("v25.8.16.34-lts"));
     }
 
     #[test]
     fn test_build_download_url_platform_specific() {
-        let url = build_download_url("25.12.5.44", "stable").unwrap();
+        let url = build_download_url("25.12.5.44", Channel::Stable).unwrap();
         let (os, arch) = detect_platform().unwrap();
         match os {
             Os::MacOS => {

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -1,35 +1,62 @@
 use crate::error::{Error, Result};
 use crate::version_manager::list::{list_available_versions, VersionEntry};
+use std::fmt;
 
-/// Detects the current platform and returns (os, arch) for download URLs
-/// Returns values matching GitHub release naming: (macos|linux, aarch64|x86_64)
-pub fn detect_platform() -> Result<(&'static str, &'static str)> {
-    let os = std::env::consts::OS;
-    let arch = std::env::consts::ARCH;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Os {
+    MacOS,
+    Linux,
+}
 
-    let os_name = match os {
-        "macos" => "macos",
-        "linux" => "linux",
-        _ => {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arch {
+    X86_64,
+    Aarch64,
+}
+
+impl fmt::Display for Os {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Os::MacOS => write!(f, "macos"),
+            Os::Linux => write!(f, "linux"),
+        }
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Arch::X86_64 => write!(f, "x86_64"),
+            Arch::Aarch64 => write!(f, "aarch64"),
+        }
+    }
+}
+
+/// Detects the current platform
+pub fn detect_platform() -> Result<(Os, Arch)> {
+    let os = match std::env::consts::OS {
+        "macos" => Os::MacOS,
+        "linux" => Os::Linux,
+        other => {
             return Err(Error::UnsupportedPlatform {
-                os: os.to_string(),
-                arch: arch.to_string(),
+                os: other.to_string(),
+                arch: std::env::consts::ARCH.to_string(),
             })
         }
     };
 
-    let arch_name = match arch {
-        "x86_64" => "x86_64",
-        "aarch64" => "aarch64",
-        _ => {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => Arch::X86_64,
+        "aarch64" => Arch::Aarch64,
+        other => {
             return Err(Error::UnsupportedPlatform {
-                os: os.to_string(),
-                arch: arch.to_string(),
+                os: std::env::consts::OS.to_string(),
+                arch: other.to_string(),
             })
         }
     };
 
-    Ok((os_name, arch_name))
+    Ok((os, arch))
 }
 
 /// Resolves a version specifier to an exact version and its channel
@@ -84,7 +111,7 @@ pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
 /// Returns whether the current platform downloads a tarball (Linux) vs a bare binary (macOS)
 pub fn is_tarball_download() -> Result<bool> {
     let (os, _) = detect_platform()?;
-    Ok(os == "linux")
+    Ok(os == Os::Linux)
 }
 
 /// Builds the download URL for a specific version from GitHub releases
@@ -97,18 +124,17 @@ pub fn build_download_url(version: &str, channel: &str) -> Result<String> {
         version, channel
     );
     match os {
-        "linux" => {
+        Os::Linux => {
             let linux_arch = match arch {
-                "x86_64" => "amd64",
-                "aarch64" => "arm64",
-                _ => arch,
+                Arch::X86_64 => "amd64",
+                Arch::Aarch64 => "arm64",
             };
             Ok(format!(
                 "{}/clickhouse-common-static-{}-{}.tgz",
                 base, version, linux_arch
             ))
         }
-        _ => Ok(format!("{}/clickhouse-{}-{}", base, os, arch)),
+        Os::MacOS => Ok(format!("{}/clickhouse-{}-{}", base, os, arch)),
     }
 }
 
@@ -121,8 +147,8 @@ mod tests {
         let result = detect_platform();
         assert!(result.is_ok());
         let (os, arch) = result.unwrap();
-        assert!(os == "macos" || os == "linux");
-        assert!(arch == "x86_64" || arch == "aarch64");
+        assert!(os == Os::MacOS || os == Os::Linux);
+        assert!(arch == Arch::X86_64 || arch == Arch::Aarch64);
     }
 
     #[test]
@@ -144,22 +170,20 @@ mod tests {
         let url = build_download_url("25.12.5.44", "stable").unwrap();
         let (os, arch) = detect_platform().unwrap();
         match os {
-            "macos" => {
+            Os::MacOS => {
                 assert!(url.contains(&format!("clickhouse-macos-{}", arch)));
                 assert!(!url.ends_with(".tgz"));
             }
-            "linux" => {
+            Os::Linux => {
                 let expected_arch = match arch {
-                    "x86_64" => "amd64",
-                    "aarch64" => "arm64",
-                    _ => arch,
+                    Arch::X86_64 => "amd64",
+                    Arch::Aarch64 => "arm64",
                 };
                 assert!(url.contains(&format!(
                     "clickhouse-common-static-25.12.5.44-{}.tgz",
                     expected_arch
                 )));
             }
-            _ => panic!("unexpected os: {}", os),
         }
     }
 
@@ -167,6 +191,6 @@ mod tests {
     fn test_is_tarball_download() {
         let is_tarball = is_tarball_download().unwrap();
         let (os, _) = detect_platform().unwrap();
-        assert_eq!(is_tarball, os == "linux");
+        assert_eq!(is_tarball, os == Os::Linux);
     }
 }


### PR DESCRIPTION
## Summary

Addresses code review feedback with targeted improvements across the codebase.

### Feedback items

**1. `detect_platform` should use enums for OS/arch**
Replaced string-based `(&'static str, &'static str)` return type with `Os` and `Arch` enums. This gives exhaustive match checking in `build_download_url`, eliminating unreachable `_ =>` branches.

**2. `list_available_versions` channel handling should use enums**
Introduced a `Channel` enum (`Stable`, `Lts`) with `Display` impl and `from_tag_suffix` parser. Threaded through `VersionEntry`, `resolve_version`, `build_download_url`, `download_version`, and `install_version`. Eliminates string comparisons and `.clone()` calls on channel strings. Tag parsing now uses `rfind('-')` + `Channel::from_tag_suffix` instead of chained `strip_suffix` calls, making it easy to add new channels later.

**3. `version_spec.split('.').count() == 4` is an odd way to count 3 dots**
Changed to `version_spec.matches('.').count() == 3`.

**4. `resolve_ports` using `match` when `if let` would do, and doesn't need `Result`**
Deferred — seeking clarification from reviewer. The `match` vs `if let` is a style preference (both are clear). The `Result` return type is needed because `find_free_port` can fail if no port is available in the search range; removing it would require either panicking or silently falling back.

**5. `has_config` scan in main.rs while using clap**
Added a comment explaining the purpose: the trailing args (after `--`) are opaque passthrough to ClickHouse, not parsed by clap. We peek at them only to decide whether to inject our managed data directory defaults. Making `--config-file` a clap arg would add coupling to ClickHouse's flag naming for no benefit.

**6. `Cow` vs clone spam**
Acknowledged — for a CLI processing small data, the simpler `String`/`.clone()` approach is the right tradeoff over adding `Cow` lifetimes throughout the codebase. No changes made.

**7. `CloudClient` methods are very redundant**
Extracted shared response handling into `request()` and `request_no_body()` methods that take a `reqwest::RequestBuilder`. The `get`/`post`/`patch`/`delete` helpers are now one-liners, eliminating ~100 lines of duplicated error/response handling.

**8. `compare_versions` drops unparsable parts and mishandles partial versions**
Rewrote to: (a) treat missing parts as `0` so `20.3 < 20.3.1` and `20.3.0 == 20.3`, (b) fall back to lexicographic comparison for non-numeric parts instead of silently dropping them. Added 7 tests covering edge cases. Chose zero-fill over the wildcard approach from the referenced Go PR because we need a total ordering for sorted lists, not a matching/compatibility check.

## Test plan

- [x] All existing tests pass
- [x] 7 new version comparison tests added and passing
- [x] `cargo build` clean, no warnings
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)