### PR TITLE
Bump clickhousectl to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.1.18"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.1.18"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Bump `clickhousectl` from `0.1.18` to `0.2.0`

Stacked on #134.

## Test plan
- [x] `cargo build -p clickhousectl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)