### PR TITLE
Fix cloud service update tag patch serialization

### DIFF
--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -95,13 +95,13 @@ fn parse_service_endpoint_changes(
     Ok((!changes.is_empty()).then_some(changes))
 }
 
-fn parse_instance_tag_patches(add: &[String], remove: &[String]) -> Option<Vec<InstanceTagsPatch>> {
+fn parse_instance_tag_patches(add: &[String], remove: &[String]) -> Option<InstanceTagsPatch> {
     let patch = InstanceTagsPatch {
         add: parse_tags(add),
         remove: parse_tags(remove),
     };
 
-    (patch.add.is_some() || patch.remove.is_some()).then_some(vec![patch])
+    (patch.add.is_some() || patch.remove.is_some()).then_some(patch)
 }
 
 fn parse_org_private_endpoint_remove(
@@ -1545,8 +1545,9 @@ mod tests {
         assert_eq!(json["ipAccessList"]["remove"][0]["source"], "0.0.0.0/0");
         assert_eq!(json["privateEndpointIds"]["add"][0], "pe-1");
         assert_eq!(json["privateEndpointIds"]["remove"][0], "pe-2");
-        assert_eq!(json["tags"][0]["add"][0]["key"], "env");
-        assert_eq!(json["tags"][0]["remove"][0]["key"], "old");
+        assert!(json["tags"].is_object());
+        assert_eq!(json["tags"]["add"][0]["key"], "env");
+        assert_eq!(json["tags"]["remove"][0]["key"], "old");
         assert_eq!(json["transparentDataEncryptionKeyId"], "tde-1");
         assert_eq!(json["enableCoreDumps"], false);
     }

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -95,7 +95,7 @@ fn parse_service_endpoint_changes(
     Ok((!changes.is_empty()).then_some(changes))
 }
 
-fn parse_instance_tag_patches(add: &[String], remove: &[String]) -> Option<InstanceTagsPatch> {
+fn parse_instance_tags_patch(add: &[String], remove: &[String]) -> Option<InstanceTagsPatch> {
     let patch = InstanceTagsPatch {
         add: parse_tags(add),
         remove: parse_tags(remove),
@@ -467,7 +467,7 @@ fn build_update_service_request(
             .transpose()?,
         endpoints: parse_service_endpoint_changes(&opts.enable_endpoints, &opts.disable_endpoints)?,
         transparent_data_encryption_key_id: opts.transparent_data_encryption_key_id.clone(),
-        tags: parse_instance_tag_patches(&opts.add_tags, &opts.remove_tags),
+        tags: parse_instance_tags_patch(&opts.add_tags, &opts.remove_tags),
         enable_core_dumps: opts.enable_core_dumps,
     })
 }

--- a/src/cloud/types.rs
+++ b/src/cloud/types.rs
@@ -652,7 +652,7 @@ pub struct UpdateServiceRequest {
     pub transparent_data_encryption_key_id: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<Vec<InstanceTagsPatch>>,
+    pub tags: Option<InstanceTagsPatch>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_core_dumps: Option<bool>,

--- a/src/cloud/types_test.rs
+++ b/src/cloud/types_test.rs
@@ -641,13 +641,15 @@ fn test_update_service_request_full() {
             enabled: true,
         }]),
         transparent_data_encryption_key_id: Some("tde-key-1".to_string()),
-        tags: Some(vec![InstanceTagsPatch {
+        // The published schema currently shows an array here, but the live API
+        // expects a single patch object and rejects array payloads.
+        tags: Some(InstanceTagsPatch {
             add: Some(vec![ResourceTag {
                 key: "env".to_string(),
                 value: Some("staging".to_string()),
             }]),
             remove: None,
-        }]),
+        }),
         enable_core_dumps: Some(false),
     };
     let json = serde_json::to_value(&req).unwrap();
@@ -660,7 +662,8 @@ fn test_update_service_request_full() {
     assert_eq!(json["releaseChannel"], "fast");
     assert_eq!(json["endpoints"][0]["protocol"], "mysql");
     assert_eq!(json["transparentDataEncryptionKeyId"], "tde-key-1");
-    assert_eq!(json["tags"][0]["add"][0]["key"], "env");
+    assert!(json["tags"].is_object());
+    assert_eq!(json["tags"]["add"][0]["key"], "env");
     assert_eq!(json["enableCoreDumps"], false);
 }
 


### PR DESCRIPTION
Summary:
- serialize UpdateServiceRequest.tags as a single patch object instead of an array
- update the service update request builder to emit the live API-compatible shape
- tighten serialization tests to assert tags is an object and document the current spec/live mismatch

Testing:
- cargo test test_update_service_request_full
- cargo test build_update_service_request_supports_patch_fields

Notes:
- This PR is intentionally stacked on #35 because #35 already includes unrelated cargo fmt edits in the same files.
- Refs #36