### PR TITLE
Switch Linux builds to musl for fully static binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
-            cross: false
-          - target: aarch64-unknown-linux-gnu
+            cross: true
+          - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             cross: true
           - target: x86_64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        run: cargo install cross --tag v0.2.5
+        run: cargo install cross --version 0.2.5
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Install cross
         if: matrix.cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+        run: cargo install cross --tag v0.2.5
 
       - name: Build
         run: |
@@ -48,6 +48,17 @@ jobs:
           else
             cargo build --release --target ${{ matrix.target }}
           fi
+
+      - name: Verify static linking
+        if: contains(matrix.target, 'linux-musl')
+        run: |
+          binary="target/${{ matrix.target }}/release/clickhousectl"
+          echo "--- file output ---"
+          file "$binary"
+          file "$binary" | grep -q "statically linked"
+          echo "--- ldd output ---"
+          ! ldd "$binary" 2>&1 || ldd "$binary" 2>&1 | grep -q "not a dynamic executable"
+          echo "Static linking verified."
 
       - name: Rename binary
         run: cp target/${{ matrix.target }}/release/clickhousectl clickhousectl-${{ matrix.target }}
@@ -58,9 +69,47 @@ jobs:
           name: clickhousectl-${{ matrix.target }}
           path: clickhousectl-${{ matrix.target }}
 
+  smoke-test:
+    name: Smoke test (${{ matrix.distro }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - distro: ubuntu:20.04
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: ubuntu:22.04
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: ubuntu:24.04
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: debian:bullseye
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: debian:bookworm
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: centos:7
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: amazonlinux:2
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+          - distro: alpine:3.18
+            artifact: clickhousectl-x86_64-unknown-linux-musl
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+
+      - name: Run smoke test in ${{ matrix.distro }}
+        run: |
+          chmod +x ${{ matrix.artifact }}
+          docker run --rm \
+            -v "$PWD/${{ matrix.artifact }}:/usr/local/bin/clickhousectl:ro" \
+            ${{ matrix.distro }} \
+            sh -c 'clickhousectl --version && clickhousectl --help'
+
   release:
     name: Create Release
-    needs: build
+    needs: [build, smoke-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
     steps:
       - uses: actions/checkout@v4
 

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ BINARY_NAME="clickhousectl"
 # Detect OS
 OS="$(uname -s)"
 case "$OS" in
-  Linux)  OS_TARGET="unknown-linux-gnu" ;;
+  Linux)  OS_TARGET="unknown-linux-musl" ;;
   Darwin) OS_TARGET="apple-darwin" ;;
   *)
     echo "Error: unsupported OS: $OS" >&2


### PR DESCRIPTION
## Summary

- Switch Linux release targets from `*-linux-gnu` to `*-linux-musl`, producing fully statically linked binaries
- Use `cross` (pinned to v0.2.5) for both Linux targets to handle the musl toolchain
- Update `install.sh` to fetch the new musl binary names
- Add static-link verification step (`file` + `ldd`) for Linux artifacts
- Add Docker-based smoke tests across 8 Linux distros before release
- Expand `test-install.yml` OS matrix to cover more runners

## Context

The CLI fails on Linux systems with older glibc:

```
chctl: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by chctl)
chctl: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by chctl)
```

musl-linked binaries have zero runtime dependencies and work on any Linux distribution regardless of glibc version, similar to how ClickHouse itself ships statically linked binaries.

The project already uses `rustls` (no OpenSSL dependency), so the musl build works cleanly.

## CI improvements

**Release workflow (`release.yml`):**
- Pin `cross` to `v0.2.5` for reproducible builds
- Static-link verification: `file` + `ldd` checks on every Linux musl binary, fails the build if not statically linked
- Smoke test job runs `--version` and `--help` in Docker containers before release is published:
  - Ubuntu 20.04, 22.04, 24.04
  - Debian Bullseye, Bookworm
  - CentOS 7 (glibc 2.17)
  - Amazon Linux 2
  - Alpine 3.18 (musl-based)
- Release is gated on smoke tests passing (`needs: [build, smoke-test]`)

**Install test workflow (`test-install.yml`):**
- Expanded from `[ubuntu-latest, macos-latest]` to `[ubuntu-22.04, ubuntu-24.04,macos-14, macos-15]`

## Test plan

- [ ] CI builds succeed for both `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`
- [ ] Static-link verification step passes
- [ ] Smoke tests pass on all 8 Linux distros (especially CentOS 7 with glibc 2.17)
- [ ] Install tests pass on expanded OS matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)