### PR TITLE
Fix static-link verification to accept static-pie

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           binary="target/${{ matrix.target }}/release/clickhousectl"
           echo "--- file output ---"
           file "$binary"
-          file "$binary" | grep -q "statically linked"
+          file "$binary" | grep -qE "statically linked|static-pie linked"
           echo "--- ldd output ---"
           ! ldd "$binary" 2>&1 || ldd "$binary" 2>&1 | grep -q "not a dynamic executable"
           echo "Static linking verified."


### PR DESCRIPTION
## Summary

- The musl build produces `static-pie linked` in `file` output, not `statically linked`
- Update the grep pattern to accept both variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)