### PR TITLE
Use builds.clickhouse.com as primary download source

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -1,0 +1,142 @@
+name: Test Install
+
+on:
+  pull_request:
+    paths:
+      - "src/version_manager/**"
+      - "src/main.rs"
+      - "src/cli.rs"
+      - "Cargo.toml"
+      - ".github/workflows/test-install.yml"
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test
+
+  url-probing:
+    name: URL Probing (${{ matrix.platform }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: amd64
+            desc: Linux x86_64
+          - platform: aarch64
+            desc: Linux ARM64
+          - platform: macos
+            desc: macOS x86_64
+          - platform: macos-aarch64
+            desc: macOS ARM64
+    steps:
+      - name: Verify builds.clickhouse.com URLs
+        run: |
+          echo "Testing builds.clickhouse.com for ${{ matrix.desc }}..."
+
+          # master should always be available
+          echo -n "  master: "
+          curl -sf -o /dev/null -w "%{http_code}" \
+            "https://builds.clickhouse.com/master/${{ matrix.platform }}/clickhouse"
+          echo ""
+
+          # A known recent version should be available
+          echo -n "  25.12: "
+          curl -sf -o /dev/null -w "%{http_code}" \
+            "https://builds.clickhouse.com/25.12/${{ matrix.platform }}/clickhouse"
+          echo ""
+
+          # A version too old should return 403
+          echo -n "  24.1 (expect 403): "
+          code=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://builds.clickhouse.com/24.1/${{ matrix.platform }}/clickhouse")
+          echo "$code"
+          if [ "$code" != "403" ]; then
+            echo "Expected 403 for old version, got $code"
+            exit 1
+          fi
+
+      - name: Verify packages.clickhouse.com URLs (Linux only)
+        if: matrix.platform == 'amd64' || matrix.platform == 'aarch64'
+        run: |
+          arch=${{ matrix.platform }}
+          # packages uses arm64 not aarch64
+          if [ "$arch" = "aarch64" ]; then arch="arm64"; fi
+
+          echo "Testing packages.clickhouse.com for ${{ matrix.desc }}..."
+
+          # Check a known stable version exists
+          echo -n "  stable tarball: "
+          curl -sf -o /dev/null -w "%{http_code}" -I \
+            "https://packages.clickhouse.com/tgz/stable/clickhouse-common-static-25.3.2.39-${arch}.tgz"
+          echo ""
+
+          # Check client-only tarball exists
+          echo -n "  client-only tarball: "
+          curl -sf -o /dev/null -w "%{http_code}" -I \
+            "https://packages.clickhouse.com/tgz/stable/clickhouse-client-25.3.2.39-${arch}.tgz"
+          echo ""
+
+  install-test:
+    name: Install Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build CLI
+        run: cargo build
+
+      - name: Test install latest
+        run: |
+          ./target/debug/clickhousectl local install latest
+          # Verify a version was installed
+          ./target/debug/clickhousectl local list | grep -E "^  [0-9]"
+
+      - name: Test install minor version
+        run: |
+          ./target/debug/clickhousectl local install 25.12
+          ./target/debug/clickhousectl local list | grep "25.12"
+
+      - name: Test local use
+        run: |
+          ./target/debug/clickhousectl local use 25.12
+          ./target/debug/clickhousectl local which | grep "25.12"
+
+      - name: Test already installed (expect error)
+        run: |
+          if ./target/debug/clickhousectl local install 25.12 2>&1; then
+            echo "Should have errored for already-installed version"
+            exit 1
+          fi
+
+      - name: Test force re-install
+        run: |
+          ./target/debug/clickhousectl local install 25.12 --force
+
+      - name: Test invalid version (expect error)
+        run: |
+          if ./target/debug/clickhousectl local install foo 2>&1; then
+            echo "Should have errored for invalid version"
+            exit 1
+          fi
+
+      - name: Test 3-part version rejected (expect error)
+        run: |
+          if ./target/debug/clickhousectl local install 25.12.9 2>&1; then
+            echo "Should have errored for 3-part version"
+            exit 1
+          fi
+
+      - name: Verify installed binary works
+        run: |
+          version_dir=$(ls -d ~/.clickhouse/versions/*/clickhouse | head -1)
+          $version_dir --version

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -111,12 +111,9 @@ jobs:
           ./target/debug/clickhousectl local use 25.12
           ./target/debug/clickhousectl local which | grep "25.12"
 
-      - name: Test already installed (expect error)
+      - name: Test already installed (skips download)
         run: |
-          if ./target/debug/clickhousectl local install 25.12 2>&1; then
-            echo "Should have errored for already-installed version"
-            exit 1
-          fi
+          ./target/debug/clickhousectl local install 25.12 2>&1 | grep "already installed"
 
       - name: Test force re-install
         run: |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,7 +91,6 @@ pub enum LocalCommands {
     /// Install a ClickHouse version
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Downloads a ClickHouse binary to ~/.clickhouse/versions/{version}/.
   `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
     Install {
         /// Version to install (e.g., latest, stable, lts, 25, 25.12, 25.12.9.61)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,10 +92,7 @@ pub enum LocalCommands {
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Downloads a ClickHouse binary to ~/.clickhouse/versions/{version}/.
-  Accepts version specs: \"latest\", \"stable\", \"lts\", major like \"25\", minor like \"25.12\", or exact like \"25.12.9.61\".
-  Primary source: builds.clickhouse.com. Falls back to packages.clickhouse.com or GitHub releases for exact/older versions.
-  Use --force to re-download an already-installed version.
-  Related: `clickhousectl local list --remote` to see downloadable versions.")]
+  `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
     Install {
         /// Version to install (e.g., latest, stable, lts, 25, 25.12, 25.12.9.61)
         version: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,20 +92,24 @@ pub enum LocalCommands {
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Downloads a ClickHouse binary to ~/.clickhouse/versions/{version}/.
-  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
-  Optionally set as default with `clickhousectl local use <version>`.
-  `clickhousectl local use <version>` will auto-install if the version is missing and set as default.
+  Accepts version specs: \"latest\", \"stable\", \"lts\", major like \"25\", minor like \"25.12\", or exact like \"25.12.9.61\".
+  Primary source: builds.clickhouse.com. Falls back to packages.clickhouse.com or GitHub releases for exact/older versions.
+  Use --force to re-download an already-installed version.
   Related: `clickhousectl local list --remote` to see downloadable versions.")]
     Install {
-        /// Version to install (e.g., 25.1.2.3, 25.1, stable, lts)
+        /// Version to install (e.g., latest, stable, lts, 25, 25.12, 25.12.9.61)
         version: String,
+
+        /// Force re-install even if version is already installed
+        #[arg(long)]
+        force: bool,
     },
 
     /// List installed versions
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Without flags: shows locally installed versions (exact version strings).
-  With --remote: shows versions available for download from GitHub releases.
+  With --remote: shows versions available for download from builds.clickhouse.com.
   Use the exact version strings from this output with `clickhousectl local remove` or `clickhousectl local use`.
   Related: `clickhousectl local install <version>` to install, `clickhousectl local which` to see current default.")]
     List {

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -1716,22 +1716,25 @@ async fn ensure_version_installed(
 
     let version_spec = service_version.ok_or("service has no clickhouse_version set")?;
 
-    // Resolve the spec to an exact version first (e.g. "25.12" -> "25.12.9.61")
-    let resolved = version_manager::resolve_version(version_spec).await?;
+    let spec = version_manager::parse_version_spec(version_spec)?;
+    let platform = version_manager::platform::Platform::detect()?;
+    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
 
-    // Check if already installed
-    let version_dir = paths::version_dir(&resolved.version)?;
-    if version_dir.exists() {
-        return Ok(resolved.version);
+    // If exact version is known, check if already installed
+    if let Some(ref version) = resolved.exact_version {
+        let version_dir = paths::version_dir(version)?;
+        if version_dir.exists() {
+            return Ok(version.clone());
+        }
     }
 
-    // Install
     eprintln!(
         "Service requires ClickHouse {} — downloading...",
-        resolved.version
+        resolved.display_version
     );
-    version_manager::install_version(&resolved.version, resolved.channel).await?;
-    Ok(resolved.version)
+    let version =
+        version_manager::install::install_resolved(&resolved, &platform, false).await?;
+    Ok(version)
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ async fn run_skills(args: SkillsArgs) -> Result<()> {
 
 async fn run_local(cmd: LocalCommands) -> Result<()> {
     match cmd {
-        LocalCommands::Install { version } => install(&version).await,
+        LocalCommands::Install { version, force } => install(&version, force).await,
         LocalCommands::List { remote } => {
             if remote {
                 list_available().await
@@ -71,12 +71,21 @@ async fn run_local(cmd: LocalCommands) -> Result<()> {
     }
 }
 
-async fn install(version_spec: &str) -> Result<()> {
-    println!("Resolving version {}...", version_spec);
-    let entry = version_manager::resolve_version(version_spec).await?;
-    println!("Resolved to version {} ({})", entry.version, entry.channel);
+async fn install(version_spec: &str, force: bool) -> Result<()> {
+    let spec = version_manager::parse_version_spec(version_spec)?;
+    let platform = version_manager::platform::Platform::detect()?;
 
-    version_manager::install_version(&entry.version, entry.channel).await?;
+    eprintln!("Resolving {}...", spec);
+    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
+
+    let version = version_manager::install::install_resolved(&resolved, &platform, force).await?;
+
+    // If this is the first installed version, set it as default
+    if version_manager::get_default_version().is_err() {
+        version_manager::set_default_version(&version)?;
+        eprintln!("Set as default version");
+    }
+
     Ok(())
 }
 
@@ -103,8 +112,8 @@ fn list_installed() -> Result<()> {
 }
 
 async fn list_available() -> Result<()> {
-    println!("Fetching available versions...");
-    let versions = version_manager::list_available_versions().await?;
+    eprintln!("Checking available versions on builds.clickhouse.com...");
+    let versions = version_manager::list_available_versions_from_builds().await?;
 
     if versions.is_empty() {
         println!("No versions available");
@@ -113,36 +122,47 @@ async fn list_available() -> Result<()> {
 
     let installed = version_manager::list_installed_versions().unwrap_or_default();
 
-    println!("Available versions:");
-    for entry in versions.iter().take(20) {
-        if installed.contains(&entry.version) {
-            println!("  {} [{}] (installed)", entry.version, entry.channel);
+    println!("Available versions (builds.clickhouse.com):");
+    for v in &versions {
+        // Check if any installed version matches this minor
+        let prefix = format!("{}.", v);
+        let is_installed = installed.iter().any(|iv| iv.starts_with(&prefix) || iv == v);
+        if is_installed {
+            println!("  {} (installed)", v);
         } else {
-            println!("  {} [{}]", entry.version, entry.channel);
+            println!("  {}", v);
         }
     }
-
-    if versions.len() > 20 {
-        println!("  ... and {} more", versions.len() - 20);
-    }
+    println!();
+    println!("Install with: clickhousectl local install <version>");
+    println!("For exact patch versions, use: clickhousectl local install 25.12.9.61");
 
     Ok(())
 }
 
 async fn use_version(version_spec: &str) -> Result<()> {
-    println!("Resolving version {}...", version_spec);
-    let entry = version_manager::resolve_version(version_spec).await?;
-    let version = &entry.version;
+    let spec = version_manager::parse_version_spec(version_spec)?;
+    let platform = version_manager::platform::Platform::detect()?;
 
-    // Install if not already installed
-    let installed = version_manager::list_installed_versions()?;
-    if !installed.contains(version) {
-        println!("Version {} not installed, installing...", version);
-        version_manager::install_version(version, entry.channel).await?;
-    }
+    eprintln!("Resolving {}...", spec);
+    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
 
-    version_manager::set_default_version(version)?;
-    println!("Default version set to {}", version);
+    // If exact version is known, check if already installed
+    let version = if let Some(ref v) = resolved.exact_version {
+        let installed = version_manager::list_installed_versions()?;
+        if installed.contains(v) {
+            v.clone()
+        } else {
+            eprintln!("Version {} not installed, installing...", v);
+            version_manager::install::install_resolved(&resolved, &platform, false).await?
+        }
+    } else {
+        // Version not known upfront (builds source) — install will detect it
+        version_manager::install::install_resolved(&resolved, &platform, false).await?
+    };
+
+    version_manager::set_default_version(&version)?;
+    eprintln!("Default version set to {}", version);
     Ok(())
 }
 

--- a/src/version_manager/download.rs
+++ b/src/version_manager/download.rs
@@ -1,18 +1,28 @@
 use crate::error::{Error, Result};
-use crate::version_manager::list::Channel;
-use crate::version_manager::resolve::build_download_url;
+use crate::version_manager::platform::{DownloadSource, Platform};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
 
-/// Downloads a ClickHouse version to the specified path
-pub async fn download_version(version: &str, channel: Channel, dest_path: &Path) -> Result<()> {
-    let url = build_download_url(version, channel)?;
+/// Downloads from a DownloadSource to the specified path
+pub async fn download_from_source(
+    source: &DownloadSource,
+    platform: &Platform,
+    dest_path: &Path,
+) -> Result<()> {
+    let url = source.url(platform);
+    download_url(&url, dest_path).await
+}
 
-    let client = reqwest::Client::new();
+/// Downloads a file from a URL to the specified path, with progress bar
+pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .user_agent("clickhousectl")
+        .build()?;
+
     let response = client
-        .get(&url)
+        .get(url)
         .send()
         .await?
         .error_for_status()

--- a/src/version_manager/install.rs
+++ b/src/version_manager/install.rs
@@ -1,38 +1,66 @@
 use crate::error::{Error, Result};
 use crate::paths;
-use crate::version_manager::download::download_version;
-use crate::version_manager::list::Channel;
-use crate::version_manager::resolve::is_tarball_download;
+use crate::version_manager::download::download_from_source;
+use crate::version_manager::list::list_installed_versions;
+use crate::version_manager::platform::{DownloadSource, Platform};
+use crate::version_manager::resolve::ResolvedVersion;
 use std::os::unix::fs::PermissionsExt;
 
-/// Installs a ClickHouse version
-pub async fn install_version(version: &str, channel: Channel) -> Result<()> {
+/// Installs a ClickHouse version using the multi-source resolution system.
+/// Returns the exact version string of the installed binary.
+pub async fn install_resolved(
+    resolved: &ResolvedVersion,
+    platform: &Platform,
+    force: bool,
+) -> Result<String> {
     paths::ensure_dirs()?;
 
-    let version_dir = paths::version_dir(version)?;
-
-    // Check if already installed
-    if version_dir.exists() {
-        return Err(Error::VersionAlreadyInstalled(version.to_string()));
+    // If we know the exact version upfront, check if already installed
+    if let Some(ref version) = resolved.exact_version {
+        let version_dir = paths::version_dir(version)?;
+        if version_dir.exists() && !force {
+            return Err(Error::VersionAlreadyInstalled(version.to_string()));
+        }
     }
 
-    // Create the version directory
-    std::fs::create_dir_all(&version_dir)?;
+    // For builds source (minor versions like "25.12"), check if we already have
+    // an installed version matching that minor — avoids re-downloading ~150MB
+    if !force {
+        if let DownloadSource::Builds { ref version_path } = resolved.source {
+            if version_path != "master" {
+                let prefix = format!("{}.", version_path);
+                if let Ok(installed) = list_installed_versions() {
+                    if let Some(existing) = installed.iter().find(|v| v.starts_with(&prefix)) {
+                        eprintln!(
+                            "ClickHouse {} is already installed as {}",
+                            version_path, existing
+                        );
+                        eprintln!("Use --force to re-download the latest build");
+                        return Ok(existing.clone());
+                    }
+                }
+            }
+        }
+    }
 
-    let binary_path = version_dir.join("clickhouse");
+    // Download to a temp directory first
+    let temp_dir = paths::versions_dir()?.join(".download-temp");
+    if temp_dir.exists() {
+        std::fs::remove_dir_all(&temp_dir)?;
+    }
+    std::fs::create_dir_all(&temp_dir)?;
 
-    eprintln!("Downloading ClickHouse {}...", version);
+    let binary_path = temp_dir.join("clickhouse");
 
-    if is_tarball_download()? {
-        // Linux: download tarball, extract, move binary
-        let tarball_path = version_dir.join("clickhouse.tgz");
-        download_version(version, channel, &tarball_path).await?;
+    eprintln!("Downloading ClickHouse {}...", resolved.display_version);
 
+    if resolved.source.is_tarball(platform) {
+        let tarball_path = temp_dir.join("clickhouse.tgz");
+        download_from_source(&resolved.source, platform, &tarball_path).await?;
         eprintln!("Extracting...");
-        extract_tarball(&tarball_path, &version_dir, version)?;
+        extract_tarball_auto(&tarball_path, &temp_dir)?;
     } else {
-        // macOS: download binary directly
-        download_version(version, channel, &binary_path).await?;
+        download_from_source(&resolved.source, platform, &binary_path).await?;
     }
 
     // Make the binary executable
@@ -40,50 +68,152 @@ pub async fn install_version(version: &str, channel: Channel) -> Result<()> {
     perms.set_mode(0o755);
     std::fs::set_permissions(&binary_path, perms)?;
 
-    eprintln!("ClickHouse {} installed successfully", version);
-    Ok(())
+    // Detect the exact version from the binary
+    let exact_version = if resolved.exact_version_known {
+        resolved.exact_version.clone().unwrap()
+    } else {
+        eprintln!("Detecting version...");
+        detect_binary_version(&binary_path)?
+    };
+
+    // Check if this exact version is already installed (post-detection check for builds source)
+    let version_dir = paths::version_dir(&exact_version)?;
+    if version_dir.exists() && !force {
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        return Err(Error::VersionAlreadyInstalled(exact_version));
+    }
+
+    // Move to final location
+    if version_dir.exists() {
+        std::fs::remove_dir_all(&version_dir)?;
+    }
+    std::fs::create_dir_all(&version_dir)?;
+    std::fs::rename(&binary_path, version_dir.join("clickhouse"))?;
+
+    // Clean up temp dir
+    let _ = std::fs::remove_dir_all(&temp_dir);
+
+    let channel_suffix = match resolved.channel {
+        Some(ch) => format!(" ({})", ch),
+        None => String::new(),
+    };
+    eprintln!("Installed ClickHouse {}{}", exact_version, channel_suffix);
+
+    Ok(exact_version)
 }
 
-/// Extracts the ClickHouse binary from a Linux tarball
-fn extract_tarball(
+/// Detect the version of a clickhouse binary by running `./clickhouse --version`
+fn detect_binary_version(binary_path: &std::path::Path) -> Result<String> {
+    let output = std::process::Command::new(binary_path)
+        .arg("--version")
+        .output()
+        .map_err(|e| Error::Exec(format!("Failed to run clickhouse --version: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(Error::Exec(
+            "clickhouse --version returned non-zero exit code".to_string(),
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_version_output(&stdout)
+}
+
+/// Parse the version string from clickhouse --version output
+/// Example outputs:
+///   "ClickHouse client version 25.12.9.61 (official build)."
+///   "ClickHouse server version 25.12.9.61 (official build)."
+fn parse_version_output(output: &str) -> Result<String> {
+    for word in output.split_whitespace() {
+        let parts: Vec<&str> = word.trim_end_matches('.').split('.').collect();
+        if parts.len() == 4 && parts.iter().all(|p| p.parse::<u64>().is_ok()) {
+            return Ok(parts.join("."));
+        }
+    }
+
+    Err(Error::Exec(format!(
+        "Could not parse version from output: {}",
+        output.trim()
+    )))
+}
+
+/// Extract a tarball, finding the clickhouse binary automatically.
+/// Handles both packages.clickhouse.com layout (usr/bin/clickhouse inside subdir)
+/// and GitHub releases layout (same structure).
+fn extract_tarball_auto(
     tarball_path: &std::path::Path,
-    version_dir: &std::path::Path,
-    version: &str,
+    dest_dir: &std::path::Path,
 ) -> Result<()> {
-    // Extract the tarball
     let status = std::process::Command::new("tar")
         .args(["xzf", &tarball_path.to_string_lossy()])
-        .current_dir(version_dir)
+        .current_dir(dest_dir)
         .status()
         .map_err(|e| Error::Extract(format!("Failed to run tar: {}", e)))?;
 
     if !status.success() {
-        // Clean up tarball on failure
         let _ = std::fs::remove_file(tarball_path);
         return Err(Error::Extract("tar extraction failed".to_string()));
     }
 
-    // Find the clickhouse binary inside the extracted directory
-    let extracted_dir = version_dir.join(format!("clickhouse-common-static-{}", version));
-    let extracted_binary = extracted_dir.join("usr/bin/clickhouse");
+    let final_binary = dest_dir.join("clickhouse");
 
-    if !extracted_binary.exists() {
-        // Clean up on failure
-        let _ = std::fs::remove_file(tarball_path);
-        let _ = std::fs::remove_dir_all(&extracted_dir);
-        return Err(Error::Extract(format!(
-            "Binary not found at expected path: {}",
-            extracted_binary.display()
-        )));
+    // Search extracted directories for the binary
+    for entry in std::fs::read_dir(dest_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join("usr/bin/clickhouse");
+            if candidate.exists() {
+                std::fs::rename(&candidate, &final_binary)?;
+                let _ = std::fs::remove_file(tarball_path);
+                let _ = std::fs::remove_dir_all(&path);
+                return Ok(());
+            }
+        }
     }
 
-    // Move binary to final location
-    let final_binary = version_dir.join("clickhouse");
-    std::fs::rename(&extracted_binary, &final_binary)?;
+    // Binary might already be at top level
+    if final_binary.exists() {
+        let _ = std::fs::remove_file(tarball_path);
+        return Ok(());
+    }
 
-    // Clean up tarball and extracted directory
     let _ = std::fs::remove_file(tarball_path);
-    let _ = std::fs::remove_dir_all(&extracted_dir);
+    Err(Error::Extract(
+        "Could not find clickhouse binary in extracted tarball".to_string(),
+    ))
+}
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version_output_client() {
+        let output = "ClickHouse client version 25.12.9.61 (official build).";
+        assert_eq!(parse_version_output(output).unwrap(), "25.12.9.61");
+    }
+
+    #[test]
+    fn test_parse_version_output_server() {
+        let output = "ClickHouse server version 26.3.1.100 (official build).";
+        assert_eq!(parse_version_output(output).unwrap(), "26.3.1.100");
+    }
+
+    #[test]
+    fn test_parse_version_output_multiline() {
+        let output = "ClickHouse client version 25.5.2.1 (official build).\nSome other info.";
+        assert_eq!(parse_version_output(output).unwrap(), "25.5.2.1");
+    }
+
+    #[test]
+    fn test_parse_version_output_no_version() {
+        let output = "Some random output without a version.";
+        assert!(parse_version_output(output).is_err());
+    }
+
+    #[test]
+    fn test_parse_version_output_empty() {
+        assert!(parse_version_output("").is_err());
+    }
 }

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::paths;
+use chrono::Datelike;
 use serde::Deserialize;
 use std::fmt;
 
@@ -102,6 +103,41 @@ pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     // Sort versions in descending order (newest first)
     versions.sort_by(|a, b| compare_versions(&b.version, &a.version));
     Ok(versions)
+}
+
+/// Lists available minor versions by probing builds.clickhouse.com with HEAD requests.
+/// Scans from current year back to 2020, checking each YY.{1..12} pattern.
+/// Returns minor version strings sorted newest-first (e.g., ["26.3", "26.2", ...]).
+pub async fn list_available_versions_from_builds() -> Result<Vec<String>> {
+    use crate::version_manager::platform::{Platform, builds_probe_url};
+
+    let platform = Platform::detect()?;
+    let client = reqwest::Client::builder()
+        .user_agent("clickhousectl")
+        .build()
+        .map_err(|e| Error::Download(e.to_string()))?;
+
+    let current_year = chrono::Utc::now().year() as u32;
+    // ClickHouse uses YY.MM versioning — scan from current year down to 20 (2020)
+    // Use two-digit year format
+    let start_yy = current_year % 100;
+
+    let mut available = Vec::new();
+
+    for yy in (20..=start_yy).rev() {
+        for mm in (1..=12).rev() {
+            let version_path = format!("{}.{}", yy, mm);
+            let url = builds_probe_url(&version_path, &platform);
+            match client.head(&url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    available.push(version_path);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(available)
 }
 
 /// Gets the current default version

--- a/src/version_manager/mod.rs
+++ b/src/version_manager/mod.rs
@@ -1,10 +1,12 @@
 pub mod download;
 pub mod install;
 pub mod list;
+pub mod platform;
 pub mod resolve;
+pub mod spec;
 
-pub use install::install_version;
 pub use list::{
-    get_default_version, list_available_versions, list_installed_versions, set_default_version,
+    get_default_version, list_available_versions_from_builds, list_installed_versions,
+    set_default_version,
 };
-pub use resolve::resolve_version;
+pub use spec::parse_version_spec;

--- a/src/version_manager/platform.rs
+++ b/src/version_manager/platform.rs
@@ -1,0 +1,394 @@
+use crate::error::{Error, Result};
+use crate::version_manager::list::Channel;
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Os {
+    MacOS,
+    Linux,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Arch {
+    X86_64,
+    Aarch64,
+}
+
+impl fmt::Display for Os {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Os::MacOS => write!(f, "macos"),
+            Os::Linux => write!(f, "linux"),
+        }
+    }
+}
+
+impl fmt::Display for Arch {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Arch::X86_64 => write!(f, "x86_64"),
+            Arch::Aarch64 => write!(f, "aarch64"),
+        }
+    }
+}
+
+/// Detected platform (OS + architecture)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Platform {
+    pub os: Os,
+    pub arch: Arch,
+}
+
+impl Platform {
+    /// Detects the current platform
+    pub fn detect() -> Result<Self> {
+        let os = match std::env::consts::OS {
+            "macos" => Os::MacOS,
+            "linux" => Os::Linux,
+            other => {
+                return Err(Error::UnsupportedPlatform {
+                    os: other.to_string(),
+                    arch: std::env::consts::ARCH.to_string(),
+                });
+            }
+        };
+
+        let arch = match std::env::consts::ARCH {
+            "x86_64" => Arch::X86_64,
+            "aarch64" => Arch::Aarch64,
+            other => {
+                return Err(Error::UnsupportedPlatform {
+                    os: std::env::consts::OS.to_string(),
+                    arch: other.to_string(),
+                });
+            }
+        };
+
+        Ok(Platform { os, arch })
+    }
+
+    /// builds.clickhouse.com platform path segment (e.g., "amd64", "macos-aarch64")
+    pub fn builds_path(&self) -> &'static str {
+        match (self.os, self.arch) {
+            (Os::Linux, Arch::X86_64) => "amd64",
+            (Os::Linux, Arch::Aarch64) => "aarch64",
+            (Os::MacOS, Arch::X86_64) => "macos",
+            (Os::MacOS, Arch::Aarch64) => "macos-aarch64",
+        }
+    }
+
+    /// packages.clickhouse.com arch string (e.g., "amd64", "arm64")
+    /// Only valid for Linux — macOS packages are not available
+    pub fn packages_arch(&self) -> Option<&'static str> {
+        match (self.os, self.arch) {
+            (Os::Linux, Arch::X86_64) => Some("amd64"),
+            (Os::Linux, Arch::Aarch64) => Some("arm64"),
+            (Os::MacOS, _) => None,
+        }
+    }
+
+    /// GitHub releases arch/suffix for download URLs
+    pub fn github_suffix(&self) -> &'static str {
+        match (self.os, self.arch) {
+            (Os::Linux, Arch::X86_64) => "amd64",
+            (Os::Linux, Arch::Aarch64) => "arm64",
+            (Os::MacOS, Arch::X86_64) => "x86_64",
+            (Os::MacOS, Arch::Aarch64) => "aarch64",
+        }
+    }
+}
+
+/// Where to download a ClickHouse binary from
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DownloadSource {
+    /// builds.clickhouse.com — single binary, no extraction needed on any platform
+    Builds {
+        /// Version path segment: "master", "25.12", etc.
+        version_path: String,
+    },
+    /// packages.clickhouse.com — tgz tarball (Linux only)
+    Packages {
+        channel: Channel,
+        version: String,
+    },
+    /// GitHub releases — tgz (Linux) or bare binary (macOS)
+    GitHub {
+        version: String,
+        channel: Channel,
+    },
+}
+
+impl DownloadSource {
+    /// Construct the full download URL for the given platform
+    pub fn url(&self, platform: &Platform) -> String {
+        match self {
+            DownloadSource::Builds { version_path } => {
+                format!(
+                    "https://builds.clickhouse.com/{}/{}/clickhouse",
+                    version_path,
+                    platform.builds_path()
+                )
+            }
+            DownloadSource::Packages { channel, version } => {
+                let arch = platform
+                    .packages_arch()
+                    .expect("Packages source should only be used for Linux");
+                format!(
+                    "https://packages.clickhouse.com/tgz/{}/clickhouse-common-static-{}-{}.tgz",
+                    channel, version, arch
+                )
+            }
+            DownloadSource::GitHub { version, channel } => {
+                let base = format!(
+                    "https://github.com/ClickHouse/ClickHouse/releases/download/v{}-{}",
+                    version, channel
+                );
+                match platform.os {
+                    Os::Linux => {
+                        format!(
+                            "{}/clickhouse-common-static-{}-{}.tgz",
+                            base,
+                            version,
+                            platform.github_suffix()
+                        )
+                    }
+                    Os::MacOS => {
+                        format!(
+                            "{}/clickhouse-macos-{}",
+                            base,
+                            platform.github_suffix()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /// Whether this source downloads a tarball that needs extraction
+    pub fn is_tarball(&self, platform: &Platform) -> bool {
+        match self {
+            DownloadSource::Builds { .. } => false, // Always a single binary
+            DownloadSource::Packages { .. } => true, // Always a tgz
+            DownloadSource::GitHub { .. } => platform.os == Os::Linux, // tgz on Linux, binary on macOS
+        }
+    }
+}
+
+/// Construct the HEAD-check URL for probing builds.clickhouse.com availability
+pub fn builds_probe_url(version_path: &str, platform: &Platform) -> String {
+    format!(
+        "https://builds.clickhouse.com/{}/{}/clickhouse",
+        version_path,
+        platform.builds_path()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Platform detection --
+
+    #[test]
+    fn test_detect_platform() {
+        let p = Platform::detect().unwrap();
+        assert!(p.os == Os::MacOS || p.os == Os::Linux);
+        assert!(p.arch == Arch::X86_64 || p.arch == Arch::Aarch64);
+    }
+
+    // -- builds.clickhouse.com paths --
+
+    #[test]
+    fn test_builds_path_linux_amd64() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        assert_eq!(p.builds_path(), "amd64");
+    }
+
+    #[test]
+    fn test_builds_path_linux_aarch64() {
+        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        assert_eq!(p.builds_path(), "aarch64");
+    }
+
+    #[test]
+    fn test_builds_path_macos_x86() {
+        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        assert_eq!(p.builds_path(), "macos");
+    }
+
+    #[test]
+    fn test_builds_path_macos_aarch64() {
+        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        assert_eq!(p.builds_path(), "macos-aarch64");
+    }
+
+    // -- packages.clickhouse.com arch --
+
+    #[test]
+    fn test_packages_arch_linux() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        assert_eq!(p.packages_arch(), Some("amd64"));
+        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        assert_eq!(p.packages_arch(), Some("arm64"));
+    }
+
+    #[test]
+    fn test_packages_arch_macos_none() {
+        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        assert_eq!(p.packages_arch(), None);
+        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        assert_eq!(p.packages_arch(), None);
+    }
+
+    // -- GitHub suffix --
+
+    #[test]
+    fn test_github_suffix() {
+        assert_eq!(Platform { os: Os::Linux, arch: Arch::X86_64 }.github_suffix(), "amd64");
+        assert_eq!(Platform { os: Os::Linux, arch: Arch::Aarch64 }.github_suffix(), "arm64");
+        assert_eq!(Platform { os: Os::MacOS, arch: Arch::X86_64 }.github_suffix(), "x86_64");
+        assert_eq!(Platform { os: Os::MacOS, arch: Arch::Aarch64 }.github_suffix(), "aarch64");
+    }
+
+    // -- URL construction: builds.clickhouse.com --
+
+    #[test]
+    fn test_builds_url_master_linux_amd64() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::Builds { version_path: "master".to_string() };
+        assert_eq!(src.url(&p), "https://builds.clickhouse.com/master/amd64/clickhouse");
+    }
+
+    #[test]
+    fn test_builds_url_minor_macos_aarch64() {
+        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let src = DownloadSource::Builds { version_path: "25.12".to_string() };
+        assert_eq!(
+            src.url(&p),
+            "https://builds.clickhouse.com/25.12/macos-aarch64/clickhouse"
+        );
+    }
+
+    #[test]
+    fn test_builds_url_minor_linux_aarch64() {
+        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let src = DownloadSource::Builds { version_path: "25.8".to_string() };
+        assert_eq!(
+            src.url(&p),
+            "https://builds.clickhouse.com/25.8/aarch64/clickhouse"
+        );
+    }
+
+    // -- URL construction: packages.clickhouse.com --
+
+    #[test]
+    fn test_packages_url_stable_linux_amd64() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::Packages {
+            channel: Channel::Stable,
+            version: "25.12.9.61".to_string(),
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://packages.clickhouse.com/tgz/stable/clickhouse-common-static-25.12.9.61-amd64.tgz"
+        );
+    }
+
+    #[test]
+    fn test_packages_url_lts_linux_arm64() {
+        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let src = DownloadSource::Packages {
+            channel: Channel::Lts,
+            version: "24.8.6.70".to_string(),
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://packages.clickhouse.com/tgz/lts/clickhouse-common-static-24.8.6.70-arm64.tgz"
+        );
+    }
+
+    // -- URL construction: GitHub releases --
+
+    #[test]
+    fn test_github_url_linux_amd64() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::GitHub {
+            version: "25.12.5.44".to_string(),
+            channel: Channel::Stable,
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.5.44-stable/clickhouse-common-static-25.12.5.44-amd64.tgz"
+        );
+    }
+
+    #[test]
+    fn test_github_url_macos_aarch64() {
+        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let src = DownloadSource::GitHub {
+            version: "25.12.5.44".to_string(),
+            channel: Channel::Stable,
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://github.com/ClickHouse/ClickHouse/releases/download/v25.12.5.44-stable/clickhouse-macos-aarch64"
+        );
+    }
+
+    #[test]
+    fn test_github_url_macos_x86() {
+        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        let src = DownloadSource::GitHub {
+            version: "24.8.6.70".to_string(),
+            channel: Channel::Lts,
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://github.com/ClickHouse/ClickHouse/releases/download/v24.8.6.70-lts/clickhouse-macos-x86_64"
+        );
+    }
+
+    // -- Tarball detection --
+
+    #[test]
+    fn test_builds_never_tarball() {
+        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let macos = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let src = DownloadSource::Builds { version_path: "master".to_string() };
+        assert!(!src.is_tarball(&linux));
+        assert!(!src.is_tarball(&macos));
+    }
+
+    #[test]
+    fn test_packages_always_tarball() {
+        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::Packages {
+            channel: Channel::Stable,
+            version: "25.12.9.61".to_string(),
+        };
+        assert!(src.is_tarball(&linux));
+    }
+
+    #[test]
+    fn test_github_tarball_linux_only() {
+        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let macos = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let src = DownloadSource::GitHub {
+            version: "25.12.5.44".to_string(),
+            channel: Channel::Stable,
+        };
+        assert!(src.is_tarball(&linux));
+        assert!(!src.is_tarball(&macos));
+    }
+
+    // -- Probe URL --
+
+    #[test]
+    fn test_builds_probe_url() {
+        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        assert_eq!(
+            builds_probe_url("25.12", &p),
+            "https://builds.clickhouse.com/25.12/macos-aarch64/clickhouse"
+        );
+    }
+}

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -1,192 +1,265 @@
 use crate::error::{Error, Result};
-use crate::version_manager::list::{Channel, VersionEntry, list_available_versions};
-use std::fmt;
+use crate::version_manager::list::{Channel, list_available_versions};
+use crate::version_manager::platform::{DownloadSource, Platform, builds_probe_url};
+use crate::version_manager::spec::VersionSpec;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Os {
-    MacOS,
-    Linux,
+/// Result of resolving a version spec — contains everything needed to download
+#[derive(Debug, Clone)]
+pub struct ResolvedVersion {
+    /// The download source to use
+    pub source: DownloadSource,
+    /// Human-readable description of what was resolved (for display)
+    pub display_version: String,
+    /// Whether the exact version is known before download
+    /// (false for builds.clickhouse.com where we detect version post-download)
+    pub exact_version_known: bool,
+    /// The exact version string, if known
+    pub exact_version: Option<String>,
+    /// Channel, if known
+    pub channel: Option<Channel>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Arch {
-    X86_64,
-    Aarch64,
-}
-
-impl fmt::Display for Os {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Os::MacOS => write!(f, "macos"),
-            Os::Linux => write!(f, "linux"),
-        }
+/// Resolve a VersionSpec into a concrete download source
+pub async fn resolve(spec: &VersionSpec, platform: &Platform) -> Result<ResolvedVersion> {
+    match spec {
+        VersionSpec::Latest => resolve_latest(platform).await,
+        VersionSpec::Channel(channel) => resolve_channel(*channel, platform).await,
+        VersionSpec::Major(major) => resolve_major(*major, platform).await,
+        VersionSpec::Minor(major, minor) => resolve_minor(*major, *minor, platform).await,
+        VersionSpec::Exact(version) => resolve_exact(version, platform).await,
     }
 }
 
-impl fmt::Display for Arch {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Arch::X86_64 => write!(f, "x86_64"),
-            Arch::Aarch64 => write!(f, "aarch64"),
-        }
-    }
+/// `install latest` — always from builds.clickhouse.com/master
+async fn resolve_latest(_platform: &Platform) -> Result<ResolvedVersion> {
+    Ok(ResolvedVersion {
+        source: DownloadSource::Builds {
+            version_path: "master".to_string(),
+        },
+        display_version: "latest".to_string(),
+        exact_version_known: false,
+        exact_version: None,
+        channel: None,
+    })
 }
 
-/// Detects the current platform
-pub fn detect_platform() -> Result<(Os, Arch)> {
-    let os = match std::env::consts::OS {
-        "macos" => Os::MacOS,
-        "linux" => Os::Linux,
-        other => {
-            return Err(Error::UnsupportedPlatform {
-                os: other.to_string(),
-                arch: std::env::consts::ARCH.to_string(),
-            });
-        }
-    };
-
-    let arch = match std::env::consts::ARCH {
-        "x86_64" => Arch::X86_64,
-        "aarch64" => Arch::Aarch64,
-        other => {
-            return Err(Error::UnsupportedPlatform {
-                os: std::env::consts::OS.to_string(),
-                arch: other.to_string(),
-            });
-        }
-    };
-
-    Ok((os, arch))
-}
-
-/// Resolves a version specifier to an exact version and its channel
-/// Supports:
-/// - Exact: "25.1.2.3" -> ("25.1.2.3", "stable") (assumes stable for exact versions)
-/// - Partial: "25.1" -> latest matching "25.1.x.x" with its actual channel
-/// - Channel: "stable" -> latest stable, "lts" -> latest lts
-pub async fn resolve_version(version_spec: &str) -> Result<VersionEntry> {
-    // For all specifiers, fetch available versions to get accurate channel info
+/// `install stable` / `install lts` — GH API to find minor, then builds
+async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<ResolvedVersion> {
     let available = list_available_versions().await?;
+    let entry = available
+        .iter()
+        .find(|e| e.channel == channel)
+        .ok_or_else(|| Error::NoMatchingVersion(channel.to_string()))?;
 
-    // If it looks like an exact version (e.g. 25.12.5.44), find its channel from the list
-    if version_spec.matches('.').count() == 3 {
-        let channel = available
-            .iter()
-            .find(|e| e.version == version_spec)
-            .map(|e| e.channel)
-            .unwrap_or(Channel::Stable);
-        return Ok(VersionEntry {
-            version: version_spec.to_string(),
-            channel,
+    // Extract minor version (e.g., "25.12" from "25.12.9.61")
+    let minor = extract_minor(&entry.version)?;
+
+    // Try builds first
+    if probe_builds(&minor, platform).await {
+        return Ok(ResolvedVersion {
+            source: DownloadSource::Builds {
+                version_path: minor.clone(),
+            },
+            display_version: format!("{} ({})", minor, channel),
+            exact_version_known: false,
+            exact_version: None,
+            channel: Some(channel),
         });
     }
 
-    match version_spec {
-        "stable" => available
-            .iter()
-            .find(|e| e.channel == Channel::Stable)
-            .cloned()
-            .ok_or_else(|| Error::NoMatchingVersion(version_spec.to_string())),
-        "lts" => available
-            .iter()
-            .find(|e| e.channel == Channel::Lts)
-            .cloned()
-            .ok_or_else(|| Error::NoMatchingVersion(version_spec.to_string())),
-        partial => {
-            // Find the latest version matching the partial spec
-            let prefix = format!("{}.", partial);
-            available
-                .iter()
-                .find(|e| e.version.starts_with(&prefix) || e.version == partial)
-                .cloned()
-                .ok_or_else(|| Error::NoMatchingVersion(partial.to_string()))
+    // Fallback: use packages (Linux) or GitHub (macOS)
+    Ok(fallback_source(
+        &entry.version,
+        entry.channel,
+        platform,
+    ))
+}
+
+/// `install 25` — probe builds for highest 25.x minor
+async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersion> {
+    // Probe builds.clickhouse.com for all possible minors in this major (1..12)
+    let mut highest_available: Option<u32> = None;
+    let client = reqwest::Client::builder()
+        .user_agent("clickhousectl")
+        .build()
+        .map_err(|e| Error::Download(e.to_string()))?;
+
+    for minor in 1..=12 {
+        let url = builds_probe_url(&format!("{}.{}", major, minor), platform);
+        match client.head(&url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                highest_available = Some(minor);
+            }
+            _ => {}
         }
+    }
+
+    if let Some(minor) = highest_available {
+        let version_path = format!("{}.{}", major, minor);
+        return Ok(ResolvedVersion {
+            source: DownloadSource::Builds {
+                version_path: version_path.clone(),
+            },
+            display_version: version_path,
+            exact_version_known: false,
+            exact_version: None,
+            channel: None,
+        });
+    }
+
+    // Fallback: try GH API
+    let available = list_available_versions().await?;
+    let prefix = format!("{}.", major);
+    let entry = available
+        .iter()
+        .find(|e| e.version.starts_with(&prefix))
+        .ok_or_else(|| Error::NoMatchingVersion(major.to_string()))?;
+
+    Ok(fallback_source(
+        &entry.version,
+        entry.channel,
+        platform,
+    ))
+}
+
+/// `install 25.12` — try builds, fallback to packages/GH
+async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<ResolvedVersion> {
+    let version_path = format!("{}.{}", major, minor);
+
+    // Try builds first
+    if probe_builds(&version_path, platform).await {
+        return Ok(ResolvedVersion {
+            source: DownloadSource::Builds {
+                version_path: version_path.clone(),
+            },
+            display_version: version_path,
+            exact_version_known: false,
+            exact_version: None,
+            channel: None,
+        });
+    }
+
+    // Fallback: GH API to find exact version for this minor
+    let available = list_available_versions().await?;
+    let prefix = format!("{}.", version_path);
+    let entry = available
+        .iter()
+        .find(|e| e.version.starts_with(&prefix) || e.version == version_path)
+        .ok_or_else(|| Error::NoMatchingVersion(version_path))?;
+
+    Ok(fallback_source(
+        &entry.version,
+        entry.channel,
+        platform,
+    ))
+}
+
+/// `install 25.12.9.61` — exact version, needs channel from GH API
+async fn resolve_exact(version: &str, platform: &Platform) -> Result<ResolvedVersion> {
+    // Look up channel from GH API
+    let available = list_available_versions().await?;
+    let channel = available
+        .iter()
+        .find(|e| e.version == version)
+        .map(|e| e.channel)
+        .unwrap_or(Channel::Stable); // Default to stable if not found
+
+    Ok(fallback_source(version, channel, platform))
+}
+
+/// Build a fallback download source: packages for Linux, GitHub for macOS
+fn fallback_source(version: &str, channel: Channel, platform: &Platform) -> ResolvedVersion {
+    let source = if platform.packages_arch().is_some() {
+        // Linux: use packages.clickhouse.com
+        DownloadSource::Packages {
+            channel,
+            version: version.to_string(),
+        }
+    } else {
+        // macOS: use GitHub releases
+        DownloadSource::GitHub {
+            version: version.to_string(),
+            channel,
+        }
+    };
+
+    ResolvedVersion {
+        source,
+        display_version: version.to_string(),
+        exact_version_known: true,
+        exact_version: Some(version.to_string()),
+        channel: Some(channel),
     }
 }
 
-/// Returns whether the current platform downloads a tarball (Linux) vs a bare binary (macOS)
-pub fn is_tarball_download() -> Result<bool> {
-    let (os, _) = detect_platform()?;
-    Ok(os == Os::Linux)
+/// Probe builds.clickhouse.com with a HEAD request to check if a version exists
+async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
+    let url = builds_probe_url(version_path, platform);
+    let client = match reqwest::Client::builder()
+        .user_agent("clickhousectl")
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+
+    match client.head(&url).send().await {
+        Ok(resp) => resp.status().is_success(),
+        Err(_) => false,
+    }
 }
 
-/// Builds the download URL for a specific version from GitHub releases
-/// macOS: .../clickhouse-macos-{arch}
-/// Linux: .../clickhouse-common-static-{version}-{arch}.tgz
-pub fn build_download_url(version: &str, channel: Channel) -> Result<String> {
-    let (os, arch) = detect_platform()?;
-    let base = format!(
-        "https://github.com/ClickHouse/ClickHouse/releases/download/v{}-{}",
-        version, channel
-    );
-    match os {
-        Os::Linux => {
-            let linux_arch = match arch {
-                Arch::X86_64 => "amd64",
-                Arch::Aarch64 => "arm64",
-            };
-            Ok(format!(
-                "{}/clickhouse-common-static-{}-{}.tgz",
-                base, version, linux_arch
-            ))
-        }
-        Os::MacOS => Ok(format!("{}/clickhouse-{}-{}", base, os, arch)),
+/// Extract the minor version from a full version string (e.g., "25.12.9.61" -> "25.12")
+fn extract_minor(version: &str) -> Result<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    if parts.len() >= 2 {
+        Ok(format!("{}.{}", parts[0], parts[1]))
+    } else {
+        Err(Error::NoMatchingVersion(format!(
+            "cannot extract minor version from '{}'",
+            version
+        )))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::version_manager::platform::Os;
 
     #[test]
-    fn test_detect_platform() {
-        let result = detect_platform();
-        assert!(result.is_ok());
-        let (os, arch) = result.unwrap();
-        assert!(os == Os::MacOS || os == Os::Linux);
-        assert!(arch == Arch::X86_64 || arch == Arch::Aarch64);
+    fn test_extract_minor() {
+        assert_eq!(extract_minor("25.12.9.61").unwrap(), "25.12");
+        assert_eq!(extract_minor("24.8.6.70").unwrap(), "24.8");
+        assert_eq!(extract_minor("25.12").unwrap(), "25.12");
     }
 
     #[test]
-    fn test_build_download_url_stable() {
-        let url = build_download_url("25.12.5.44", Channel::Stable).unwrap();
-        assert!(url.starts_with("https://github.com/ClickHouse/ClickHouse/releases/download/"));
-        assert!(url.contains("v25.12.5.44-stable"));
+    fn test_extract_minor_invalid() {
+        assert!(extract_minor("25").is_err());
     }
 
     #[test]
-    fn test_build_download_url_lts() {
-        let url = build_download_url("25.8.16.34", Channel::Lts).unwrap();
-        assert!(url.starts_with("https://github.com/ClickHouse/ClickHouse/releases/download/"));
-        assert!(url.contains("v25.8.16.34-lts"));
+    fn test_fallback_source_linux() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: crate::version_manager::platform::Arch::X86_64,
+        };
+        let resolved = fallback_source("25.12.9.61", Channel::Stable, &platform);
+        assert!(matches!(resolved.source, DownloadSource::Packages { .. }));
+        assert_eq!(resolved.exact_version, Some("25.12.9.61".to_string()));
+        assert!(resolved.exact_version_known);
     }
 
     #[test]
-    fn test_build_download_url_platform_specific() {
-        let url = build_download_url("25.12.5.44", Channel::Stable).unwrap();
-        let (os, arch) = detect_platform().unwrap();
-        match os {
-            Os::MacOS => {
-                assert!(url.contains(&format!("clickhouse-macos-{}", arch)));
-                assert!(!url.ends_with(".tgz"));
-            }
-            Os::Linux => {
-                let expected_arch = match arch {
-                    Arch::X86_64 => "amd64",
-                    Arch::Aarch64 => "arm64",
-                };
-                assert!(url.contains(&format!(
-                    "clickhouse-common-static-25.12.5.44-{}.tgz",
-                    expected_arch
-                )));
-            }
-        }
-    }
-
-    #[test]
-    fn test_is_tarball_download() {
-        let is_tarball = is_tarball_download().unwrap();
-        let (os, _) = detect_platform().unwrap();
-        assert_eq!(is_tarball, os == Os::Linux);
+    fn test_fallback_source_macos() {
+        let platform = Platform {
+            os: Os::MacOS,
+            arch: crate::version_manager::platform::Arch::Aarch64,
+        };
+        let resolved = fallback_source("25.12.9.61", Channel::Stable, &platform);
+        assert!(matches!(resolved.source, DownloadSource::GitHub { .. }));
+        assert_eq!(resolved.exact_version, Some("25.12.9.61".to_string()));
+        assert!(resolved.exact_version_known);
     }
 }

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -1,7 +1,8 @@
 use crate::error::{Error, Result};
-use crate::version_manager::list::{Channel, list_available_versions};
+use crate::version_manager::list::{Channel, VersionEntry, list_available_versions};
 use crate::version_manager::platform::{DownloadSource, Platform, builds_probe_url};
 use crate::version_manager::spec::VersionSpec;
+use serde::Deserialize;
 
 /// Result of resolving a version spec — contains everything needed to download
 #[derive(Debug, Clone)]
@@ -107,19 +108,19 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
         });
     }
 
-    // Fallback: try GH API
-    let available = list_available_versions().await?;
-    let prefix = format!("{}.", major);
-    let entry = available
-        .iter()
-        .find(|e| e.version.starts_with(&prefix))
-        .ok_or_else(|| Error::NoMatchingVersion(major.to_string()))?;
+    // Fallback: try GH matching-refs API for each minor, highest first
+    for minor in (1..=12).rev() {
+        let prefix = format!("{}.{}", major, minor);
+        if let Ok(entry) = find_version_by_refs(&prefix).await {
+            return Ok(fallback_source(
+                &entry.version,
+                entry.channel,
+                platform,
+            ));
+        }
+    }
 
-    Ok(fallback_source(
-        &entry.version,
-        entry.channel,
-        platform,
-    ))
+    Err(Error::NoMatchingVersion(major.to_string()))
 }
 
 /// `install 25.12` — try builds, fallback to packages/GH
@@ -139,13 +140,8 @@ async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<Re
         });
     }
 
-    // Fallback: GH API to find exact version for this minor
-    let available = list_available_versions().await?;
-    let prefix = format!("{}.", version_path);
-    let entry = available
-        .iter()
-        .find(|e| e.version.starts_with(&prefix) || e.version == version_path)
-        .ok_or_else(|| Error::NoMatchingVersion(version_path))?;
+    // Fallback: targeted GH API call to find exact version for this minor
+    let entry = find_version_by_refs(&version_path).await?;
 
     Ok(fallback_source(
         &entry.version,
@@ -156,15 +152,42 @@ async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<Re
 
 /// `install 25.12.9.61` — exact version, needs channel from GH API
 async fn resolve_exact(version: &str, platform: &Platform) -> Result<ResolvedVersion> {
-    // Look up channel from GH API
-    let available = list_available_versions().await?;
-    let channel = available
-        .iter()
-        .find(|e| e.version == version)
-        .map(|e| e.channel)
-        .unwrap_or(Channel::Stable); // Default to stable if not found
-
+    // Use matching-refs to find the exact tag and its channel
+    // For "25.12.9.61", search refs matching "v25.12.9.61" — should return the exact tag
+    let channel = find_exact_channel(version).await.unwrap_or(Channel::Stable);
     Ok(fallback_source(version, channel, platform))
+}
+
+/// Look up the channel for an exact version via GitHub's matching-refs API
+async fn find_exact_channel(version: &str) -> Result<Channel> {
+    let url = format!(
+        "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
+        version
+    );
+    let client = reqwest::Client::builder().user_agent("clickhousectl").build()?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
+
+    let refs: Vec<GitRef> = response.json().await?;
+
+    for git_ref in &refs {
+        let Some(tag) = git_ref.ref_name.strip_prefix("refs/tags/v") else {
+            continue;
+        };
+        if let Some(dash_pos) = tag.rfind('-') {
+            let suffix = &tag[dash_pos + 1..];
+            if let Some(channel) = Channel::from_tag_suffix(suffix) {
+                return Ok(channel);
+            }
+        }
+    }
+
+    Err(Error::NoMatchingVersion(version.to_string()))
 }
 
 /// Build a fallback download source: packages for Linux, GitHub for macOS
@@ -207,6 +230,53 @@ async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
         Ok(resp) => resp.status().is_success(),
         Err(_) => false,
     }
+}
+
+#[derive(Deserialize)]
+struct GitRef {
+    #[serde(rename = "ref")]
+    ref_name: String,
+}
+
+/// Find the latest release version matching a prefix using GitHub's matching-refs API.
+/// This is a single targeted API call that works regardless of how old the version is.
+/// prefix should be like "25.2" or "24.8" — we search for tags matching `v{prefix}.`
+async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
+    let url = format!(
+        "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
+        prefix
+    );
+    let client = reqwest::Client::builder().user_agent("clickhousectl").build()?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
+
+    let refs: Vec<GitRef> = response.json().await?;
+
+    // Parse refs like "refs/tags/v25.2.2.39-stable" into VersionEntry
+    // Filter for stable/lts only, take the latest (last in sorted order)
+    let mut best: Option<VersionEntry> = None;
+    for git_ref in &refs {
+        let Some(tag) = git_ref.ref_name.strip_prefix("refs/tags/v") else {
+            continue;
+        };
+        if let Some(dash_pos) = tag.rfind('-') {
+            let version = &tag[..dash_pos];
+            let suffix = &tag[dash_pos + 1..];
+            if let Some(channel) = Channel::from_tag_suffix(suffix) {
+                best = Some(VersionEntry {
+                    version: version.to_string(),
+                    channel,
+                });
+            }
+        }
+    }
+
+    best.ok_or_else(|| Error::NoMatchingVersion(prefix.to_string()))
 }
 
 /// Extract the minor version from a full version string (e.g., "25.12.9.61" -> "25.12")

--- a/src/version_manager/spec.rs
+++ b/src/version_manager/spec.rs
@@ -1,0 +1,178 @@
+use crate::error::{Error, Result};
+use crate::version_manager::list::Channel;
+use std::fmt;
+
+/// Parsed version specification from user input
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionSpec {
+    /// `latest` — bleeding-edge master build
+    Latest,
+    /// `stable` or `lts` — resolve via GitHub API to a minor version
+    Channel(Channel),
+    /// `25` — resolve to highest available minor in that major
+    Major(u32),
+    /// `25.12` — download directly from builds
+    Minor(u32, u32),
+    /// `25.12.9.61` — exact 4-part version
+    Exact(String),
+}
+
+impl fmt::Display for VersionSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VersionSpec::Latest => write!(f, "latest"),
+            VersionSpec::Channel(ch) => write!(f, "{}", ch),
+            VersionSpec::Major(major) => write!(f, "{}", major),
+            VersionSpec::Minor(major, minor) => write!(f, "{}.{}", major, minor),
+            VersionSpec::Exact(v) => write!(f, "{}", v),
+        }
+    }
+}
+
+/// Parse a user-provided version string into a VersionSpec
+pub fn parse_version_spec(input: &str) -> Result<VersionSpec> {
+    let input = input.trim();
+
+    if input.is_empty() {
+        return Err(Error::NoMatchingVersion("empty version".to_string()));
+    }
+
+    // Keywords
+    match input {
+        "latest" => return Ok(VersionSpec::Latest),
+        "stable" => return Ok(VersionSpec::Channel(Channel::Stable)),
+        "lts" => return Ok(VersionSpec::Channel(Channel::Lts)),
+        _ => {}
+    }
+
+    // Numeric version parts
+    let parts: Vec<&str> = input.split('.').collect();
+
+    // Validate all parts are numeric
+    for part in &parts {
+        if part.parse::<u32>().is_err() {
+            return Err(Error::NoMatchingVersion(format!(
+                "invalid version '{}': all parts must be numeric",
+                input
+            )));
+        }
+    }
+
+    match parts.len() {
+        1 => {
+            let major: u32 = parts[0].parse().unwrap();
+            Ok(VersionSpec::Major(major))
+        }
+        2 => {
+            let major: u32 = parts[0].parse().unwrap();
+            let minor: u32 = parts[1].parse().unwrap();
+            Ok(VersionSpec::Minor(major, minor))
+        }
+        3 => Err(Error::NoMatchingVersion(format!(
+            "3-part version '{}' is not supported. Use a full 4-part version (e.g., {}.1)",
+            input, input
+        ))),
+        4 => Ok(VersionSpec::Exact(input.to_string())),
+        _ => Err(Error::NoMatchingVersion(format!(
+            "invalid version '{}': expected 1-2 or 4 parts",
+            input
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_latest() {
+        assert_eq!(parse_version_spec("latest").unwrap(), VersionSpec::Latest);
+    }
+
+    #[test]
+    fn test_parse_stable() {
+        assert_eq!(
+            parse_version_spec("stable").unwrap(),
+            VersionSpec::Channel(Channel::Stable)
+        );
+    }
+
+    #[test]
+    fn test_parse_lts() {
+        assert_eq!(
+            parse_version_spec("lts").unwrap(),
+            VersionSpec::Channel(Channel::Lts)
+        );
+    }
+
+    #[test]
+    fn test_parse_major() {
+        assert_eq!(parse_version_spec("25").unwrap(), VersionSpec::Major(25));
+    }
+
+    #[test]
+    fn test_parse_minor() {
+        assert_eq!(
+            parse_version_spec("25.12").unwrap(),
+            VersionSpec::Minor(25, 12)
+        );
+    }
+
+    #[test]
+    fn test_parse_exact() {
+        assert_eq!(
+            parse_version_spec("25.12.9.61").unwrap(),
+            VersionSpec::Exact("25.12.9.61".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_3_part_rejected() {
+        let err = parse_version_spec("25.12.9").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("3-part version"), "got: {}", msg);
+        assert!(msg.contains("25.12.9.1"), "should hint at 4-part: {}", msg);
+    }
+
+    #[test]
+    fn test_parse_5_part_rejected() {
+        assert!(parse_version_spec("25.12.9.61.2").is_err());
+    }
+
+    #[test]
+    fn test_parse_empty_rejected() {
+        assert!(parse_version_spec("").is_err());
+    }
+
+    #[test]
+    fn test_parse_non_numeric_rejected() {
+        assert!(parse_version_spec("foo").is_err());
+        assert!(parse_version_spec("25.foo").is_err());
+        assert!(parse_version_spec("abc.12.9.61").is_err());
+    }
+
+    #[test]
+    fn test_parse_whitespace_trimmed() {
+        assert_eq!(
+            parse_version_spec("  stable  ").unwrap(),
+            VersionSpec::Channel(Channel::Stable)
+        );
+        assert_eq!(
+            parse_version_spec(" 25.12 ").unwrap(),
+            VersionSpec::Minor(25, 12)
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(VersionSpec::Latest.to_string(), "latest");
+        assert_eq!(VersionSpec::Channel(Channel::Stable).to_string(), "stable");
+        assert_eq!(VersionSpec::Channel(Channel::Lts).to_string(), "lts");
+        assert_eq!(VersionSpec::Major(25).to_string(), "25");
+        assert_eq!(VersionSpec::Minor(25, 12).to_string(), "25.12");
+        assert_eq!(
+            VersionSpec::Exact("25.12.9.61".to_string()).to_string(),
+            "25.12.9.61"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Switches primary download source from GitHub releases to `builds.clickhouse.com` (single binaries, no extraction needed)
- Transparent fallback to `packages.clickhouse.com` (Linux) and GitHub releases (macOS) for exact patch versions or older releases not on builds
- New version spec support: `latest`, `stable`, `lts`, major (`25`), minor (`25.12`), exact (`25.12.9.61`)
- Post-download version detection via `clickhouse --version` for builds source (stores under exact version)
- Minor-prefix dedup: `install 25.12` skips download if `25.12.*` already installed, hints `--force`
- `local list --remote` now probes builds.clickhouse.com with HEAD requests instead of GitHub API
- Adds `--force` flag to `install` command
- New modules: `spec.rs` (version parsing, 12 tests), `platform.rs` (URL construction for 3 sources, 22 tests)
- New GitHub Actions CI workflow (`test-install.yml`) with unit tests, URL probing (4-platform matrix), and full install integration tests (ubuntu + macos)

## Download source strategy

| Spec | Primary | Fallback |
|------|---------|----------|
| `latest` | builds/master | — |
| `stable` / `lts` | GH API → minor → builds | packages (Linux) / GH (macOS) |
| `25` (major) | Probe builds for highest 25.x | GH API → packages/GH |
| `25.12` (minor) | builds/25.12 | GH API → packages/GH |
| `25.12.9.61` (exact) | packages (Linux) / GH (macOS) | — |

## Test plan

- [ ] `cargo test` — 192 unit tests pass (including 39 new tests across spec, platform, resolve, install)
- [ ] `cargo clippy` — no new warnings
- [ ] CI workflow runs on this PR (unit tests, URL probing, install integration tests on ubuntu + macos)
- [ ] Manual: `clickhousectl local install latest` downloads from builds, detects version, stores correctly
- [ ] Manual: `clickhousectl local install 25.12` downloads from builds, second run skips with hint
- [ ] Manual: `clickhousectl local install 25.12 --force` re-downloads
- [ ] Manual: `clickhousectl local list --remote` shows versions from builds probing

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)