### PR TITLE
Bump version to 0.1.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhousectl"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "atty",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.14 for release

## Test plan
- [x] `cargo build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)