### PR TITLE
Improve client usability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,5 @@ cargo add rpassword                  # add latest version
 ```bash
 cargo run -- local install stable
 cargo run -- local server start      # starts server in .clickhouse/servers/default/
-cargo run -- local client -- --query "SELECT 1"
+cargo run -- local client --query "SELECT 1"
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Cross-compilation for aarch64-linux uses `cross` (see `.github/workflows/release
 
 `clickhousectl` is the official ClickHouse CLI — a version manager + cloud CLI. Two top-level subcommands: `local` and `cloud`.
 
-1. **Local** (`local install|list|use|remove|which|init|run|server`) — version management in `src/version_manager/`, server management in `src/server.rs`, run/init in `main.rs`. Binaries live in `~/.clickhouse/versions/{version}/clickhouse`, default tracked in `~/.clickhouse/default`. Project data lives in `.clickhouse/`.
+1. **Local** (`local install|list|use|remove|which|init|client|server`) — version management in `src/version_manager/`, server management in `src/server.rs`, client/init in `main.rs`. Binaries live in `~/.clickhouse/versions/{version}/clickhouse`, default tracked in `~/.clickhouse/default`. Project data lives in `.clickhouse/`.
 
 2. **Cloud** (`cloud org|service|backup|auth`) — handled by `src/cloud/`. `CloudClient` wraps reqwest with Basic auth. Commands go through `cloud/commands.rs`, types in `cloud/types.rs`. All cloud commands support `--json` output.
 
@@ -62,7 +62,7 @@ cargo add rpassword                  # add latest version
 
 - CLI is defined with clap derive macros in `src/cli.rs`, dispatched in `src/main.rs`
 - `src/paths.rs` handles `~/.clickhouse/` paths (global install dir); `src/init.rs` handles `.clickhouse/` paths (project-local data dir)
-- `run server` uses `exec()` (process replacement), so code after `cmd.exec()` only runs on failure
+- `local client` uses `exec()` (process replacement), so code after `cmd.exec()` only runs on failure
 - Error types use `thiserror` in `src/error.rs`; cloud module has its own error type wrapped as `Error::Cloud(String)`
 - Version resolution (`version_manager/resolve.rs`) handles specs like `stable`, `lts`, `25.12`, or exact `25.12.5.44` — all resolve to an exact version + channel via GitHub API
 - Releases are triggered by pushing a version tag (`v0.1.3`), which runs the GitHub Actions workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,5 +80,5 @@ cargo add rpassword                  # add latest version
 ```bash
 cargo run -- local install stable
 cargo run -- local server start      # starts server in .clickhouse/servers/default/
-cargo run -- local run client -- --query "SELECT 1"
+cargo run -- local client -- --query "SELECT 1"
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ clickhouse/
 # Connect to a running server with clickhouse-client
 clickhousectl local client                           # Connects to "default" server
 clickhousectl local client --name dev                # Connects to "dev" server
-clickhousectl local client -- --query "SHOW DATABASES"
+clickhousectl local client --query "SHOW DATABASES"  # Run a query
+clickhousectl local client --host remote-host --port 9000  # Connect to a specific host/port
 ```
 
 ### Creating and managing ClickHouse servers

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ clickhouse/
 
 ```bash
 # Connect to a running server with clickhouse-client
-clickhousectl local client
-clickhousectl local client -- --host localhost --query "SHOW DATABASES"
+clickhousectl local client                           # Connects to "default" server
+clickhousectl local client --name dev                # Connects to "dev" server
+clickhousectl local client -- --query "SHOW DATABASES"
 ```
 
 ### Creating and managing ClickHouse servers

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ clickhouse/
 clickhousectl local client                           # Connects to "default" server
 clickhousectl local client --name dev                # Connects to "dev" server
 clickhousectl local client --query "SHOW DATABASES"  # Run a query
+clickhousectl local client --queries-file schema.sql # Run queries from a file
 clickhousectl local client --host remote-host --port 9000  # Connect to a specific host/port
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 With `clickhousectl` you can:
 - Install and manage local ClickHouse versions
 - Launch and manage local ClickHouse servers
