### PR TITLE
Update top-level help text

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,7 @@ fn parse_time_only(value: &str) -> Result<String, String> {
 
 #[derive(Parser)]
 #[command(name = "clickhousectl")]
-#[command(about = "ClickHouse version manager", long_about = None)]
+#[command(about = "The official CLI for ClickHouse: local and cloud", long_about = None)]
 #[command(version)]
 #[command(after_help = "\
 CONTEXT FOR AGENTS:


### PR DESCRIPTION
## Summary
- Changes `--help` about text from "ClickHouse version manager" to "The official CLI for ClickHouse: local and cloud"

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)