### PR TITLE
Set custom user agent with version for Cloud API calls

### DIFF
--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -51,7 +51,7 @@ impl CloudClient {
         let auth_header = format!("Basic {}", encoded);
 
         let client = Client::builder()
-            .user_agent("clickhousectl-cli")
+            .user_agent(format!("clickhousectl/{}", env!("CARGO_PKG_VERSION")))
             .build()
             .map_err(|e| CloudError {
                 message: format!("Failed to create HTTP client: {}", e),

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -255,23 +255,3 @@ impl CloudClient {
             })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_user_agent() {
-        let ua = user_agent();
-        let version = env!("CARGO_PKG_VERSION");
-        assert_eq!(ua, format!("clickhousectl/{}", version));
-        assert!(ua.starts_with("clickhousectl/"));
-        // Version should be a valid semver-like string (digits and dots)
-        let version_part = ua.strip_prefix("clickhousectl/").unwrap();
-        assert!(
-            version_part.chars().all(|c| c.is_ascii_digit() || c == '.'),
-            "version should only contain digits and dots, got: {}",
-            version_part
-        );
-    }
-}

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -5,6 +5,10 @@ use std::env;
 
 const BASE_URL: &str = "https://api.clickhouse.cloud/v1";
 
+pub fn user_agent() -> String {
+    format!("clickhousectl/{}", env!("CARGO_PKG_VERSION"))
+}
+
 #[derive(Debug)]
 pub struct CloudError {
     pub message: String,
@@ -51,7 +55,7 @@ impl CloudClient {
         let auth_header = format!("Basic {}", encoded);
 
         let client = Client::builder()
-            .user_agent(format!("clickhousectl/{}", env!("CARGO_PKG_VERSION")))
+            .user_agent(user_agent())
             .build()
             .map_err(|e| CloudError {
                 message: format!("Failed to create HTTP client: {}", e),
@@ -249,5 +253,25 @@ impl CloudClient {
             .ok_or_else(|| CloudError {
                 message: "No organization found for this API key".into(),
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_agent() {
+        let ua = user_agent();
+        let version = env!("CARGO_PKG_VERSION");
+        assert_eq!(ua, format!("clickhousectl/{}", version));
+        assert!(ua.starts_with("clickhousectl/"));
+        // Version should be a valid semver-like string (digits and dots)
+        let version_part = ua.strip_prefix("clickhousectl/").unwrap();
+        assert!(
+            version_part.chars().all(|c| c.is_ascii_digit() || c == '.'),
+            "version should only contain digits and dots, got: {}",
+            version_part
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Updates the Cloud API client user agent from static `clickhousectl-cli` to `clickhousectl/{version}` (e.g. `clickhousectl/0.1.11`)
- Uses `env!("CARGO_PKG_VERSION")` so the version stays in sync with `Cargo.toml` automatically

Closes #22

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)