### PR TITLE
Add cloud service query for HTTP SQL execution (stacked on #120)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +463,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,9 +593,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -603,6 +628,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -836,6 +870,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,7 +903,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -973,6 +1015,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1195,6 +1243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1353,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1611,6 +1675,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2016,6 +2086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2139,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -2098,6 +2175,15 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -2162,6 +2248,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2172,6 +2280,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2530,6 +2650,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/README.md
+++ b/README.md
@@ -289,6 +289,14 @@ CLICKHOUSE_PASSWORD=secret clickhousectl cloud service client --name my-service 
 # Use a local client version instead of auto-downloading the matching one
 clickhousectl cloud service client --name my-service --allow-mismatched-client-version
 
+# Run SQL over HTTP — no local clickhouse-client needed, uses active cloud credentials
+clickhousectl cloud service query --name my-service --query "SELECT 1"
+clickhousectl cloud service query --id <service-id> --queries-file script.sql --database analytics
+echo "SELECT count() FROM system.tables" | clickhousectl cloud service query --name my-service
+
+# Override output format (default: PrettyCompact on tty, TabSeparated when piped)
+clickhousectl cloud service query --name my-service -q "SELECT 1" --format JSONEachRow
+
 # Update service metadata and patches
 clickhousectl cloud service update <service-id> \
   --name my-renamed-service \

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -122,6 +122,23 @@ impl Client {
         }
     }
 
