### PR TITLE
Add --force flag to cloud service delete

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run cloud integration suite
         env:
           CLICKHOUSECTL_BIN: target/debug/clickhousectl
-        run: cargo test --test cloud_cli cloud_service_crud_lifecycle -- --ignored --nocapture --test-threads=1
+        run: cargo test --test cloud_cli -- --ignored --nocapture
 
       - name: Upload debug artifacts on failure
         if: failure()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -538,12 +538,15 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Permanently deletes a ClickHouse Cloud service. This action is irreversible.
-  Takes a service ID — get it from `clickhousectl cloud service list`.
-  Add --json for machine-readable output.
+  Use --force to stop a running service before deleting it in one step.
   Related: `clickhousectl cloud service stop <id>` to idle instead of delete.")]
     Delete {
         /// Service ID
         service_id: String,
+
+        /// Stop the service first if it is running, then delete
+        #[arg(long)]
+        force: bool,
 
         /// Organization ID (auto-detected if not specified)
         #[arg(long)]

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -620,10 +620,40 @@ pub async fn service_create(
 pub async fn service_delete(
     client: &CloudClient,
     service_id: &str,
+    force: bool,
     org_id: Option<&str>,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, org_id).await?;
+
+    if force {
+        let svc = client.get_service(&org_id, service_id).await?;
+        let state = svc.state.to_string();
+        if matches!(state.as_str(), "running" | "idle" | "starting") {
+            eprintln!("Stopping service {} before deletion...", service_id);
+            client
+                .change_service_state(&org_id, service_id, ServiceStateCommand::Stop)
+                .await?;
+
+            // Poll until the service is stopped
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                let svc = client.get_service(&org_id, service_id).await?;
+                let state = svc.state.to_string();
+                eprintln!("  state: {}", state);
+                if matches!(state.as_str(), "stopped" | "idle") {
+                    break;
+                }
+                if matches!(state.as_str(), "terminated" | "failed" | "deleted") {
+                    return Err(format!(
+                        "service entered unexpected state '{}' while waiting for stop",
+                        state
+                    )
+                    .into());
+                }
+            }
+        }
+    }
 
     let response = client.delete_service(&org_id, service_id).await?;
     if json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -529,8 +529,13 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                 };
                 cloud::commands::service_create(&client, opts, json).await
             }
