### PR TITLE
Bump version to 0.1.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhousectl"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump version from 0.1.17 to 0.1.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)