### PR TITLE
Restructure CLI into local and cloud top-level subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,20 +18,18 @@ Cross-compilation for aarch64-linux uses `cross` (see `.github/workflows/release
 
 ## Architecture
 
-`clickhousectl` is the official ClickHouse CLI — a version manager + cloud CLI. Three concerns, three module groups:
+`clickhousectl` is the official ClickHouse CLI — a version manager + cloud CLI. Two top-level subcommands: `local` and `cloud`.
 
-1. **Version management** (top-level commands: `install`, `list`, `use`, `remove`, `which`) — handled by `src/version_manager/`. Binaries live in `~/.clickhouse/versions/{version}/clickhouse`, default tracked in `~/.clickhouse/default`.
+1. **Local** (`local install|list|use|remove|which|init|run|server`) — version management in `src/version_manager/`, server management in `src/server.rs`, run/init in `main.rs`. Binaries live in `~/.clickhouse/versions/{version}/clickhouse`, default tracked in `~/.clickhouse/default`. Project data lives in `.clickhouse/`.
 
-2. **Local server** (`run server`, `run client`, `run local`, `run --sql`) — handled in `run_clickhouse()` in `main.rs`. Uses `std::os::unix::process::CommandExt::exec()` to replace the process with ClickHouse. Project data lives in `.clickhouse/{version}/` (version-scoped to prevent compatibility issues).
-
-3. **Cloud API** (`cloud org|service|backup`) — handled by `src/cloud/`. `CloudClient` wraps reqwest with Basic auth. Commands go through `cloud/commands.rs`, types in `cloud/types.rs`. All cloud commands support `--json` output.
+2. **Cloud** (`cloud org|service|backup|auth`) — handled by `src/cloud/`. `CloudClient` wraps reqwest with Basic auth. Commands go through `cloud/commands.rs`, types in `cloud/types.rs`. All cloud commands support `--json` output.
 
 ## Adding commands
 
-### New top-level or run subcommand
+### New local subcommand
 
-1. Define in `src/cli.rs` using clap derive macros
-2. Add match arm in `src/main.rs`
+1. Add variant to `LocalCommands` in `src/cli.rs` using clap derive macros
+2. Add match arm in `run_local()` in `src/main.rs`
 3. Implement handler (in `main.rs` for simple commands, or a dedicated module)
 
 ### New cloud subcommand
@@ -80,7 +78,7 @@ cargo add rpassword                  # add latest version
 ## Testing locally
 
 ```bash
-cargo run -- install stable
-cargo run -- run server              # starts server in .clickhouse/{version}/
-cargo run -- run client --query "SELECT 1"
+cargo run -- local install stable
+cargo run -- local server start      # starts server in .clickhouse/servers/default/
+cargo run -- local run client -- --query "SELECT 1"
 ```

--- a/README.md
+++ b/README.md
@@ -89,17 +89,9 @@ clickhouse/
 ### Running queries
 
 ```bash
-# Quick SQL query (uses clickhouse-local)
-clickhousectl local run --sql "SELECT 1"
-clickhousectl local run -s "SELECT * FROM system.functions LIMIT 5"
-
-# Run clickhouse-local with full options
-clickhousectl local run local --query "SELECT 1"
-clickhousectl local run local -- --help
-
 # Connect to a running server with clickhouse-client
-clickhousectl local run client
-clickhousectl local run client -- --host localhost --query "SHOW DATABASES"
+clickhousectl local client
+clickhousectl local client -- --host localhost --query "SHOW DATABASES"
 ```
 
 ### Creating and managing ClickHouse servers

--- a/README.md
+++ b/README.md
@@ -36,24 +36,24 @@ cargo install --path .
 
 ```bash
 # Install a version
-clickhousectl install stable          # Latest stable release
-clickhousectl install lts             # Latest LTS release
-clickhousectl install 25.12           # Latest 25.12.x.x
-clickhousectl install 25.12.5.44      # Exact version
+clickhousectl local install stable          # Latest stable release
+clickhousectl local install lts             # Latest LTS release
+clickhousectl local install 25.12           # Latest 25.12.x.x
+clickhousectl local install 25.12.5.44      # Exact version
 
 # List versions
-clickhousectl list                    # Installed versions
-clickhousectl list --remote           # Available for download
+clickhousectl local list                    # Installed versions
+clickhousectl local list --remote           # Available for download
 
 # Manage default version
-clickhousectl use stable              # Latest stable (installs if needed)
-clickhousectl use lts                 # Latest LTS (installs if needed)
-clickhousectl use 25.12               # Latest 25.12.x.x (installs if needed)
-clickhousectl use 25.12.5.44          # Exact version
-clickhousectl which                   # Show current default
+clickhousectl local use stable              # Latest stable (installs if needed)
+clickhousectl local use lts                 # Latest LTS (installs if needed)
+clickhousectl local use 25.12               # Latest 25.12.x.x (installs if needed)
+clickhousectl local use 25.12.5.44          # Exact version
+clickhousectl local which                   # Show current default
 
 # Remove a version
-clickhousectl remove 25.12.5.44
+clickhousectl local remove 25.12.5.44
 ```
 
 #### ClickHouse binary storage
@@ -71,7 +71,7 @@ ClickHouse binaries are stored in a global repository, so they can be used by mu
 ### Initializing a project
 
 ```bash
-clickhousectl init
+clickhousectl local init
 ```
 
 `init` bootstraps your current working directory with a standard folder structure for your ClickHouse project files. It is optional; you are welcome to use your own folder structure if preferred. 
@@ -90,16 +90,16 @@ clickhouse/
 
 ```bash
 # Quick SQL query (uses clickhouse-local)
-clickhousectl run --sql "SELECT 1"
-clickhousectl run -s "SELECT * FROM system.functions LIMIT 5"
+clickhousectl local run --sql "SELECT 1"
+clickhousectl local run -s "SELECT * FROM system.functions LIMIT 5"
 
 # Run clickhouse-local with full options
-clickhousectl run local --query "SELECT 1"
-clickhousectl run local -- --help
+clickhousectl local run local --query "SELECT 1"
+clickhousectl local run local -- --help
 
 # Connect to a running server with clickhouse-client
-clickhousectl run client
-clickhousectl run client -- --host localhost --query "SHOW DATABASES"
+clickhousectl local run client
+clickhousectl local run client -- --host localhost --query "SHOW DATABASES"
 ```
 
 ### Creating and managing ClickHouse servers
@@ -108,21 +108,21 @@ Start and manage ClickHouse server instances. Each server gets its own isolated 
 
 ```bash
 # Start a server (runs in background by default)
-clickhousectl server start                          # Named "default"
-clickhousectl server start --name dev               # Named "dev"
-clickhousectl server start --foreground             # Run in foreground (-F / --fg)
-clickhousectl server start --http-port 8124 --tcp-port 9001  # Explicit ports
-clickhousectl server start -- --config-file=/path/to/config.xml
+clickhousectl local server start                          # Named "default"
+clickhousectl local server start --name dev               # Named "dev"
+clickhousectl local server start --foreground             # Run in foreground (-F / --fg)
+clickhousectl local server start --http-port 8124 --tcp-port 9001  # Explicit ports
+clickhousectl local server start -- --config-file=/path/to/config.xml
 
 # List all servers (running and stopped)
-clickhousectl server list
+clickhousectl local server list
 
 # Stop servers
-clickhousectl server stop default                   # Stop by name
-clickhousectl server stop-all                       # Stop all running servers
+clickhousectl local server stop default                   # Stop by name
+clickhousectl local server stop-all                       # Stop all running servers
 
 # Remove a stopped server and its data
-clickhousectl server remove test
+clickhousectl local server remove test
 ```
 
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
@@ -144,7 +144,7 @@ All server data lives inside `.clickhouse/` in your project directory:
         └── data/           # ClickHouse data files for "dev" server
 ```
 
-Each named server has its own data directory, so servers are fully isolated from each other. Data persists between restarts — stop and start a server by name to pick up where you left off. Use `clickhousectl server remove <name>` to permanently delete a server's data.
+Each named server has its own data directory, so servers are fully isolated from each other. Data persists between restarts — stop and start a server by name to pick up where you left off. Use `clickhousectl local server remove <name>` to permanently delete a server's data.
 
 ## Cloud
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ CONTEXT FOR AGENTS:
 
   `npx skills add clickhouse/agent-skills`
 
-  Typical local workflow: `clickhousectl install stable && clickhousectl use stable && clickhousectl server start`.
+  Typical local workflow: `clickhousectl local install stable && clickhousectl local use stable && clickhousectl local server start`.
 
   Use `clickhousectl <command> --help` to get more context for specific commands.")]
 pub struct Cli {
@@ -26,93 +26,15 @@ pub struct Cli {
 
 #[derive(Subcommand)]
 pub enum Commands {
-    /// Install a ClickHouse version
+    /// Work with local ClickHouse installations
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Downloads a ClickHouse binary to ~/.clickhouse/versions/{version}/.
-  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
-  Optionally set as default with `clickhousectl use <version>`.
-  `clickhousectl use <version>` will auto-install if the version is missing and set as default.
-  Related: `clickhousectl list --remote` to see downloadable versions.")]
-    Install {
-        /// Version to install (e.g., 25.1.2.3, 25.1, stable, lts)
-        version: String,
-    },
-
-    /// List installed versions
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Without flags: shows locally installed versions (exact version strings).
-  With --remote: shows versions available for download from GitHub releases.
-  Use the exact version strings from this output with `clickhousectl remove` or `clickhousectl use`.
-  Related: `clickhousectl install <version>` to install, `clickhousectl which` to see current default.")]
-    List {
-        /// List versions available for download
-        #[arg(long)]
-        remote: bool,
-    },
-
-    /// Set the default version
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Sets the default ClickHouse version used by `clickhousectl run` commands.
-  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
-  Auto-installs the version if not already present.
-  Related: `clickhousectl which` to verify, `clickhousectl server start` to start a server.")]
-    Use {
-        /// Version to use as default
-        version: String,
-    },
-
-    /// Remove an installed version
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Removes an installed ClickHouse version from ~/.clickhouse/versions/.
-  Takes an exact version string as shown by `clickhousectl list` (e.g., \"25.12.5.44\").
-  Does NOT accept keywords like \"stable\" — use the exact version number.
-  Related: `clickhousectl list` to see installed versions.")]
-    Remove {
-        /// Version to remove
-        version: String,
-    },
-
-    /// Show the current default version
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Shows the current default version and binary path. No arguments needed.
-  Use this to verify which version is active before running commands.
-  Related: `clickhousectl use <version>` to change the default.")]
-    Which,
-
-    /// Initialize a project-local ClickHouse configuration
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Creates a .clickhouse/ directory (runtime data, git-ignored) and a clickhouse/ project
-  scaffold with subdirs: tables/, materialized_views/, queries/, seed/ (each with .gitkeep).
-  The clickhouse/ directory is meant to be committed — organize your SQL files there.
-  Related: `clickhousectl server start` to start a server with project-local data.")]
-    Init,
-
-    /// Run ClickHouse client or local commands
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Run clickhouse-client or clickhouse-local. Requires a default version set via `clickhousectl use`.
-  Shortcut: `clickhousectl run --sql 'SELECT 1'` runs a query via clickhouse-local.
-  For servers, use `clickhousectl server start` instead.
-  Related: `clickhousectl use <version>` to set default, `clickhousectl server start` to start a server.")]
-    Run(RunArgs),
-
-    /// Manage local ClickHouse server instances
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Manage named ClickHouse server instances. Each server has its own data directory.
-  Subcommands: start, list, stop, stop-all, remove.
-  Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
-  Typical: `clickhousectl server start` (starts \"default\"), `clickhousectl server start --name test --port 1`.
-  Related: `clickhousectl run client` to connect to a running server.")]
-    Server {
+  Manage local ClickHouse installations: install versions, run queries, manage servers.
+  Typical workflow: `clickhousectl local install stable && clickhousectl local use stable && clickhousectl local server start`.
+  Use `clickhousectl local <command> --help` for details on each subcommand.")]
+    Local {
         #[command(subcommand)]
-        command: ServerCommands,
+        command: LocalCommands,
     },
 
     /// ClickHouse Cloud API commands
@@ -127,6 +49,98 @@ CONTEXT FOR AGENTS:
   Typical workflow: `cloud org list` → get org ID → `cloud service list` → manage services.
   Related: `clickhousectl cloud org list` to start.")]
     Cloud(CloudArgs),
+}
+
+#[derive(Subcommand)]
+pub enum LocalCommands {
+    /// Install a ClickHouse version
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Downloads a ClickHouse binary to ~/.clickhouse/versions/{version}/.
+  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
+  Optionally set as default with `clickhousectl local use <version>`.
+  `clickhousectl local use <version>` will auto-install if the version is missing and set as default.
+  Related: `clickhousectl local list --remote` to see downloadable versions.")]
+    Install {
+        /// Version to install (e.g., 25.1.2.3, 25.1, stable, lts)
+        version: String,
+    },
+
+    /// List installed versions
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Without flags: shows locally installed versions (exact version strings).
+  With --remote: shows versions available for download from GitHub releases.
+  Use the exact version strings from this output with `clickhousectl local remove` or `clickhousectl local use`.
+  Related: `clickhousectl local install <version>` to install, `clickhousectl local which` to see current default.")]
+    List {
+        /// List versions available for download
+        #[arg(long)]
+        remote: bool,
+    },
+
+    /// Set the default version
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Sets the default ClickHouse version used by `clickhousectl local run` commands.
+  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
+  Auto-installs the version if not already present.
+  Related: `clickhousectl local which` to verify, `clickhousectl local server start` to start a server.")]
+    Use {
+        /// Version to use as default
+        version: String,
+    },
+
+    /// Remove an installed version
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Removes an installed ClickHouse version from ~/.clickhouse/versions/.
+  Takes an exact version string as shown by `clickhousectl local list` (e.g., \"25.12.5.44\").
+  Does NOT accept keywords like \"stable\" — use the exact version number.
+  Related: `clickhousectl local list` to see installed versions.")]
+    Remove {
+        /// Version to remove
+        version: String,
+    },
+
+    /// Show the current default version
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Shows the current default version and binary path. No arguments needed.
+  Use this to verify which version is active before running commands.
+  Related: `clickhousectl local use <version>` to change the default.")]
+    Which,
+
+    /// Initialize a project-local ClickHouse configuration
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Creates a .clickhouse/ directory (runtime data, git-ignored) and a clickhouse/ project
+  scaffold with subdirs: tables/, materialized_views/, queries/, seed/ (each with .gitkeep).
+  The clickhouse/ directory is meant to be committed — organize your SQL files there.
+  Related: `clickhousectl local server start` to start a server with project-local data.")]
+    Init,
+
+    /// Run ClickHouse client or local commands
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Run clickhouse-client or clickhouse-local. Requires a default version set via `clickhousectl local use`.
+  Shortcut: `clickhousectl local run --sql 'SELECT 1'` runs a query via clickhouse-local.
+  For servers, use `clickhousectl local server start` instead.
+  Related: `clickhousectl local use <version>` to set default, `clickhousectl local server start` to start a server.")]
+    Run(RunArgs),
+
+    /// Manage local ClickHouse server instances
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Manage named ClickHouse server instances. Each server has its own data directory.
+  Subcommands: start, list, stop, stop-all, remove.
+  Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
+  Typical: `clickhousectl local server start` (starts \"default\"), `clickhousectl local server start --name test`.
+  Related: `clickhousectl local run client` to connect to a running server.")]
+    Server {
+        #[command(subcommand)]
+        command: ServerCommands,
+    },
 }
 
 #[derive(Args)]
@@ -144,10 +158,10 @@ pub enum RunCommands {
     /// Run clickhouse-client
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Connects to a running clickhouse-server. Server must already be running via `clickhousectl server start`.
-  Pass clickhouse-client args after -- (e.g., `clickhousectl run client -- --query 'SELECT 1'`).
+  Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
+  Pass clickhouse-client args after -- (e.g., `clickhousectl local run client -- --query 'SELECT 1'`).
   Common args: --host, --port, --query, --multiquery, --format.
-  Related: `clickhousectl server start` to start a server first.")]
+  Related: `clickhousectl local server start` to start a server first.")]
     Client {
         /// Arguments to pass to clickhouse-client
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -158,10 +172,10 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Runs clickhouse-local for file/query processing without a server.
-  Pass clickhouse-local args after -- (e.g., `clickhousectl run local -- --query 'SELECT 1'`).
-  Shortcut: `clickhousectl run --sql 'SELECT 1'` does the same without the local subcommand.
+  Pass clickhouse-local args after -- (e.g., `clickhousectl local run local -- --query 'SELECT 1'`).
+  Shortcut: `clickhousectl local run --sql 'SELECT 1'` does the same without the local subcommand.
   Useful for processing files, running queries against local data, or testing SQL.
-  Related: `clickhousectl run --sql` for quick one-off queries.")]
+  Related: `clickhousectl local run --sql` for quick one-off queries.")]
     Local {
         /// Arguments to pass to clickhouse-local
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -445,7 +459,7 @@ CONTEXT FOR AGENTS:
   Runs in background by default. Use --foreground (-F / --fg) to run in foreground.
   If --name is given and that server is already running, the command will error.
   Shows count of already-running servers before starting.
-  Related: `clickhousectl server list` to see servers, `clickhousectl server stop <name>` to stop one.")]
+  Related: `clickhousectl local server list` to see servers, `clickhousectl local server stop <name>` to stop one.")]
     Start {
         /// Server name (default: \"default\", or random if default is already running)
         #[arg(long)]
@@ -474,16 +488,16 @@ CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Automatically cleans up stale entries for processes that are no longer running.
   Shows name, status (running/stopped), PID, version, and ports.
-  Related: `clickhousectl server start` to start a server, `clickhousectl server stop <name>` to stop one.")]
+  Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
     List,
 
     /// Stop a running server by name
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Stops a named ClickHouse server. Use the name from `clickhousectl server list`.
+  Stops a named ClickHouse server. Use the name from `clickhousectl local server list`.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
-  The server's data directory is preserved — restart with `clickhousectl server start --name <name>`.
-  Related: `clickhousectl server list` to see servers.")]
+  The server's data directory is preserved — restart with `clickhousectl local server start --name <name>`.
+  Related: `clickhousectl local server list` to see servers.")]
     Stop {
         /// Name of the server to stop
         name: String,
@@ -495,7 +509,7 @@ CONTEXT FOR AGENTS:
   Stops all running ClickHouse server instances.
   Sends SIGTERM first, then SIGKILL if processes don't exit.
   Data directories are preserved.
-  Related: `clickhousectl server list` to see servers.")]
+  Related: `clickhousectl local server list` to see servers.")]
     StopAll,
 
     /// Remove a stopped server and its data
@@ -503,7 +517,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  Related: `clickhousectl server stop <name>` to stop first, `clickhousectl server list` to see servers.")]
+  Related: `clickhousectl local server stop <name>` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
         /// Name of the server to remove
         name: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -82,7 +82,7 @@ CONTEXT FOR AGENTS:
     /// Set the default version
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Sets the default ClickHouse version used by `clickhousectl local run` commands.
+  Sets the default ClickHouse version used by `clickhousectl local client` and `clickhousectl local server`.
   Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
   Auto-installs the version if not already present.
   Related: `clickhousectl local which` to verify, `clickhousectl local server start` to start a server.")]
@@ -120,46 +120,11 @@ CONTEXT FOR AGENTS:
   Related: `clickhousectl local server start` to start a server with project-local data.")]
     Init,
 
-    /// Run ClickHouse client or local commands
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Run clickhouse-client or clickhouse-local. Requires a default version set via `clickhousectl local use`.
-  Shortcut: `clickhousectl local run --sql 'SELECT 1'` runs a query via clickhouse-local.
-  For servers, use `clickhousectl local server start` instead.
-  Related: `clickhousectl local use <version>` to set default, `clickhousectl local server start` to start a server.")]
-    Run(RunArgs),
-
-    /// Manage local ClickHouse server instances
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Manage named ClickHouse server instances. Each server has its own data directory.
-  Subcommands: start, list, stop, stop-all, remove.
-  Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
-  Typical: `clickhousectl local server start` (starts \"default\"), `clickhousectl local server start --name test`.
-  Related: `clickhousectl local run client` to connect to a running server.")]
-    Server {
-        #[command(subcommand)]
-        command: ServerCommands,
-    },
-}
-
-#[derive(Args)]
-pub struct RunArgs {
-    /// Execute SQL query using clickhouse local
-    #[arg(long, short)]
-    pub sql: Option<String>,
-
-    #[command(subcommand)]
-    pub command: Option<RunCommands>,
-}
-
-#[derive(Subcommand)]
-pub enum RunCommands {
-    /// Run clickhouse-client
+    /// Connect to a running ClickHouse server with clickhouse-client
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
-  Pass clickhouse-client args after -- (e.g., `clickhousectl local run client -- --query 'SELECT 1'`).
+  Pass clickhouse-client args after -- (e.g., `clickhousectl local client -- --query 'SELECT 1'`).
   Common args: --host, --port, --query, --multiquery, --format.
   Related: `clickhousectl local server start` to start a server first.")]
     Client {
@@ -168,18 +133,17 @@ CONTEXT FOR AGENTS:
         args: Vec<String>,
     },
 
-    /// Run clickhouse-local
+    /// Manage local ClickHouse server instances
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Runs clickhouse-local for file/query processing without a server.
-  Pass clickhouse-local args after -- (e.g., `clickhousectl local run local -- --query 'SELECT 1'`).
-  Shortcut: `clickhousectl local run --sql 'SELECT 1'` does the same without the local subcommand.
-  Useful for processing files, running queries against local data, or testing SQL.
-  Related: `clickhousectl local run --sql` for quick one-off queries.")]
-    Local {
-        /// Arguments to pass to clickhouse-local
-        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
+  Manage named ClickHouse server instances. Each server has its own data directory.
+  Subcommands: start, list, stop, stop-all, remove.
+  Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
+  Typical: `clickhousectl local server start` (starts \"default\"), `clickhousectl local server start --name test`.
+  Related: `clickhousectl local client` to connect to a running server.")]
+    Server {
+        #[command(subcommand)]
+        command: ServerCommands,
     },
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     #[error("No versions installed")]
     NoVersionsInstalled,
 
-    #[error("No default version set. Run: clickhousectl use <version>")]
+    #[error("No default version set. Run: clickhousectl local use <version>")]
     NoDefaultVersion,
 
     #[error("Version {0} is already installed")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ mod version_manager;
 
 use clap::Parser;
 use cli::{
-    BackupCommands, CloudArgs, CloudCommands, Cli, Commands, LocalCommands, OrgCommands, RunArgs,
-    RunCommands, ServerCommands, ServiceCommands,
+    BackupCommands, CloudArgs, CloudCommands, Cli, Commands, LocalCommands, OrgCommands,
+    ServerCommands, ServiceCommands,
 };
 use cloud::CloudClient;
 use error::{Error, Result};
@@ -52,7 +52,7 @@ async fn run_local(cmd: LocalCommands) -> Result<()> {
             init::init()?;
             Ok(())
         }
-        LocalCommands::Run(args) => run_clickhouse(args),
+        LocalCommands::Client { args } => run_client(args),
         LocalCommands::Server { command } => run_server_commands(command),
     }
 }
@@ -159,7 +159,7 @@ fn which() -> Result<()> {
     Ok(())
 }
 
-fn run_clickhouse(args: RunArgs) -> Result<()> {
+fn run_client(args: Vec<String>) -> Result<()> {
     let version = version_manager::get_default_version()?;
     let binary = paths::binary_path(&version)?;
 
@@ -167,34 +167,10 @@ fn run_clickhouse(args: RunArgs) -> Result<()> {
         return Err(Error::VersionNotFound(version));
     }
 
-    // If --sql is provided, run clickhouse local with the query
-    if let Some(sql) = args.sql {
-        let mut cmd = Command::new(&binary);
-        cmd.arg("local").arg("--query").arg(&sql);
-        let err = cmd.exec();
-        return Err(Error::Exec(err.to_string()));
-    }
-
-    match args.command {
-        Some(RunCommands::Client { args }) => {
-            let mut cmd = Command::new(&binary);
-            cmd.arg("client").args(&args);
-            let err = cmd.exec();
-            Err(Error::Exec(err.to_string()))
-        }
-        Some(RunCommands::Local { args }) => {
-            let mut cmd = Command::new(&binary);
-            cmd.arg("local").args(&args);
-            let err = cmd.exec();
-            Err(Error::Exec(err.to_string()))
-        }
-        None => {
-            eprintln!("Usage: clickhousectl local run --sql <QUERY>");
-            eprintln!("       clickhousectl local run client [ARGS...]");
-            eprintln!("       clickhousectl local run local [ARGS...]");
-            std::process::exit(1);
-        }
-    }
+    let mut cmd = Command::new(&binary);
+    cmd.arg("client").args(&args);
+    let err = cmd.exec();
+    Err(Error::Exec(err.to_string()))
 }
 
 fn start_server(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ mod version_manager;
 
 use clap::Parser;
 use cli::{
-    BackupCommands, CloudArgs, CloudCommands, Cli, Commands, OrgCommands, RunArgs, RunCommands,
-    ServerCommands, ServiceCommands,
+    BackupCommands, CloudArgs, CloudCommands, Cli, Commands, LocalCommands, OrgCommands, RunArgs,
+    RunCommands, ServerCommands, ServiceCommands,
 };
 use cloud::CloudClient;
 use error::{Error, Result};
@@ -30,24 +30,30 @@ async fn main() {
 
 async fn run(cmd: Commands) -> Result<()> {
     match cmd {
-        Commands::Install { version } => install(&version).await,
-        Commands::List { remote } => {
+        Commands::Local { command } => run_local(command).await,
+        Commands::Cloud(args) => run_cloud(args).await,
+    }
+}
+
+async fn run_local(cmd: LocalCommands) -> Result<()> {
+    match cmd {
+        LocalCommands::Install { version } => install(&version).await,
+        LocalCommands::List { remote } => {
             if remote {
                 list_available().await
             } else {
                 list_installed()
             }
         }
-        Commands::Use { version } => use_version(&version).await,
-        Commands::Remove { version } => remove(&version),
-        Commands::Which => which(),
-        Commands::Init => {
+        LocalCommands::Use { version } => use_version(&version).await,
+        LocalCommands::Remove { version } => remove(&version),
+        LocalCommands::Which => which(),
+        LocalCommands::Init => {
             init::init()?;
             Ok(())
         }
-        Commands::Run(args) => run_clickhouse(args),
-        Commands::Server { command } => run_server_commands(command),
-        Commands::Cloud(args) => run_cloud(args).await,
+        LocalCommands::Run(args) => run_clickhouse(args),
+        LocalCommands::Server { command } => run_server_commands(command),
     }
 }
 
@@ -66,7 +72,7 @@ fn list_installed() -> Result<()> {
 
     if versions.is_empty() {
         println!("No versions installed");
-        println!("Run: clickhousectl install stable");
+        println!("Run: clickhousectl local install stable");
         return Ok(());
     }
 
@@ -183,9 +189,9 @@ fn run_clickhouse(args: RunArgs) -> Result<()> {
             Err(Error::Exec(err.to_string()))
         }
         None => {
-            eprintln!("Usage: clickhousectl run --sql <QUERY>");
-            eprintln!("       clickhousectl run client [ARGS...]");
-            eprintln!("       clickhousectl run local [ARGS...]");
+            eprintln!("Usage: clickhousectl local run --sql <QUERY>");
+            eprintln!("       clickhousectl local run client [ARGS...]");
+            eprintln!("       clickhousectl local run local [ARGS...]");
             std::process::exit(1);
         }
     }
@@ -217,7 +223,7 @@ fn start_server(
     let running = server::running_server_count();
     if running > 0 {
         eprintln!(
-            "Note: {} server{} already running (use `chv server list` to see them)",
+            "Note: {} server{} already running (use `clickhousectl local server list` to see them)",
             running,
             if running == 1 { "" } else { "s" }
         );


### PR DESCRIPTION
## Summary

- Introduces two top-level subcommands: `local` and `cloud`
- Moves all local ClickHouse commands (`install`, `list`, `use`, `remove`, `which`, `init`, `server`) under `clickhousectl local`
- Flattens `run client` to `local client` as a direct subcommand
- Drops `run`, `sql`, and `run local` commands to simplify the CLI surface
- Updates all help text, README, and CLAUDE.md

### Before
```
clickhousectl install|list|use|remove|which|init|run|server|cloud
```

### After
```
clickhousectl local install|list|use|remove|which|init|client|server
clickhousectl cloud auth|org|service|backup
```

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (12 tests)
- [ ] `clickhousectl local --help` shows all subcommands
- [ ] `clickhousectl local install stable` works
- [ ] `clickhousectl local server start` works
- [ ] `clickhousectl local client` connects to running server
- [ ] `clickhousectl cloud --help` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)