### PR TITLE
Run cloud integration on PRs touching code

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -4,6 +4,12 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 3 * * 1-5"
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `pull_request` trigger to the cloud integration workflow
- Scoped to only run when `src/**`, `tests/**`, `Cargo.toml`, or `Cargo.lock` are changed
- PRs that only touch docs, CI config, CODEOWNERS, etc. will skip this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)