-- Execute queries against ClickHouse servers, or using clickhouse-local
+- Execute queries against ClickHouse servers
 - Setup ClickHouse Cloud and create cloud-managed ClickHouse clusters
 - Manage ClickHouse Cloud resources
 - Push your local ClickHouse development to cloud

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,15 +125,27 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
   Use --name <name> to connect to a specific named server (default: \"default\").
-  Pass clickhouse-client args after -- (e.g., `clickhousectl local client -- --query 'SELECT 1'`).
-  Common args: --host, --port, --query, --multiquery, --format.
+  --host, --port, and --query are promoted as first-class flags.
+  Additional clickhouse-client args can be passed after --.
   Related: `clickhousectl local server start` to start a server first, `clickhousectl local server list` to see servers.")]
     Client {
         /// Server name to connect to (default: "default")
         #[arg(long, short)]
         name: Option<String>,
 
-        /// Arguments to pass to clickhouse-client
+        /// Host to connect to
+        #[arg(long, default_value = "localhost")]
+        host: String,
+
+        /// TCP port to connect to (auto-detected from --name if not set)
+        #[arg(long, short)]
+        port: Option<u16>,
+
+        /// Execute a SQL query
+        #[arg(long, short)]
+        query: Option<String>,
+
+        /// Additional arguments to pass to clickhouse-client
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -124,10 +124,15 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
+  Use --name <name> to connect to a specific named server (default: \"default\").
   Pass clickhouse-client args after -- (e.g., `clickhousectl local client -- --query 'SELECT 1'`).
   Common args: --host, --port, --query, --multiquery, --format.
-  Related: `clickhousectl local server start` to start a server first.")]
+  Related: `clickhousectl local server start` to start a server first, `clickhousectl local server list` to see servers.")]
     Client {
+        /// Server name to connect to (default: "default")
+        #[arg(long, short)]
+        name: Option<String>,
+
         /// Arguments to pass to clickhouse-client
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,11 +123,14 @@ CONTEXT FOR AGENTS:
     /// Connect to a running ClickHouse server with clickhouse-client
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
-  Use --name <name> to connect to a specific named server (default: \"default\").
-  --host, --port, --query, and --queries-file are promoted as first-class flags.
+  Two connection modes:
+  1. Named server: `clickhousectl local client --name dev` — looks up port and version from a
+     locally managed server started via `clickhousectl local server start`. Defaults to \"default\".
+  2. Explicit host/port: `clickhousectl local client --host myhost --port 9000` — connects to any
+     ClickHouse server directly, bypassing local server lookup.
+  --query and --queries-file execute SQL inline or from a file.
   Additional clickhouse-client args can be passed after --.
-  Related: `clickhousectl local server start` to start a server first, `clickhousectl local server list` to see servers.")]
+  Related: `clickhousectl local server start` to start a local server, `clickhousectl local server list` to see servers.")]
     Client {
         /// Server name to connect to (default: "default")
         #[arg(long, short)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,7 +125,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Connects to a running clickhouse-server. Server must already be running via `clickhousectl local server start`.
   Use --name <name> to connect to a specific named server (default: \"default\").
-  --host, --port, and --query are promoted as first-class flags.
+  --host, --port, --query, and --queries-file are promoted as first-class flags.
   Additional clickhouse-client args can be passed after --.
   Related: `clickhousectl local server start` to start a server first, `clickhousectl local server list` to see servers.")]
     Client {
@@ -144,6 +144,10 @@ CONTEXT FOR AGENTS:
         /// Execute a SQL query
         #[arg(long, short)]
         query: Option<String>,
+
+        /// Execute queries from a SQL file
+        #[arg(long)]
+        queries_file: Option<String>,
 
         /// Additional arguments to pass to clickhouse-client
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,11 +136,11 @@ CONTEXT FOR AGENTS:
         #[arg(long, short)]
         name: Option<String>,
 
-        /// Host to connect to
-        #[arg(long, default_value = "localhost")]
-        host: String,
+        /// Host to connect to (bypasses local server lookup)
+        #[arg(long)]
+        host: Option<String>,
 
-        /// TCP port to connect to (auto-detected from --name if not set)
+        /// TCP port to connect to (bypasses local server lookup if set)
         #[arg(long, short)]
         port: Option<u16>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,11 +180,15 @@ fn run_client(
         Some(p) => (p, version_manager::get_default_version()?),
         None => {
             let server_name = name.as_deref().unwrap_or("default");
-            let servers = server::list_running_servers();
-            let info = servers
+            let entries = server::list_all_servers();
+            let entry = entries
                 .iter()
-                .find(|s| s.name == server_name)
+                .find(|e| e.name == server_name)
                 .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+            let info = entry
+                .info
+                .as_ref()
+                .ok_or_else(|| Error::ServerNotRunning(server_name.to_string()))?;
             (info.tcp_port, info.version.clone())
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,29 +168,31 @@ fn which() -> Result<()> {
 
 fn run_client(
     name: Option<String>,
-    host: String,
+    host: Option<String>,
     port: Option<u16>,
     query: Option<String>,
     queries_file: Option<String>,
     args: Vec<String>,
 ) -> Result<()> {
-    // Resolve port and version: explicit --port bypasses server lookup and uses
-    // the default version; otherwise look up the named server for both.
-    let (tcp_port, version) = match port {
-        Some(p) => (p, version_manager::get_default_version()?),
-        None => {
-            let server_name = name.as_deref().unwrap_or("default");
-            let entries = server::list_all_servers();
-            let entry = entries
-                .iter()
-                .find(|e| e.name == server_name)
-                .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
-            let info = entry
-                .info
-                .as_ref()
-                .ok_or_else(|| Error::ServerNotRunning(server_name.to_string()))?;
-            (info.tcp_port, info.version.clone())
-        }
+    // If --host or --port is set, connect directly (bypass local server lookup).
+    // Otherwise, look up the named server for port and version.
+    let (resolved_host, tcp_port, version) = if host.is_some() || port.is_some() {
+        let h = host.unwrap_or_else(|| "localhost".to_string());
+        let p = port.unwrap_or(9000);
+        let v = version_manager::get_default_version()?;
+        (h, p, v)
+    } else {
+        let server_name = name.as_deref().unwrap_or("default");
+        let entries = server::list_all_servers();
+        let entry = entries
+            .iter()
+            .find(|e| e.name == server_name)
+            .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+        let info = entry
+            .info
+            .as_ref()
+            .ok_or_else(|| Error::ServerNotRunning(server_name.to_string()))?;
+        ("localhost".to_string(), info.tcp_port, info.version.clone())
     };
 
     let binary = paths::binary_path(&version)?;
@@ -202,7 +204,7 @@ fn run_client(
     let mut cmd = Command::new(&binary);
     cmd.arg("client")
         .arg("--host")
-        .arg(&host)
+        .arg(&resolved_host)
         .arg("--port")
         .arg(tcp_port.to_string());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,13 @@ async fn run_local(cmd: LocalCommands) -> Result<()> {
             init::init()?;
             Ok(())
         }
-        LocalCommands::Client { name, args } => run_client(name, args),
+        LocalCommands::Client {
+            name,
+            host,
+            port,
+            query,
+            args,
+        } => run_client(name, host, port, query, args),
         LocalCommands::Server { command } => run_server_commands(command),
     }
 }
@@ -159,14 +165,26 @@ fn which() -> Result<()> {
     Ok(())
 }
 
-fn run_client(name: Option<String>, args: Vec<String>) -> Result<()> {
-    let name = name.as_deref().unwrap_or("default");
-
-    let servers = server::list_running_servers();
-    let info = servers
-        .iter()
-        .find(|s| s.name == name)
-        .ok_or_else(|| Error::ServerNotFound(name.to_string()))?;
+fn run_client(
+    name: Option<String>,
+    host: String,
+    port: Option<u16>,
+    query: Option<String>,
+    args: Vec<String>,
+) -> Result<()> {
+    // Resolve port: explicit --port wins, otherwise look up from named server
+    let tcp_port = match port {
+        Some(p) => p,
+        None => {
+            let server_name = name.as_deref().unwrap_or("default");
+            let servers = server::list_running_servers();
+            let info = servers
+                .iter()
+                .find(|s| s.name == server_name)
+                .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+            info.tcp_port
+        }
+    };
 
     let version = version_manager::get_default_version()?;
     let binary = paths::binary_path(&version)?;
@@ -177,8 +195,15 @@ fn run_client(name: Option<String>, args: Vec<String>) -> Result<()> {
 
     let mut cmd = Command::new(&binary);
     cmd.arg("client")
+        .arg("--host")
+        .arg(&host)
         .arg("--port")
-        .arg(info.tcp_port.to_string());
+        .arg(tcp_port.to_string());
+
+    if let Some(q) = &query {
+        cmd.arg("--query").arg(q);
+    }
+
     cmd.args(&args);
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,9 +174,10 @@ fn run_client(
     queries_file: Option<String>,
     args: Vec<String>,
 ) -> Result<()> {
-    // Resolve port: explicit --port wins, otherwise look up from named server
-    let tcp_port = match port {
-        Some(p) => p,
+    // Resolve port and version: explicit --port bypasses server lookup and uses
+    // the default version; otherwise look up the named server for both.
+    let (tcp_port, version) = match port {
+        Some(p) => (p, version_manager::get_default_version()?),
         None => {
             let server_name = name.as_deref().unwrap_or("default");
             let servers = server::list_running_servers();
@@ -184,11 +185,10 @@ fn run_client(
                 .iter()
                 .find(|s| s.name == server_name)
                 .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
-            info.tcp_port
+            (info.tcp_port, info.version.clone())
         }
     };
 
-    let version = version_manager::get_default_version()?;
     let binary = paths::binary_path(&version)?;
 
     if !binary.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,9 @@ async fn run_local(cmd: LocalCommands) -> Result<()> {
             host,
             port,
             query,
+            queries_file,
             args,
-        } => run_client(name, host, port, query, args),
+        } => run_client(name, host, port, query, queries_file, args),
         LocalCommands::Server { command } => run_server_commands(command),
     }
 }
@@ -170,6 +171,7 @@ fn run_client(
     host: String,
     port: Option<u16>,
     query: Option<String>,
+    queries_file: Option<String>,
     args: Vec<String>,
 ) -> Result<()> {
     // Resolve port: explicit --port wins, otherwise look up from named server
@@ -202,6 +204,10 @@ fn run_client(
 
     if let Some(q) = &query {
         cmd.arg("--query").arg(q);
+    }
+
+    if let Some(f) = &queries_file {
+        cmd.arg("--queries-file").arg(f);
     }
 
     cmd.args(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ async fn run_local(cmd: LocalCommands) -> Result<()> {
             init::init()?;
             Ok(())
         }
-        LocalCommands::Client { args } => run_client(args),
+        LocalCommands::Client { name, args } => run_client(name, args),
         LocalCommands::Server { command } => run_server_commands(command),
     }
 }
@@ -159,7 +159,15 @@ fn which() -> Result<()> {
     Ok(())
 }
 
-fn run_client(args: Vec<String>) -> Result<()> {
+fn run_client(name: Option<String>, args: Vec<String>) -> Result<()> {
+    let name = name.as_deref().unwrap_or("default");
+
+    let servers = server::list_running_servers();
+    let info = servers
+        .iter()
+        .find(|s| s.name == name)
+        .ok_or_else(|| Error::ServerNotFound(name.to_string()))?;
+
     let version = version_manager::get_default_version()?;
     let binary = paths::binary_path(&version)?;
 
@@ -168,7 +176,10 @@ fn run_client(args: Vec<String>) -> Result<()> {
     }
 
     let mut cmd = Command::new(&binary);
-    cmd.arg("client").args(&args);
+    cmd.arg("client")
+        .arg("--port")
+        .arg(info.tcp_port.to_string());
+    cmd.args(&args);
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
 }


### PR DESCRIPTION
## Summary

- Add `--name` flag to `local client` to connect to a specific named server (defaults to "default")
- Promote `--host`, `--port`, `--query`, and `--queries-file` as first-class flags instead of requiring passthrough
- Port is auto-detected from the named server if `--port` is not explicitly set
- Use the server's ClickHouse version for client binary selection (prevents client/server version mismatch)
- Distinguish "server not found" from "server not running" errors for better diagnostics

### Usage

```bash
clickhousectl local client                              # Connects to "default" server
clickhousectl local client --name dev                   # Connects to "dev" server
clickhousectl local client --query "SHOW DATABASES"     # Run a query
clickhousectl local client --queries-file schema.sql    # Run queries from a file
clickhousectl local client --host remote --port 9000    # Connect to a specific host/port
```

## Test plan

- [x] `local server start` then `local client` connects to "default" on correct port
- [x] `local server start --name dev --tcp-port 9001` then `local client --name dev` connects on port 9001
- [x] `local client --name nonexistent` errors with "Server not found"
- [x] `local server start --name test`, `local server stop test`, then `local client --name test` errors with "Server not running"
- [x] `local client --query "SELECT 1"` executes and returns result
- [x] `local client --queries-file test.sql` executes queries from file
- [x] `local client --host localhost --port 9000` connects using explicit host/port (bypasses server lookup)
- [x] Client binary matches the server's version, not the current default (start server with version A, change default to version B, `local client` still uses version A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)