### PR TITLE
Add self-update command and background update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,20 @@ Supports global or project scope installation. Project scope installs Skills int
 - `--all` install Skills for all supported agents
 - `--detected-only` install Skills for supported agents that were detected on the system
 
+## Self-update
+
+`clickhousectl` can update itself to the latest release:
+
+```bash
+# Update to the latest version
+clickhousectl update
+
+# Check for updates without installing
+clickhousectl update --check
+```
+
+The CLI also checks for updates in the background (at most once per 24 hours) and displays a notice when a newer version is available.
+
 ## Cloud integration testing
 
 Cloud commands are tested against a real ClickHouse Cloud workspace. All changes to Cloud commands must pass CI testing before merge. CI tests are under [`tests/cloud_cli.rs`](tests/cloud_cli.rs).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,6 +62,13 @@ CONTEXT FOR AGENTS:
   Using any flags skips interactive mode. Project scope is the default. Universal `.agents/skills`
   is always included.")]
     Skills(SkillsArgs),
+
+    /// Update clickhousectl to the latest version
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Self-update command. Downloads the latest clickhousectl release from GitHub and replaces the
+  current binary. Use --check to see if an update is available without installing.")]
+    Update(UpdateArgs),
 }
 
 #[derive(Args, Debug)]
@@ -86,6 +93,13 @@ pub struct SkillsArgs {
     /// Install into global agent config directories in your home directory
     #[arg(long)]
     pub global: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct UpdateArgs {
+    /// Check for updates without installing
+    #[arg(long)]
+    pub check: bool,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod init;
 mod local;
 mod paths;
 mod skills;
+mod update;
 mod user_agent;
 mod version_manager;
 
@@ -12,7 +13,7 @@ use clap::Parser;
 use cli::{
     ActivityCommands, AuthCommands, BackupCommands, BackupConfigCommands, Cli, CloudArgs,
     CloudCommands, Commands, InvitationCommands, KeyCommands, MemberCommands, OrgCommands,
-    PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands, SkillsArgs,
+    PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands, SkillsArgs, UpdateArgs,
 };
 
 use cloud::CloudClient;
@@ -22,7 +23,20 @@ use error::{Error, Result};
 async fn main() {
     let cli = Cli::parse();
 
+    // Run background update check for commands other than `update` itself
+    let is_update_cmd = matches!(cli.command, Commands::Update(_));
+    let update_check = if !is_update_cmd {
+        Some(tokio::spawn(update::maybe_notify_update()))
+    } else {
+        None
+    };
+
     let result = run(cli.command).await;
+
+    // Wait for the update check to finish so the notice can print
+    if let Some(handle) = update_check {
+        let _ = handle.await;
+    }
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);
@@ -35,6 +49,27 @@ async fn run(cmd: Commands) -> Result<()> {
         Commands::Local(args) => local::run(args.command, args.json).await,
         Commands::Skills(args) => run_skills(args).await,
         Commands::Cloud(args) => run_cloud(*args).await,
+        Commands::Update(args) => run_update(args).await,
+    }
+}
+
+async fn run_update(args: UpdateArgs) -> Result<()> {
+    if args.check {
+        match update::check_for_update().await? {
+            Some((current, latest)) => {
+                println!(
+                    "Update available: v{} → v{}",
+                    current, latest
+                );
+                println!("Run `clickhousectl update` to upgrade.");
+            }
+            None => {
+                println!("Already up to date (v{}).", env!("CARGO_PKG_VERSION"));
+            }
+        }
+        Ok(())
+    } else {
+        update::perform_update().await
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,10 @@ async fn main() {
     let result = run(cli.command).await;
 
     // Give the cache refresh a brief window to finish so short-lived commands
-    // (e.g. `local which`) don't always drop it before the write completes.
-    // This is bounded — it will never block more than 5 seconds.
+    // don't always drop it before the write completes. The background HTTP
+    // request itself has a 400ms timeout, so 500ms here is enough headroom.
     if let Some(handle) = cache_refresh {
-        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(500), handle).await;
     }
 
     if let Err(e) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,14 +24,23 @@ async fn main() {
     let cli = Cli::parse();
 
     // For non-update commands: print a cached update notice (sync, no network)
-    // and spawn a fire-and-forget task to refresh the cache in the background.
+    // and spawn a background task to refresh the cache.
     let is_update_cmd = matches!(cli.command, Commands::Update(_));
-    if !is_update_cmd {
+    let cache_refresh = if !is_update_cmd {
         update::print_cached_update_notice();
-        tokio::spawn(update::refresh_update_cache());
-    }
+        Some(tokio::spawn(update::refresh_update_cache()))
+    } else {
+        None
+    };
 
     let result = run(cli.command).await;
+
+    // Give the cache refresh a brief window to finish so short-lived commands
+    // (e.g. `local which`) don't always drop it before the write completes.
+    // This is bounded — it will never block more than 5 seconds.
+    if let Some(handle) = cache_refresh {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+    }
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,20 +23,15 @@ use error::{Error, Result};
 async fn main() {
     let cli = Cli::parse();
 
-    // Run background update check for commands other than `update` itself
+    // For non-update commands: print a cached update notice (sync, no network)
+    // and spawn a fire-and-forget task to refresh the cache in the background.
     let is_update_cmd = matches!(cli.command, Commands::Update(_));
-    let update_check = if !is_update_cmd {
-        Some(tokio::spawn(update::maybe_notify_update()))
-    } else {
-        None
-    };
+    if !is_update_cmd {
+        update::print_cached_update_notice();
+        tokio::spawn(update::refresh_update_cache());
+    }
 
     let result = run(cli.command).await;
-
-    // Wait for the update check to finish so the notice can print
-    if let Some(handle) = update_check {
-        let _ = handle.await;
-    }
 
     if let Err(e) = result {
         eprintln!("Error: {}", e);

--- a/src/update.rs
+++ b/src/update.rs
@@ -64,6 +64,7 @@ async fn fetch_latest_release() -> Result<GitHubRelease> {
     let url = format!("https://api.github.com/repos/{}/releases/latest", GITHUB_REPO);
     let client = reqwest::Client::builder()
         .user_agent(crate::user_agent::user_agent())
+        .timeout(std::time::Duration::from_secs(10))
         .build()?;
 
     let response = client
@@ -212,44 +213,46 @@ fn read_update_check() -> Option<(u64, String)> {
     Some((ts, version))
 }
 
-/// Check if we should perform a background update check (respecting the 24h cache).
-/// Prints a notice to stderr if an update is available. Returns quietly on any error.
-pub async fn maybe_notify_update() {
-    // Check cache first
-    if let Some((ts, cached_version)) = read_update_check()
-        && now_secs() - ts < CHECK_INTERVAL_SECS
-    {
-        // Cache is fresh — use cached result
+/// Print an update notice from cached data only. No network, no async.
+/// Called synchronously before the command runs so output never interleaves.
+pub fn print_cached_update_notice() {
+    if let Some((_, cached_version)) = read_update_check() {
         let current = env!("CARGO_PKG_VERSION");
         if is_newer(current, &cached_version) {
-            print_update_notice(current, &cached_version);
-        }
-        return;
-    }
-
-    // Cache is stale or missing — check GitHub
-    let result = check_for_update().await;
-    match result {
-        Ok(Some((current, latest))) => {
-            let _ = save_update_check(&latest);
-            print_update_notice(&current, &latest);
-        }
-        Ok(None) => {
-            let current = env!("CARGO_PKG_VERSION");
-            let _ = save_update_check(current);
-        }
-        Err(_) => {
-            // Silently ignore errors — don't disrupt normal usage
+            eprintln!(
+                "\nA new version of clickhousectl is available: v{} (current: v{})",
+                cached_version, current
+            );
+            eprintln!("Run `clickhousectl update` to upgrade.\n");
         }
     }
 }
 
-fn print_update_notice(current: &str, latest: &str) {
-    eprintln!(
-        "\nA new version of clickhousectl is available: v{} (current: v{})",
-        latest, current
-    );
-    eprintln!("Run `clickhousectl update` to upgrade.\n");
+/// Refresh the update cache in the background if stale. Fire-and-forget —
+/// never prints, silently ignores errors. The *next* invocation will see
+/// the refreshed cache and print the notice synchronously.
+pub async fn refresh_update_cache() {
+    // Only hit the network if cache is stale or missing
+    let needs_refresh = match read_update_check() {
+        Some((ts, _)) => now_secs().saturating_sub(ts) >= CHECK_INTERVAL_SECS,
+        None => true,
+    };
+    if !needs_refresh {
+        return;
+    }
+
+    let Ok(result) = check_for_update().await else {
+        return;
+    };
+    match result {
+        Some((_current, latest)) => {
+            let _ = save_update_check(&latest);
+        }
+        None => {
+            let current = env!("CARGO_PKG_VERSION");
+            let _ = save_update_check(current);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,284 @@
+use crate::error::{Error, Result};
+use crate::paths;
+use serde::Deserialize;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const GITHUB_REPO: &str = "ClickHouse/clickhousectl";
+const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60; // 24 hours
+
+#[derive(Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    assets: Vec<GitHubAsset>,
+}
+
+#[derive(Deserialize)]
+struct GitHubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+/// The asset name suffix for this platform's binary in GitHub Releases.
+fn asset_name() -> Result<&'static str> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    match (os, arch) {
+        ("macos", "x86_64") => Ok("clickhousectl-x86_64-apple-darwin"),
+        ("macos", "aarch64") => Ok("clickhousectl-aarch64-apple-darwin"),
+        ("linux", "x86_64") => Ok("clickhousectl-x86_64-unknown-linux-musl"),
+        ("linux", "aarch64") => Ok("clickhousectl-aarch64-unknown-linux-musl"),
+        _ => Err(Error::UnsupportedPlatform {
+            os: os.to_string(),
+            arch: arch.to_string(),
+        }),
+    }
+}
+
+/// Parse a version tag like "v0.1.17" into a comparable tuple.
+fn parse_version(tag: &str) -> Option<(u32, u32, u32)> {
+    let v = tag.strip_prefix('v').unwrap_or(tag);
+    let parts: Vec<&str> = v.split('.').collect();
+    if parts.len() == 3 {
+        Some((
+            parts[0].parse().ok()?,
+            parts[1].parse().ok()?,
+            parts[2].parse().ok()?,
+        ))
+    } else {
+        None
+    }
+}
+
+/// Returns true if `latest` is newer than `current`.
+fn is_newer(current: &str, latest: &str) -> bool {
+    match (parse_version(current), parse_version(latest)) {
+        (Some(c), Some(l)) => l > c,
+        _ => false,
+    }
+}
+
+/// Fetch the latest release info from GitHub.
+async fn fetch_latest_release() -> Result<GitHubRelease> {
+    let url = format!("https://api.github.com/repos/{}/releases/latest", GITHUB_REPO);
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
+
+    let release: GitHubRelease = response.json().await?;
+    Ok(release)
+}
+
+/// Check for updates. Returns Some((current, latest)) if an update is available.
+pub async fn check_for_update() -> Result<Option<(String, String)>> {
+    let current = env!("CARGO_PKG_VERSION");
+    let release = fetch_latest_release().await?;
+    let latest = &release.tag_name;
+
+    if is_newer(current, latest) {
+        let display = latest.strip_prefix('v').unwrap_or(latest);
+        Ok(Some((current.to_string(), display.to_string())))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Download the latest release and replace the current binary.
+pub async fn perform_update() -> Result<()> {
+    let current = env!("CARGO_PKG_VERSION");
+    let release = fetch_latest_release().await?;
+    let latest = &release.tag_name;
+
+    if !is_newer(current, latest) {
+        let display = latest.strip_prefix('v').unwrap_or(latest);
+        println!("Already up to date (v{}).", display);
+        return Ok(());
+    }
+
+    let expected_asset = asset_name()?;
+    let asset = release
+        .assets
+        .iter()
+        .find(|a| a.name == expected_asset)
+        .ok_or_else(|| {
+            Error::Download(format!(
+                "No compatible binary found for this platform (expected {})",
+                expected_asset
+            ))
+        })?;
+
+    let display = latest.strip_prefix('v').unwrap_or(latest);
+    println!("Downloading clickhousectl v{}...", display);
+
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()?;
+
+    let response = client
+        .get(&asset.browser_download_url)
+        .send()
+        .await?
+        .error_for_status()
+        .map_err(|e| Error::Download(format!("Download failed: {}", e)))?;
+
+    let bytes = response.bytes().await?;
+
+    // Get the path to the currently running binary
+    let current_exe = std::env::current_exe().map_err(|e| {
+        Error::Io(std::io::Error::new(
+            e.kind(),
+            format!("Could not determine current executable path: {}", e),
+        ))
+    })?;
+
+    // Resolve symlinks to get the actual binary path
+    let actual_path = fs::canonicalize(&current_exe).unwrap_or(current_exe);
+
+    // Write to a temporary file next to the binary, then atomic-rename
+    let tmp_path = actual_path.with_extension("tmp-update");
+    fs::write(&tmp_path, &bytes).map_err(|e| {
+        Error::Download(format!(
+            "Failed to write update to {}: {}. Check file permissions.",
+            tmp_path.display(),
+            e
+        ))
+    })?;
+
+    // Make it executable on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755)).map_err(|e| {
+            let _ = fs::remove_file(&tmp_path);
+            Error::Download(format!("Failed to set executable permissions: {}", e))
+        })?;
+    }
+
+    // Atomic rename
+    fs::rename(&tmp_path, &actual_path).map_err(|e| {
+        let _ = fs::remove_file(&tmp_path);
+        Error::Download(format!(
+            "Failed to replace binary at {}: {}. Check file permissions.",
+            actual_path.display(),
+            e
+        ))
+    })?;
+
+    println!("Updated clickhousectl: v{} → v{}", current, display);
+    // Save the check cache so we don't nag right after updating
+    let _ = save_update_check(display);
+    Ok(())
+}
+
+// --- Background update check with caching ---
+
+fn update_check_path() -> Result<PathBuf> {
+    Ok(paths::base_dir()?.join("last_update_check"))
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Save the update check result (timestamp + latest version).
+fn save_update_check(latest_version: &str) -> Result<()> {
+    let path = update_check_path()?;
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let content = format!("{}\n{}", now_secs(), latest_version);
+    fs::write(&path, content)?;
+    Ok(())
+}
+
+/// Read the cached update check. Returns Some((timestamp, latest_version)) if valid.
+fn read_update_check() -> Option<(u64, String)> {
+    let path = update_check_path().ok()?;
+    let content = fs::read_to_string(path).ok()?;
+    let mut lines = content.lines();
+    let ts: u64 = lines.next()?.parse().ok()?;
+    let version = lines.next()?.to_string();
+    Some((ts, version))
+}
+
+/// Check if we should perform a background update check (respecting the 24h cache).
+/// Prints a notice to stderr if an update is available. Returns quietly on any error.
+pub async fn maybe_notify_update() {
+    // Check cache first
+    if let Some((ts, cached_version)) = read_update_check()
+        && now_secs() - ts < CHECK_INTERVAL_SECS
+    {
+        // Cache is fresh — use cached result
+        let current = env!("CARGO_PKG_VERSION");
+        if is_newer(current, &cached_version) {
+            print_update_notice(current, &cached_version);
+        }
+        return;
+    }
+
+    // Cache is stale or missing — check GitHub
+    let result = check_for_update().await;
+    match result {
+        Ok(Some((current, latest))) => {
+            let _ = save_update_check(&latest);
+            print_update_notice(&current, &latest);
+        }
+        Ok(None) => {
+            let current = env!("CARGO_PKG_VERSION");
+            let _ = save_update_check(current);
+        }
+        Err(_) => {
+            // Silently ignore errors — don't disrupt normal usage
+        }
+    }
+}
+
+fn print_update_notice(current: &str, latest: &str) {
+    eprintln!(
+        "\nA new version of clickhousectl is available: v{} (current: v{})",
+        latest, current
+    );
+    eprintln!("Run `clickhousectl update` to upgrade.\n");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_version() {
+        assert_eq!(parse_version("v0.1.17"), Some((0, 1, 17)));
+        assert_eq!(parse_version("0.1.17"), Some((0, 1, 17)));
+        assert_eq!(parse_version("v1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_version("v1.2"), None);
+        assert_eq!(parse_version("garbage"), None);
+    }
+
+    #[test]
+    fn test_is_newer() {
+        assert!(is_newer("0.1.17", "v0.2.0"));
+        assert!(is_newer("0.1.17", "0.1.18"));
+        assert!(is_newer("0.1.17", "1.0.0"));
+        assert!(!is_newer("0.1.17", "0.1.17"));
+        assert!(!is_newer("0.1.17", "0.1.16"));
+        assert!(!is_newer("0.2.0", "0.1.99"));
+    }
+
+    #[test]
+    fn test_asset_name() {
+        // Should return something valid on macOS/Linux test hosts
+        let name = asset_name().unwrap();
+        assert!(name.starts_with("clickhousectl-"));
+    }
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -121,6 +121,7 @@ pub async fn perform_update() -> Result<()> {
 
     let client = reqwest::Client::builder()
         .user_agent(crate::user_agent::user_agent())
+        .timeout(std::time::Duration::from_secs(300))
         .build()?;
 
     let response = client

--- a/src/update.rs
+++ b/src/update.rs
@@ -59,12 +59,12 @@ fn is_newer(current: &str, latest: &str) -> bool {
     }
 }
 
-/// Fetch the latest release info from GitHub.
-async fn fetch_latest_release() -> Result<GitHubRelease> {
+/// Fetch the latest release info from GitHub with configurable timeout.
+async fn fetch_latest_release(timeout: std::time::Duration) -> Result<GitHubRelease> {
     let url = format!("https://api.github.com/repos/{}/releases/latest", GITHUB_REPO);
     let client = reqwest::Client::builder()
         .user_agent(crate::user_agent::user_agent())
-        .timeout(std::time::Duration::from_secs(10))
+        .timeout(timeout)
         .build()?;
 
     let response = client
@@ -78,10 +78,16 @@ async fn fetch_latest_release() -> Result<GitHubRelease> {
     Ok(release)
 }
 
+/// Timeout for explicit user-initiated commands (update, update --check).
+const EXPLICIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+/// Timeout for the implicit background cache refresh.
+const BACKGROUND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(400);
+
 /// Check for updates. Returns Some((current, latest)) if an update is available.
+/// Uses the explicit (longer) timeout since this is called from user-initiated commands.
 pub async fn check_for_update() -> Result<Option<(String, String)>> {
     let current = env!("CARGO_PKG_VERSION");
-    let release = fetch_latest_release().await?;
+    let release = fetch_latest_release(EXPLICIT_TIMEOUT).await?;
     let latest = &release.tag_name;
 
     if is_newer(current, latest) {
@@ -95,7 +101,7 @@ pub async fn check_for_update() -> Result<Option<(String, String)>> {
 /// Download the latest release and replace the current binary.
 pub async fn perform_update() -> Result<()> {
     let current = env!("CARGO_PKG_VERSION");
-    let release = fetch_latest_release().await?;
+    let release = fetch_latest_release(EXPLICIT_TIMEOUT).await?;
     let latest = &release.tag_name;
 
     if !is_newer(current, latest) {
@@ -229,9 +235,9 @@ pub fn print_cached_update_notice() {
     }
 }
 
-/// Refresh the update cache in the background if stale. Fire-and-forget —
-/// never prints, silently ignores errors. The *next* invocation will see
-/// the refreshed cache and print the notice synchronously.
+/// Refresh the update cache in the background if stale. Never prints.
+/// On any failure (timeout, network error, etc.), writes the current version
+/// to the cache so we don't retry for another 24 hours.
 pub async fn refresh_update_cache() {
     // Only hit the network if cache is stale or missing
     let needs_refresh = match read_update_check() {
@@ -242,15 +248,16 @@ pub async fn refresh_update_cache() {
         return;
     }
 
-    let Ok(result) = check_for_update().await else {
-        return;
-    };
-    match result {
-        Some((_current, latest)) => {
-            let _ = save_update_check(&latest);
+    let current = env!("CARGO_PKG_VERSION");
+    let release = fetch_latest_release(BACKGROUND_TIMEOUT).await;
+    match release {
+        Ok(r) => {
+            let latest = r.tag_name;
+            let display = latest.strip_prefix('v').unwrap_or(&latest);
+            let _ = save_update_check(display);
         }
-        None => {
-            let current = env!("CARGO_PKG_VERSION");
+        Err(_) => {
+            // Failed or timed out — write current version so we back off for 24h
             let _ = save_update_check(current);
         }
     }


### PR DESCRIPTION
## Summary

- Adds `clickhousectl update` command that downloads the latest release binary from GitHub Releases and replaces the current binary in-place
- Adds `clickhousectl update --check` to check for updates without installing
- Adds a background update check that runs on every command (at most once per 24h, cached in `~/.clickhouse/last_update_check`) and prints a notice to stderr when a newer version is available
- The background check runs concurrently with the actual command to avoid slowing down normal usage

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (254 tests, including 3 new tests for version parsing, comparison, and asset name detection)
- [x] `cargo clippy` clean
- [ ] Manual test: `clickhousectl update --check` reports current version status
- [ ] Manual test: `clickhousectl update` downloads and replaces binary
- [ ] Manual test: background notice appears on stale cache, suppressed when cache is fresh

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)