### PR TITLE
Add process discovery and global server management

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,14 @@ clickhousectl local server start -- --config-file=/path/to/config.xml
 
 # List all servers (running and stopped)
 clickhousectl local server list
+clickhousectl local server list --global                  # List servers across all projects
 
 # Stop servers
 clickhousectl local server stop default                   # Stop by name
+clickhousectl local server stop default --global          # Stop from any project
+clickhousectl local server stop default --global --project /path/to/project  # Disambiguate
 clickhousectl local server stop-all                       # Stop all running servers
+clickhousectl local server stop-all --global              # Stop all servers system-wide
 
 # Remove a stopped server and its data
 clickhousectl local server remove test
@@ -127,6 +131,10 @@ clickhousectl local server remove test
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
 
 **Ports:** Defaults are HTTP 8123 and TCP 9000. If these are already in use, free ports are automatically assigned and shown in the output. Use `--http-port` and `--tcp-port` to set explicit ports.
+
+**Orphaned server recovery:** If server metadata files are lost while the ClickHouse process is still running, the CLI automatically recovers them via process discovery. Running `server list`, `server start`, or any server command will detect orphaned processes belonging to the current project and bring them back under management.
+
+**Global server management:** Use `--global` with `list`, `stop`, and `stop-all` to operate across all projects system-wide. `server list --global` shows all running ClickHouse servers with a Project column indicating which directory each belongs to.
 
 #### Project-local data directory
 

--- a/src/local/cli.rs
+++ b/src/local/cli.rs
@@ -180,10 +180,9 @@ CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Automatically cleans up stale entries for processes that are no longer running.
   Shows name, status (running/stopped), PID, version, and ports.
-  Use --global to list servers across all projects system-wide.
   Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
     List {
-        /// List servers across all projects, not just the current one
+        /// System-wide maintenance only: list servers across all projects. You almost certainly want the default project-scoped list instead.
         #[arg(long)]
         global: bool,
     },
@@ -194,14 +193,12 @@ CONTEXT FOR AGENTS:
   Stops a named ClickHouse server. Use the name from `clickhousectl local server list`.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data directory is preserved — restart with `clickhousectl local server start --name <name>`.
-  Use --global to stop a server from any project. If the name is ambiguous across projects,
-  use --project to specify which one.
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
         /// Name of the server to stop
         name: String,
 
-        /// Stop a server from any project, not just the current one
+        /// System-wide maintenance only: stop a server from any project. You almost certainly want the default project-scoped stop instead.
         #[arg(long)]
         global: bool,
 
@@ -216,10 +213,9 @@ CONTEXT FOR AGENTS:
   Stops all running ClickHouse server instances.
   Sends SIGTERM first, then SIGKILL if processes don't exit.
   Data directories are preserved.
-  Use --global to stop all servers across all projects system-wide.
   Related: `clickhousectl local server list` to see servers.")]
     StopAll {
-        /// Stop all servers across all projects, not just the current one
+        /// System-wide maintenance only: stop all servers across all projects. You almost certainly want the default project-scoped stop-all instead.
         #[arg(long)]
         global: bool,
     },

--- a/src/local/cli.rs
+++ b/src/local/cli.rs
@@ -180,8 +180,13 @@ CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Automatically cleans up stale entries for processes that are no longer running.
   Shows name, status (running/stopped), PID, version, and ports.
+  Use --global to list servers across all projects system-wide.
   Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
-    List,
+    List {
+        /// List servers across all projects, not just the current one
+        #[arg(long)]
+        global: bool,
+    },
 
     /// Stop a running server by name
     #[command(after_help = "\
@@ -189,10 +194,20 @@ CONTEXT FOR AGENTS:
   Stops a named ClickHouse server. Use the name from `clickhousectl local server list`.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data directory is preserved — restart with `clickhousectl local server start --name <name>`.
+  Use --global to stop a server from any project. If the name is ambiguous across projects,
+  use --project to specify which one.
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
         /// Name of the server to stop
         name: String,
+
+        /// Stop a server from any project, not just the current one
+        #[arg(long)]
+        global: bool,
+
+        /// Project directory to disambiguate when using --global
+        #[arg(long, requires = "global")]
+        project: Option<String>,
     },
 
     /// Stop all running server instances
@@ -201,8 +216,13 @@ CONTEXT FOR AGENTS:
   Stops all running ClickHouse server instances.
   Sends SIGTERM first, then SIGKILL if processes don't exit.
   Data directories are preserved.
