### PR TITLE
Use consistent versioned user-agent for all HTTP requests

### DIFF
--- a/src/cloud/auth.rs
+++ b/src/cloud/auth.rs
@@ -149,7 +149,7 @@ pub async fn device_auth_login(api_url: &str) -> Result<TokenStore, Box<dyn std:
     })?;
 
     let client = reqwest::Client::builder()
-        .user_agent(super::client::user_agent())
+        .user_agent(crate::user_agent::user_agent())
         .build()?;
 
     // Step 1: Request device code
@@ -267,7 +267,7 @@ pub async fn refresh_access_token(
         .ok_or_else(|| format!("Cannot refresh: unknown API host in '{}'", tokens.api_url))?;
 
     let client = reqwest::Client::builder()
-        .user_agent(super::client::user_agent())
+        .user_agent(crate::user_agent::user_agent())
         .build()?;
 
     let form_body = format!(

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -5,10 +5,6 @@ use std::env;
 
 const DEFAULT_BASE_URL: &str = "https://api.clickhouse.cloud/v1";
 
-pub fn user_agent() -> String {
-    crate::user_agent::user_agent()
-}
-
 #[derive(Debug)]
 pub struct CloudError {
     pub message: String,
@@ -42,7 +38,7 @@ impl CloudClient {
         url_override: Option<&str>,
     ) -> Result<Self> {
         let client = Client::builder()
-            .user_agent(user_agent())
+            .user_agent(crate::user_agent::user_agent())
             .build()
             .map_err(|e| CloudError {
                 message: format!("Failed to create HTTP client: {}", e),

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -68,17 +68,17 @@ impl CloudClient {
         }
 
         // Try OAuth tokens
-        if let Some(tokens) = crate::cloud::auth::load_tokens() {
-            if crate::cloud::auth::is_token_valid(&tokens) {
-                let base_url = url_override
-                    .map(crate::cloud::auth::normalize_api_url)
-                    .unwrap_or(tokens.api_url.clone());
-                return Ok(Self {
-                    client,
-                    auth_mode: AuthMode::Bearer(format!("Bearer {}", tokens.access_token)),
-                    base_url,
-                });
-            }
+        if let Some(tokens) = crate::cloud::auth::load_tokens()
+            && crate::cloud::auth::is_token_valid(&tokens)
+        {
+            let base_url = url_override
+                .map(crate::cloud::auth::normalize_api_url)
+                .unwrap_or(tokens.api_url.clone());
+            return Ok(Self {
+                client,
+                auth_mode: AuthMode::Bearer(format!("Bearer {}", tokens.access_token)),
+                base_url,
+            });
         }
 
         let base_url = url_override
@@ -142,11 +142,12 @@ impl CloudClient {
 
         if !status.is_success() {
             if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
-                && let Some(err) = api_resp.error {
-                    return Err(CloudError {
-                        message: err.message,
-                    });
-                }
+                && let Some(err) = api_resp.error
+            {
+                return Err(CloudError {
+                    message: err.message,
+                });
+            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });
@@ -175,11 +176,12 @@ impl CloudClient {
         if !status.is_success() {
             let body = response.text().await.unwrap_or_default();
             if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
-                && let Some(err) = api_resp.error {
-                    return Err(CloudError {
-                        message: err.message,
-                    });
-                }
+                && let Some(err) = api_resp.error
+            {
+                return Err(CloudError {
+                    message: err.message,
+                });
+            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });
@@ -205,11 +207,12 @@ impl CloudClient {
 
         if !status.is_success() {
             if let Ok(api_resp) = serde_json::from_str::<ApiResponse<()>>(&body)
-                && let Some(err) = api_resp.error {
-                    return Err(CloudError {
-                        message: err.message,
-                    });
-                }
+                && let Some(err) = api_resp.error
+            {
+                return Err(CloudError {
+                    message: err.message,
+                });
+            }
             return Err(CloudError {
                 message: format!("API error ({}): {}", status, body),
             });

--- a/src/cloud/client.rs
+++ b/src/cloud/client.rs
@@ -6,7 +6,7 @@ use std::env;
 const DEFAULT_BASE_URL: &str = "https://api.clickhouse.cloud/v1";
 
 pub fn user_agent() -> String {
-    format!("clickhousectl/{}", env!("CARGO_PKG_VERSION"))
+    crate::user_agent::user_agent()
 }
 
 #[derive(Debug)]

--- a/src/cloud/commands.rs
+++ b/src/cloud/commands.rs
@@ -632,10 +632,11 @@ pub async fn service_create(
             println!("  Max Memory/Replica: {} GB", max_mem);
         }
         if let Some(endpoints) = &response.service.endpoints
-            && let Some(ep) = endpoints.first() {
-                println!("  Host: {}", ep.host);
-                println!("  Port: {}", ep.port);
-            }
+            && let Some(ep) = endpoints.first()
+        {
+            println!("  Host: {}", ep.host);
+            println!("  Port: {}", ep.port);
+        }
         println!();
         println!("Credentials (save these, password shown only once):");
         println!("  Username: default");
@@ -1729,8 +1730,7 @@ async fn ensure_version_installed(
         "Service requires ClickHouse {} — downloading...",
         resolved.display_version
     );
-    let version =
-        version_manager::install::install_resolved(&resolved, &platform, false).await?;
+    let version = version_manager::install::install_resolved(&resolved, &platform, false).await?;
     Ok(version)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,9 @@ async fn list_available() -> Result<()> {
     for v in &versions {
         // Check if any installed version matches this minor
         let prefix = format!("{}.", v);
-        let is_installed = installed.iter().any(|iv| iv.starts_with(&prefix) || iv == v);
+        let is_installed = installed
+            .iter()
+            .any(|iv| iv.starts_with(&prefix) || iv == v);
         if is_installed {
             println!("  {} (installed)", v);
         } else {
@@ -178,10 +180,11 @@ fn remove(version: &str) -> Result<()> {
 
     // Check if this is the default version
     if let Ok(default) = version_manager::get_default_version()
-        && default == version {
-            let default_file = paths::default_file()?;
-            let _ = std::fs::remove_file(default_file);
-        }
+        && default == version
+    {
+        let default_file = paths::default_file()?;
+        let _ = std::fs::remove_file(default_file);
+    }
 
     std::fs::remove_dir_all(&version_dir)?;
     println!("Removed version {}", version);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod init;
 mod paths;
 mod server;
 mod skills;
+mod user_agent;
 mod version_manager;
 
 use clap::Parser;

--- a/src/user_agent.rs
+++ b/src/user_agent.rs
@@ -1,0 +1,4 @@
+/// Returns the canonical user-agent string for all outbound HTTP requests.
+pub fn user_agent() -> String {
+    format!("clickhousectl/{}", env!("CARGO_PKG_VERSION"))
+}

--- a/src/version_manager/download.rs
+++ b/src/version_manager/download.rs
@@ -18,7 +18,7 @@ pub async fn download_from_source(
 /// Downloads a file from a URL to the specified path, with progress bar
 pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
     let client = reqwest::Client::builder()
-        .user_agent("clickhousectl")
+        .user_agent(crate::user_agent::user_agent())
         .build()?;
 
     let response = client

--- a/src/version_manager/install.rs
+++ b/src/version_manager/install.rs
@@ -25,21 +25,20 @@ pub async fn install_resolved(
 
     // For builds source (minor versions like "25.12"), check if we already have
     // an installed version matching that minor — avoids re-downloading ~150MB
-    if !force {
-        if let DownloadSource::Builds { ref version_path } = resolved.source {
-            if version_path != "master" {
-                let prefix = format!("{}.", version_path);
-                if let Ok(installed) = list_installed_versions() {
-                    if let Some(existing) = installed.iter().find(|v| v.starts_with(&prefix)) {
-                        eprintln!(
-                            "ClickHouse {} is already installed as {}",
-                            version_path, existing
-                        );
-                        eprintln!("Use --force to re-download the latest build");
-                        return Ok(existing.clone());
-                    }
-                }
-            }
+    if !force
+        && let DownloadSource::Builds { ref version_path } = resolved.source
+        && version_path != "master"
+    {
+        let prefix = format!("{}.", version_path);
+        if let Ok(installed) = list_installed_versions()
+            && let Some(existing) = installed.iter().find(|v| v.starts_with(&prefix))
+        {
+            eprintln!(
+                "ClickHouse {} is already installed as {}",
+                version_path, existing
+            );
+            eprintln!("Use --force to re-download the latest build");
+            return Ok(existing.clone());
         }
     }
 
@@ -140,10 +139,7 @@ fn parse_version_output(output: &str) -> Result<String> {
 /// Extract a tarball, finding the clickhouse binary automatically.
 /// Handles both packages.clickhouse.com layout (usr/bin/clickhouse inside subdir)
 /// and GitHub releases layout (same structure).
-fn extract_tarball_auto(
-    tarball_path: &std::path::Path,
-    dest_dir: &std::path::Path,
-) -> Result<()> {
+fn extract_tarball_auto(tarball_path: &std::path::Path, dest_dir: &std::path::Path) -> Result<()> {
     let status = std::process::Command::new("tar")
         .args(["xzf", &tarball_path.to_string_lossy()])
         .current_dir(dest_dir)

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -42,13 +42,14 @@ pub fn list_installed_versions() -> Result<Vec<String>> {
     for entry in std::fs::read_dir(&versions_dir)? {
         let entry = entry?;
         if entry.path().is_dir()
-            && let Some(name) = entry.file_name().to_str() {
-                // Only include if it has a clickhouse binary
-                let binary = entry.path().join("clickhouse");
-                if binary.exists() {
-                    versions.push(name.to_string());
-                }
+            && let Some(name) = entry.file_name().to_str()
+        {
+            // Only include if it has a clickhouse binary
+            let binary = entry.path().join("clickhouse");
+            if binary.exists() {
+                versions.push(name.to_string());
             }
+        }
     }
 
     // Sort versions in descending order (newest first)
@@ -71,7 +72,9 @@ pub struct VersionEntry {
 /// Fetches available versions from GitHub releases
 pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     let url = "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
-    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()?;
 
     let response = client
         .get(url)
@@ -86,16 +89,17 @@ pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
         // Tag format: v25.12.5.44-stable or v24.8.10.6-lts
         let tag = &release.tag_name;
         if let Some(version) = tag.strip_prefix('v')
-            && let Some(dash_pos) = version.rfind('-') {
-                let v = &version[..dash_pos];
-                let suffix = &version[dash_pos + 1..];
-                if let Some(channel) = Channel::from_tag_suffix(suffix) {
-                    versions.push(VersionEntry {
-                        version: v.to_string(),
-                        channel,
-                    });
-                }
+            && let Some(dash_pos) = version.rfind('-')
+        {
+            let v = &version[..dash_pos];
+            let suffix = &version[dash_pos + 1..];
+            if let Some(channel) = Channel::from_tag_suffix(suffix) {
+                versions.push(VersionEntry {
+                    version: v.to_string(),
+                    channel,
+                });
             }
+        }
     }
 
     // Sort versions in descending order (newest first)

--- a/src/version_manager/list.rs
+++ b/src/version_manager/list.rs
@@ -71,7 +71,7 @@ pub struct VersionEntry {
 /// Fetches available versions from GitHub releases
 pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     let url = "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
-    let client = reqwest::Client::builder().user_agent("ch-cli").build()?;
+    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
 
     let response = client
         .get(url)
@@ -111,7 +111,7 @@ pub async fn list_available_versions_from_builds() -> Result<Vec<String>> {
 
     let platform = Platform::detect()?;
     let client = reqwest::Client::builder()
-        .user_agent("clickhousectl")
+        .user_agent(crate::user_agent::user_agent())
         .build()
         .map_err(|e| Error::Download(e.to_string()))?;
 

--- a/src/version_manager/platform.rs
+++ b/src/version_manager/platform.rs
@@ -107,15 +107,9 @@ pub enum DownloadSource {
         version_path: String,
     },
     /// packages.clickhouse.com — tgz tarball (Linux only)
-    Packages {
-        channel: Channel,
-        version: String,
-    },
+    Packages { channel: Channel, version: String },
     /// GitHub releases — tgz (Linux) or bare binary (macOS)
-    GitHub {
-        version: String,
-        channel: Channel,
-    },
+    GitHub { version: String, channel: Channel },
 }
 
 impl DownloadSource {
@@ -153,11 +147,7 @@ impl DownloadSource {
                         )
                     }
                     Os::MacOS => {
-                        format!(
-                            "{}/clickhouse-macos-{}",
-                            base,
-                            platform.github_suffix()
-                        )
+                        format!("{}/clickhouse-macos-{}", base, platform.github_suffix())
                     }
                 }
             }
@@ -200,25 +190,37 @@ mod tests {
 
     #[test]
     fn test_builds_path_linux_amd64() {
-        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
         assert_eq!(p.builds_path(), "amd64");
     }
 
     #[test]
     fn test_builds_path_linux_aarch64() {
-        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::Aarch64,
+        };
         assert_eq!(p.builds_path(), "aarch64");
     }
 
     #[test]
     fn test_builds_path_macos_x86() {
-        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::X86_64,
+        };
         assert_eq!(p.builds_path(), "macos");
     }
 
     #[test]
     fn test_builds_path_macos_aarch64() {
-        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
         assert_eq!(p.builds_path(), "macos-aarch64");
     }
 
@@ -226,17 +228,29 @@ mod tests {
 
     #[test]
     fn test_packages_arch_linux() {
-        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
         assert_eq!(p.packages_arch(), Some("amd64"));
-        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::Aarch64,
+        };
         assert_eq!(p.packages_arch(), Some("arm64"));
     }
 
     #[test]
     fn test_packages_arch_macos_none() {
-        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::X86_64,
+        };
         assert_eq!(p.packages_arch(), None);
-        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
         assert_eq!(p.packages_arch(), None);
     }
 
@@ -244,25 +258,66 @@ mod tests {
 
     #[test]
     fn test_github_suffix() {
-        assert_eq!(Platform { os: Os::Linux, arch: Arch::X86_64 }.github_suffix(), "amd64");
-        assert_eq!(Platform { os: Os::Linux, arch: Arch::Aarch64 }.github_suffix(), "arm64");
-        assert_eq!(Platform { os: Os::MacOS, arch: Arch::X86_64 }.github_suffix(), "x86_64");
-        assert_eq!(Platform { os: Os::MacOS, arch: Arch::Aarch64 }.github_suffix(), "aarch64");
+        assert_eq!(
+            Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64
+            }
+            .github_suffix(),
+            "amd64"
+        );
+        assert_eq!(
+            Platform {
+                os: Os::Linux,
+                arch: Arch::Aarch64
+            }
+            .github_suffix(),
+            "arm64"
+        );
+        assert_eq!(
+            Platform {
+                os: Os::MacOS,
+                arch: Arch::X86_64
+            }
+            .github_suffix(),
+            "x86_64"
+        );
+        assert_eq!(
+            Platform {
+                os: Os::MacOS,
+                arch: Arch::Aarch64
+            }
+            .github_suffix(),
+            "aarch64"
+        );
     }
 
     // -- URL construction: builds.clickhouse.com --
 
     #[test]
     fn test_builds_url_master_linux_amd64() {
-        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
-        let src = DownloadSource::Builds { version_path: "master".to_string() };
-        assert_eq!(src.url(&p), "https://builds.clickhouse.com/master/amd64/clickhouse");
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let src = DownloadSource::Builds {
+            version_path: "master".to_string(),
+        };
+        assert_eq!(
+            src.url(&p),
+            "https://builds.clickhouse.com/master/amd64/clickhouse"
+        );
     }
 
     #[test]
     fn test_builds_url_minor_macos_aarch64() {
-        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
-        let src = DownloadSource::Builds { version_path: "25.12".to_string() };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let src = DownloadSource::Builds {
+            version_path: "25.12".to_string(),
+        };
         assert_eq!(
             src.url(&p),
             "https://builds.clickhouse.com/25.12/macos-aarch64/clickhouse"
@@ -271,8 +326,13 @@ mod tests {
 
     #[test]
     fn test_builds_url_minor_linux_aarch64() {
-        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
-        let src = DownloadSource::Builds { version_path: "25.8".to_string() };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::Aarch64,
+        };
+        let src = DownloadSource::Builds {
+            version_path: "25.8".to_string(),
+        };
         assert_eq!(
             src.url(&p),
             "https://builds.clickhouse.com/25.8/aarch64/clickhouse"
@@ -283,7 +343,10 @@ mod tests {
 
     #[test]
     fn test_packages_url_stable_linux_amd64() {
-        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
         let src = DownloadSource::Packages {
             channel: Channel::Stable,
             version: "25.12.9.61".to_string(),
@@ -296,7 +359,10 @@ mod tests {
 
     #[test]
     fn test_packages_url_lts_linux_arm64() {
-        let p = Platform { os: Os::Linux, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::Aarch64,
+        };
         let src = DownloadSource::Packages {
             channel: Channel::Lts,
             version: "24.8.6.70".to_string(),
@@ -311,7 +377,10 @@ mod tests {
 
     #[test]
     fn test_github_url_linux_amd64() {
-        let p = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
         let src = DownloadSource::GitHub {
             version: "25.12.5.44".to_string(),
             channel: Channel::Stable,
@@ -324,7 +393,10 @@ mod tests {
 
     #[test]
     fn test_github_url_macos_aarch64() {
-        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
         let src = DownloadSource::GitHub {
             version: "25.12.5.44".to_string(),
             channel: Channel::Stable,
@@ -337,7 +409,10 @@ mod tests {
 
     #[test]
     fn test_github_url_macos_x86() {
-        let p = Platform { os: Os::MacOS, arch: Arch::X86_64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::X86_64,
+        };
         let src = DownloadSource::GitHub {
             version: "24.8.6.70".to_string(),
             channel: Channel::Lts,
@@ -352,16 +427,27 @@ mod tests {
 
     #[test]
     fn test_builds_never_tarball() {
-        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
-        let macos = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
-        let src = DownloadSource::Builds { version_path: "master".to_string() };
+        let linux = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let macos = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
+        let src = DownloadSource::Builds {
+            version_path: "master".to_string(),
+        };
         assert!(!src.is_tarball(&linux));
         assert!(!src.is_tarball(&macos));
     }
 
     #[test]
     fn test_packages_always_tarball() {
-        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
+        let linux = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
         let src = DownloadSource::Packages {
             channel: Channel::Stable,
             version: "25.12.9.61".to_string(),
@@ -371,8 +457,14 @@ mod tests {
 
     #[test]
     fn test_github_tarball_linux_only() {
-        let linux = Platform { os: Os::Linux, arch: Arch::X86_64 };
-        let macos = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let linux = Platform {
+            os: Os::Linux,
+            arch: Arch::X86_64,
+        };
+        let macos = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
         let src = DownloadSource::GitHub {
             version: "25.12.5.44".to_string(),
             channel: Channel::Stable,
@@ -385,7 +477,10 @@ mod tests {
 
     #[test]
     fn test_builds_probe_url() {
-        let p = Platform { os: Os::MacOS, arch: Arch::Aarch64 };
+        let p = Platform {
+            os: Os::MacOS,
+            arch: Arch::Aarch64,
+        };
         assert_eq!(
             builds_probe_url("25.12", &p),
             "https://builds.clickhouse.com/25.12/macos-aarch64/clickhouse"

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -69,11 +69,7 @@ async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<Resolv
     }
 
     // Fallback: use packages (Linux) or GitHub (macOS)
-    Ok(fallback_source(
-        &entry.version,
-        entry.channel,
-        platform,
-    ))
+    Ok(fallback_source(&entry.version, entry.channel, platform))
 }
 
 /// `install 25` — probe builds for highest 25.x minor
@@ -112,11 +108,7 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
     for minor in (1..=12).rev() {
         let prefix = format!("{}.{}", major, minor);
         if let Ok(entry) = find_version_by_refs(&prefix).await {
-            return Ok(fallback_source(
-                &entry.version,
-                entry.channel,
-                platform,
-            ));
+            return Ok(fallback_source(&entry.version, entry.channel, platform));
         }
     }
 
@@ -143,11 +135,7 @@ async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<Re
     // Fallback: targeted GH API call to find exact version for this minor
     let entry = find_version_by_refs(&version_path).await?;
 
-    Ok(fallback_source(
-        &entry.version,
-        entry.channel,
-        platform,
-    ))
+    Ok(fallback_source(&entry.version, entry.channel, platform))
 }
 
 /// `install 25.12.9.61` — exact version, needs channel from GH API
@@ -164,7 +152,9 @@ async fn find_exact_channel(version: &str) -> Result<Channel> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
         version
     );
-    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()?;
 
     let response = client
         .get(&url)
@@ -246,7 +236,9 @@ async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix
     );
-    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()?;
 
     let response = client
         .get(&url)

--- a/src/version_manager/resolve.rs
+++ b/src/version_manager/resolve.rs
@@ -81,7 +81,7 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
     // Probe builds.clickhouse.com for all possible minors in this major (1..12)
     let mut highest_available: Option<u32> = None;
     let client = reqwest::Client::builder()
-        .user_agent("clickhousectl")
+        .user_agent(crate::user_agent::user_agent())
         .build()
         .map_err(|e| Error::Download(e.to_string()))?;
 
@@ -164,7 +164,7 @@ async fn find_exact_channel(version: &str) -> Result<Channel> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
         version
     );
-    let client = reqwest::Client::builder().user_agent("clickhousectl").build()?;
+    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
 
     let response = client
         .get(&url)
@@ -219,7 +219,7 @@ fn fallback_source(version: &str, channel: Channel, platform: &Platform) -> Reso
 async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
     let url = builds_probe_url(version_path, platform);
     let client = match reqwest::Client::builder()
-        .user_agent("clickhousectl")
+        .user_agent(crate::user_agent::user_agent())
         .build()
     {
         Ok(c) => c,
@@ -246,7 +246,7 @@ async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix
     );
-    let client = reqwest::Client::builder().user_agent("clickhousectl").build()?;
+    let client = reqwest::Client::builder().user_agent(crate::user_agent::user_agent()).build()?;
 
     let response = client
         .get(&url)

--- a/tests/cloud_cli/service_crud.rs
+++ b/tests/cloud_cli/service_crud.rs
@@ -1,8 +1,7 @@
 use crate::support::{
-    CleanupRegistry, CliRunner, FailureRecorder, StepKind, TestContext, TestResult,
-    json_string, log_phase, log_run_header, poll_until,
-    service_has_ip_access_entry, service_list_is_empty, service_name_in_list,
-    service_present_in_list,
+    CleanupRegistry, CliRunner, FailureRecorder, StepKind, TestContext, TestResult, json_string,
+    log_phase, log_run_header, poll_until, service_has_ip_access_entry, service_list_is_empty,
+    service_name_in_list, service_present_in_list,
 };
 use serde_json::Value;
 
@@ -471,11 +470,9 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 let output = runner.service_client_query(&service_id, &password, "SELECT 1")?;
                 let trimmed = output.stdout.trim();
                 if trimmed != "1" {
-                    return Err(format!(
-                        "expected SELECT 1 to return '1', got '{}'",
-                        trimmed
-                    )
-                    .into());
+                    return Err(
+                        format!("expected SELECT 1 to return '1', got '{}'", trimmed).into(),
+                    );
                 }
                 Ok(())
             },
@@ -493,11 +490,7 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 )?;
                 let trimmed = output.stdout.trim();
                 if trimmed != "cloud_client_ok" {
-                    return Err(format!(
-                        "expected 'cloud_client_ok', got '{}'",
-                        trimmed
-                    )
-                    .into());
+                    return Err(format!("expected 'cloud_client_ok', got '{}'", trimmed).into());
                 }
                 Ok(())
             },
@@ -508,17 +501,11 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
             StepKind::NonBlocking,
             "cloud service client with generate-password",
             || {
-                let output = runner.service_client_query_generate_password(
-                    &service_id,
-                    "SELECT 'gen_pw_ok'",
-                )?;
+                let output = runner
+                    .service_client_query_generate_password(&service_id, "SELECT 'gen_pw_ok'")?;
                 let trimmed = output.stdout.trim();
                 if trimmed != "gen_pw_ok" {
-                    return Err(format!(
-                        "expected 'gen_pw_ok', got '{}'",
-                        trimmed
-                    )
-                    .into());
+                    return Err(format!("expected 'gen_pw_ok', got '{}'", trimmed).into());
                 }
                 Ok(())
             },
@@ -592,9 +579,9 @@ fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 ]);
                 match result {
                     Err(_) => Ok(()),
-                    Ok(_) => Err(
-                        "expected delete without --force to fail on a running service".into(),
-                    ),
+                    Ok(_) => {
+                        Err("expected delete without --force to fail on a running service".into())
+                    }
                 }
             },
         )?;


### PR DESCRIPTION
## Summary
- Extracted `user_agent()` into a shared `src/user_agent.rs` module that returns `clickhousectl/{version}`
- Updated all HTTP clients in `version_manager/` (download, resolve, list) to use the shared function instead of hardcoded strings
- Fixed `list.rs` which was using `"ch-cli"` instead of `"clickhousectl"`
- `cloud/client.rs::user_agent()` now delegates to the shared module

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all 199 tests pass
- [x] `cargo clippy` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)