+    /// Build an authenticated request to an absolute URL using this client's credentials.
+    ///
+    /// The API base URL is ignored — pass the full target URL. Useful for adjacent
+    /// ClickHouse Cloud services that share the same auth scheme (e.g. the query-run
+    /// endpoint at `queries.clickhouse.cloud`).
+    pub fn authenticated_request(
+        &self,
+        method: reqwest::Method,
+        url: &str,
+    ) -> reqwest::RequestBuilder {
+        let builder = self.http.request(method, url);
+        match &self.auth {
+            Auth::Basic { key_id, key_secret } => builder.basic_auth(key_id, Some(key_secret)),
+            Auth::Bearer { token } => builder.bearer_auth(token),
+        }
+    }
+
     /// Get list of available organizations
     pub async fn organization_get_list(
         &self,

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -23,7 +23,7 @@ open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
 clickhouse-cloud-api = { version = "0.1.0", path = "../clickhouse-cloud-api" }
-uuid = "1.23.0"
+uuid = { version = "1.23.0", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -198,6 +198,7 @@ impl CloudCommands {
                 ServiceCommands::List { .. } => false,
                 ServiceCommands::Get { .. } => false,
                 ServiceCommands::Client { .. } => false,
+                ServiceCommands::Query { .. } => false,
                 ServiceCommands::Prometheus { .. } => false,
                 ServiceCommands::Create { .. } => true,
                 ServiceCommands::Delete { .. } => true,
@@ -701,6 +702,43 @@ CONTEXT FOR AGENTS:
         /// Whether to request filtered metrics
         #[arg(long)]
         filtered_metrics: Option<bool>,
+    },
+
+    /// Run a SQL query against a cloud service over HTTP
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Preferred over `cloud service client` for scripted use: no local clickhouse binary
+  and reuses the active cloud credentials. If none of --query/--queries-file/stdin
+  provides SQL, the command errors. --format defaults to PrettyCompact on a terminal
+  and TabSeparated when stdout is piped.")]
+    Query {
+        /// Service name to query
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Service ID to query
+        #[arg(long)]
+        id: Option<String>,
+
+        /// SQL query to execute
+        #[arg(long, short)]
+        query: Option<String>,
+
+        /// Read SQL from this file (use '-' for stdin)
+        #[arg(long)]
+        queries_file: Option<String>,
+
+        /// Database to run the query against
+        #[arg(long)]
+        database: Option<String>,
+
+        /// Output format (e.g. TabSeparated, JSONEachRow, PrettyCompact)
+        #[arg(long)]
+        format: Option<String>,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
     },
 }
 
@@ -1558,6 +1596,11 @@ mod tests {
 
         // Query endpoint read
         assert_write(&["clickhousectl", "cloud", "service", "query-endpoint", "get", "svc-1"], false);
+
+        // Query-run (OAuth JWT works against queries.clickhouse.cloud per the spec).
+        // The write-check gates the *Cloud API*, which this command does not touch —
+        // the SQL's own semantics are enforced by ClickHouse, not by clickhousectl.
+        assert_write(&["clickhousectl", "cloud", "service", "query", "--id", "svc-1", "--query", "SELECT 1"], false);
 
         // Private endpoint read
         assert_write(&["clickhousectl", "cloud", "service", "private-endpoint", "get-config", "svc-1"], false);

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1,7 +1,11 @@
-use crate::cloud::types::DeleteResponse;
+use crate::cloud::types::{DeleteResponse, RunQueryRequest};
 use std::env;
 
 const DEFAULT_BASE_URL: &str = "https://api.clickhouse.cloud/v1";
+
+/// Base URL for the query-run service (separate host from the main Cloud API).
+/// Override with `CLICKHOUSE_CLOUD_QUERIES_URL` for testing.
+const DEFAULT_QUERIES_BASE_URL: &str = "https://queries.clickhouse.cloud";
 
 #[derive(Debug)]
 pub struct CloudError {
@@ -533,6 +537,62 @@ impl CloudClient {
             .instance_prometheus_get(org_id, service_id, filtered.as_deref())
             .await
             .map_err(|e| self.convert_error(e))
+    }
+
+    /// POST to the query-run endpoint and return a streaming response.
+    ///
+    /// The caller is responsible for reading the body — typically piping it to stdout.
+    /// `format` is passed as the `format` URL parameter; if `None`, the server's
+    /// default is used.
+    pub async fn run_query(
+        &self,
+        service_id: &str,
+        request: &RunQueryRequest<'_>,
+        format: Option<&str>,
+    ) -> Result<reqwest::Response> {
+        let base = env::var("CLICKHOUSE_CLOUD_QUERIES_URL")
+            .unwrap_or_else(|_| DEFAULT_QUERIES_BASE_URL.to_string());
+        let base = base.trim_end_matches('/');
+        let url = match format {
+            Some(f) => format!(
+                "{}/service/{}/run?format={}",
+                base,
+                service_id,
+                urlencoding::encode(f)
+            ),
+            None => format!("{}/service/{}/run", base, service_id),
+        };
+
+        let body = serde_json::to_vec(request).map_err(|e| CloudError {
+            message: format!("Failed to serialize query request: {}", e),
+        })?;
+
+        // Match the SQL Console's content-type exactly — some deployments are strict.
+        let req = self
+            .api()
+            .authenticated_request(reqwest::Method::POST, &url)
+            .header("content-type", "text/plain;charset=UTF-8")
+            .header("x-service-type", "clickhouse")
+            .header("auth-provider", "custom")
+            .body(body);
+
+        let resp = req.send().await.map_err(|e| CloudError {
+            message: format!("Query request failed: {}", e),
+        })?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            return Err(CloudError {
+                message: format!(
+                    "Query failed ({}): {}",
+                    status,
+                    if body_text.is_empty() { "no response body" } else { &body_text }
+                ),
+            });
+        }
+
+        Ok(resp)
     }
 
     // Organization endpoints (delegated to library client)

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -2030,6 +2030,100 @@ async fn ensure_version_installed(
     Ok(version)
 }
 
+pub struct ServiceQueryOptions {
+    pub name: Option<String>,
+    pub id: Option<String>,
+    pub query: Option<String>,
+    pub queries_file: Option<String>,
+    pub database: Option<String>,
+    pub format: Option<String>,
+    pub org_id: Option<String>,
+}
+
+/// Resolve the SQL text from --query, --queries-file, or stdin.
+///
+/// Precedence: --query > --queries-file > stdin. Exactly one source is used; we
+/// don't concatenate. Empty SQL is rejected here so the HTTP call never happens.
+fn read_query_sql(
+    inline: Option<&str>,
+    file: Option<&str>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use std::io::Read;
+
+    let sql = if let Some(q) = inline {
+        q.to_string()
+    } else if let Some(path) = file {
+        if path == "-" {
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf)?;
+            buf
+        } else {
+            std::fs::read_to_string(path)
+                .map_err(|e| format!("failed to read {}: {}", path, e))?
+        }
+    } else if !std::io::stdin().is_terminal() {
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        return Err("no SQL provided. Use --query, --queries-file, or pipe SQL on stdin".into());
+    };
+
+    if sql.trim().is_empty() {
+        return Err("SQL query is empty".into());
+    }
+    Ok(sql)
+}
+
+/// Default output format picked when the user didn't pass --format.
+/// Matches clickhouse-client's behavior: pretty when interactive, tabular when piped.
+fn default_query_format() -> &'static str {
+    if std::io::stdout().is_terminal() {
+        "PrettyCompact"
+    } else {
+        "TabSeparated"
+    }
+}
+
+pub async fn service_query(
+    client: &CloudClient,
+    opts: ServiceQueryOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::cloud::types::RunQueryRequest;
+    use futures_util::StreamExt;
+    use std::io::Write;
+
+    let sql = read_query_sql(opts.query.as_deref(), opts.queries_file.as_deref())?;
+
+    let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
+    let svc = resolve_service(client, &org_id, opts.name.as_deref(), opts.id.as_deref()).await?;
+
+    let format_str = opts
+        .format
+        .unwrap_or_else(|| default_query_format().to_string());
+
+    let request = RunQueryRequest {
+        run_id: uuid::Uuid::new_v4().to_string(),
+        sql: &sql,
+        database: opts.database.as_deref(),
+    };
+
+    let resp = client
+        .run_query(&svc.id.to_string(), &request, Some(&format_str))
+        .await?;
+
+    let mut stream = resp.bytes_stream();
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("error reading query response: {}", e))?;
+        out.write_all(&chunk)?;
+    }
+    out.flush()?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clickhousectl/src/cloud/types.rs
+++ b/crates/clickhousectl/src/cloud/types.rs
@@ -7,3 +7,17 @@ pub struct DeleteResponse {
     pub status: f64,
     pub request_id: String,
 }