+  Use --global to stop all servers across all projects system-wide.
   Related: `clickhousectl local server list` to see servers.")]
-    StopAll,
+    StopAll {
+        /// Stop all servers across all projects, not just the current one
+        #[arg(long)]
+        global: bool,
+    },
 
     /// Remove a stopped server and its data
     #[command(after_help = "\

--- a/src/local/discovery.rs
+++ b/src/local/discovery.rs
@@ -69,8 +69,10 @@ fn inspect_process(pid: u32) -> Option<DiscoveredProcess> {
 /// Get the current working directory of a process (macOS).
 #[cfg(target_os = "macos")]
 fn get_process_cwd(pid: u32) -> Option<String> {
+    // -a is required to AND the conditions; without it macOS lsof OR's
+    // -d and -p, returning the cwd of every process on the system.
     let output = Command::new("lsof")
-        .args(["-d", "cwd", "-Fn", "-p", &pid.to_string()])
+        .args(["-a", "-d", "cwd", "-Fn", "-p", &pid.to_string()])
         .output()
         .ok()?;
 

--- a/src/local/discovery.rs
+++ b/src/local/discovery.rs
@@ -1,0 +1,286 @@
+//! OS-level process discovery for running ClickHouse servers.
+//!
+//! Finds ClickHouse processes via `pgrep`, resolves their working directories
+//! and command-line arguments to recover server metadata (project root, name,
+//! ports, version). Used for orphaned server recovery and global server listing.
+
+use std::process::Command;
+
+/// A ClickHouse process discovered via OS-level process inspection.
+#[derive(Debug, Clone)]
+pub struct DiscoveredProcess {
+    pub pid: u32,
+    pub project_root: String,
+    pub server_name: String,
+    pub http_port: Option<u16>,
+    pub tcp_port: Option<u16>,
+    pub version: Option<String>,
+}
+
+/// Find all running ClickHouse processes started by the CLI and parse their metadata.
+///
+/// Only returns processes whose cwd matches the `.clickhouse/servers/<name>/data/` pattern,
+/// meaning they were started by this CLI. Other ClickHouse processes are ignored.
+pub fn discover_clickhouse_processes() -> Vec<DiscoveredProcess> {
+    let pids = find_clickhouse_pids();
+    let mut discovered = Vec::new();
+
+    for pid in pids {
+        if let Some(proc) = inspect_process(pid) {
+            discovered.push(proc);
+        }
+    }
+
+    discovered
+}
+
+/// Find PIDs of running `clickhouse` processes.
+fn find_clickhouse_pids() -> Vec<u32> {
+    let output = Command::new("pgrep").arg("-x").arg("clickhouse").output();
+
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .filter_map(|line| line.trim().parse::<u32>().ok())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Inspect a single process to extract server metadata from its cwd and cmdline.
+fn inspect_process(pid: u32) -> Option<DiscoveredProcess> {
+    let cwd = get_process_cwd(pid)?;
+    let (project_root, server_name) = parse_server_cwd(&cwd)?;
+    let cmdline = get_process_cmdline(pid).unwrap_or_default();
+    let http_port = parse_port_flag(&cmdline, "--http_port");
+    let tcp_port = parse_port_flag(&cmdline, "--tcp_port");
+    let version = parse_version_from_cmdline(&cmdline);
+
+    Some(DiscoveredProcess {
+        pid,
+        project_root,
+        server_name,
+        http_port,
+        tcp_port,
+        version,
+    })
+}
+
+/// Get the current working directory of a process (macOS).
+#[cfg(target_os = "macos")]
+fn get_process_cwd(pid: u32) -> Option<String> {
+    let output = Command::new("lsof")
+        .args(["-d", "cwd", "-Fn", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(path) = line.strip_prefix('n') {
+            return Some(path.to_string());
+        }
+    }
+    None
+}
+
+/// Get the current working directory of a process (Linux).
+#[cfg(target_os = "linux")]
+fn get_process_cwd(pid: u32) -> Option<String> {
+    std::fs::read_link(format!("/proc/{}/cwd", pid))
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+}
+
+/// Get the command-line string of a process.
+fn get_process_cmdline(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-o", "args=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Parse a cwd path matching `<project_root>/.clickhouse/servers/<name>/data`
+/// to extract the project root and server name.
+///
+/// Returns `None` if the path doesn't match the expected pattern.
+pub fn parse_server_cwd(cwd: &str) -> Option<(String, String)> {
+    let marker = "/.clickhouse/servers/";
+    let idx = cwd.find(marker)?;
+    let project_root = &cwd[..idx];
+    let rest = &cwd[idx + marker.len()..];
+
+    // rest should be "<name>/data" or "<name>/data/"
+    let name = rest
+        .strip_suffix("/data/")
+        .or_else(|| rest.strip_suffix("/data"))
+        .unwrap_or(rest);
+
+    if name.is_empty() || name.contains('/') {
+        return None;
+    }
+
+    Some((project_root.to_string(), name.to_string()))
+}
+
+/// Parse a port value from command-line flags like `--http_port=8123`.
+pub fn parse_port_flag(cmdline: &str, flag: &str) -> Option<u16> {
+    let prefix = format!("{}=", flag);
+    cmdline
+        .split_whitespace()
+        .find_map(|arg| arg.strip_prefix(&prefix).and_then(|v| v.parse::<u16>().ok()))
+}
+
+/// Extract the ClickHouse version from the binary path in the command line.
+///
+/// Binary paths look like: `~/.clickhouse/versions/<version>/clickhouse`
+pub fn parse_version_from_cmdline(cmdline: &str) -> Option<String> {
+    let marker = "/.clickhouse/versions/";
+    let idx = cmdline.find(marker)?;
+    let rest = &cmdline[idx + marker.len()..];
+    let version = rest.split('/').next()?;
+    if version.is_empty() {
+        return None;
+    }
+    Some(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_server_cwd tests ─────────────────────────────────────────
+
+    #[test]
+    fn parse_cwd_standard_path() {
+        let cwd = "/Users/al/project-a/.clickhouse/servers/default/data";
+        let (root, name) = parse_server_cwd(cwd).unwrap();
+        assert_eq!(root, "/Users/al/project-a");
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn parse_cwd_trailing_slash() {
+        let cwd = "/Users/al/project-a/.clickhouse/servers/default/data/";
+        let (root, name) = parse_server_cwd(cwd).unwrap();
+        assert_eq!(root, "/Users/al/project-a");
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn parse_cwd_custom_name() {
+        let cwd = "/home/user/myapp/.clickhouse/servers/bold-crane/data";
+        let (root, name) = parse_server_cwd(cwd).unwrap();
+        assert_eq!(root, "/home/user/myapp");
+        assert_eq!(name, "bold-crane");
+    }
+
+    #[test]
+    fn parse_cwd_deep_project_root() {
+        let cwd = "/Users/al/code/projects/web/.clickhouse/servers/test/data";
+        let (root, name) = parse_server_cwd(cwd).unwrap();
+        assert_eq!(root, "/Users/al/code/projects/web");
+        assert_eq!(name, "test");
+    }
+
+    #[test]
+    fn parse_cwd_not_cli_managed() {
+        // Process not started by the CLI — no matching pattern
+        assert!(parse_server_cwd("/var/lib/clickhouse").is_none());
+    }
+
+    #[test]
+    fn parse_cwd_missing_data_suffix() {
+        // cwd is the server dir but not the data subdir — ambiguous, still works
+        // because we strip /data suffix only if present
+        let cwd = "/Users/al/project/.clickhouse/servers/default";
+        // This doesn't end in /data, so "default" is treated as the rest
+        // Since "default" doesn't contain '/' and isn't empty, it's accepted
+        let (root, name) = parse_server_cwd(cwd).unwrap();
+        assert_eq!(root, "/Users/al/project");
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn parse_cwd_empty_name() {
+        let cwd = "/Users/al/project/.clickhouse/servers/";
+        assert!(parse_server_cwd(cwd).is_none());
+    }
+
+    // ── parse_port_flag tests ──────────────────────────────────────────
+
+    #[test]
+    fn parse_http_port() {
+        let cmdline =
+            "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8123 --tcp_port=9000";
+        assert_eq!(parse_port_flag(cmdline, "--http_port"), Some(8123));
+    }
+
+    #[test]
+    fn parse_tcp_port() {
+        let cmdline =
+            "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8124 --tcp_port=9001";
+        assert_eq!(parse_port_flag(cmdline, "--tcp_port"), Some(9001));
+    }
+
+    #[test]
+    fn parse_port_custom() {
+        let cmdline = "clickhouse server --http_port=18123 --tcp_port=19000";
+        assert_eq!(parse_port_flag(cmdline, "--http_port"), Some(18123));
+        assert_eq!(parse_port_flag(cmdline, "--tcp_port"), Some(19000));
+    }
+
+    #[test]
+    fn parse_port_missing() {
+        let cmdline = "clickhouse server";
+        assert_eq!(parse_port_flag(cmdline, "--http_port"), None);
+    }
+
+    #[test]
+    fn parse_port_invalid_value() {
+        let cmdline = "clickhouse server --http_port=abc";
+        assert_eq!(parse_port_flag(cmdline, "--http_port"), None);
+    }
+
+    // ── parse_version_from_cmdline tests ───────────────────────────────
+
+    #[test]
+    fn parse_version_standard() {
+        let cmdline =
+            "/Users/al/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8123";
+        assert_eq!(
+            parse_version_from_cmdline(cmdline),
+            Some("25.12.5.44".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_version_linux_path() {
+        let cmdline = "/home/user/.clickhouse/versions/24.8.1.1/clickhouse server";
+        assert_eq!(
+            parse_version_from_cmdline(cmdline),
+            Some("24.8.1.1".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_version_not_managed() {
+        let cmdline = "/usr/bin/clickhouse server";
+        assert_eq!(parse_version_from_cmdline(cmdline), None);
+    }
+
+    #[test]
+    fn parse_version_empty_version() {
+        let cmdline = "/home/user/.clickhouse/versions//clickhouse server";
+        assert_eq!(parse_version_from_cmdline(cmdline), None);
+    }
+}

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod discovery;
 pub mod output;
 pub mod server;
 
@@ -378,90 +379,36 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             foreground,
             args,
         } => start_server(name, version, http_port, tcp_port, foreground, args, json).await,
-        ServerCommands::List => {
-            let entries = server::list_all_servers();
-            let running_count = entries.iter().filter(|e| e.running).count();
-            let total = entries.len();
-
-            let out = output::ServerListOutput {
-                servers: entries
-                    .into_iter()
-                    .map(|e| {
-                        let (pid, version, http_port, tcp_port) = match e.info {
-                            Some(info) => (
-                                Some(info.pid),
-                                Some(info.version),
-                                Some(info.http_port),
-                                Some(info.tcp_port),
-                            ),
-                            None => (None, None, None, None),
-                        };
-                        output::ServerListEntry {
-                            name: e.name,
-                            running: e.running,
-                            pid,
-                            version,
-                            http_port,
-                            tcp_port,
-                        }
-                    })
-                    .collect(),
-                total_servers: total,
-                total_running_servers: running_count,
-            };
-            output::print_output(&out, json);
-            Ok(())
-        }
-        ServerCommands::Stop { name } => {
-            if !json {
-                println!("Stopping server '{}'...", name);
-            }
-            server::kill_server(&name)?;
-            let out = output::ServerStopOutput { name };
-            output::print_output(&out, json);
-            Ok(())
-        }
-        ServerCommands::StopAll => {
-            let servers = server::list_running_servers();
-            let mut stop_entries = Vec::new();
-            for s in &servers {
-                if !json {
-                    print!("Stopping '{}'...", s.name);
-                }
-                match server::kill_server(&s.name) {
-                    Ok(()) => {
-                        if !json {
-                            println!(" stopped");
-                        }
-                        stop_entries.push(output::ServerStopEntry {
-                            name: s.name.clone(),
-                            stopped: true,
-                            error: None,
-                        });
-                    }
-                    Err(e) => {
-                        if !json {
-                            println!(" error: {}", e);
-                        }
-                        stop_entries.push(output::ServerStopEntry {
-                            name: s.name.clone(),
-                            stopped: false,
-                            error: Some(e.to_string()),
-                        });
-                    }
-                }
-            }
-            if json {
-                let out = output::ServerStopAllOutput {
-                    servers: stop_entries,
-                };
-                output::print_output(&out, json);
-            } else if servers.is_empty() {
-                println!("No running servers");
+        ServerCommands::List { global } => {
+            if global {
+                list_servers_global(json)
             } else {
-                println!("Done");
+                list_servers_local(json)
             }
-            Ok(())
+        }
+        ServerCommands::Stop {
+            name,
+            global,
+            project,
+        } => {
+            if global {
+                stop_server_global(&name, project.as_deref(), json)
+            } else {
+                if !json {
+                    println!("Stopping server '{}'...", name);
+                }
+                server::kill_server(&name)?;
+                let out = output::ServerStopOutput { name };
+                output::print_output(&out, json);
+                Ok(())
+            }
+        }
+        ServerCommands::StopAll { global } => {
+            if global {
+                stop_all_servers_global(json)
+            } else {
+                stop_all_servers_local(json)
+            }
         }
         ServerCommands::Remove { name } => {
             if server::is_server_running(&name) {
@@ -480,6 +427,188 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             Ok(())
         }
     }
+}
+
+fn list_servers_local(json: bool) -> Result<()> {
+    let entries = server::list_all_servers();
+    let running_count = entries.iter().filter(|e| e.running).count();
+    let total = entries.len();
+
+    let out = output::ServerListOutput {
+        servers: entries
+            .into_iter()
+            .map(|e| {
+                let (pid, version, http_port, tcp_port) = match e.info {
+                    Some(info) => (
+                        Some(info.pid),
+                        Some(info.version),
+                        Some(info.http_port),
+                        Some(info.tcp_port),
+                    ),
+                    None => (None, None, None, None),
+                };
+                output::ServerListEntry {
+                    name: e.name,
+                    running: e.running,
+                    pid,
+                    version,
+                    http_port,
+                    tcp_port,
+                    project: None,
+                }
+            })
+            .collect(),
+        total_servers: total,
+        total_running_servers: running_count,
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+fn list_servers_global(json: bool) -> Result<()> {
+    let entries = server::list_all_servers_global();
+    let total = entries.len();
+
+    let out = output::ServerListOutput {
+        servers: entries
+            .into_iter()
+            .map(|e| output::ServerListEntry {
+                name: e.name,
+                running: true,
+                pid: Some(e.pid),
+                version: e.version,
+                http_port: e.http_port,
+                tcp_port: e.tcp_port,
+                project: Some(e.project),
+            })
+            .collect(),
+        total_servers: total,
+        total_running_servers: total,
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<()> {
+    let all = server::list_all_servers_global();
+    let mut matches: Vec<_> = all.iter().filter(|e| e.name == name).collect();
+
+    if let Some(proj) = project {
+        matches.retain(|e| e.project == proj);
+    }
+
+    if matches.is_empty() {
+        return Err(Error::ServerNotFound(name.to_string()));
+    }
+
+    if matches.len() > 1 {
+        let projects: Vec<_> = matches.iter().map(|e| e.project.as_str()).collect();
+        return Err(Error::Exec(format!(
+            "Server '{}' exists in multiple projects: {}. Use --project to specify which one.",
+            name,
+            projects.join(", ")
+        )));
+    }
+
+    let entry = matches[0];
+    if !json {
+        println!(
+            "Stopping server '{}' in {}...",
+            entry.name, entry.project
+        );
+    }
+    server::kill_server_by_pid(entry.pid)?;
+    let out = output::ServerStopOutput {
+        name: name.to_string(),
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+fn stop_all_servers_local(json: bool) -> Result<()> {
+    let servers = server::list_running_servers();
+    let mut stop_entries = Vec::new();
+    for s in &servers {
+        if !json {
+            print!("Stopping '{}'...", s.name);
+        }
+        match server::kill_server(&s.name) {
+            Ok(()) => {
+                if !json {
+                    println!(" stopped");
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: true,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                if !json {
+                    println!(" error: {}", e);
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: false,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+    if json {
+        let out = output::ServerStopAllOutput {
+            servers: stop_entries,
+        };
+        output::print_output(&out, json);
+    } else if servers.is_empty() {
+        println!("No running servers");
+    } else {
+        println!("Done");
+    }
+    Ok(())
+}
+
+fn stop_all_servers_global(json: bool) -> Result<()> {
+    let servers = server::list_all_servers_global();
+    let mut stop_entries = Vec::new();
+    for s in &servers {
+        if !json {
+            print!("Stopping '{}' ({})...", s.name, s.project);
+        }
+        match server::kill_server_by_pid(s.pid) {
+            Ok(()) => {
+                if !json {
+                    println!(" stopped");
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: true,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                if !json {
+                    println!(" error: {}", e);
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: false,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+    if json {
+        let out = output::ServerStopAllOutput {
+            servers: stop_entries,
+        };
+        output::print_output(&out, json);
+    } else if servers.is_empty() {
+        println!("No running servers");
+    } else {
+        println!("Done");
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -246,6 +246,10 @@ async fn start_server(
         return Err(Error::JsonForegroundConflict);
     }
 
+    // Recover any orphaned servers so name resolution and collision checks
+    // see processes that lost their metadata files.
+    server::recover_current_project_servers();
+
     // Resolve server name and check for collisions before any downloads
     let server_name = server::resolve_name(name.as_deref());
 
@@ -394,6 +398,10 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             if global {
                 stop_server_global(&name, project.as_deref(), json)
             } else {
+                // Recover orphaned servers so we can stop processes
+                // that lost their metadata files.
+                server::recover_current_project_servers();
+
                 if !json {
                     println!("Stopping server '{}'...", name);
                 }
@@ -411,6 +419,10 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             }
         }
         ServerCommands::Remove { name } => {
+            // Recover orphaned servers so we correctly detect a running
+            // process even when its metadata file is missing.
+            server::recover_current_project_servers();
+
             if server::is_server_running(&name) {
                 return Err(Error::ServerAlreadyRunning(name));
             }

--- a/src/local/output.rs
+++ b/src/local/output.rs
@@ -211,6 +211,8 @@ pub struct ServerListEntry {
     pub http_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tcp_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -236,30 +238,74 @@ struct ServerListRow {
     tcp_port: String,
 }
 
+#[derive(Tabled)]
+struct ServerListRowGlobal {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Status")]
+    status: String,
+    #[tabled(rename = "PID")]
+    pid: String,
+    #[tabled(rename = "Version")]
+    version: String,
+    #[tabled(rename = "HTTP Port")]
+    http_port: String,
+    #[tabled(rename = "TCP Port")]
+    tcp_port: String,
+    #[tabled(rename = "Project")]
+    project: String,
+}
+
 impl fmt::Display for ServerListOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.servers.is_empty() {
             write!(f, "No servers")?;
             return Ok(());
         }
-        let rows: Vec<ServerListRow> = self
-            .servers
-            .iter()
-            .map(|e| ServerListRow {
-                name: e.name.clone(),
-                status: if e.running {
-                    "running".to_string()
-                } else {
-                    "stopped".to_string()
-                },
-                pid: e.pid.map(|p| p.to_string()).unwrap_or_default(),
-                version: e.version.clone().unwrap_or_default(),
-                http_port: e.http_port.map(|p| p.to_string()).unwrap_or_default(),
-                tcp_port: e.tcp_port.map(|p| p.to_string()).unwrap_or_default(),
-            })
-            .collect();
-        let table = Table::new(rows).with(Style::rounded()).to_string();
-        writeln!(f, "{table}")?;
+
+        let has_project = self.servers.iter().any(|e| e.project.is_some());
+
+        if has_project {
+            let rows: Vec<ServerListRowGlobal> = self
+                .servers
+                .iter()
+                .map(|e| ServerListRowGlobal {
+                    name: e.name.clone(),
+                    status: if e.running {
+                        "running".to_string()
+                    } else {
+                        "stopped".to_string()
+                    },
+                    pid: e.pid.map(|p| p.to_string()).unwrap_or_default(),
+                    version: e.version.clone().unwrap_or_default(),
+                    http_port: e.http_port.map(|p| p.to_string()).unwrap_or_default(),
+                    tcp_port: e.tcp_port.map(|p| p.to_string()).unwrap_or_default(),
+                    project: e.project.clone().unwrap_or_default(),
+                })
+                .collect();
+            let table = Table::new(rows).with(Style::rounded()).to_string();
+            writeln!(f, "{table}")?;
+        } else {
+            let rows: Vec<ServerListRow> = self
+                .servers
+                .iter()
+                .map(|e| ServerListRow {
+                    name: e.name.clone(),
+                    status: if e.running {
+                        "running".to_string()
+                    } else {
+                        "stopped".to_string()
+                    },
+                    pid: e.pid.map(|p| p.to_string()).unwrap_or_default(),
+                    version: e.version.clone().unwrap_or_default(),
+                    http_port: e.http_port.map(|p| p.to_string()).unwrap_or_default(),
+                    tcp_port: e.tcp_port.map(|p| p.to_string()).unwrap_or_default(),
+                })
+                .collect();
+            let table = Table::new(rows).with(Style::rounded()).to_string();
+            writeln!(f, "{table}")?;
+        }
+
         write!(
             f,
             "\n{} server{}, {} running",
@@ -503,6 +549,7 @@ mod tests {
                     version: Some("25.12.5.44".to_string()),
                     http_port: Some(8123),
                     tcp_port: Some(9000),
+                    project: None,
                 },
                 ServerListEntry {
                     name: "test".to_string(),
@@ -511,6 +558,7 @@ mod tests {
                     version: None,
                     http_port: None,
                     tcp_port: None,
+                    project: None,
                 },
             ],
             total_servers: 2,
@@ -756,6 +804,7 @@ mod tests {
                     version: Some("25.12.5.44".to_string()),
                     http_port: Some(8123),
                     tcp_port: Some(9000),
+                    project: None,
                 },
                 ServerListEntry {
                     name: "test".to_string(),
@@ -764,6 +813,7 @@ mod tests {
                     version: None,
                     http_port: None,
                     tcp_port: None,
+                    project: None,
                 },
             ],
             total_servers: 2,
@@ -806,6 +856,7 @@ mod tests {
                 version: Some("25.12.5.44".to_string()),
                 http_port: Some(8123),
                 tcp_port: Some(9000),
+                project: None,
             }],
             total_servers: 1,
             total_running_servers: 1,

--- a/src/local/server.rs
+++ b/src/local/server.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::init;
+use crate::local::discovery;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -97,7 +98,11 @@ fn load_running_info(name: &str) -> Option<ServerInfo> {
 
 /// List all known servers (both running and stopped).
 /// Discovers servers by scanning data directories in .clickhouse/servers/.
+/// Also runs process discovery to recover any orphaned servers for the current project.
 pub fn list_all_servers() -> Vec<ServerEntry> {
+    // Recover any orphaned servers before listing
+    recover_current_project_servers();
+
     let dir = servers_dir();
     let mut entries = Vec::new();
 
@@ -297,4 +302,97 @@ pub fn now_timestamp() -> String {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default();
     format!("{}", duration.as_secs())
+}
+
+/// Recover orphaned servers for the current project via process discovery.
+///
+/// Scans for running ClickHouse processes whose cwd matches this project's
+/// `.clickhouse/servers/<name>/data/` path. If a process is found that has no
+/// metadata file, a new `ServerInfo` is saved so it appears in `server list`
+/// and can be managed normally.
+pub fn recover_current_project_servers() {
+    let current_dir = match std::env::current_dir().and_then(|p| p.canonicalize()) {
+        Ok(p) => p.display().to_string(),
+        Err(_) => return,
+    };
+
+    let processes = discovery::discover_clickhouse_processes();
+    for proc in processes {
+        // Canonicalize the discovered project root for comparison
+        let discovered_root = match std::path::Path::new(&proc.project_root).canonicalize() {
+            Ok(p) => p.display().to_string(),
+            Err(_) => proc.project_root.clone(),
+        };
+
+        if discovered_root != current_dir {
+            continue;
+        }
+
+        // Only recover if we don't already have metadata for this server
+        if load_running_info(&proc.server_name).is_some() {
+            continue;
+        }
+
+        let info = ServerInfo {
+            name: proc.server_name,
+            pid: proc.pid,
+            version: proc.version.unwrap_or_else(|| "unknown".to_string()),
+            http_port: proc.http_port.unwrap_or(0),
+            tcp_port: proc.tcp_port.unwrap_or(0),
+            started_at: "recovered".to_string(),
+            cwd: current_dir.clone(),
+        };
+        let _ = save_server_info(&info);
+    }
+}
+
+/// A server entry for global listing — always running (discovered via process inspection).
+pub struct GlobalServerEntry {
+    pub name: String,
+    pub pid: u32,
+    pub project: String,
+    pub http_port: Option<u16>,
+    pub tcp_port: Option<u16>,
+    pub version: Option<String>,
+}
+
+/// List all running ClickHouse servers across all projects via process discovery.
+pub fn list_all_servers_global() -> Vec<GlobalServerEntry> {
+    let processes = discovery::discover_clickhouse_processes();
+    processes
+        .into_iter()
+        .map(|p| GlobalServerEntry {
+            name: p.server_name,
+            pid: p.pid,
+            project: p.project_root,
+            http_port: p.http_port,
+            tcp_port: p.tcp_port,
+            version: p.version,
+        })
+        .collect()
+}
+
+/// Kill a server found via global process discovery.
+/// Takes a PID directly and kills it, without requiring local metadata.
+pub fn kill_server_by_pid(pid: u32) -> Result<()> {
+    if !is_process_alive(pid) {
+        return Err(Error::ServerNotRunning(format!("PID {}", pid)));
+    }
+
+    unsafe {
+        libc::kill(pid as i32, libc::SIGTERM);
+    }
+
+    std::thread::sleep(std::time::Duration::from_millis(500));
+
+    if is_process_alive(pid) {
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        if is_process_alive(pid) {
+            unsafe {
+                libc::kill(pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+
+    Ok(())
 }

--- a/src/local/server.rs
+++ b/src/local/server.rs
@@ -164,25 +164,52 @@ fn is_process_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as i32, 0) == 0 }
 }
 
-/// Kill a server by name.
-pub fn kill_server(name: &str) -> Result<()> {
-    let info = load_running_info(name).ok_or_else(|| Error::ServerNotRunning(name.to_string()))?;
-
-    unsafe {
-        libc::kill(info.pid as i32, libc::SIGTERM);
+/// Send a signal to a process and return an error if the signal could not be delivered
+/// (e.g. EPERM from a process owned by another user).
+fn send_signal(pid: u32, signal: i32) -> Result<()> {
+    let ret = unsafe { libc::kill(pid as i32, signal) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        Err(Error::Exec(format!(
+            "Failed to send signal to PID {}: {}",
+            pid, err
+        )))
+    } else {
+        Ok(())
     }
+}
+
+/// Attempt to terminate a process: SIGTERM, wait, SIGKILL if needed, then verify exit.
+fn kill_process(pid: u32) -> Result<()> {
+    send_signal(pid, libc::SIGTERM)?;
 
     // Wait briefly for graceful shutdown
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    if is_process_alive(info.pid) {
+    if is_process_alive(pid) {
         std::thread::sleep(std::time::Duration::from_secs(2));
-        if is_process_alive(info.pid) {
-            unsafe {
-                libc::kill(info.pid as i32, libc::SIGKILL);
-            }
+        if is_process_alive(pid) {
+            send_signal(pid, libc::SIGKILL)?;
+            // Give the kernel a moment to reap the process
+            std::thread::sleep(std::time::Duration::from_millis(100));
         }
     }
+
+    if is_process_alive(pid) {
+        return Err(Error::Exec(format!(
+            "Process {} did not exit after SIGKILL",
+            pid
+        )));
+    }
+
+    Ok(())
+}
+
+/// Kill a server by name.
+pub fn kill_server(name: &str) -> Result<()> {
+    let info = load_running_info(name).ok_or_else(|| Error::ServerNotRunning(name.to_string()))?;
+
+    kill_process(info.pid)?;
 
     remove_server_info(name);
     Ok(())
@@ -379,20 +406,5 @@ pub fn kill_server_by_pid(pid: u32) -> Result<()> {
         return Err(Error::ServerNotRunning(format!("PID {}", pid)));
     }
 
-    unsafe {
-        libc::kill(pid as i32, libc::SIGTERM);
-    }
-
-    std::thread::sleep(std::time::Duration::from_millis(500));
-
-    if is_process_alive(pid) {
-        std::thread::sleep(std::time::Duration::from_secs(2));
-        if is_process_alive(pid) {
-            unsafe {
-                libc::kill(pid as i32, libc::SIGKILL);
-            }
-        }
-    }
-
-    Ok(())
+    kill_process(pid)
 }


### PR DESCRIPTION
## Summary

Closes #102 https://github.com/ClickHouse/clickhousectl/issues/89 

- **Process discovery module** (`src/local/discovery.rs`): Finds running ClickHouse processes via `pgrep`, resolves their cwd (macOS: `lsof`, Linux: `/proc/<pid>/cwd`), and parses command-line args to extract ports and version. Only processes whose cwd matches `.clickhouse/servers/<name>/data/` are recognized as CLI-managed.
- **Orphaned server recovery**: `server list`, `server start`, and other server commands automatically run process discovery on the current project. If a running ClickHouse process has no metadata file, a `ServerInfo` is recovered and saved so it appears in listings and can be managed normally.
- **`--global` flag on `server list`**: Shows all running ClickHouse servers across all projects with a Project column indicating which directory each belongs to.
- **`--global` flag on `server stop`**: Stops a server from any project by name. If the name is ambiguous across projects, `--project` can disambiguate.
- **`--global` flag on `server stop-all`**: Stops every CLI-managed ClickHouse process system-wide.

## Test plan

- [x] All 267 existing tests pass
- [x] `cargo clippy` clean
- [x] 16 new unit tests for parsing logic (`parse_server_cwd`, `parse_port_flag`, `parse_version_from_cmdline`)
- [ ] Manual: start a server, delete its `.json` metadata file, run `server list` → server should be recovered
- [ ] Manual: start servers in two different project directories, run `server list --global` from either → both shown
- [ ] Manual: `server stop-all --global` kills all servers across projects
- [ ] Manual: `server stop <name> --global --project /path` targets the correct server when names collide

🤖 Generated with [Claude Code](https://claude.com/claude-code)