### PR TITLE
add signup command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,7 @@ CONTEXT FOR AGENTS:
   OAuth login (`cloud auth login`) is read-only — it can list and inspect resources but cannot create, modify, or delete.
   For write operations, authenticate with API keys:
     clickhousectl cloud auth login --api-key YOUR_KEY --api-secret YOUR_SECRET
+  If the user doesn't have an account, suggest `clickhousectl cloud auth signup` first.
   Add --json to any cloud command for machine-readable output.
   Typical workflow: `cloud auth login` → `cloud auth status` → `cloud org list` → `cloud service list`")]
     Cloud(Box<CloudArgs>),

--- a/src/cloud/cli.rs
+++ b/src/cloud/cli.rs
@@ -65,6 +65,8 @@ CONTEXT FOR AGENTS:
     },
     /// Show current authentication status
     Status,
+    /// Open the ClickHouse Cloud sign-up page in your browser
+    Signup,
 }
 
 #[derive(Args)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,22 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                     Ok(())
                 }
             }
+            AuthCommands::Signup => {
+                let api_url = args
+                    .url
+                    .as_deref()
+                    .unwrap_or("https://api.clickhouse.cloud");
+                let parsed = url::Url::parse(api_url)
+                    .map_err(|e| Error::Cloud(format!("Invalid URL: {}", e)))?;
+                let host = parsed.host_str().unwrap_or("api.clickhouse.cloud");
+                let base_host = host.strip_prefix("api.").unwrap_or(host);
+                let url = format!("https://console.{}/signUp", base_host);
+                println!("Opening ClickHouse Cloud sign-up page...");
+                if open::that(&url).is_err() {
+                    println!("Could not open browser. Please visit: {}", url);
+                }
+                Ok(())
+            }
             AuthCommands::Logout { oauth, api_keys } => {
                 match (oauth, api_keys) {
                     (true, false) => {


### PR DESCRIPTION
This is a tiny new command to help discover the sign up page. Chloe and I have decided that signup is not worth exploring at the moment as the industry has not settled on a strategy that is safe and secure yet.

Auth0 has not caught up with this requirement yet and none of the popular cli's I've explored have not supported this. Sign up security is based on browsers so its hard to translate it to a cli experience.

The new `cloud auth signup` command simply opens our sign up page.