+
+/// Request body for the query-run endpoint at `queries.clickhouse.cloud`.
+///
+/// Unlike the OpenAPI spec types, this endpoint lives outside the main Cloud API
+/// and takes a JSON body with run-scoped fields. Content-type is `text/plain`
+/// (the server is lenient about this) but the body is JSON.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RunQueryRequest<'a> {
+    pub run_id: String,
+    pub sql: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<&'a str>,
+}

--- a/crates/clickhousectl/src/cloud/types_test.rs
+++ b/crates/clickhousectl/src/cloud/types_test.rs
@@ -1,4 +1,4 @@
-use super::types::DeleteResponse;
+use super::types::{DeleteResponse, RunQueryRequest};
 
 // Contract policy for this suite:
 // - mirror GA request/response schemas and query surfaces only
@@ -29,6 +29,31 @@ fn test_delete_response_serialize() {
     assert_eq!(json["status"], 200.0);
     assert_eq!(json["requestId"], "0182edf5-8c5b-4586-a6f8-78452320e4b1");
     assert!(json.get("request_id").is_none());
+}
+
+#[test]
+fn test_run_query_request_serialize_with_database() {
+    let req = RunQueryRequest {
+        run_id: "5b02a72e-be42-4442-82f8-9e572d9aae1b".to_string(),
+        sql: "SELECT 1",
+        database: Some("galaxy"),
+    };
+    let json = serde_json::to_value(&req).unwrap();
+    assert_eq!(json["runId"], "5b02a72e-be42-4442-82f8-9e572d9aae1b");
+    assert_eq!(json["sql"], "SELECT 1");
+    assert_eq!(json["database"], "galaxy");
+    assert!(json.get("run_id").is_none());
+}
+
+#[test]
+fn test_run_query_request_serialize_omits_null_database() {
+    let req = RunQueryRequest {
+        run_id: "abc".to_string(),
+        sql: "SELECT 1",
+        database: None,
+    };
+    let json = serde_json::to_value(&req).unwrap();
+    assert!(json.get("database").is_none());
 }
 
 // ── Activity tests (library types) ─────────────────────────────────

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -630,6 +630,26 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                 };
                 cloud::commands::service_client(&client, opts).await
             }
+            ServiceCommands::Query {
+                name,
+                id,
+                query,
+                queries_file,
+                database,
+                format,
+                org_id,
+            } => {
+                let opts = cloud::commands::ServiceQueryOptions {
+                    name,
+                    id,
+                    query,
+                    queries_file,
+                    database,
+                    format,
+                    org_id,
+                };
+                cloud::commands::service_query(&client, opts).await
+            }
             ServiceCommands::Prometheus {
                 service_id,
                 org_id,


### PR DESCRIPTION
## Summary

Closes #115. Stacked on #120 (`issue-48-debug-auth-source`) — rebase/merge that first.

New `clickhousectl cloud service query` subcommand that executes SQL against a cloud service over HTTP via `queries.clickhouse.cloud`, reusing whatever credentials are already configured. No local `clickhouse` binary and no service password required.

- `--query` / `--queries-file` / stdin for SQL input
- `--database` selects the target database
- `--format` overrides output format (defaults to `PrettyCompact` on a TTY, `TabSeparated` when piped)
- Response body is streamed straight to stdout

OAuth JWT works here the same as an API key (matches the sample curl in the issue), so the command is classified read-only for the OAuth write-gate — the SQL's own semantics are enforced on the ClickHouse side.

### Library change

Adds `Client::authenticated_request` in `clickhouse-cloud-api` so CloudClient can reuse the same auth/http for adjacent hosts. No generated-code changes.

### Not in this PR

Leaving `cloud service client` in place for now — issue 115 calls this out as a "much better approach" that eventually replaces it, but removal is a follow-up.

## Test plan

- [x] `cargo test --workspace` passes (209 tests, +2 new for `RunQueryRequest` serialization)
- [x] `cargo build` clean, `cargo clippy` clean on changed crates
- [x] `cloud service query --help` renders and matches the `feedback_agent_context_help` memory (CONTEXT FOR AGENTS adds non-obvious context only)
- [ ] Manual: `cloud service query --name <svc> --query "SELECT 1"` hits queries.clickhouse.cloud with OAuth JWT
- [ ] Manual: same command with API key auth works
- [ ] Manual: piping SQL on stdin works; redirecting stdout picks TabSeparated

🤖 Generated with [Claude Code](https://claude.com/claude-code)