-            ServiceCommands::Delete { service_id, org_id } => {
-                cloud::commands::service_delete(&client, &service_id, org_id.as_deref(), json).await
+            ServiceCommands::Delete {
+                service_id,
+                force,
+                org_id,
+            } => {
+                cloud::commands::service_delete(&client, &service_id, force, org_id.as_deref(), json)
+                    .await
             }
             ServiceCommands::Start { service_id, org_id } => {
                 cloud::commands::service_start(&client, &service_id, org_id.as_deref(), json).await

--- a/tests/cloud_cli.rs
+++ b/tests/cloud_cli.rs
@@ -1,3 +1,6 @@
+#[path = "cloud_cli/force_delete.rs"]
+mod force_delete;
+
 #[path = "cloud_cli/service_crud.rs"]
 mod service_crud;
 

--- a/tests/cloud_cli/force_delete.rs
+++ b/tests/cloud_cli/force_delete.rs
@@ -1,0 +1,130 @@
+use crate::support::{
+    CleanupRegistry, CliRunner, FailureRecorder, StepKind, TestContext, TestResult, json_string,
+    log_phase, log_run_header, poll_until,
+};
+
+#[test]
+#[ignore = "requires live ClickHouse Cloud credentials and provisions real resources"]
+fn cloud_service_force_delete() -> TestResult<()> {
+    let ctx = TestContext::from_env()?;
+    let runner = CliRunner::new(&ctx);
+    let mut cleanup = CleanupRegistry::default();
+
+    let test_result = (|| -> TestResult<()> {
+        log_run_header("cloud_service_force_delete", &ctx);
+        let mut failures = FailureRecorder::default();
+        let service_name = format!("{}-force-del", ctx.service_name());
+
+        log_phase("Create Single-Node Service");
+        let mut create_args = vec![
+            "service".to_string(),
+            "create".to_string(),
+            "--name".to_string(),
+            service_name.clone(),
+            "--provider".to_string(),
+            ctx.provider.clone(),
+            "--region".to_string(),
+            ctx.region.clone(),
+            "--num-replicas".to_string(),
+            "1".to_string(),
+            "--org-id".to_string(),
+            ctx.org_id.clone(),
+        ];
+
+        for tag in ctx.run_tags() {
+            create_args.push("--tag".to_string());
+            create_args.push(tag);
+        }
+
+        let created = failures
+            .run(&ctx, StepKind::Blocking, "create service", || {
+                runner.run_cloud(create_args)
+            })?
+            .expect("blocking steps always return a value");
+        let service_id = json_string(&created.json, &["/service/id", "/id"])?.to_string();
+        eprintln!("service_id: <redacted>");
+        cleanup.register_service(service_id.clone());
+
+        failures
+            .run(
+                &ctx,
+                StepKind::Blocking,
+                "wait for service steady state",
+                || {
+                    poll_until(
+                        "service steady state",
+                        ctx.steady_state_timeout,
+                        ctx.poll_interval,
+                        || {
+                            let output = runner.service_get(&service_id)?;
+                            let state = json_string(&output.json, &["/service/state", "/state"])?;
+                            if matches!(state, "running" | "idle") {
+                                Ok(Some(output))
+                            } else {
+                                Ok(None)
+                            }
+                        },
+                    )
+                },
+            )?
+            .expect("blocking steps always return a value");
+
+        log_phase("Force Delete Running Service");
+        failures.run(&ctx, StepKind::Blocking, "force delete service", || {
+            runner.run_cloud([
+                "service".to_string(),
+                "delete".to_string(),
+                service_id.clone(),
+                "--force".to_string(),
+                "--org-id".to_string(),
+                ctx.org_id.clone(),
+            ])
+        })?;
+        cleanup.unregister_service(&service_id);
+
+        failures.run(
+            &ctx,
+            StepKind::Blocking,
+            "confirm service is gone",
+            || {
+                poll_until(
+                    "service deletion",
+                    ctx.delete_timeout,
+                    ctx.poll_interval,
+                    || match runner.service_get(&service_id) {
+                        Ok(output) => {
+                            let state =
+                                json_string(&output.json, &["/service/state", "/state"])?;
+                            if matches!(state, "deleted" | "deleting") {
+                                Ok(None)
+                            } else {
+                                Ok(None)
+                            }
+                        }
+                        Err(error) => {
+                            let message = error.to_string();
+                            if message.contains("404") || message.contains("not found") {
+                                Ok(Some(()))
+                            } else {
+                                Err(error)
+                            }
+                        }
+                    },
+                )
+            },
+        )?;
+
+        failures.finish()
+    })();
+
+    let cleanup_result = cleanup.cleanup(&runner);
+
+    match (test_result, cleanup_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(cleanup_error)) => Err(cleanup_error.into()),
+        (Err(error), Err(cleanup_error)) => {
+            Err(format!("{error}\ncleanup failed:\n{cleanup_error}").into())
+        }
+    }
+}

--- a/tests/cloud_cli/force_delete.rs
+++ b/tests/cloud_cli/force_delete.rs
@@ -74,6 +74,25 @@ fn cloud_service_force_delete() -> TestResult<()> {
             .expect("blocking steps always return a value");
 
         log_phase("Force Delete Running Service");
+        failures.run(
+            &ctx,
+            StepKind::Blocking,
+            "delete without --force fails on running service",
+            || {
+                let result = runner.run_cloud_raw([
+                    "service".to_string(),
+                    "delete".to_string(),
+                    service_id.clone(),
+                    "--org-id".to_string(),
+                    ctx.org_id.clone(),
+                ]);
+                match result {
+                    Err(_) => Ok(()),
+                    Ok(_) => Err("expected delete without --force to fail on a running service".into()),
+                }
+            },
+        )?;
+
         failures.run(&ctx, StepKind::Blocking, "force delete service", || {
             runner.run_cloud([
                 "service".to_string(),

--- a/tests/cloud_cli/force_delete.rs
+++ b/tests/cloud_cli/force_delete.rs
@@ -27,6 +27,10 @@ fn cloud_service_force_delete() -> TestResult<()> {
             ctx.region.clone(),
             "--num-replicas".to_string(),
             "1".to_string(),
+            "--min-replica-memory-gb".to_string(),
+            "8".to_string(),
+            "--max-replica-memory-gb".to_string(),
+            "8".to_string(),
             "--org-id".to_string(),
             ctx.org_id.clone(),
         ];


### PR DESCRIPTION
## Summary
- Adds `--force` flag to `cloud service delete`
- When set, stops the service first (if running/idle/starting), polls until stopped, then deletes
- Without `--force`, behavior is unchanged

## Usage
```bash
# Fails if service is running
clickhousectl cloud service delete <id>

# Stops and deletes in one step
clickhousectl cloud service delete <id> --force
```

## Test plan
- [x] `delete` without `--force` still fails on a running service
- [x] `delete --force` on a running service stops then deletes
- [x] `delete --force` on an already stopped service deletes directly
- [x] All existing tests pass

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)