### PR TITLE
Download client-only binary for cloud service client

### DIFF
--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -1624,9 +1624,9 @@ pub async fn service_client(
     let host = &endpoint.host;
     let port = endpoint.port as u16;
 
-    // Determine which client version to use
+    // Determine which client binary to use
     let service_version = svc.clickhouse_version.as_deref();
-    let version = if opts.allow_mismatched_client_version {
+    let client_binary = if opts.allow_mismatched_client_version {
         // Try to use the local default version
         match version_manager::get_default_version() {
             Ok(local_ver) => {
@@ -1639,21 +1639,27 @@ pub async fn service_client(
                         local_ver, svc_ver
                     );
                 }
-                local_ver
+                ClientBinary {
+                    path: paths::binary_path(&local_ver)?,
+                    needs_client_arg: true,
+                }
             }
             Err(_) => {
-                // No local default — fall back to installing the service version
+                // No local default — fall back to service version
                 eprintln!("No local default version set, falling back to service version.");
-                ensure_version_installed(service_version).await?
+                ensure_client_binary(service_version).await?
             }
         }
     } else {
-        ensure_version_installed(service_version).await?
+        ensure_client_binary(service_version).await?
     };
 
-    let binary = paths::binary_path(&version)?;
-    if !binary.exists() {
-        return Err(format!("clickhouse binary not found at {}", binary.display()).into());
+    if !client_binary.path.exists() {
+        return Err(format!(
+            "clickhouse binary not found at {}",
+            client_binary.path.display()
+        )
+        .into());
     }
 
     // Resolve password: --generate-password > --password > env var > TTY prompt
@@ -1683,9 +1689,12 @@ pub async fn service_client(
     // Build and exec the clickhouse-client command
     eprintln!("Connecting to {} ({}:{})...", svc.name, host, port);
 
-    let mut cmd = std::process::Command::new(&binary);
-    cmd.arg("client")
-        .arg("--host")
+    let mut cmd = std::process::Command::new(&client_binary.path);
+    // Full binary needs "client" subcommand; standalone clickhouse-client does not
+    if client_binary.needs_client_arg {
+        cmd.arg("client");
+    }
+    cmd.arg("--host")
         .arg(host)
         .arg("--port")
         .arg(port.to_string())
@@ -1708,38 +1717,124 @@ pub async fn service_client(
     Err(format!("failed to exec clickhouse-client: {}", err).into())
 }
 
-/// Ensure a ClickHouse version is installed locally, installing it if needed.
-async fn ensure_version_installed(
+/// A resolved client binary — either the full clickhouse binary or standalone clickhouse-client
+struct ClientBinary {
+    path: std::path::PathBuf,
+    /// True for full binary (needs `client` subcommand), false for standalone clickhouse-client
+    needs_client_arg: bool,
+}
+
+/// Extract a minor version from a cloud API version string.
+/// Cloud API returns 3-part versions like "24.3.1" — we extract "24.3".
+fn cloud_version_to_minor(version: &str) -> &str {
+    // Find the second dot and take everything before it
+    let mut dots = 0;
+    for (i, c) in version.char_indices() {
+        if c == '.' {
+            dots += 1;
+            if dots == 2 {
+                return &version[..i];
+            }
+        }
+    }
+    // If fewer than 2 dots, return as-is (e.g., "25.12" stays "25.12")
+    version
+}
+
+/// Ensure a client binary is available for connecting to a cloud service.
+/// Prefers: full binary already installed > client-only binary > download client-only (Linux) or full (macOS)
+async fn ensure_client_binary(
     service_version: Option<&str>,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> Result<ClientBinary, Box<dyn std::error::Error>> {
     use crate::{paths, version_manager};
 
-    let version_spec = service_version.ok_or("service has no clickhouse_version set")?;
+    let cloud_version = service_version.ok_or("service has no clickhouse_version set")?;
+    let minor = cloud_version_to_minor(cloud_version);
 
-    let spec = version_manager::parse_version_spec(version_spec)?;
     let platform = version_manager::platform::Platform::detect()?;
-    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
 
-    // If exact version is known, check if already installed
-    if let Some(ref version) = resolved.exact_version {
-        let version_dir = paths::version_dir(version)?;
-        if version_dir.exists() {
-            return Ok(version.clone());
+    // 1. Check if a full binary matching this minor is already installed
+    let minor_prefix = format!("{}.", minor);
+    if let Ok(installed) = version_manager::list_installed_versions() {
+        if let Some(existing) = installed.iter().find(|v| v.starts_with(&minor_prefix)) {
+            let binary = paths::binary_path(existing)?;
+            if binary.exists() {
+                return Ok(ClientBinary {
+                    path: binary,
+                    needs_client_arg: true,
+                });
+            }
         }
     }
 
+    // 2. Check if client-only binary exists for this minor
+    //    We use the minor version as the client dir name
+    let client_binary = paths::client_binary_path(minor)?;
+    if client_binary.exists() {
+        return Ok(ClientBinary {
+            path: client_binary,
+            needs_client_arg: false,
+        });
+    }
+
+    // 3. Need to download — resolve the minor version to get exact version + channel
+    let spec = version_manager::parse_version_spec(minor)?;
+    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
+
+    // On Linux: download client-only from packages.clickhouse.com (~36KB)
+    if platform.packages_arch().is_some() {
+        if let Some(ref exact_version) = resolved.exact_version {
+            let channel = resolved
+                .channel
+                .unwrap_or(version_manager::list::Channel::Stable);
+            let source = version_manager::platform::DownloadSource::PackagesClient {
+                channel,
+                version: exact_version.clone(),
+            };
+            let path = version_manager::install::install_client(
+                &source, &platform, minor,
+            )
+            .await?;
+            return Ok(ClientBinary {
+                path,
+                needs_client_arg: false,
+            });
+        }
+    }
+
+    // On macOS (or if packages resolution failed): download full binary
     eprintln!(
-        "Service requires ClickHouse {} — downloading...",
+        "Service requires ClickHouse {} — downloading full binary...",
         resolved.display_version
     );
     let version =
         version_manager::install::install_resolved(&resolved, &platform, false).await?;
-    Ok(version)
+    let binary = paths::binary_path(&version)?;
+    Ok(ClientBinary {
+        path: binary,
+        needs_client_arg: true,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cloud_version_3part_to_minor() {
+        assert_eq!(cloud_version_to_minor("24.3.1"), "24.3");
+        assert_eq!(cloud_version_to_minor("25.12.5"), "25.12");
+    }
+
+    #[test]
+    fn cloud_version_2part_unchanged() {
+        assert_eq!(cloud_version_to_minor("25.12"), "25.12");
+    }
+
+    #[test]
+    fn cloud_version_4part_to_minor() {
+        assert_eq!(cloud_version_to_minor("25.12.9.61"), "25.12");
+    }
 
     #[test]
     fn parse_tag_rejects_empty_keys() {

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -1777,19 +1777,14 @@ async fn ensure_client_binary(
         });
     }
 
-    // 3. Need to download — resolve the minor version to get exact version + channel
-    let spec = version_manager::parse_version_spec(minor)?;
-    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
-
+    // 3. Need to download
     // On Linux: download client-only from packages.clickhouse.com (~36KB)
+    // This requires an exact version, so use matching-refs API to find it
     if platform.packages_arch().is_some() {
-        if let Some(ref exact_version) = resolved.exact_version {
-            let channel = resolved
-                .channel
-                .unwrap_or(version_manager::list::Channel::Stable);
+        if let Ok(entry) = version_manager::resolve::find_version_by_refs(minor).await {
             let source = version_manager::platform::DownloadSource::PackagesClient {
-                channel,
-                version: exact_version.clone(),
+                channel: entry.channel,
+                version: entry.version.clone(),
             };
             let path = version_manager::install::install_client(
                 &source, &platform, minor,
@@ -1802,7 +1797,9 @@ async fn ensure_client_binary(
         }
     }
 
-    // On macOS (or if packages resolution failed): download full binary
+    // On macOS (or if refs lookup failed): download full binary
+    let spec = version_manager::parse_version_spec(minor)?;
+    let resolved = version_manager::resolve::resolve(&spec, &platform).await?;
     eprintln!(
         "Service requires ClickHouse {} — downloading full binary...",
         resolved.display_version

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -27,6 +27,21 @@ pub fn binary_path(version: &str) -> Result<PathBuf> {
     Ok(version_dir(version)?.join("clickhouse"))
 }
 
+/// Returns the clients directory (~/.clickhouse/clients/)
+pub fn clients_dir() -> Result<PathBuf> {
+    Ok(base_dir()?.join("clients"))
+}
+
+/// Returns the directory for a specific client version (~/.clickhouse/clients/<version>/)
+pub fn client_dir(version: &str) -> Result<PathBuf> {
+    Ok(clients_dir()?.join(version))
+}
+
+/// Returns the path to the client-only binary for a specific version
+pub fn client_binary_path(version: &str) -> Result<PathBuf> {
+    Ok(client_dir(version)?.join("clickhouse-client"))
+}
+
 /// Returns the path to the default version file (~/.clickhouse/default)
 pub fn default_file() -> Result<PathBuf> {
     Ok(base_dir()?.join("default"))
@@ -35,6 +50,8 @@ pub fn default_file() -> Result<PathBuf> {
 /// Ensures all necessary directories exist
 pub fn ensure_dirs() -> Result<()> {
     let versions = versions_dir()?;
-    std::fs::create_dir_all(&versions).map_err(|_| Error::CreateDir(versions))?;
+    std::fs::create_dir_all(&versions).map_err(|_| Error::CreateDir(versions.clone()))?;
+    let clients = clients_dir()?;
+    std::fs::create_dir_all(&clients).map_err(|_| Error::CreateDir(clients))?;
     Ok(())
 }

--- a/src/version_manager/install.rs
+++ b/src/version_manager/install.rs
@@ -102,6 +102,85 @@ pub async fn install_resolved(
     Ok(exact_version)
 }
 
+/// Installs a client-only binary from packages.clickhouse.com.
+/// Downloads ~36KB tarball and extracts clickhouse-client to ~/.clickhouse/clients/{version}/
+pub async fn install_client(
+    source: &DownloadSource,
+    platform: &Platform,
+    version: &str,
+) -> Result<std::path::PathBuf> {
+    paths::ensure_dirs()?;
+
+    let client_dir = paths::client_dir(version)?;
+
+    // Already installed?
+    let binary_path = client_dir.join("clickhouse-client");
+    if binary_path.exists() {
+        return Ok(binary_path);
+    }
+
+    std::fs::create_dir_all(&client_dir)?;
+
+    eprintln!("Downloading ClickHouse client {}...", version);
+
+    let tarball_path = client_dir.join("clickhouse-client.tgz");
+    download_from_source(source, platform, &tarball_path).await?;
+
+    eprintln!("Extracting...");
+    extract_client_tarball(&tarball_path, &client_dir)?;
+
+    // Make executable
+    let mut perms = std::fs::metadata(&binary_path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&binary_path, perms)?;
+
+    eprintln!("Installed ClickHouse client {}", version);
+    Ok(binary_path)
+}
+
+/// Extract client tarball — binary is at clickhouse-client-{version}/usr/bin/clickhouse-client
+fn extract_client_tarball(
+    tarball_path: &std::path::Path,
+    dest_dir: &std::path::Path,
+) -> Result<()> {
+    let status = std::process::Command::new("tar")
+        .args(["xzf", &tarball_path.to_string_lossy()])
+        .current_dir(dest_dir)
+        .status()
+        .map_err(|e| Error::Extract(format!("Failed to run tar: {}", e)))?;
+
+    if !status.success() {
+        let _ = std::fs::remove_file(tarball_path);
+        return Err(Error::Extract("tar extraction failed".to_string()));
+    }
+
+    let final_binary = dest_dir.join("clickhouse-client");
+
+    // Search extracted directories for clickhouse-client
+    for entry in std::fs::read_dir(dest_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join("usr/bin/clickhouse-client");
+            if candidate.exists() {
+                std::fs::rename(&candidate, &final_binary)?;
+                let _ = std::fs::remove_file(tarball_path);
+                let _ = std::fs::remove_dir_all(&path);
+                return Ok(());
+            }
+        }
+    }
+
+    let _ = std::fs::remove_file(tarball_path);
+    if final_binary.exists() {
+        return Ok(());
+    }
+
+    Err(Error::Extract(
+        "Could not find clickhouse-client binary in extracted tarball".to_string(),
+    ))
+}
+
 /// Detect the version of a clickhouse binary by running `./clickhouse --version`
 fn detect_binary_version(binary_path: &std::path::Path) -> Result<String> {
     let output = std::process::Command::new(binary_path)

--- a/src/version_manager/platform.rs
+++ b/src/version_manager/platform.rs
@@ -116,6 +116,11 @@ pub enum DownloadSource {
         version: String,
         channel: Channel,
     },
+    /// packages.clickhouse.com client-only tarball (Linux only, ~36KB)
+    PackagesClient {
+        channel: Channel,
+        version: String,
+    },
 }
 
 impl DownloadSource {
@@ -161,15 +166,25 @@ impl DownloadSource {
                     }
                 }
             }
+            DownloadSource::PackagesClient { channel, version } => {
+                let arch = platform
+                    .packages_arch()
+                    .expect("PackagesClient source should only be used for Linux");
+                format!(
+                    "https://packages.clickhouse.com/tgz/{}/clickhouse-client-{}-{}.tgz",
+                    channel, version, arch
+                )
+            }
         }
     }
 
     /// Whether this source downloads a tarball that needs extraction
     pub fn is_tarball(&self, platform: &Platform) -> bool {
         match self {
-            DownloadSource::Builds { .. } => false, // Always a single binary
-            DownloadSource::Packages { .. } => true, // Always a tgz
-            DownloadSource::GitHub { .. } => platform.os == Os::Linux, // tgz on Linux, binary on macOS
+            DownloadSource::Builds { .. } => false,
+            DownloadSource::Packages { .. } => true,
+            DownloadSource::GitHub { .. } => platform.os == Os::Linux,
+            DownloadSource::PackagesClient { .. } => true,
         }
     }
 }
@@ -379,6 +394,44 @@ mod tests {
         };
         assert!(src.is_tarball(&linux));
         assert!(!src.is_tarball(&macos));
+    }
+
+    // -- URL construction: packages client-only --
+
+    #[test]
+    fn test_packages_client_url_stable_linux_amd64() {
+        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::PackagesClient {
+            channel: Channel::Stable,
+            version: "25.3.2.39".to_string(),
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://packages.clickhouse.com/tgz/stable/clickhouse-client-25.3.2.39-amd64.tgz"
+        );
+    }
+
+    #[test]
+    fn test_packages_client_url_lts_linux_arm64() {
+        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let src = DownloadSource::PackagesClient {
+            channel: Channel::Lts,
+            version: "24.8.6.70".to_string(),
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://packages.clickhouse.com/tgz/lts/clickhouse-client-24.8.6.70-arm64.tgz"
+        );
+    }
+
+    #[test]
+    fn test_packages_client_always_tarball() {
+        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let src = DownloadSource::PackagesClient {
+            channel: Channel::Stable,
+            version: "25.3.2.39".to_string(),
+        };
+        assert!(src.is_tarball(&linux));
     }
 
     // -- Probe URL --

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -241,7 +241,7 @@ struct GitRef {
 /// Find the latest release version matching a prefix using GitHub's matching-refs API.
 /// This is a single targeted API call that works regardless of how old the version is.
 /// prefix should be like "25.2" or "24.8" — we search for tags matching `v{prefix}.`
-async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
+pub async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
     let url = format!(
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix

--- a/tests/cloud_cli/service_crud.rs
+++ b/tests/cloud_cli/service_crud.rs
@@ -312,6 +312,47 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
         failures.run(
             &ctx,
             StepKind::NonBlocking,
+            "verify client-only binary was used on linux",
+            || {
+                let clients_dir = ctx.temp_home_path().join(".clickhouse").join("clients");
+                if cfg!(target_os = "linux") {
+                    if !clients_dir.exists() {
+                        return Err(
+                            "expected ~/.clickhouse/clients/ to exist on linux after cloud service client query"
+                                .into(),
+                        );
+                    }
+                    let has_client_binary = std::fs::read_dir(&clients_dir)?
+                        .filter_map(|e| e.ok())
+                        .any(|e| e.path().join("clickhouse-client").exists());
+                    if !has_client_binary {
+                        return Err(
+                            "expected a clickhouse-client binary in ~/.clickhouse/clients/*/"
+                                .into(),
+                        );
+                    }
+                    // Verify no full binary was downloaded (versions dir should be empty or absent)
+                    let versions_dir = ctx.temp_home_path().join(".clickhouse").join("versions");
+                    let has_full_binary = versions_dir.exists()
+                        && std::fs::read_dir(&versions_dir)?
+                            .filter_map(|e| e.ok())
+                            .any(|e| e.path().join("clickhouse").exists());
+                    if has_full_binary {
+                        return Err(
+                            "full binary was downloaded instead of client-only on linux".into(),
+                        );
+                    }
+                    eprintln!("  verified: client-only binary used (not full binary)");
+                } else {
+                    eprintln!("  skipped: client-only verification only applies to linux");
+                }
+                Ok(())
+            },
+        )?;
+
+        failures.run(
+            &ctx,
+            StepKind::NonBlocking,
             "cloud service client query by name",
             || {
                 let output = runner.service_client_query_by_name(

--- a/tests/cloud_cli/service_crud.rs
+++ b/tests/cloud_cli/service_crud.rs
@@ -315,6 +315,7 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
             "verify client-only binary was used on linux",
             || {
                 let clients_dir = ctx.temp_home_path().join(".clickhouse").join("clients");
+                let versions_dir = ctx.temp_home_path().join(".clickhouse").join("versions");
                 if cfg!(target_os = "linux") {
                     if !clients_dir.exists() {
                         return Err(
@@ -331,8 +332,6 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 .into(),
                         );
                     }
-                    // Verify no full binary was downloaded (versions dir should be empty or absent)
-                    let versions_dir = ctx.temp_home_path().join(".clickhouse").join("versions");
                     let has_full_binary = versions_dir.exists()
                         && std::fs::read_dir(&versions_dir)?
                             .filter_map(|e| e.ok())
@@ -344,7 +343,17 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
                     }
                     eprintln!("  verified: client-only binary used (not full binary)");
                 } else {
-                    eprintln!("  skipped: client-only verification only applies to linux");
+                    // macOS: no client-only package available, should use full binary
+                    let has_full_binary = versions_dir.exists()
+                        && std::fs::read_dir(&versions_dir)?
+                            .filter_map(|e| e.ok())
+                            .any(|e| e.path().join("clickhouse").exists());
+                    if !has_full_binary {
+                        return Err(
+                            "expected full binary in ~/.clickhouse/versions/*/ on macOS".into(),
+                        );
+                    }
+                    eprintln!("  verified: full binary used (no client-only on macOS)");
                 }
                 Ok(())
             },


### PR DESCRIPTION
## Summary

- On Linux, `cloud service client` now downloads the ~36KB `clickhouse-client` package from packages.clickhouse.com instead of the ~164MB full binary
- Client-only binaries stored in `~/.clickhouse/clients/{version}/`
- Falls back to full binary on macOS (no client-only package available)
- Handles Cloud API 3-part versions (e.g., `"24.3.1"`) by extracting minor version for resolution

## Lookup order

1. Full binary already installed (`~/.clickhouse/versions/{matching}/clickhouse`) → reuse with `client` arg
2. Client-only already installed (`~/.clickhouse/clients/{minor}/clickhouse-client`) → reuse directly
3. Download: Linux → packages.clickhouse.com client tarball (~36KB); macOS → builds.clickhouse.com full binary

## Test plan

- [ ] `cargo test` — 198 tests pass (3 new for cloud version parsing)
- [ ] `cargo build` — clean, no warnings
- [ ] Manual (Linux): `cloud service client` downloads ~36KB client, not ~164MB full binary
- [ ] Manual (macOS): `cloud service client` still works via full binary
- [ ] Manual: if `local install 25.12` was done first, `cloud service client` reuses that binary

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)