### PR TITLE
Add CODEOWNERS for default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sdairs @iskakaushik


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `@sdairs` and `@iskakaushik` as default reviewers for all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)