### PR TITLE
Fix all clippy warnings

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,7 +70,7 @@ CONTEXT FOR AGENTS:
   Agents should suggest the user to sign up at https://clickhouse.cloud, and then use `clickhousectl cloud auth login` to authenticate.
   Add --json to any cloud command for machine-readable output.
   Typical workflow: `cloud auth login` → `cloud auth status` → `cloud org list` → `cloud service list`")]
-    Cloud(CloudArgs),
+    Cloud(Box<CloudArgs>),
 
     /// Install ClickHouse agent skills into supported coding agents
     #[command(after_help = "\

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -141,13 +141,12 @@ impl CloudClient {
         })?;
 
         if !status.is_success() {
-            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body) {
-                if let Some(err) = api_resp.error {
+            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
+                && let Some(err) = api_resp.error {
                     return Err(CloudError {
                         message: err.message,
                     });
                 }
-            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });
@@ -175,13 +174,12 @@ impl CloudClient {
         let status = response.status();
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
-            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body) {
-                if let Some(err) = api_resp.error {
+            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
+                && let Some(err) = api_resp.error {
                     return Err(CloudError {
                         message: err.message,
                     });
                 }
-            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });
@@ -206,13 +204,12 @@ impl CloudClient {
         })?;
 
         if !status.is_success() {
-            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body) {
-                if let Some(err) = api_resp.error {
+            if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
+                && let Some(err) = api_resp.error {
                     return Err(CloudError {
                         message: err.message,
                     });
                 }
-            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });
@@ -304,7 +301,7 @@ impl CloudClient {
     }
 
     async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T> {
-        self.request(self.client.get(&self.url(path))).await
+        self.request(self.client.get(self.url(path))).await
     }
 
     async fn post<T: serde::de::DeserializeOwned, B: serde::Serialize>(
@@ -312,7 +309,7 @@ impl CloudClient {
         path: &str,
         body: &B,
     ) -> Result<T> {
-        self.request(self.client.post(&self.url(path)).json(body))
+        self.request(self.client.post(self.url(path)).json(body))
             .await
     }
 
@@ -321,12 +318,12 @@ impl CloudClient {
         path: &str,
         body: &B,
     ) -> Result<T> {
-        self.request(self.client.patch(&self.url(path)).json(body))
+        self.request(self.client.patch(self.url(path)).json(body))
             .await
     }
 
     async fn delete(&self, path: &str) -> Result<()> {
-        self.request_no_body(self.client.delete(&self.url(path)))
+        self.request_no_body(self.client.delete(self.url(path)))
             .await
     }
 

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -631,12 +631,11 @@ pub async fn service_create(
         if let Some(max_mem) = response.service.max_replica_memory_gb {
             println!("  Max Memory/Replica: {} GB", max_mem);
         }
-        if let Some(endpoints) = &response.service.endpoints {
-            if let Some(ep) = endpoints.first() {
+        if let Some(endpoints) = &response.service.endpoints
+            && let Some(ep) = endpoints.first() {
                 println!("  Host: {}", ep.host);
                 println!("  Port: {}", ep.port);
             }
-        }
         println!();
         println!("Credentials (save these, password shown only once):");
         println!("  Username: default");
@@ -753,7 +752,7 @@ pub async fn backup_list(
         for backup in backups {
             let size = backup
                 .size_in_bytes
-                .map(|s| format_bytes(s))
+                .map(format_bytes)
                 .unwrap_or_else(|| "-".to_string());
             let created = backup.started_at.as_deref().unwrap_or("-");
             println!("  {} - {} ({}) {}", backup.id, backup.status, size, created);
@@ -844,25 +843,29 @@ pub async fn service_update(
     Ok(())
 }
 
+pub struct ServiceScaleOptions {
+    pub min_replica_memory_gb: Option<u32>,
+    pub max_replica_memory_gb: Option<u32>,
+    pub num_replicas: Option<u32>,
+    pub idle_scaling: Option<bool>,
+    pub idle_timeout_minutes: Option<u32>,
+    pub org_id: Option<String>,
+}
+
 pub async fn service_scale(
     client: &CloudClient,
     service_id: &str,
-    min_replica_memory_gb: Option<u32>,
-    max_replica_memory_gb: Option<u32>,
-    num_replicas: Option<u32>,
-    idle_scaling: Option<bool>,
-    idle_timeout_minutes: Option<u32>,
-    org_id: Option<&str>,
+    opts: ServiceScaleOptions,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
+    let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
 
     let request = ReplicaScalingRequest {
-        min_replica_memory_gb: min_replica_memory_gb.map(f64::from),
-        max_replica_memory_gb: max_replica_memory_gb.map(f64::from),
-        num_replicas: num_replicas.map(f64::from),
-        idle_scaling,
-        idle_timeout_minutes: idle_timeout_minutes.map(f64::from),
+        min_replica_memory_gb: opts.min_replica_memory_gb.map(f64::from),
+        max_replica_memory_gb: opts.max_replica_memory_gb.map(f64::from),
+        num_replicas: opts.num_replicas.map(f64::from),
+        idle_scaling: opts.idle_scaling,
+        idle_timeout_minutes: opts.idle_timeout_minutes.map(f64::from),
     };
 
     let svc = client

--- a/src/cloud/types.rs
+++ b/src/cloud/types.rs
@@ -318,6 +318,7 @@ string_enum! {
 }
 
 string_enum! {
+    #[allow(clippy::enum_variant_names)]
     pub enum ByocConfigState {
         InfraReady => "infra-ready",
         InfraProvisioning => "infra-provisioning",
@@ -325,12 +326,14 @@ string_enum! {
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for CloudProvider {
     fn default() -> Self {
         Self::Aws
     }
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for CloudRegion {
     fn default() -> Self {
         Self::UsEast1
@@ -1101,6 +1104,7 @@ pub struct Activity {
 /// Backup
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "bucketProvider")]
+#[allow(clippy::upper_case_acronyms)]
 pub enum BackupBucket {
     #[serde(rename = "AWS")]
     AWS {

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn run(cmd: Commands) -> Result<()> {
     match cmd {
         Commands::Local { command } => run_local(command).await,
         Commands::Skills(args) => run_skills(args).await,
-        Commands::Cloud(args) => run_cloud(args).await,
+        Commands::Cloud(args) => run_cloud(*args).await,
     }
 }
 
@@ -156,12 +156,11 @@ fn remove(version: &str) -> Result<()> {
     }
 
     // Check if this is the default version
-    if let Ok(default) = version_manager::get_default_version() {
-        if default == version {
+    if let Ok(default) = version_manager::get_default_version()
+        && default == version {
             let default_file = paths::default_file()?;
             let _ = std::fs::remove_file(default_file);
         }
-    }
 
     std::fs::remove_dir_all(&version_dir)?;
     println!("Removed version {}", version);
@@ -682,12 +681,14 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                 cloud::commands::service_scale(
                     &client,
                     &service_id,
-                    min_replica_memory_gb,
-                    max_replica_memory_gb,
-                    num_replicas,
-                    idle_scaling,
-                    idle_timeout_minutes,
-                    org_id.as_deref(),
+                    cloud::commands::ServiceScaleOptions {
+                        min_replica_memory_gb,
+                        max_replica_memory_gb,
+                        num_replicas,
+                        idle_scaling,
+                        idle_timeout_minutes,
+                        org_id,
+                    },
                     json,
                 )
                 .await

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -392,9 +392,9 @@ fn collect_skill_files_recursive(
     Ok(())
 }
 
-fn resolve_selection<'a>(
+fn resolve_selection(
     _install_root: &Path,
-    detected: &'a [&'static AgentSpec],
+    detected: &[&'static AgentSpec],
     args: &SkillsArgs,
 ) -> Result<Vec<&'static AgentSpec>> {
     if args.all {

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -40,15 +40,14 @@ pub fn list_installed_versions() -> Result<Vec<String>> {
     let mut versions = Vec::new();
     for entry in std::fs::read_dir(&versions_dir)? {
         let entry = entry?;
-        if entry.path().is_dir() {
-            if let Some(name) = entry.file_name().to_str() {
+        if entry.path().is_dir()
+            && let Some(name) = entry.file_name().to_str() {
                 // Only include if it has a clickhouse binary
                 let binary = entry.path().join("clickhouse");
                 if binary.exists() {
                     versions.push(name.to_string());
                 }
             }
-        }
     }
 
     // Sort versions in descending order (newest first)
@@ -85,8 +84,8 @@ pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     for release in releases {
         // Tag format: v25.12.5.44-stable or v24.8.10.6-lts
         let tag = &release.tag_name;
-        if let Some(version) = tag.strip_prefix('v') {
-            if let Some(dash_pos) = version.rfind('-') {
+        if let Some(version) = tag.strip_prefix('v')
+            && let Some(dash_pos) = version.rfind('-') {
                 let v = &version[..dash_pos];
                 let suffix = &version[dash_pos + 1..];
                 if let Some(channel) = Channel::from_tag_suffix(suffix) {
@@ -96,7 +95,6 @@ pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
                     });
                 }
             }
-        }
     }
 
     // Sort versions in descending order (newest first)


### PR DESCRIPTION
## Summary
- Resolve all 21 clippy warnings across 7 files
- No behavioral changes — pure lint cleanup

## Changes
- **cli.rs**: Box `Cloud(CloudArgs)` variant to fix large enum size disparity
- **client.rs**: Collapse nested ifs, remove needless borrows on URL params
- **commands.rs**: Collapse nested if, replace redundant closure, wrap `service_scale` args in `ServiceScaleOptions`
- **types.rs**: Add `#[allow]` attributes for serde-constrained enum names (Infra prefix, AWS/GCP/AZURE)
- **skills.rs**: Elide unnecessary lifetime
- **list.rs**: Collapse nested ifs in version parsing
- **main.rs**: Collapse nested if, update for boxed CloudArgs and ServiceScaleOptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)