### PR TITLE
Add `local postgres` subcommand backed by Docker

### DIFF
--- a/.github/workflows/test-postgres-integration.yml
+++ b/.github/workflows/test-postgres-integration.yml
@@ -1,0 +1,39 @@
+name: Test local postgres (integration)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "crates/clickhousectl/src/local/**"
+      - "crates/clickhousectl/Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/test-postgres-integration.sh"
+      - ".github/workflows/test-postgres-integration.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: local postgres edge cases
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build clickhousectl
+        run: cargo build -p clickhousectl
+
+      - name: Pull postgres images
+        run: |
+          docker pull postgres:16-alpine
+          docker pull postgres:17-alpine
+          docker pull postgres:18
+
+      - name: Run integration tests
+        run: scripts/test-postgres-integration.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+/.env
+/.env.local
 /.agents/
 /.claude/
 /.codex/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bollard"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.53.1-rc.29.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +228,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -259,9 +313,11 @@ dependencies = [
 name = "clickhousectl"
 version = "0.2.0"
 dependencies = [
+ "bollard",
  "chrono",
  "clap",
  "clickhouse-cloud-api",
+ "crossterm",
  "dirs",
  "flate2",
  "futures-util",
@@ -269,6 +325,7 @@ dependencies = [
  "is-ai-agent",
  "libc",
  "open",
+ "rand 0.10.1",
  "reqwest",
  "rpassword",
  "serde",
@@ -322,6 +379,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,12 +404,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -363,6 +465,28 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
 
 [[package]]
 name = "dirs"
@@ -394,6 +518,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -608,6 +741,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -657,6 +791,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -727,6 +867,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +918,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1060,6 +1230,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1279,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1320,7 +1497,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1374,7 +1551,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1384,7 +1572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1395,6 +1583,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1535,6 +1729,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1733,6 +1936,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,6 +1963,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2087,6 +2322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,6 +2572,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2338,6 +2595,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/README.md
+++ b/README.md
@@ -142,6 +142,37 @@ clickhousectl local server dotenv --user default --password secret --database my
 
 **Global server management:** Use `--global` with `list`, `stop`, and `stop-all` to operate across all projects system-wide. `server list --global` shows all running ClickHouse servers with a Project column indicating which directory each belongs to.
 
+#### Local Postgres (Docker-backed)
+
+When you also need a local Postgres alongside ClickHouse — e.g. for testing CDC pipelines or ingesting from Postgres — use `local postgres`. It manages a `postgres:<tag>` Docker container per named server, with data bind-mounted into `.clickhouse/servers/<name>/data/` and a generated random password stored in `.clickhouse/servers/<name>.json`. Requires Docker to be installed and running.
+
+```bash
+# Pre-pull a Postgres image (optional; start will pull on demand)
+clickhousectl local install postgres@16
+
+# Start a Postgres instance (defaults: postgres:latest, port 5432, user "postgres", db "postgres")
+clickhousectl local postgres start
+clickhousectl local postgres start --name dev --version 16 --port 5433
+clickhousectl local postgres start --user app --password s3cret --database myapp
+clickhousectl local postgres start -e POSTGRES_INITDB_ARGS=--data-checksums
+
+# List everything (ClickHouse + Postgres are merged in `server list`)
+clickhousectl local server list
+
+# Connect with psql (uses host psql if installed; otherwise falls back to docker exec)
+clickhousectl local postgres client --name dev
+clickhousectl local postgres client --name dev --query "SELECT 1"
+
+# Write POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE into .env
+clickhousectl local postgres dotenv --name dev
+
+# Stop / remove
+clickhousectl local postgres stop dev
+clickhousectl local postgres remove dev
+```
+
+Containers are tagged with `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`, `clickhousectl.project=<cwd>`, and `created_by=clickhousectl_<version>` labels. `server list` recovers orphaned containers belonging to the current project via these labels, so deleting `.clickhouse/servers/<name>.json` is non-destructive — the next list/start command rediscovers it.
+
 #### Project-local data directory
 
 All server data lives inside `.clickhouse/` in your project directory:

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ clickhousectl local server dotenv --user default --password secret --database my
 
 #### Local Postgres (Docker-backed)
 
-When you also need a local Postgres alongside ClickHouse — e.g. for testing CDC pipelines or ingesting from Postgres — use `local postgres`. It manages a `postgres:<tag>` Docker container per named server, with data bind-mounted into `.clickhouse/servers/<name>/data/` and a generated random password stored in `.clickhouse/servers/<name>.json`. Requires Docker to be installed and running.
+When you also need a local Postgres alongside ClickHouse — e.g. for testing CDC pipelines or ingesting from Postgres — use `local postgres`. Each instance is keyed on `(name, major version)` so the same name can host multiple Postgres majors with isolated data: data lives at `.clickhouse/servers/<name>-pg<major>/data/`, metadata at `.clickhouse/servers/<name>-pg<major>.json`, and the container is `clickhousectl-pg-<name>-<major>`. ClickHouse paths (`<name>/data/`, `<name>.json`) stay separate, so a name can be used by both engines. Requires Docker to be installed and running.
 
 ```bash
 # Pre-pull a Postgres image (optional; start will pull on demand). Supported: 16, 17, 18 (and any sub-tag like 16-alpine, 17.0, 18-bookworm).
@@ -166,12 +166,15 @@ clickhousectl local postgres client --name dev --query "SELECT 1"
 # Write POSTGRES_HOST/PORT/USER/PASSWORD/DATABASE into .env
 clickhousectl local postgres dotenv --name dev
 
-# Stop / remove
+# Stop / remove. Pass --version when more than one major shares a name.
 clickhousectl local postgres stop dev
+clickhousectl local postgres stop dev --version 16        # disambiguate
 clickhousectl local postgres remove dev
 ```
 
-Containers are tagged with `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`, `clickhousectl.project=<cwd>`, and `created_by=clickhousectl_<version>` labels. `server list` recovers orphaned containers belonging to the current project via these labels, so deleting `.clickhouse/servers/<name>.json` is non-destructive — the next list/start command rediscovers it.
+`local postgres start --name dev` (no `--version`) resumes the existing instance when there's exactly one for that name; if multiple majors share the name, you'll be asked to pick. Stop preserves the container and metadata so the next start resumes it; only `remove` tears down the container and deletes the data directory.
+
+Containers are tagged with `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`, `clickhousectl.major=<major>`, `clickhousectl.project=<cwd>`, and `created_by=clickhousectl_<version>` labels. `server list` recovers orphaned containers belonging to the current project via these labels, so deleting `.clickhouse/servers/<name>-pg<major>.json` is non-destructive — the next list/start rediscovers it.
 
 #### Project-local data directory
 

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ clickhousectl local server dotenv --user default --password secret --database my
 When you also need a local Postgres alongside ClickHouse — e.g. for testing CDC pipelines or ingesting from Postgres — use `local postgres`. It manages a `postgres:<tag>` Docker container per named server, with data bind-mounted into `.clickhouse/servers/<name>/data/` and a generated random password stored in `.clickhouse/servers/<name>.json`. Requires Docker to be installed and running.
 
 ```bash
-# Pre-pull a Postgres image (optional; start will pull on demand)
+# Pre-pull a Postgres image (optional; start will pull on demand). Supported: 16, 17, 18 (and any sub-tag like 16-alpine, 17.0, 18-bookworm).
 clickhousectl local install postgres@16
 
-# Start a Postgres instance (defaults: postgres:latest, port 5432, user "postgres", db "postgres")
+# Start a Postgres instance (defaults: postgres:18, port 5432, user "postgres", db "postgres")
 clickhousectl local postgres start
 clickhousectl local postgres start --name dev --version 16 --port 5433
 clickhousectl local postgres start --user app --password s3cret --database myapp

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -25,6 +25,9 @@ tabled = "0.20.0"
 clickhouse-cloud-api = { version = "0.1.0", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
+bollard = "0.21.0"
+crossterm = "0.29.0"
+rand = "0.10.1"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -43,7 +43,8 @@ pub enum Commands {
 CONTEXT FOR AGENTS:
   Manage local ClickHouse installations: install versions, run queries, manage servers.
   Typical workflow: `clickhousectl local install stable && clickhousectl local use stable && clickhousectl local server start`.
-  Use `clickhousectl local <command> --help` for details on each subcommand.")]
+  Use `clickhousectl local <command> --help` for details on each subcommand.
+  For a local Postgres instance via Docker, see `clickhousectl local postgres --help`.")]
     Local(LocalArgs),
 
     /// Work with serverless ClickHouse in ClickHouse Cloud

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -63,6 +63,13 @@ pub enum Error {
 
     #[error("--json and --foreground cannot be used together")]
     JsonForegroundConflict,
+
+    #[error("Docker is not available: {0}")]
+    DockerNotAvailable(String),
+
+    #[error("Docker error: {0}")]
+    #[allow(clippy::enum_variant_names)]
+    DockerError(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -328,6 +328,9 @@ CONTEXT FOR AGENTS:
     Stop {
         /// Name of the server to stop
         name: String,
+        /// Postgres version to disambiguate when multiple share a name
+        #[arg(long, short = 'v')]
+        version: Option<String>,
     },
 
     /// Stop all running Postgres containers in this project
@@ -337,6 +340,9 @@ CONTEXT FOR AGENTS:
     Remove {
         /// Name of the server to remove
         name: String,
+        /// Postgres version to disambiguate when multiple share a name
+        #[arg(long, short = 'v')]
+        version: Option<String>,
     },
 
     /// Connect to a running Postgres instance with psql
@@ -355,6 +361,10 @@ CONTEXT FOR AGENTS:
         /// Server name to connect to (default: "default")
         #[arg(long, short)]
         name: Option<String>,
+
+        /// Postgres version to disambiguate when multiple share a name
+        #[arg(long, short = 'v')]
+        version: Option<String>,
 
         /// Host to connect to (bypasses local server lookup)
         #[arg(long)]
@@ -387,6 +397,10 @@ CONTEXT FOR AGENTS:
         /// Server name (default: "default")
         #[arg(long)]
         name: Option<String>,
+
+        /// Postgres version to disambiguate when multiple share a name
+        #[arg(long, short = 'v')]
+        version: Option<String>,
 
         /// Write to .env.local instead of .env
         #[arg(long)]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -128,6 +128,20 @@ CONTEXT FOR AGENTS:
         #[command(subcommand)]
         command: ServerCommands,
     },
+
+    /// Manage local Postgres instances (Docker-backed)
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Manage named Postgres server instances backed by Docker. Each instance runs as
+  a `postgres:<tag>` container with data bind-mounted at .clickhouse/servers/<name>/data/.
+  Subcommands: start, stop, stop-all, remove, client, dotenv.
+  Typical: `clickhousectl local postgres start` (starts \"default\" on port 5432).
+  `local server list` shows ClickHouse + Postgres entries together.
+  Requires Docker to be installed and running.")]
+    Postgres {
+        #[command(subcommand)]
+        command: PostgresCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -261,5 +275,121 @@ CONTEXT FOR AGENTS:
         /// Include CLICKHOUSE_DATABASE with this value
         #[arg(long)]
         database: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum PostgresCommands {
+    /// Start a Postgres container
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Starts a named Postgres server backed by a Docker container.
+  Without --name, the first server is called \"default\"; if \"default\" is running,
+  a random name is generated (e.g. \"bold-crane\").
+  --version (-v) selects a postgres image tag (e.g. 16, 16-alpine, 15.4). Defaults to \"latest\".
+  Image is pulled if not already present locally.
+  --port defaults to 5432; if taken, a free port is auto-assigned.
+  Data persists at .clickhouse/servers/<name>/data/ and is bind-mounted into the container.
+  A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
+  Containers are labeled `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`,
+  `clickhousectl.project=<cwd>`, `created_by=clickhousectl_<version>` for safe discovery.
+  Requires Docker to be installed and running.")]
+    Start {
+        /// Server name (default: "default", or random if default is already running)
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Postgres image tag (e.g. 16, 16-alpine, 15.4). Default: latest. Pulls if missing.
+        #[arg(long, short = 'v')]
+        version: Option<String>,
+
+        /// Host TCP port (default: 5432, auto-assigns a free port if in use)
+        #[arg(long)]
+        port: Option<u16>,
+
+        /// POSTGRES_USER (default: postgres)
+        #[arg(long)]
+        user: Option<String>,
+
+        /// POSTGRES_PASSWORD (default: random 24-char alphanumeric)
+        #[arg(long)]
+        password: Option<String>,
+
+        /// POSTGRES_DB (default: postgres)
+        #[arg(long)]
+        database: Option<String>,
+
+        /// Extra env vars for the container, repeatable: -e KEY=VALUE
+        #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
+        env: Vec<String>,
+    },
+
+    /// Stop a running Postgres container by name
+    Stop {
+        /// Name of the server to stop
+        name: String,
+    },
+
+    /// Stop all running Postgres containers in this project
+    StopAll,
+
+    /// Remove a stopped Postgres server and its data directory
+    Remove {
+        /// Name of the server to remove
+        name: String,
+    },
+
+    /// Connect to a running Postgres instance with psql
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Two connection modes:
+  1. Named server: `clickhousectl local postgres client --name dev` — looks up the host port
+     and credentials from a locally managed Postgres started via `local postgres start`.
+     Defaults to \"default\".
+  2. Explicit host/port: `clickhousectl local postgres client --host myhost --port 5432`.
+  If `psql` is on PATH on the host, it is execed directly. Otherwise, falls back to running
+  `psql` inside the container via Docker exec (no host psql required).
+  --query and --queries-file pass through to psql (-c / -f).
+  Additional psql args can be passed after --.")]
+    Client {
+        /// Server name to connect to (default: "default")
+        #[arg(long, short)]
+        name: Option<String>,
+
+        /// Host to connect to (bypasses local server lookup)
+        #[arg(long)]
+        host: Option<String>,
+
+        /// TCP port to connect to (bypasses local server lookup if set)
+        #[arg(long, short)]
+        port: Option<u16>,
+
+        /// Execute a single SQL query
+        #[arg(long, short)]
+        query: Option<String>,
+
+        /// Execute queries from a SQL file
+        #[arg(long)]
+        queries_file: Option<String>,
+
+        /// Additional arguments to pass to psql
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Write Postgres connection env vars to a .env file
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Writes POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DATABASE
+  into .env (or .env.local with --local) based on a running Postgres server.
+  If the file already exists, existing POSTGRES_* vars are replaced in-place.")]
+    Dotenv {
+        /// Server name (default: "default")
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Write to .env.local instead of .env
+        #[arg(long)]
+        local: bool,
     },
 }

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -120,7 +120,6 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Manage named ClickHouse server instances. Each server has its own data directory.
-  Subcommands: start, list, stop, stop-all, remove.
   Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
   Typical: `clickhousectl local server start` (starts \"default\"), `clickhousectl local server start --name test`.
   Related: `clickhousectl local client` to connect to a running server.")]
@@ -132,9 +131,9 @@ CONTEXT FOR AGENTS:
     /// Manage local Postgres instances (Docker-backed)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Manage named Postgres server instances backed by Docker. Each instance runs as
-  a `postgres:<tag>` container with data bind-mounted at .clickhouse/servers/<name>/data/.
-  Subcommands: start, stop, stop-all, remove, client, dotenv.
+  Manage named Postgres server instances backed by Docker. Each instance is keyed on
+  (name, major version) and runs as a `postgres:<tag>` container with data bind-mounted
+  at .clickhouse/servers/<name>-pg<major>/data/.
   Typical: `clickhousectl local postgres start` (starts \"default\" on port 5432).
   `local server list` shows ClickHouse + Postgres entries together.
   Requires Docker to be installed and running.")]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -286,8 +286,8 @@ CONTEXT FOR AGENTS:
   Starts a named Postgres server backed by a Docker container.
   Without --name, the first server is called \"default\"; if \"default\" is running,
   a random name is generated (e.g. \"bold-crane\").
-  --version (-v) selects a postgres image tag (e.g. 16, 16-alpine, 15.4). Defaults to \"latest\".
-  Image is pulled if not already present locally.
+  --version (-v) selects a postgres image tag (16, 17, or 18 — e.g. 16, 16-alpine, 17.0, 18-bookworm).
+  Defaults to 18. Image is pulled if not already present locally.
   --port defaults to 5432; if taken, a free port is auto-assigned.
   Data persists at .clickhouse/servers/<name>/data/ and is bind-mounted into the container.
   A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
@@ -299,7 +299,7 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         name: Option<String>,
 
-        /// Postgres image tag (e.g. 16, 16-alpine, 15.4). Default: latest. Pulls if missing.
+        /// Postgres image tag (16, 17, or 18 — e.g. 16, 16-alpine, 17.0, 18-bookworm). Default: 18. Pulls if missing.
         #[arg(long, short = 'v')]
         version: Option<String>,
 

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -560,6 +560,97 @@ pub fn stop_blocking(id: &str) -> Result<()> {
 }
 
 /// Best-effort stop, then remove the container.
+/// Remove a host directory and its contents, even when files inside are
+/// owned by container UIDs (postgres' uid 999) the host user can't `rm`.
+///
+/// Tries `std::fs::remove_dir_all` first, which is enough on macOS because
+/// Docker Desktop maps host UIDs transparently. On Linux bind mounts are
+/// direct, so fall back to a one-shot Alpine container running as root
+/// that nukes the directory from inside.
+pub fn remove_host_dir_blocking(host_path: &std::path::Path) -> Result<()> {
+    if !host_path.exists() {
+        return Ok(());
+    }
+    if std::fs::remove_dir_all(host_path).is_ok() {
+        return Ok(());
+    }
+    let parent = host_path
+        .parent()
+        .ok_or_else(|| Error::DockerError("path has no parent".into()))?
+        .canonicalize()?;
+    let basename = host_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| Error::DockerError("path has no basename".into()))?
+        .to_string();
+    let parent_str = parent.display().to_string();
+
+    block_on(async move {
+        use bollard::errors::Error as BErr;
+        use bollard::models::{ContainerCreateBody, HostConfig};
+        use bollard::query_parameters::{
+            CreateContainerOptionsBuilder, CreateImageOptionsBuilder, StartContainerOptions,
+            WaitContainerOptions,
+        };
+
+        let docker = connect().await?;
+
+        // Pull alpine on first use.
+        if let Err(BErr::DockerResponseServerError { status_code: 404, .. }) =
+            docker.inspect_image("alpine:latest").await
+        {
+            let mut s = docker.create_image(
+                Some(
+                    CreateImageOptionsBuilder::default()
+                        .from_image("alpine:latest")
+                        .build(),
+                ),
+                None,
+                None,
+            );
+            while let Some(item) = s.next().await {
+                item.map_err(|e| Error::DockerError(e.to_string()))?;
+            }
+        }
+
+        let bind = format!("{}:/work", parent_str);
+        let cmd = format!("rm -rf /work/{}", basename);
+        let cfg = ContainerCreateBody {
+            image: Some("alpine:latest".into()),
+            cmd: Some(vec!["sh".into(), "-c".into(), cmd]),
+            host_config: Some(HostConfig {
+                binds: Some(vec![bind]),
+                auto_remove: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let created = docker
+            .create_container(
+                Some(CreateContainerOptionsBuilder::default().build()),
+                cfg,
+            )
+            .await
+            .map_err(|e| Error::DockerError(e.to_string()))?;
+        docker
+            .start_container(&created.id, None::<StartContainerOptions>)
+            .await
+            .map_err(|e| Error::DockerError(e.to_string()))?;
+        let mut wait = docker.wait_container(&created.id, None::<WaitContainerOptions>);
+        while let Some(item) = wait.next().await {
+            // Ignore individual stream errors — auto_remove will reap on exit.
+            let _ = item;
+        }
+        Ok::<(), Error>(())
+    })?;
+
+    // If anything is left (e.g. the dir itself remained empty), clean up host-side.
+    if host_path.exists() {
+        let _ = std::fs::remove_dir_all(host_path);
+    }
+    Ok(())
+}
+
 pub fn stop_and_remove_blocking(id: &str) -> Result<()> {
     let id = id.to_string();
     block_on(async move {

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -110,10 +110,17 @@ pub async fn run_postgres(docker: &Docker, opts: PostgresRunOpts<'_>) -> Result<
         ..Default::default()
     };
 
+    // Pin PGDATA to the legacy path. Postgres 18+ default-stores data at
+    // /var/lib/postgresql/<major>/docker; older majors use /var/lib/postgresql/data.
+    // We bind-mount a single host directory per server, so we force one
+    // consistent path regardless of major version. Each managed server is
+    // pinned to a single image tag (changing tag requires `remove`), so we
+    // never need pg_upgrade-style cross-version layout.
     let mut env: Vec<String> = vec![
         format!("POSTGRES_USER={}", opts.user),
         format!("POSTGRES_PASSWORD={}", opts.password),
         format!("POSTGRES_DB={}", opts.database),
+        "PGDATA=/var/lib/postgresql/data".to_string(),
     ];
     env.extend(opts.extra_env);
 

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -1,0 +1,516 @@
+//! Docker integration for `local postgres`.
+//!
+//! All Docker work goes through the async Docker API — there is no shell-out
+//! to the `docker` CLI anywhere in this crate, including for interactive
+//! `psql` exec (which uses an attached exec stream + crossterm raw mode and
+//! forwards SIGWINCH as `resize_exec`).
+//!
+//! Containers we create are tagged with these labels so we can later discover
+//! them even if the local metadata file is missing:
+//!
+//!  * `clickhousectl.engine=postgres`
+//!  * `clickhousectl.name=<server-name>`
+//!  * `clickhousectl.project=<canonical project cwd>`
+//!  * `created_by=clickhousectl_<crate-version>`
+
+use crate::error::{Error, Result};
+use bollard::Docker;
+use futures_util::StreamExt;
+use std::collections::HashMap;
+
+pub const LABEL_ENGINE: &str = "clickhousectl.engine";
+pub const LABEL_NAME: &str = "clickhousectl.name";
+pub const LABEL_PROJECT: &str = "clickhousectl.project";
+pub const LABEL_CREATED_BY: &str = "created_by";
+
+/// Value of the `created_by` label — `clickhousectl_<crate version>`.
+pub fn created_by_value() -> String {
+    format!("clickhousectl_{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// Container name we use for a managed Postgres server.
+pub fn container_name(server_name: &str) -> String {
+    format!("clickhousectl-pg-{}", server_name)
+}
+
+/// Connect to the local Docker daemon and verify it's reachable.
+pub async fn connect() -> Result<Docker> {
+    let docker = Docker::connect_with_local_defaults().map_err(|e| {
+        Error::DockerNotAvailable(format!("could not initialize docker client: {e}"))
+    })?;
+    docker.ping().await.map_err(|e| {
+        Error::DockerNotAvailable(format!(
+            "Docker daemon is not reachable ({e}). Install Docker Desktop or start the daemon."
+        ))
+    })?;
+    Ok(docker)
+}
+
+/// Pull `postgres:<tag>`, streaming progress to stderr.
+pub async fn pull_image(docker: &Docker, tag: &str) -> Result<()> {
+    use bollard::query_parameters::CreateImageOptionsBuilder;
+    let from = format!("postgres:{}", tag);
+    let opts = CreateImageOptionsBuilder::default().from_image(&from).build();
+    let mut stream = docker.create_image(Some(opts), None, None);
+    while let Some(item) = stream.next().await {
+        let info = item.map_err(|e| Error::DockerError(e.to_string()))?;
+        if let Some(status) = info.status.as_deref() {
+            eprintln!("  {}", status);
+        }
+    }
+    Ok(())
+}
+
+/// Check whether `postgres:<tag>` is already present locally (no pull).
+pub async fn image_exists(docker: &Docker, tag: &str) -> Result<bool> {
+    use bollard::errors::Error as BErr;
+    let name = format!("postgres:{}", tag);
+    match docker.inspect_image(&name).await {
+        Ok(_) => Ok(true),
+        Err(BErr::DockerResponseServerError { status_code: 404, .. }) => Ok(false),
+        Err(e) => Err(Error::DockerError(e.to_string())),
+    }
+}
+
+pub struct PostgresRunOpts<'a> {
+    pub server_name: &'a str,
+    pub tag: &'a str,
+    pub host_port: u16,
+    pub data_dir: &'a std::path::Path,
+    pub project_cwd: &'a str,
+    pub user: &'a str,
+    pub password: &'a str,
+    pub database: &'a str,
+    pub extra_env: Vec<String>,
+}
+
+/// Create + start a Postgres container; return its ID.
+pub async fn run_postgres(docker: &Docker, opts: PostgresRunOpts<'_>) -> Result<String> {
+    use bollard::models::{ContainerCreateBody, HostConfig, PortBinding};
+    use bollard::query_parameters::{CreateContainerOptionsBuilder, StartContainerOptions};
+
+    let mut port_bindings: HashMap<String, Option<Vec<PortBinding>>> = HashMap::new();
+    port_bindings.insert(
+        "5432/tcp".to_string(),
+        Some(vec![PortBinding {
+            host_ip: Some("127.0.0.1".to_string()),
+            host_port: Some(opts.host_port.to_string()),
+        }]),
+    );
+
+    let canonical_data = opts
+        .data_dir
+        .canonicalize()
+        .map_err(|e| Error::DockerError(format!("data dir canonicalize: {e}")))?;
+    let bind = format!("{}:/var/lib/postgresql/data", canonical_data.display());
+
+    let host_config = HostConfig {
+        port_bindings: Some(port_bindings),
+        binds: Some(vec![bind]),
+        ..Default::default()
+    };
+
+    let mut env: Vec<String> = vec![
+        format!("POSTGRES_USER={}", opts.user),
+        format!("POSTGRES_PASSWORD={}", opts.password),
+        format!("POSTGRES_DB={}", opts.database),
+    ];
+    env.extend(opts.extra_env);
+
+    let mut labels: HashMap<String, String> = HashMap::new();
+    labels.insert(LABEL_ENGINE.into(), "postgres".into());
+    labels.insert(LABEL_NAME.into(), opts.server_name.into());
+    labels.insert(LABEL_PROJECT.into(), opts.project_cwd.into());
+    labels.insert(LABEL_CREATED_BY.into(), created_by_value());
+
+    let container_config = ContainerCreateBody {
+        image: Some(format!("postgres:{}", opts.tag)),
+        env: Some(env),
+        host_config: Some(host_config),
+        labels: Some(labels),
+        ..Default::default()
+    };
+
+    let create_opts = CreateContainerOptionsBuilder::default()
+        .name(&container_name(opts.server_name))
+        .build();
+
+    let created = docker
+        .create_container(Some(create_opts), container_config)
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+
+    docker
+        .start_container(&created.id, None::<StartContainerOptions>)
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+
+    Ok(created.id)
+}
+
+/// If a container with our managed name (`clickhousectl-pg-<name>`) exists in
+/// any state, remove it — but only when it carries our labels for the current
+/// project. Returns Ok(()) if the name is free or was successfully cleaned up,
+/// or an actionable error if the name is held by an unrelated container.
+pub async fn ensure_name_free(
+    docker: &Docker,
+    server_name: &str,
+    project_cwd: &str,
+) -> Result<()> {
+    use bollard::errors::Error as BErr;
+    let cname = container_name(server_name);
+    match docker.inspect_container(&cname, None).await {
+        Ok(info) => {
+            let labels_match = info
+                .config
+                .as_ref()
+                .and_then(|c| c.labels.as_ref())
+                .map(|l| {
+                    l.get(LABEL_ENGINE).map(String::as_str) == Some("postgres")
+                        && l.get(LABEL_PROJECT).map(String::as_str) == Some(project_cwd)
+                })
+                .unwrap_or(false);
+            if !labels_match {
+                return Err(Error::DockerError(format!(
+                    "container '{cname}' already exists but is not managed by clickhousectl. \
+                     Remove it manually or pick a different --name."
+                )));
+            }
+            let id = info.id.unwrap_or(cname.clone());
+            let _ = stop_container(docker, &id).await;
+            remove_container(docker, &id).await
+        }
+        Err(BErr::DockerResponseServerError { status_code: 404, .. }) => Ok(()),
+        Err(e) => Err(Error::DockerError(e.to_string())),
+    }
+}
+
+pub async fn is_container_running(docker: &Docker, id: &str) -> bool {
+    match docker.inspect_container(id, None).await {
+        Ok(resp) => resp.state.and_then(|s| s.running).unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+pub async fn stop_container(docker: &Docker, id: &str) -> Result<()> {
+    use bollard::query_parameters::StopContainerOptionsBuilder;
+    docker
+        .stop_container(
+            id,
+            Some(StopContainerOptionsBuilder::default().t(10).build()),
+        )
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    Ok(())
+}
+
+pub async fn remove_container(docker: &Docker, id: &str) -> Result<()> {
+    use bollard::query_parameters::RemoveContainerOptionsBuilder;
+    docker
+        .remove_container(
+            id,
+            Some(RemoveContainerOptionsBuilder::default().force(true).build()),
+        )
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    Ok(())
+}
+
+pub async fn container_logs_tail(docker: &Docker, id: &str, n: usize) -> Result<String> {
+    use bollard::query_parameters::LogsOptionsBuilder;
+    let opts = LogsOptionsBuilder::default()
+        .stdout(true)
+        .stderr(true)
+        .tail(&n.to_string())
+        .build();
+    let mut stream = docker.logs(id, Some(opts));
+    let mut buf = String::new();
+    while let Some(line) = stream.next().await {
+        let l = line.map_err(|e| Error::DockerError(e.to_string()))?;
+        buf.push_str(&l.to_string());
+    }
+    Ok(buf)
+}
+
+pub struct DiscoveredContainer {
+    pub container_id: String,
+    pub server_name: String,
+    pub image: String,
+    pub host_port: Option<u16>,
+}
+
+/// Find Postgres containers we created in `project_cwd`. Filtered on the
+/// engine + project labels — both unique to containers this CLI created — but
+/// **not** on the version-stamped `created_by` label, so containers created by
+/// older releases of the CLI remain manageable after upgrade.
+pub async fn list_project_postgres(
+    docker: &Docker,
+    project_cwd: &str,
+) -> Result<Vec<DiscoveredContainer>> {
+    use bollard::query_parameters::ListContainersOptionsBuilder;
+
+    let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+    filters.insert(
+        "label".to_string(),
+        vec![
+            format!("{}=postgres", LABEL_ENGINE),
+            format!("{}={}", LABEL_PROJECT, project_cwd),
+        ],
+    );
+
+    let opts = ListContainersOptionsBuilder::default()
+        .all(true)
+        .filters(&filters)
+        .build();
+
+    let containers = docker
+        .list_containers(Some(opts))
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+
+    let mut out = Vec::new();
+    for c in containers {
+        let id = match c.id {
+            Some(s) => s,
+            None => continue,
+        };
+        let labels = c.labels.unwrap_or_default();
+        let server_name = match labels.get(LABEL_NAME) {
+            Some(s) => s.clone(),
+            None => continue,
+        };
+        let image = c.image.unwrap_or_default();
+        let host_port = c.ports.as_ref().and_then(|ports| {
+            ports
+                .iter()
+                .find(|p| p.private_port == 5432)
+                .and_then(|p| p.public_port)
+        });
+        out.push(DiscoveredContainer {
+            container_id: id,
+            server_name,
+            image,
+            host_port,
+        });
+    }
+    Ok(out)
+}
+
+/// Run `psql` inside a container with a full interactive TTY:
+/// host stdin/stdout are wired to the docker exec stream, the host terminal
+/// goes into raw mode, and SIGWINCH is forwarded as `resize_exec`.
+pub async fn exec_psql_in_container(
+    docker: &Docker,
+    container_id: &str,
+    psql_args: &[String],
+) -> Result<()> {
+    use bollard::exec::StartExecResults;
+    use bollard::models::ExecConfig;
+    use bollard::query_parameters::ResizeExecOptionsBuilder;
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut cmd = vec!["psql".to_string()];
+    cmd.extend(psql_args.iter().cloned());
+
+    let exec = docker
+        .create_exec(
+            container_id,
+            ExecConfig {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(true),
+                tty: Some(true),
+                cmd: Some(cmd),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    let exec_id = exec.id;
+
+    let started = docker
+        .start_exec(&exec_id, None)
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    let (mut output, mut input) = match started {
+        StartExecResults::Attached { output, input } => (output, input),
+        StartExecResults::Detached => return Ok(()),
+    };
+
+    // Initial size resize.
+    if let Ok((cols, rows)) = crossterm::terminal::size() {
+        let _ = docker
+            .resize_exec(
+                &exec_id,
+                ResizeExecOptionsBuilder::default()
+                    .h(rows as i32)
+                    .w(cols as i32)
+                    .build(),
+            )
+            .await;
+    }
+
+    enable_raw_mode().map_err(|e| Error::DockerError(format!("raw mode: {e}")))?;
+    struct RawModeGuard;
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let _ = disable_raw_mode();
+        }
+    }
+    let _guard = RawModeGuard;
+
+    #[cfg(unix)]
+    let resize_task = {
+        use tokio::signal::unix::{signal, SignalKind};
+        let docker_clone = docker.clone();
+        let exec_id_clone = exec_id.clone();
+        tokio::spawn(async move {
+            if let Ok(mut sig) = signal(SignalKind::window_change()) {
+                while sig.recv().await.is_some() {
+                    if let Ok((cols, rows)) = crossterm::terminal::size() {
+                        let _ = docker_clone
+                            .resize_exec(
+                                &exec_id_clone,
+                                ResizeExecOptionsBuilder::default()
+                                    .h(rows as i32)
+                                    .w(cols as i32)
+                                    .build(),
+                            )
+                            .await;
+                    }
+                }
+            }
+        })
+    };
+
+    // Pump stdin into the exec stream.
+    let stdin_task = tokio::spawn(async move {
+        let mut stdin = tokio::io::stdin();
+        let mut buf = [0u8; 1024];
+        loop {
+            match stdin.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    if input.write_all(&buf[..n]).await.is_err() {
+                        break;
+                    }
+                    let _ = input.flush().await;
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    // Pump exec output to stdout.
+    let mut stdout = tokio::io::stdout();
+    while let Some(chunk) = output.next().await {
+        match chunk {
+            Ok(out) => {
+                let bytes = out.into_bytes();
+                let _ = stdout.write_all(&bytes).await;
+                let _ = stdout.flush().await;
+            }
+            Err(_) => break,
+        }
+    }
+
+    stdin_task.abort();
+    #[cfg(unix)]
+    resize_task.abort();
+    drop(_guard);
+
+    if let Ok(info) = docker.inspect_exec(&exec_id).await
+        && let Some(code) = info.exit_code
+        && code != 0
+    {
+        std::process::exit(code as i32);
+    }
+    Ok(())
+}
+
+// ── Blocking shims (callable from sync `server.rs`) ─────────────────────────
+
+/// Drive an async task to completion from sync code.
+///
+/// Inside a multi-thread tokio runtime (the CLI's default `#[tokio::main]`),
+/// uses `block_in_place` so we don't deadlock the executor. Outside any
+/// runtime (rare — basically only from non-tokio tests), spins up a fresh
+/// runtime. Will panic if called inside a `current_thread` runtime; we don't
+/// use one anywhere.
+pub(crate) fn block_on<F: std::future::Future>(f: F) -> F::Output {
+    use tokio::runtime::Handle;
+    match Handle::try_current() {
+        Ok(h) => tokio::task::block_in_place(|| h.block_on(f)),
+        Err(_) => {
+            let rt = tokio::runtime::Runtime::new()
+                .expect("failed to build tokio runtime for docker blocking shim");
+            rt.block_on(f)
+        }
+    }
+}
+
+pub fn is_container_running_blocking(id: &str) -> bool {
+    let id = id.to_string();
+    block_on(async move {
+        let docker = match connect().await {
+            Ok(d) => d,
+            Err(_) => return false,
+        };
+        is_container_running(&docker, &id).await
+    })
+}
+
+pub fn stop_and_remove_blocking(id: &str) -> Result<()> {
+    let id = id.to_string();
+    block_on(async move {
+        let docker = connect().await?;
+        // best-effort: stop may fail if the container is already stopped.
+        let _ = stop_container(&docker, &id).await;
+        remove_container(&docker, &id).await
+    })
+}
+
+/// Discover Postgres containers belonging to this project that don't yet have
+/// a metadata file under `.clickhouse/servers/`, and write a `ServerInfo` for
+/// each so they show up in `local server list` and can be managed.
+///
+/// Safe to call multiple times in one CLI invocation. When Docker isn't
+/// reachable, `connect()` fails fast (no socket → immediate error, no I/O
+/// timeout) and we return silently.
+pub fn recover_project_postgres_blocking(project_cwd: &str) {
+    use crate::local::server::{
+        ensure_server_data_dir, save_server_info, server_meta_path_for_recovery, Engine,
+        ServerInfo,
+    };
+    let cwd_owned = project_cwd.to_string();
+    let _ = block_on(async move {
+        let docker = match connect().await {
+            Ok(d) => d,
+            Err(_) => return Ok::<(), Error>(()),
+        };
+        let containers = match list_project_postgres(&docker, &cwd_owned).await {
+            Ok(c) => c,
+            Err(_) => return Ok(()),
+        };
+        for c in containers {
+            if server_meta_path_for_recovery(&c.server_name).exists() {
+                continue;
+            }
+            let _ = ensure_server_data_dir(&c.server_name);
+            let info = ServerInfo {
+                name: c.server_name.clone(),
+                pid: 0,
+                version: c.image.clone(),
+                http_port: 0,
+                tcp_port: c.host_port.unwrap_or(0),
+                started_at: "recovered".to_string(),
+                cwd: cwd_owned.clone(),
+                engine: Engine::Postgres,
+                container_id: Some(c.container_id.clone()),
+            };
+            let _ = save_server_info(&info);
+        }
+        Ok(())
+    });
+}

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -296,6 +296,71 @@ pub async fn list_project_postgres(
     Ok(out)
 }
 
+/// Run `psql` inside a container in non-interactive mode: no TTY, no raw
+/// mode, no stdin. Streams stdout+stderr to the host. Used when the caller
+/// passes `--query` or `--queries-file` so the output can be piped/scripted.
+pub async fn exec_psql_one_shot(
+    docker: &Docker,
+    container_id: &str,
+    psql_args: &[String],
+) -> Result<()> {
+    use bollard::exec::StartExecResults;
+    use bollard::models::ExecConfig;
+    use tokio::io::AsyncWriteExt;
+
+    let mut cmd = vec!["psql".to_string()];
+    cmd.extend(psql_args.iter().cloned());
+
+    let exec = docker
+        .create_exec(
+            container_id,
+            ExecConfig {
+                attach_stdout: Some(true),
+                attach_stderr: Some(true),
+                attach_stdin: Some(false),
+                tty: Some(false),
+                cmd: Some(cmd),
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    let exec_id = exec.id;
+
+    let started = docker
+        .start_exec(&exec_id, None)
+        .await
+        .map_err(|e| Error::DockerError(e.to_string()))?;
+    let mut output = match started {
+        StartExecResults::Attached { output, .. } => output,
+        StartExecResults::Detached => return Ok(()),
+    };
+
+    let mut stdout = tokio::io::stdout();
+    let mut stderr = tokio::io::stderr();
+    while let Some(chunk) = output.next().await {
+        match chunk {
+            Ok(bollard::container::LogOutput::StdErr { message }) => {
+                let _ = stderr.write_all(&message).await;
+            }
+            Ok(out) => {
+                let _ = stdout.write_all(&out.into_bytes()).await;
+            }
+            Err(_) => break,
+        }
+    }
+    let _ = stdout.flush().await;
+    let _ = stderr.flush().await;
+
+    if let Ok(info) = docker.inspect_exec(&exec_id).await
+        && let Some(code) = info.exit_code
+        && code != 0
+    {
+        std::process::exit(code as i32);
+    }
+    Ok(())
+}
+
 /// Run `psql` inside a container with a full interactive TTY:
 /// host stdin/stdout are wired to the docker exec stream, the host terminal
 /// goes into raw mode, and SIGWINCH is forwarded as `resize_exec`.
@@ -461,13 +526,35 @@ pub fn is_container_running_blocking(id: &str) -> bool {
     })
 }
 
+/// Stop a container, leaving it on disk so it can be `docker start`ed again.
+pub fn stop_blocking(id: &str) -> Result<()> {
+    let id = id.to_string();
+    block_on(async move {
+        let docker = connect().await?;
+        stop_container(&docker, &id).await
+    })
+}
+
+/// Best-effort stop, then remove the container.
 pub fn stop_and_remove_blocking(id: &str) -> Result<()> {
     let id = id.to_string();
     block_on(async move {
         let docker = connect().await?;
-        // best-effort: stop may fail if the container is already stopped.
         let _ = stop_container(&docker, &id).await;
         remove_container(&docker, &id).await
+    })
+}
+
+/// `docker start` an existing stopped container.
+pub fn start_existing_blocking(id: &str) -> Result<()> {
+    use bollard::query_parameters::StartContainerOptions;
+    let id = id.to_string();
+    block_on(async move {
+        let docker = connect().await?;
+        docker
+            .start_container(&id, None::<StartContainerOptions>)
+            .await
+            .map_err(|e| Error::DockerError(e.to_string()))
     })
 }
 

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 
 pub const LABEL_ENGINE: &str = "clickhousectl.engine";
 pub const LABEL_NAME: &str = "clickhousectl.name";
+pub const LABEL_MAJOR: &str = "clickhousectl.major";
 pub const LABEL_PROJECT: &str = "clickhousectl.project";
 pub const LABEL_CREATED_BY: &str = "created_by";
 
@@ -28,9 +29,10 @@ pub fn created_by_value() -> String {
     format!("clickhousectl_{}", env!("CARGO_PKG_VERSION"))
 }
 
-/// Container name we use for a managed Postgres server.
-pub fn container_name(server_name: &str) -> String {
-    format!("clickhousectl-pg-{}", server_name)
+/// Container name for a Postgres instance: `clickhousectl-pg-<name>-<major>`.
+/// Distinct (name, major) pairs always get distinct container names.
+pub fn pg_container_name(user_name: &str, major: &str) -> String {
+    format!("clickhousectl-pg-{}-{}", user_name, major)
 }
 
 /// Connect to the local Docker daemon and verify it's reachable.
@@ -73,7 +75,10 @@ pub async fn image_exists(docker: &Docker, tag: &str) -> Result<bool> {
 }
 
 pub struct PostgresRunOpts<'a> {
-    pub server_name: &'a str,
+    /// User-facing instance name (e.g. `dev`).
+    pub user_name: &'a str,
+    /// Major version digits (e.g. `16`).
+    pub major: &'a str,
     pub tag: &'a str,
     pub host_port: u16,
     pub data_dir: &'a std::path::Path,
@@ -126,7 +131,8 @@ pub async fn run_postgres(docker: &Docker, opts: PostgresRunOpts<'_>) -> Result<
 
     let mut labels: HashMap<String, String> = HashMap::new();
     labels.insert(LABEL_ENGINE.into(), "postgres".into());
-    labels.insert(LABEL_NAME.into(), opts.server_name.into());
+    labels.insert(LABEL_NAME.into(), opts.user_name.into());
+    labels.insert(LABEL_MAJOR.into(), opts.major.into());
     labels.insert(LABEL_PROJECT.into(), opts.project_cwd.into());
     labels.insert(LABEL_CREATED_BY.into(), created_by_value());
 
@@ -139,7 +145,7 @@ pub async fn run_postgres(docker: &Docker, opts: PostgresRunOpts<'_>) -> Result<
     };
 
     let create_opts = CreateContainerOptionsBuilder::default()
-        .name(&container_name(opts.server_name))
+        .name(&pg_container_name(opts.user_name, opts.major))
         .build();
 
     let created = docker
@@ -155,17 +161,18 @@ pub async fn run_postgres(docker: &Docker, opts: PostgresRunOpts<'_>) -> Result<
     Ok(created.id)
 }
 
-/// If a container with our managed name (`clickhousectl-pg-<name>`) exists in
-/// any state, remove it — but only when it carries our labels for the current
-/// project. Returns Ok(()) if the name is free or was successfully cleaned up,
-/// or an actionable error if the name is held by an unrelated container.
+/// If a container with our managed name (`clickhousectl-pg-<name>-<major>`)
+/// exists in any state, remove it — but only when it carries our labels for
+/// the current project. Returns Ok(()) if the name is free or was cleaned
+/// up, or an actionable error if the name is held by an unrelated container.
 pub async fn ensure_name_free(
     docker: &Docker,
-    server_name: &str,
+    user_name: &str,
+    major: &str,
     project_cwd: &str,
 ) -> Result<()> {
     use bollard::errors::Error as BErr;
-    let cname = container_name(server_name);
+    let cname = pg_container_name(user_name, major);
     match docker.inspect_container(&cname, None).await {
         Ok(info) => {
             let labels_match = info
@@ -241,7 +248,10 @@ pub async fn container_logs_tail(docker: &Docker, id: &str, n: usize) -> Result<
 
 pub struct DiscoveredContainer {
     pub container_id: String,
-    pub server_name: String,
+    /// User-facing instance name from the `clickhousectl.name` label.
+    pub user_name: String,
+    /// Major-version digits from the `clickhousectl.major` label.
+    pub major: String,
     pub image: String,
     pub host_port: Option<u16>,
 }
@@ -282,7 +292,13 @@ pub async fn list_project_postgres(
             None => continue,
         };
         let labels = c.labels.unwrap_or_default();
-        let server_name = match labels.get(LABEL_NAME) {
+        let user_name = match labels.get(LABEL_NAME) {
+            Some(s) => s.clone(),
+            None => continue,
+        };
+        // Skip containers from older versions of this CLI that didn't write a
+        // major label — we can't reconstruct their disk key safely.
+        let major = match labels.get(LABEL_MAJOR) {
             Some(s) => s.clone(),
             None => continue,
         };
@@ -295,7 +311,8 @@ pub async fn list_project_postgres(
         });
         out.push(DiscoveredContainer {
             container_id: id,
-            server_name,
+            user_name,
+            major,
             image,
             host_port,
         });
@@ -574,8 +591,8 @@ pub fn start_existing_blocking(id: &str) -> Result<()> {
 /// timeout) and we return silently.
 pub fn recover_project_postgres_blocking(project_cwd: &str) {
     use crate::local::server::{
-        ensure_server_data_dir, save_server_info, server_meta_path_for_recovery, Engine,
-        ServerInfo,
+        ensure_pg_data_dir, pg_instance_key, save_server_info,
+        server_meta_path_for_recovery, Engine, ServerInfo,
     };
     let cwd_owned = project_cwd.to_string();
     let _ = block_on(async move {
@@ -588,12 +605,13 @@ pub fn recover_project_postgres_blocking(project_cwd: &str) {
             Err(_) => return Ok(()),
         };
         for c in containers {
-            if server_meta_path_for_recovery(&c.server_name).exists() {
+            let key = pg_instance_key(&c.user_name, &c.major);
+            if server_meta_path_for_recovery(&key).exists() {
                 continue;
             }
-            let _ = ensure_server_data_dir(&c.server_name);
+            let _ = ensure_pg_data_dir(&c.user_name, &c.major);
             let info = ServerInfo {
-                name: c.server_name.clone(),
+                name: key,
                 pid: 0,
                 version: c.image.clone(),
                 http_port: 0,

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -54,6 +54,7 @@ fn parse_postgres_install_spec(spec: &str) -> Option<&str> {
 }
 
 async fn install_postgres(tag: &str, force: bool, json: bool) -> Result<()> {
+    postgres::validate_pg_tag(tag)?;
     let docker = docker::connect().await?;
     if !force && docker::image_exists(&docker, tag).await? {
         let out = output::InstallOutput {
@@ -290,6 +291,22 @@ async fn start_server(
 
     // Resolve server name and check for collisions before any downloads
     let server_name = server::resolve_name(name.as_deref())?;
+
+    // Reject names already used by another engine — both engines share
+    // `.clickhouse/servers/<name>/` so reusing the dir under a different
+    // engine would clobber the other engine's data. Run this before the
+    // running-collision check so the engine error is preferred.
+    if let Some(prior) = server::load_info(&server_name)
+        && prior.engine != server::Engine::Clickhouse
+    {
+        return Err(Error::Exec(format!(
+            "name '{}' is already in use by a {} server. Use a different --name, \
+             or run `clickhousectl local postgres remove {}` first.",
+            server_name,
+            prior.engine.as_str(),
+            server_name
+        )));
+    }
 
     if name.is_some() && server::is_server_running(&server_name) {
         return Err(Error::ServerAlreadyRunning(server_name));
@@ -654,20 +671,28 @@ fn list_servers_local(json: bool) -> Result<()> {
         servers: entries
             .into_iter()
             .map(|e| {
+                let running = e.running;
                 let (pid, version, http_port, tcp_port, engine, container_id) = match e.info {
-                    Some(info) => (
-                        Some(info.pid),
-                        Some(info.version),
-                        Some(info.http_port),
-                        Some(info.tcp_port),
-                        info.engine.as_str().to_string(),
-                        info.container_id,
-                    ),
+                    Some(info) => {
+                        let is_ch = info.engine == server::Engine::Clickhouse;
+                        // pid only meaningful for a running ClickHouse process.
+                        let pid = if is_ch && running { Some(info.pid) } else { None };
+                        // http_port doesn't apply to Postgres.
+                        let http_port = if is_ch { Some(info.http_port) } else { None };
+                        (
+                            pid,
+                            Some(info.version),
+                            http_port,
+                            Some(info.tcp_port),
+                            info.engine.as_str().to_string(),
+                            info.container_id,
+                        )
+                    }
                     None => (None, None, None, None, "clickhouse".to_string(), None),
                 };
                 output::ServerListEntry {
                     name: e.name,
-                    running: e.running,
+                    running,
                     pid,
                     version,
                     http_port,

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -292,22 +292,6 @@ async fn start_server(
     // Resolve server name and check for collisions before any downloads
     let server_name = server::resolve_name(name.as_deref())?;
 
-    // Reject names already used by another engine — both engines share
-    // `.clickhouse/servers/<name>/` so reusing the dir under a different
-    // engine would clobber the other engine's data. Run this before the
-    // running-collision check so the engine error is preferred.
-    if let Some(prior) = server::load_info(&server_name)
-        && prior.engine != server::Engine::Clickhouse
-    {
-        return Err(Error::Exec(format!(
-            "name '{}' is already in use by a {} server. Use a different --name, \
-             or run `clickhousectl local postgres remove {}` first.",
-            server_name,
-            prior.engine.as_str(),
-            server_name
-        )));
-    }
-
     if name.is_some() && server::is_server_running(&server_name) {
         return Err(Error::ServerAlreadyRunning(server_name));
     }
@@ -672,26 +656,41 @@ fn list_servers_local(json: bool) -> Result<()> {
             .into_iter()
             .map(|e| {
                 let running = e.running;
-                let (pid, version, http_port, tcp_port, engine, container_id) = match e.info {
-                    Some(info) => {
-                        let is_ch = info.engine == server::Engine::Clickhouse;
-                        // pid only meaningful for a running ClickHouse process.
-                        let pid = if is_ch && running { Some(info.pid) } else { None };
-                        // http_port doesn't apply to Postgres.
-                        let http_port = if is_ch { Some(info.http_port) } else { None };
-                        (
-                            pid,
-                            Some(info.version),
-                            http_port,
-                            Some(info.tcp_port),
-                            info.engine.as_str().to_string(),
-                            info.container_id,
-                        )
-                    }
-                    None => (None, None, None, None, "clickhouse".to_string(), None),
-                };
+                let (display_name, pid, version, http_port, tcp_port, engine, container_id) =
+                    match e.info {
+                        Some(info) => {
+                            let is_ch = info.engine == server::Engine::Clickhouse;
+                            let pid = if is_ch && running { Some(info.pid) } else { None };
+                            let http_port = if is_ch { Some(info.http_port) } else { None };
+                            // For Postgres the disk key is `<name>-pg<major>`;
+                            // show users the friendly name without the suffix.
+                            let display = if is_ch {
+                                e.name.clone()
+                            } else {
+                                postgres::user_name_from_key(&e.name).to_string()
+                            };
+                            (
+                                display,
+                                pid,
+                                Some(info.version),
+                                http_port,
+                                Some(info.tcp_port),
+                                info.engine.as_str().to_string(),
+                                info.container_id,
+                            )
+                        }
+                        None => (
+                            e.name.clone(),
+                            None,
+                            None,
+                            None,
+                            None,
+                            "clickhouse".to_string(),
+                            None,
+                        ),
+                    };
                 output::ServerListEntry {
-                    name: e.name,
+                    name: display_name,
                     running,
                     pid,
                     version,

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1,6 +1,8 @@
 pub mod cli;
 pub mod discovery;
+pub mod docker;
 pub mod output;
+pub mod postgres;
 pub mod server;
 
 use cli::{LocalCommands, ServerCommands};
@@ -40,10 +42,46 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
             args,
         } => run_client(name, host, port, query, queries_file, args),
         LocalCommands::Server { command } => run_server_commands(command, json).await,
+        LocalCommands::Postgres { command } => postgres::run(command, json).await,
     }
 }
 
+/// If the version spec looks like `postgres@<tag>` or `postgres:<tag>`, extract
+/// the tag. The CLI accepts both `@` (more shell-friendly, no need to quote)
+/// and `:` (matches Docker image syntax).
+fn parse_postgres_install_spec(spec: &str) -> Option<&str> {
+    spec.strip_prefix("postgres@").or_else(|| spec.strip_prefix("postgres:"))
+}
+
+async fn install_postgres(tag: &str, force: bool, json: bool) -> Result<()> {
+    let docker = docker::connect().await?;
+    if !force && docker::image_exists(&docker, tag).await? {
+        let out = output::InstallOutput {
+            version: format!("postgres@{tag}"),
+            set_as_default: false,
+        };
+        if !json {
+            eprintln!("postgres:{tag} is already pulled");
+        }
+        output::print_output(&out, json);
+        return Ok(());
+    }
+
+    eprintln!("Pulling postgres:{tag}...");
+    docker::pull_image(&docker, tag).await?;
+
+    let out = output::InstallOutput {
+        version: format!("postgres@{tag}"),
+        set_as_default: false,
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
 async fn install(version_spec: &str, force: bool, json: bool) -> Result<()> {
+    if let Some(tag) = parse_postgres_install_spec(version_spec) {
+        return install_postgres(tag, force, json).await;
+    }
     let spec = version_manager::parse_version_spec(version_spec)?;
     let platform = version_manager::platform::Platform::detect()?;
 
@@ -335,6 +373,8 @@ async fn start_server(
             tcp_port,
             started_at: server::now_timestamp(),
             cwd,
+            engine: server::Engine::Clickhouse,
+            container_id: None,
         };
         server::save_server_info(&info)?;
 
@@ -362,6 +402,8 @@ async fn start_server(
             tcp_port,
             started_at: server::now_timestamp(),
             cwd,
+            engine: server::Engine::Clickhouse,
+            container_id: None,
         };
         server::save_server_info(&info)?;
 
@@ -423,7 +465,7 @@ fn dotenv_server(
 
     let content = if path.exists() {
         let existing = std::fs::read_to_string(path)?;
-        update_dotenv(&existing, &vars)
+        update_dotenv(&existing, "CLICKHOUSE_", &vars)
     } else {
         vars.iter()
             .map(|(k, v)| format_dotenv_line("", k, v))
@@ -452,7 +494,7 @@ fn dotenv_server(
 /// Format a dotenv line. Values that are plain alphanumeric tokens are written
 /// bare; anything containing spaces, `#`, quotes, backslashes, or newlines is
 /// double-quoted with inner `"`, `\`, and newlines escaped.
-fn format_dotenv_line(prefix: &str, key: &str, val: &str) -> String {
+pub(crate) fn format_dotenv_line(prefix: &str, key: &str, val: &str) -> String {
     let needs_quoting = val.is_empty()
         || val
             .bytes()
@@ -469,11 +511,10 @@ fn format_dotenv_line(prefix: &str, key: &str, val: &str) -> String {
     }
 }
 
-/// Extract a CLICKHOUSE_* key from a dotenv line, handling optional `export`
-/// prefix and whitespace around `=`.
-/// Returns the bare key (e.g. "CLICKHOUSE_HOST") or None if the line isn't
-/// a CLICKHOUSE_* assignment.
-fn extract_dotenv_key(line: &str) -> Option<&str> {
+/// Extract a `<prefix>*` key from a dotenv line, handling optional `export`
+/// prefix and whitespace around `=`. Returns the bare key (e.g. "CLICKHOUSE_HOST"
+/// for prefix "CLICKHOUSE_") or None if the line isn't a matching assignment.
+fn extract_dotenv_key<'a>(line: &'a str, prefix: &str) -> Option<&'a str> {
     let s = line.trim();
     let s = s
         .strip_prefix("export")
@@ -481,31 +522,32 @@ fn extract_dotenv_key(line: &str) -> Option<&str> {
         .unwrap_or(s);
     let eq_pos = s.find('=')?;
     let key = s[..eq_pos].trim_end();
-    if key.starts_with("CLICKHOUSE_") && key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
-    {
+    if key.starts_with(prefix) && key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
         Some(key)
     } else {
         None
     }
 }
 
-/// Update an existing .env file: replace CLICKHOUSE_* vars in-place, append any missing ones.
-fn update_dotenv(existing: &str, vars: &[(&str, String)]) -> String {
+/// Update an existing .env file: replace `<prefix>*` vars in-place, append any
+/// missing ones. Lines for the same prefix that aren't in `vars` are preserved
+/// (e.g. a manually-set CLICKHOUSE_PASSWORD survives a host/port-only update).
+pub(crate) fn update_dotenv(existing: &str, prefix: &str, vars: &[(&str, String)]) -> String {
     let mut result = String::new();
     let mut written: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
     for line in existing.lines() {
-        if let Some(key) = extract_dotenv_key(line) {
+        if let Some(key) = extract_dotenv_key(line, prefix) {
             if let Some((_, val)) = vars.iter().find(|(k, _)| *k == key) {
-                let prefix = if line.trim_start().starts_with("export") {
+                let line_prefix = if line.trim_start().starts_with("export") {
                     "export "
                 } else {
                     ""
                 };
-                result.push_str(&format_dotenv_line(prefix, key, val));
+                result.push_str(&format_dotenv_line(line_prefix, key, val));
                 written.insert(key);
             } else {
-                // A CLICKHOUSE_* var we don't manage — keep as-is
+                // A matching-prefix var we don't manage — keep as-is
                 result.push_str(line);
             }
         } else {
@@ -514,7 +556,6 @@ fn update_dotenv(existing: &str, vars: &[(&str, String)]) -> String {
         result.push('\n');
     }
 
-    // Append any vars that weren't already in the file
     for (key, val) in vars {
         if !written.contains(key) {
             result.push_str(&format_dotenv_line("", key, val));
@@ -613,14 +654,16 @@ fn list_servers_local(json: bool) -> Result<()> {
         servers: entries
             .into_iter()
             .map(|e| {
-                let (pid, version, http_port, tcp_port) = match e.info {
+                let (pid, version, http_port, tcp_port, engine, container_id) = match e.info {
                     Some(info) => (
                         Some(info.pid),
                         Some(info.version),
                         Some(info.http_port),
                         Some(info.tcp_port),
+                        info.engine.as_str().to_string(),
+                        info.container_id,
                     ),
-                    None => (None, None, None, None),
+                    None => (None, None, None, None, "clickhouse".to_string(), None),
                 };
                 output::ServerListEntry {
                     name: e.name,
@@ -630,6 +673,8 @@ fn list_servers_local(json: bool) -> Result<()> {
                     http_port,
                     tcp_port,
                     project: None,
+                    engine,
+                    container_id,
                 }
             })
             .collect(),
@@ -655,6 +700,8 @@ fn list_servers_global(json: bool) -> Result<()> {
                 http_port: e.http_port,
                 tcp_port: e.tcp_port,
                 project: Some(e.project),
+                engine: e.engine.as_str().to_string(),
+                container_id: e.container_id,
             })
             .collect(),
         total_servers: total,
@@ -701,7 +748,13 @@ fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<(
 }
 
 fn stop_all_servers_local(json: bool) -> Result<()> {
-    let servers = server::list_running_servers();
+    // `local server stop-all` historically only managed ClickHouse processes.
+    // Postgres has its own `local postgres stop-all`; don't silently sweep it
+    // up here.
+    let servers: Vec<_> = server::list_running_servers()
+        .into_iter()
+        .filter(|s| s.engine == server::Engine::Clickhouse)
+        .collect();
     let mut stop_entries = Vec::new();
     for s in &servers {
         if !json {
@@ -801,12 +854,43 @@ mod tests {
     }
 
     #[test]
+    fn parse_postgres_install_spec_recognizes_at_and_colon() {
+        assert_eq!(parse_postgres_install_spec("postgres@16"), Some("16"));
+        assert_eq!(parse_postgres_install_spec("postgres:16-alpine"), Some("16-alpine"));
+        assert_eq!(parse_postgres_install_spec("25.12"), None);
+        assert_eq!(parse_postgres_install_spec("stable"), None);
+    }
+
+    #[test]
+    fn update_dotenv_postgres_prefix_isolates_clickhouse_vars() {
+        let existing = "CLICKHOUSE_HOST=localhost\nCLICKHOUSE_PORT=9000\nDATABASE_URL=x\n";
+        let vars = vec![
+            ("POSTGRES_HOST", "localhost".to_string()),
+            ("POSTGRES_PORT", "5432".to_string()),
+        ];
+        let result = update_dotenv(existing, "POSTGRES_", &vars);
+        assert!(result.contains("CLICKHOUSE_HOST=localhost"));
+        assert!(result.contains("CLICKHOUSE_PORT=9000"));
+        assert!(result.contains("POSTGRES_HOST=localhost"));
+        assert!(result.contains("POSTGRES_PORT=5432"));
+    }
+
+    #[test]
+    fn extract_dotenv_key_postgres_prefix() {
+        assert_eq!(
+            extract_dotenv_key("POSTGRES_USER=postgres", "POSTGRES_"),
+            Some("POSTGRES_USER")
+        );
+        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST=x", "POSTGRES_"), None);
+    }
+
+    #[test]
     fn update_dotenv_creates_fresh_content() {
         let vars = vec![
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PORT", "9000".to_string()),
         ];
-        let result = update_dotenv("", &vars);
+        let result = update_dotenv("", "CLICKHOUSE_", &vars);
         assert_eq!(result, "CLICKHOUSE_HOST=localhost\nCLICKHOUSE_PORT=9000\n");
     }
 
@@ -817,7 +901,7 @@ mod tests {
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PORT", "9000".to_string()),
         ];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("CLICKHOUSE_HOST=localhost"));
         assert!(result.contains("CLICKHOUSE_PORT=9000"));
         assert!(result.contains("DATABASE_URL=postgres://..."));
@@ -829,7 +913,7 @@ mod tests {
     fn update_dotenv_preserves_non_clickhouse_vars() {
         let existing = "FOO=bar\nBAZ=qux\n";
         let vars = vec![("CLICKHOUSE_HOST", "localhost".to_string())];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("FOO=bar"));
         assert!(result.contains("BAZ=qux"));
         assert!(result.contains("CLICKHOUSE_HOST=localhost"));
@@ -842,7 +926,7 @@ mod tests {
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PORT", "9000".to_string()),
         ];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("CLICKHOUSE_HOST=localhost"));
         assert!(result.contains("CLICKHOUSE_PORT=9000"));
     }
@@ -854,7 +938,7 @@ mod tests {
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PORT", "9000".to_string()),
         ];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("export CLICKHOUSE_HOST=localhost"));
         assert!(result.contains("export CLICKHOUSE_PORT=9000"));
         assert!(!result.contains("oldhost"));
@@ -865,7 +949,7 @@ mod tests {
     fn update_dotenv_handles_spaces_around_equals() {
         let existing = "CLICKHOUSE_HOST = oldhost\n";
         let vars = vec![("CLICKHOUSE_HOST", "localhost".to_string())];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("CLICKHOUSE_HOST=localhost"));
         assert!(!result.contains("oldhost"));
     }
@@ -874,7 +958,7 @@ mod tests {
     fn update_dotenv_handles_export_with_spaces() {
         let existing = "export CLICKHOUSE_PORT = 1234\nDATABASE_URL=postgres://...\n";
         let vars = vec![("CLICKHOUSE_PORT", "9000".to_string())];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("export CLICKHOUSE_PORT=9000"));
         assert!(result.contains("DATABASE_URL=postgres://..."));
         assert!(!result.contains("1234"));
@@ -885,40 +969,40 @@ mod tests {
         let existing = "CLICKHOUSE_HOST=localhost\nCLICKHOUSE_PASSWORD=secret\n";
         // Only updating HOST — PASSWORD should be left alone
         let vars = vec![("CLICKHOUSE_HOST", "newhost".to_string())];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains("CLICKHOUSE_HOST=newhost"));
         assert!(result.contains("CLICKHOUSE_PASSWORD=secret"));
     }
 
     #[test]
     fn extract_dotenv_key_simple() {
-        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST=localhost"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
     }
 
     #[test]
     fn extract_dotenv_key_with_export() {
-        assert_eq!(extract_dotenv_key("export CLICKHOUSE_HOST=localhost"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(extract_dotenv_key("export CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
     }
 
     #[test]
     fn extract_dotenv_key_with_spaces() {
-        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST = localhost"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST = localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
         assert_eq!(
-            extract_dotenv_key("export CLICKHOUSE_HOST = localhost"),
+            extract_dotenv_key("export CLICKHOUSE_HOST = localhost", "CLICKHOUSE_"),
             Some("CLICKHOUSE_HOST")
         );
     }
 
     #[test]
     fn extract_dotenv_key_non_clickhouse() {
-        assert_eq!(extract_dotenv_key("DATABASE_URL=postgres://..."), None);
-        assert_eq!(extract_dotenv_key("export FOO=bar"), None);
+        assert_eq!(extract_dotenv_key("DATABASE_URL=postgres://...", "CLICKHOUSE_"), None);
+        assert_eq!(extract_dotenv_key("export FOO=bar", "CLICKHOUSE_"), None);
     }
 
     #[test]
     fn extract_dotenv_key_comment_and_blank() {
-        assert_eq!(extract_dotenv_key("# CLICKHOUSE_HOST=localhost"), None);
-        assert_eq!(extract_dotenv_key(""), None);
+        assert_eq!(extract_dotenv_key("# CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), None);
+        assert_eq!(extract_dotenv_key("", "CLICKHOUSE_"), None);
     }
 
     #[test]
@@ -977,7 +1061,7 @@ mod tests {
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PASSWORD", "my secret#123".to_string()),
         ];
-        let result = update_dotenv("", &vars);
+        let result = update_dotenv("", "CLICKHOUSE_", &vars);
         assert!(result.contains("CLICKHOUSE_HOST=localhost"));
         assert!(result.contains(r#"CLICKHOUSE_PASSWORD="my secret#123""#));
     }
@@ -986,7 +1070,7 @@ mod tests {
     fn update_dotenv_quotes_when_replacing_in_place() {
         let existing = "CLICKHOUSE_PASSWORD=old\n";
         let vars = vec![("CLICKHOUSE_PASSWORD", "new pass".to_string())];
-        let result = update_dotenv(existing, &vars);
+        let result = update_dotenv(existing, "CLICKHOUSE_", &vars);
         assert!(result.contains(r#"CLICKHOUSE_PASSWORD="new pass""#));
     }
 }

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -213,6 +213,10 @@ pub struct ServerListEntry {
     pub tcp_port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub project: Option<String>,
+    /// "clickhouse" or "postgres".
+    pub engine: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -230,6 +234,24 @@ struct ServerListRow {
     status: String,
     #[tabled(rename = "PID")]
     pid: String,
+    #[tabled(rename = "Version")]
+    version: String,
+    #[tabled(rename = "HTTP Port")]
+    http_port: String,
+    #[tabled(rename = "TCP Port")]
+    tcp_port: String,
+}
+
+#[derive(Tabled)]
+struct ServerListRowWithEngine {
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Engine")]
+    engine: String,
+    #[tabled(rename = "Status")]
+    status: String,
+    #[tabled(rename = "ID")]
+    pid_or_container: String,
     #[tabled(rename = "Version")]
     version: String,
     #[tabled(rename = "HTTP Port")]
@@ -264,6 +286,44 @@ impl fmt::Display for ServerListOutput {
         }
 
         let has_project = self.servers.iter().any(|e| e.project.is_some());
+        let has_postgres = self.servers.iter().any(|e| e.engine == "postgres");
+
+        if !has_project && has_postgres {
+            // Show an engine-aware table that combines PID (ClickHouse) and
+            // container short-id (Postgres) into a single "ID" column.
+            let rows: Vec<ServerListRowWithEngine> = self
+                .servers
+                .iter()
+                .map(|e| {
+                    let id = if e.engine == "postgres" {
+                        e.container_id
+                            .as_deref()
+                            .map(|s| s.chars().take(12).collect::<String>())
+                            .unwrap_or_default()
+                    } else {
+                        e.pid.map(|p| p.to_string()).unwrap_or_default()
+                    };
+                    ServerListRowWithEngine {
+                        name: e.name.clone(),
+                        engine: e.engine.clone(),
+                        status: if e.running { "running".into() } else { "stopped".into() },
+                        pid_or_container: id,
+                        version: e.version.clone().unwrap_or_default(),
+                        http_port: e.http_port.map(|p| p.to_string()).unwrap_or_default(),
+                        tcp_port: e.tcp_port.map(|p| p.to_string()).unwrap_or_default(),
+                    }
+                })
+                .collect();
+            let table = Table::new(rows).with(Style::markdown()).to_string();
+            writeln!(f, "{table}")?;
+            return write!(
+                f,
+                "\n{} server{}, {} running",
+                self.total_servers,
+                if self.total_servers == 1 { "" } else { "s" },
+                self.total_running_servers
+            );
+        }
 
         if has_project {
             let rows: Vec<ServerListRowGlobal> = self
@@ -313,6 +373,59 @@ impl fmt::Display for ServerListOutput {
             if self.total_servers == 1 { "" } else { "s" },
             self.total_running_servers
         )
+    }
+}
+
+// ── postgres start ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PostgresStartOutput {
+    pub name: String,
+    pub container_id: String,
+    pub image: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+}
+
+impl fmt::Display for PostgresStartOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let short = self.container_id.chars().take(12).collect::<String>();
+        writeln!(
+            f,
+            "Postgres '{}' running (container: {})",
+            self.name, short
+        )?;
+        writeln!(f, "  Image:    {}", self.image)?;
+        writeln!(f, "  Port:     {}", self.port)?;
+        writeln!(f, "  User:     {}", self.user)?;
+        writeln!(f, "  Password: {}", self.password)?;
+        writeln!(f, "  Database: {}", self.database)?;
+        write!(
+            f,
+            "  Connect:  clickhousectl local postgres client --name {}",
+            self.name
+        )
+    }
+}
+
+// ── postgres dotenv ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PostgresDotenvOutput {
+    pub file: String,
+    pub server: String,
+    pub vars: Vec<DotenvVar>,
+}
+
+impl fmt::Display for PostgresDotenvOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Wrote to {} (postgres '{}')", self.file, self.server)?;
+        for var in &self.vars {
+            writeln!(f, "  {}={}", var.key, var.value)?;
+        }
+        Ok(())
     }
 }
 
@@ -575,6 +688,8 @@ mod tests {
                     http_port: Some(8123),
                     tcp_port: Some(9000),
                     project: None,
+                    engine: "clickhouse".to_string(),
+                    container_id: None,
                 },
                 ServerListEntry {
                     name: "test".to_string(),
@@ -584,6 +699,8 @@ mod tests {
                     http_port: None,
                     tcp_port: None,
                     project: None,
+                    engine: "clickhouse".to_string(),
+                    container_id: None,
                 },
             ],
             total_servers: 2,
@@ -830,6 +947,8 @@ mod tests {
                     http_port: Some(8123),
                     tcp_port: Some(9000),
                     project: None,
+                    engine: "clickhouse".to_string(),
+                    container_id: None,
                 },
                 ServerListEntry {
                     name: "test".to_string(),
@@ -839,6 +958,8 @@ mod tests {
                     http_port: None,
                     tcp_port: None,
                     project: None,
+                    engine: "clickhouse".to_string(),
+                    container_id: None,
                 },
             ],
             total_servers: 2,
@@ -882,6 +1003,8 @@ mod tests {
                 http_port: Some(8123),
                 tcp_port: Some(9000),
                 project: None,
+                    engine: "clickhouse".to_string(),
+                    container_id: None,
             }],
             total_servers: 1,
             total_running_servers: 1,

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -1,0 +1,502 @@
+//! Handlers for `clickhousectl local postgres ...` subcommands.
+//!
+//! All Docker work goes through `local::docker`. State is reused from
+//! `local::server` — Postgres entries land in the same metadata directory and
+//! show up alongside ClickHouse in `local server list`.
+
+use crate::error::{Error, Result};
+use crate::local::cli::PostgresCommands;
+use crate::local::docker::{self, PostgresRunOpts};
+use crate::local::output;
+use crate::local::server::{self, Engine, ServerInfo};
+use rand::distr::{Alphanumeric, SampleString};
+use std::process::Command;
+
+const DEFAULT_PG_PORT: u16 = 5432;
+const DEFAULT_USER: &str = "postgres";
+const DEFAULT_DATABASE: &str = "postgres";
+
+pub async fn run(cmd: PostgresCommands, json: bool) -> Result<()> {
+    match cmd {
+        PostgresCommands::Start {
+            name,
+            version,
+            port,
+            user,
+            password,
+            database,
+            env,
+        } => start(name, version, port, user, password, database, env, json).await,
+        PostgresCommands::Stop { name } => stop(&name, json).await,
+        PostgresCommands::StopAll => stop_all(json).await,
+        PostgresCommands::Remove { name } => remove(&name, json),
+        PostgresCommands::Client {
+            name,
+            host,
+            port,
+            query,
+            queries_file,
+            args,
+        } => client(name, host, port, query, queries_file, args).await,
+        PostgresCommands::Dotenv { name, local } => dotenv(name.as_deref(), local, json),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start(
+    name: Option<String>,
+    version: Option<String>,
+    port: Option<u16>,
+    user: Option<String>,
+    password: Option<String>,
+    database: Option<String>,
+    extra_env: Vec<String>,
+    json: bool,
+) -> Result<()> {
+    server::recover_current_project_servers();
+
+    let server_name = server::resolve_name(name.as_deref())?;
+
+    if name.is_some() && server::is_server_running(&server_name) {
+        return Err(Error::ServerAlreadyRunning(server_name));
+    }
+
+    let docker = docker::connect().await?;
+
+    let tag = version.as_deref().unwrap_or("latest");
+    if !docker::image_exists(&docker, tag).await? {
+        eprintln!("Pulling postgres:{tag}...");
+        docker::pull_image(&docker, tag).await?;
+    }
+
+    let host_port = resolve_port(port)?;
+
+    server::ensure_server_data_dir(&server_name)?;
+    let data_dir = server::server_data_dir(&server_name);
+
+    let project_cwd = std::env::current_dir()
+        .and_then(|p| p.canonicalize())
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    // Clear out any stale stopped container with the same name (only if we
+    // can prove we own it via labels) so create_container doesn't 409.
+    docker::ensure_name_free(&docker, &server_name, &project_cwd).await?;
+
+    let user = user.unwrap_or_else(|| DEFAULT_USER.to_string());
+    let database = database.unwrap_or_else(|| DEFAULT_DATABASE.to_string());
+
+    // If POSTGRES_PASSWORD is in extra_env, prefer it; else use --password; else generate.
+    let password_from_env = extra_env
+        .iter()
+        .find_map(|kv| kv.strip_prefix("POSTGRES_PASSWORD="))
+        .map(|s| s.to_string());
+    let password = password_from_env
+        .or(password)
+        .unwrap_or_else(generate_password);
+
+    let opts = PostgresRunOpts {
+        server_name: &server_name,
+        tag,
+        host_port,
+        data_dir: &data_dir,
+        project_cwd: &project_cwd,
+        user: &user,
+        password: &password,
+        database: &database,
+        extra_env,
+    };
+
+    let container_id = docker::run_postgres(&docker, opts).await?;
+
+    let info = ServerInfo {
+        name: server_name.clone(),
+        pid: 0,
+        version: format!("postgres:{tag}"),
+        http_port: 0,
+        tcp_port: host_port,
+        started_at: server::now_timestamp(),
+        cwd: project_cwd.clone(),
+        engine: Engine::Postgres,
+        container_id: Some(container_id.clone()),
+    };
+    server::save_server_info(&info)?;
+
+    // Health check: wait up to 3s for the container to be running.
+    let healthy = wait_running(&docker, &container_id, 30).await;
+    if !healthy {
+        let logs = docker::container_logs_tail(&docker, &container_id, 50)
+            .await
+            .unwrap_or_default();
+        // Best-effort cleanup so we don't leave a broken container.
+        let _ = docker::stop_container(&docker, &container_id).await;
+        let _ = docker::remove_container(&docker, &container_id).await;
+        server::remove_server_info(&server_name);
+        return Err(Error::DockerError(format!(
+            "Postgres container '{}' did not start.\n--- container logs ---\n{}",
+            server_name, logs
+        )));
+    }
+
+    let out = output::PostgresStartOutput {
+        name: server_name,
+        container_id,
+        image: format!("postgres:{tag}"),
+        port: host_port,
+        user,
+        password,
+        database,
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+async fn wait_running(docker: &bollard::Docker, id: &str, attempts: usize) -> bool {
+    for _ in 0..attempts {
+        if docker::is_container_running(docker, id).await {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    false
+}
+
+fn resolve_port(explicit: Option<u16>) -> Result<u16> {
+    if let Some(p) = explicit {
+        if p == 0 {
+            return Err(Error::Exec(
+                "--port 0 is not allowed; pick a specific port or omit the flag".into(),
+            ));
+        }
+        return Ok(p);
+    }
+    if std::net::TcpListener::bind(("127.0.0.1", DEFAULT_PG_PORT)).is_ok() {
+        return Ok(DEFAULT_PG_PORT);
+    }
+    for p in (DEFAULT_PG_PORT + 1)..=(DEFAULT_PG_PORT + 100) {
+        if std::net::TcpListener::bind(("127.0.0.1", p)).is_ok() {
+            return Ok(p);
+        }
+    }
+    Err(Error::Exec("could not find a free TCP port for Postgres".into()))
+}
+
+fn generate_password() -> String {
+    // 24 alphanumeric chars. Persisted in `.clickhouse/servers/<name>.json`
+    // so other processes (and `dotenv`) can recover the value.
+    Alphanumeric.sample_string(&mut rand::rng(), 24)
+}
+
+async fn stop(name: &str, json: bool) -> Result<()> {
+    server::validate_server_name(name)?;
+    server::recover_current_project_servers();
+    if !json {
+        println!("Stopping Postgres '{}'...", name);
+    }
+    server::kill_server(name)?;
+    let out = output::ServerStopOutput {
+        name: name.to_string(),
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+async fn stop_all(json: bool) -> Result<()> {
+    server::recover_current_project_servers();
+    let servers: Vec<_> = server::list_running_servers()
+        .into_iter()
+        .filter(|s| s.engine == Engine::Postgres)
+        .collect();
+    let mut stop_entries = Vec::new();
+    for s in &servers {
+        if !json {
+            print!("Stopping '{}'...", s.name);
+        }
+        match server::kill_server(&s.name) {
+            Ok(()) => {
+                if !json {
+                    println!(" stopped");
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: true,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                if !json {
+                    println!(" error: {}", e);
+                }
+                stop_entries.push(output::ServerStopEntry {
+                    name: s.name.clone(),
+                    stopped: false,
+                    error: Some(e.to_string()),
+                });
+            }
+        }
+    }
+    if json {
+        let out = output::ServerStopAllOutput {
+            servers: stop_entries,
+        };
+        output::print_output(&out, json);
+    } else if servers.is_empty() {
+        println!("No running Postgres servers");
+    } else {
+        println!("Done");
+    }
+    Ok(())
+}
+
+fn remove(name: &str, json: bool) -> Result<()> {
+    server::validate_server_name(name)?;
+    server::recover_current_project_servers();
+    if server::is_server_running(name) {
+        return Err(Error::ServerAlreadyRunning(name.to_string()));
+    }
+    let data_dir = server::server_data_dir(name);
+    if !data_dir.exists() {
+        return Err(Error::ServerNotFound(name.to_string()));
+    }
+    let server_dir = data_dir.parent().unwrap();
+    std::fs::remove_dir_all(server_dir)?;
+    server::remove_server_info(name);
+    let out = output::ServerRemoveOutput {
+        name: name.to_string(),
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn client(
+    name: Option<String>,
+    host: Option<String>,
+    port: Option<u16>,
+    query: Option<String>,
+    queries_file: Option<String>,
+    extra_args: Vec<String>,
+) -> Result<()> {
+    let server_name = name.as_deref().unwrap_or("default").to_string();
+
+    if host.is_some() || port.is_some() {
+        // Direct connect — no server lookup; require host psql.
+        let h = host.unwrap_or_else(|| "127.0.0.1".to_string());
+        let p = port.unwrap_or(DEFAULT_PG_PORT);
+        return exec_host_psql(&h, p, DEFAULT_USER, None, DEFAULT_DATABASE, query, queries_file, extra_args);
+    }
+
+    server::recover_current_project_servers();
+    let entries = server::list_all_servers();
+    let entry = entries
+        .iter()
+        .find(|e| e.name == server_name)
+        .ok_or_else(|| Error::ServerNotFound(server_name.clone()))?;
+    let info = entry
+        .info
+        .as_ref()
+        .ok_or_else(|| Error::ServerNotRunning(server_name.clone()))?;
+    if info.engine != Engine::Postgres {
+        return Err(Error::Exec(format!(
+            "server '{}' is a {} server, not Postgres. Use `local client` for ClickHouse.",
+            server_name,
+            info.engine.as_str()
+        )));
+    }
+
+    // Read connection info from container env (POSTGRES_USER / DB).
+    let docker = docker::connect().await?;
+    let container_id = info
+        .container_id
+        .as_deref()
+        .ok_or_else(|| Error::DockerError("missing container_id".into()))?;
+    let (user, password, database) = read_pg_env(&docker, container_id).await;
+
+    // Prefer host psql; fall back to docker exec.
+    if host_has_psql() {
+        return exec_host_psql(
+            "127.0.0.1",
+            info.tcp_port,
+            &user,
+            Some(&password),
+            &database,
+            query,
+            queries_file,
+            extra_args,
+        );
+    }
+
+    // Build psql args for docker exec.
+    let mut psql_args: Vec<String> = vec![
+        "-U".into(), user,
+        "-d".into(), database,
+    ];
+    if let Some(q) = query {
+        psql_args.push("-c".into());
+        psql_args.push(q);
+    }
+    if let Some(f) = queries_file {
+        psql_args.push("-f".into());
+        psql_args.push(f);
+    }
+    psql_args.extend(extra_args);
+
+    docker::exec_psql_in_container(&docker, container_id, &psql_args).await
+}
+
+/// Read POSTGRES_USER/PASSWORD/DB from the container's effective env so we
+/// don't lose track of user-provided values across recoveries.
+async fn read_pg_env(docker: &bollard::Docker, id: &str) -> (String, String, String) {
+    let inspect = docker.inspect_container(id, None).await.ok();
+    let env: Vec<String> = inspect
+        .and_then(|c| c.config)
+        .and_then(|c| c.env)
+        .unwrap_or_default();
+    let get = |k: &str| -> Option<String> {
+        env.iter()
+            .find_map(|e| e.strip_prefix(&format!("{k}=")).map(|s| s.to_string()))
+    };
+    (
+        get("POSTGRES_USER").unwrap_or_else(|| DEFAULT_USER.into()),
+        get("POSTGRES_PASSWORD").unwrap_or_default(),
+        get("POSTGRES_DB").unwrap_or_else(|| DEFAULT_DATABASE.into()),
+    )
+}
+
+fn host_has_psql() -> bool {
+    Command::new("psql")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn exec_host_psql(
+    host: &str,
+    port: u16,
+    user: &str,
+    password: Option<&str>,
+    database: &str,
+    query: Option<String>,
+    queries_file: Option<String>,
+    extra_args: Vec<String>,
+) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    let mut cmd = Command::new("psql");
+    cmd.arg("-h").arg(host)
+        .arg("-p").arg(port.to_string())
+        .arg("-U").arg(user)
+        .arg("-d").arg(database);
+    if let Some(p) = password {
+        cmd.env("PGPASSWORD", p);
+    }
+    if let Some(q) = query {
+        cmd.arg("-c").arg(q);
+    }
+    if let Some(f) = queries_file {
+        cmd.arg("-f").arg(f);
+    }
+    cmd.args(&extra_args);
+    let err = cmd.exec();
+    Err(Error::Exec(err.to_string()))
+}
+
+fn dotenv(name: Option<&str>, use_local: bool, json: bool) -> Result<()> {
+    let server_name = name.unwrap_or("default");
+    let entries = server::list_all_servers();
+    let entry = entries
+        .iter()
+        .find(|e| e.name == server_name)
+        .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+    let info = entry
+        .info
+        .as_ref()
+        .ok_or_else(|| Error::ServerNotRunning(server_name.to_string()))?;
+    if info.engine != Engine::Postgres {
+        return Err(Error::Exec(format!(
+            "server '{}' is a {} server, not Postgres",
+            server_name,
+            info.engine.as_str()
+        )));
+    }
+
+    // Read user/password/db from the container env so we always emit accurate creds.
+    let (user, password, database) = docker::block_on(read_pg_env_for_dotenv(
+        info.container_id.as_deref().unwrap_or_default(),
+    ));
+
+    let vars: Vec<(&str, String)> = vec![
+        ("POSTGRES_HOST", "127.0.0.1".to_string()),
+        ("POSTGRES_PORT", info.tcp_port.to_string()),
+        ("POSTGRES_USER", user),
+        ("POSTGRES_PASSWORD", password),
+        ("POSTGRES_DATABASE", database),
+    ];
+
+    let filename = if use_local { ".env.local" } else { ".env" };
+    let path = std::path::Path::new(filename);
+
+    let content = if path.exists() {
+        let existing = std::fs::read_to_string(path)?;
+        crate::local::update_dotenv(&existing, "POSTGRES_", &vars)
+    } else {
+        vars.iter()
+            .map(|(k, v)| crate::local::format_dotenv_line("", k, v))
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n"
+    };
+
+    std::fs::write(path, &content)?;
+
+    let out = output::PostgresDotenvOutput {
+        file: filename.to_string(),
+        server: server_name.to_string(),
+        vars: vars
+            .into_iter()
+            .map(|(k, v)| output::DotenvVar {
+                key: k.to_string(),
+                value: v,
+            })
+            .collect(),
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+async fn read_pg_env_for_dotenv(container_id: &str) -> (String, String, String) {
+    if container_id.is_empty() {
+        return (DEFAULT_USER.into(), String::new(), DEFAULT_DATABASE.into());
+    }
+    match docker::connect().await {
+        Ok(d) => read_pg_env(&d, container_id).await,
+        Err(_) => (DEFAULT_USER.into(), String::new(), DEFAULT_DATABASE.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_port_rejects_zero() {
+        let err = resolve_port(Some(0)).unwrap_err();
+        assert!(matches!(err, Error::Exec(msg) if msg.contains("--port 0")));
+    }
+
+    #[test]
+    fn resolve_port_passes_through_explicit_value() {
+        // Use a port unlikely to be bound; we just want the passthrough path.
+        assert_eq!(resolve_port(Some(54321)).unwrap(), 54321);
+    }
+
+    #[test]
+    fn generate_password_is_24_alphanumeric() {
+        let p = generate_password();
+        assert_eq!(p.len(), 24);
+        assert!(p.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+}

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -19,6 +19,13 @@ const DEFAULT_DATABASE: &str = "postgres";
 /// range; users can override with any 16/17/18 tag (`16`, `16-alpine`, etc).
 pub const DEFAULT_PG_TAG: &str = "18";
 
+/// Extract the major-version digits from a Postgres image tag. `16-alpine` →
+/// `"16"`, `17.0` → `"17"`, `18-bookworm` → `"18"`. Validation is the caller's
+/// responsibility (`validate_pg_tag`) — this only parses.
+pub(crate) fn pg_major_from_tag(tag: &str) -> String {
+    tag.chars().take_while(|c| c.is_ascii_digit()).collect()
+}
+
 /// Accept Postgres image tags whose major version is 16, 17, or 18 — anything
 /// else is unsupported for now. Examples that pass: `16`, `16-alpine`, `17.0`,
 /// `18-bookworm`, `16.4-alpine3.20`. Examples that fail: `latest`, `15`, `19`.
@@ -45,18 +52,21 @@ pub async fn run(cmd: PostgresCommands, json: bool) -> Result<()> {
             database,
             env,
         } => start(name, version, port, user, password, database, env, json).await,
-        PostgresCommands::Stop { name } => stop(&name, json).await,
+        PostgresCommands::Stop { name, version } => stop(&name, version.as_deref(), json).await,
         PostgresCommands::StopAll => stop_all(json).await,
-        PostgresCommands::Remove { name } => remove(&name, json),
+        PostgresCommands::Remove { name, version } => remove(&name, version.as_deref(), json),
         PostgresCommands::Client {
             name,
+            version,
             host,
             port,
             query,
             queries_file,
             args,
-        } => client(name, host, port, query, queries_file, args).await,
-        PostgresCommands::Dotenv { name, local } => dotenv(name.as_deref(), local, json),
+        } => client(name, version, host, port, query, queries_file, args).await,
+        PostgresCommands::Dotenv { name, version, local } => {
+            dotenv(name.as_deref(), version.as_deref(), local, json)
+        }
     }
 }
 
@@ -73,26 +83,52 @@ async fn start(
 ) -> Result<()> {
     server::recover_current_project_servers();
 
-    let server_name = server::resolve_name(name.as_deref())?;
+    // User-facing name (no version suffix). Defaults to "default" when no
+    // postgres "default" is currently running.
+    let user_name = match name.as_deref() {
+        Some(n) => {
+            server::validate_server_name(n)?;
+            n.to_string()
+        }
+        None => default_pg_name(),
+    };
 
-    // Read prior metadata up-front so the cross-engine guard fires before
-    // any liveness side-effects (and before we touch Docker).
-    let prior = server::load_info(&server_name);
-    if let Some(p) = &prior
-        && p.engine != Engine::Postgres
-    {
-        return Err(Error::Exec(format!(
-            "name '{}' is already in use by a {} server. Use a different --name, \
-             or run `clickhousectl local server remove {}` first.",
-            server_name,
-            p.engine.as_str(),
-            server_name
-        )));
-    }
+    // If `--version` is omitted but there's already exactly one instance for
+    // this name, resume it — the user almost certainly wants their existing
+    // data, not a freshly-initialized DEFAULT_PG_TAG. With multiple
+    // instances, we ask them to disambiguate. Only when zero exist do we
+    // default to DEFAULT_PG_TAG.
+    let (tag, major) = match version.as_deref() {
+        Some(v) => {
+            validate_pg_tag(v)?;
+            (v.to_string(), pg_major_from_tag(v))
+        }
+        None => {
+            let existing = server::find_pg_instances(&user_name);
+            match existing.len() {
+                0 => (DEFAULT_PG_TAG.to_string(), pg_major_from_tag(DEFAULT_PG_TAG)),
+                1 => {
+                    let info = &existing[0];
+                    let stored_tag = info.version.strip_prefix("postgres:").unwrap_or(&info.version);
+                    (stored_tag.to_string(), pg_major_from_tag(stored_tag))
+                }
+                _ => {
+                    let versions: Vec<String> =
+                        existing.iter().map(|i| i.version.clone()).collect();
+                    return Err(Error::Exec(format!(
+                        "multiple postgres instances named '{}' ({}); pass --version to select one",
+                        user_name,
+                        versions.join(", ")
+                    )));
+                }
+            }
+        }
+    };
+    let tag = tag.as_str();
 
-    if name.is_some() && server::is_server_running(&server_name) {
-        return Err(Error::ServerAlreadyRunning(server_name));
-    }
+    // Disk identifier — uniquely scopes (name, major) so two majors of the
+    // same name never share container/data/metadata.
+    let key = server::pg_instance_key(&user_name, &major);
 
     let docker = docker::connect().await?;
 
@@ -101,44 +137,40 @@ async fn start(
         .map(|p| p.display().to_string())
         .unwrap_or_default();
 
-    if let Some(prior) = prior {
+    // Resume path: an instance for this exact (name, major) already exists.
+    if let Some(prior) = server::load_info(&key) {
         let cid = prior.container_id.as_deref().unwrap_or("");
         let container_present =
             !cid.is_empty() && docker.inspect_container(cid, None).await.is_ok();
         if container_present {
-            // Resume the existing container with its persisted settings —
-            // PGDATA is already initdb'd against the original credentials,
-            // so passing different ones now silently wouldn't take.
-            if version.is_some()
-                || port.is_some()
+            if server::is_server_running(&key) {
+                return Err(Error::ServerAlreadyRunning(user_name));
+            }
+            if port.is_some()
                 || user.is_some()
                 || password.is_some()
                 || database.is_some()
                 || !extra_env.is_empty()
             {
                 eprintln!(
-                    "Note: '{}' already exists; resuming with stored settings. \
-                     To change image/port/credentials, run `local postgres remove {}` first.",
-                    server_name, server_name
+                    "Note: postgres:{major} '{}' already exists; resuming with stored settings. \
+                     Run `local postgres remove {}` to start over.",
+                    user_name, user_name
                 );
             }
             return resume_existing(&docker, prior, json).await;
         }
-        // Metadata exists but the container is gone (e.g. external `docker rm`).
-        // Don't silently create a fresh container against the existing data dir
-        // — it would either fail (corrupt PGDATA) or come up with a password
-        // that doesn't match what we'd advertise. Force the user to choose.
+        // Metadata orphaned — container removed externally. Force explicit
+        // cleanup to avoid silently re-initing against potentially-stale data.
         return Err(Error::Exec(format!(
-            "Postgres '{name}' has metadata but the container is gone. Run \
-             `clickhousectl local postgres remove {name}` to clear the data dir \
+            "Postgres '{}' (postgres:{}) has metadata but the container is gone. \
+             Run `clickhousectl local postgres remove {}` to clear the data dir \
              and start fresh.",
-            name = server_name
+            user_name, major, user_name
         )));
     }
 
-    // Fresh-create path.
-    let tag = version.as_deref().unwrap_or(DEFAULT_PG_TAG);
-    validate_pg_tag(tag)?;
+    // Fresh create.
     if !docker::image_exists(&docker, tag).await? {
         eprintln!("Pulling postgres:{tag}...");
         docker::pull_image(&docker, tag).await?;
@@ -146,10 +178,12 @@ async fn start(
 
     let host_port = resolve_port(port)?;
 
-    server::ensure_server_data_dir(&server_name)?;
-    let data_dir = server::server_data_dir(&server_name);
+    server::ensure_pg_data_dir(&user_name, &major)?;
+    let data_dir = server::pg_data_dir(&user_name, &major);
 
-    docker::ensure_name_free(&docker, &server_name, &project_cwd).await?;
+    // Defensive cleanup of any unmanaged container colliding on our chosen
+    // container name (only if labels confirm we own it).
+    docker::ensure_name_free(&docker, &user_name, &major, &project_cwd).await?;
 
     let user = user.unwrap_or_else(|| DEFAULT_USER.to_string());
     let database = database.unwrap_or_else(|| DEFAULT_DATABASE.to_string());
@@ -163,7 +197,8 @@ async fn start(
         .unwrap_or_else(generate_password);
 
     let opts = PostgresRunOpts {
-        server_name: &server_name,
+        user_name: &user_name,
+        major: &major,
         tag,
         host_port,
         data_dir: &data_dir,
@@ -177,7 +212,7 @@ async fn start(
     let container_id = docker::run_postgres(&docker, opts).await?;
 
     let info = ServerInfo {
-        name: server_name.clone(),
+        name: key.clone(),
         pid: 0,
         version: format!("postgres:{tag}"),
         http_port: 0,
@@ -196,15 +231,15 @@ async fn start(
             .unwrap_or_default();
         let _ = docker::stop_container(&docker, &container_id).await;
         let _ = docker::remove_container(&docker, &container_id).await;
-        server::remove_server_info(&server_name);
+        server::remove_server_info(&key);
         return Err(Error::DockerError(format!(
             "Postgres container '{}' did not start.\n--- container logs ---\n{}",
-            server_name, logs
+            user_name, logs
         )));
     }
 
     let out = output::PostgresStartOutput {
-        name: server_name,
+        name: user_name,
         container_id,
         image: format!("postgres:{tag}"),
         port: host_port,
@@ -216,6 +251,55 @@ async fn start(
     Ok(())
 }
 
+/// Default user-facing name when `--name` is omitted: `"default"` if no
+/// postgres "default" is running, otherwise a random adjective-noun.
+fn default_pg_name() -> String {
+    let any_default_running = server::find_pg_instances("default")
+        .iter()
+        .any(|i| i
+            .container_id
+            .as_deref()
+            .map(docker::is_container_running_blocking)
+            .unwrap_or(false));
+    if any_default_running {
+        // Fall back to the existing random-name generator, which checks
+        // metadata file uniqueness across engines.
+        server::resolve_name(None).unwrap_or_else(|_| "default".into())
+    } else {
+        "default".into()
+    }
+}
+
+/// Resolve `--name <X> [--version <V>]` to a single Postgres instance on disk.
+/// If `version` is given, target the (X, major(V)) pair directly. Otherwise:
+/// 0 instances → ServerNotFound; 1 → use it; >1 → ask for `--version`.
+fn resolve_pg_target(
+    user_name: &str,
+    version: Option<&str>,
+) -> Result<server::ServerInfo> {
+    if let Some(v) = version {
+        validate_pg_tag(v)?;
+        let major = pg_major_from_tag(v);
+        let key = server::pg_instance_key(user_name, &major);
+        return server::load_info(&key)
+            .filter(|i| i.engine == Engine::Postgres)
+            .ok_or_else(|| Error::ServerNotFound(format!("{user_name} (postgres:{major})")));
+    }
+    let instances = server::find_pg_instances(user_name);
+    match instances.len() {
+        0 => Err(Error::ServerNotFound(user_name.to_string())),
+        1 => Ok(instances.into_iter().next().unwrap()),
+        _ => {
+            let versions: Vec<String> = instances.iter().map(|i| i.version.clone()).collect();
+            Err(Error::Exec(format!(
+                "multiple postgres instances named '{}' ({}); pass --version to select one",
+                user_name,
+                versions.join(", ")
+            )))
+        }
+    }
+}
+
 /// Resume an existing stopped Postgres container. Reads credentials from the
 /// container's persisted env (the source of truth — PGDATA was initialized
 /// for them) and refreshes the metadata.
@@ -225,6 +309,7 @@ async fn resume_existing(
     json: bool,
 ) -> Result<()> {
     let container_id = prior.container_id.clone().expect("checked by caller");
+    let display_name = user_name_from_key(&prior.name).to_string();
 
     docker::start_existing_blocking(&container_id)?;
 
@@ -235,7 +320,7 @@ async fn resume_existing(
             .unwrap_or_default();
         return Err(Error::DockerError(format!(
             "Postgres container '{}' did not resume.\n--- container logs ---\n{}",
-            prior.name, logs
+            display_name, logs
         )));
     }
 
@@ -248,7 +333,7 @@ async fn resume_existing(
     server::save_server_info(&info)?;
 
     let out = output::PostgresStartOutput {
-        name: info.name,
+        name: display_name,
         container_id,
         image: info.version,
         port: info.tcp_port,
@@ -258,6 +343,18 @@ async fn resume_existing(
     };
     output::print_output(&out, json);
     Ok(())
+}
+
+/// Extract the user-facing name from a disk key. `dev-pg16` → `dev`;
+/// anything that doesn't match the suffix shape passes through unchanged.
+pub(crate) fn user_name_from_key(key: &str) -> &str {
+    if let Some(idx) = key.rfind("-pg") {
+        let suffix = &key[idx + 3..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            return &key[..idx];
+        }
+    }
+    key
 }
 
 async fn wait_running(docker: &bollard::Docker, id: &str, attempts: usize) -> bool {
@@ -296,15 +393,21 @@ fn generate_password() -> String {
     Alphanumeric.sample_string(&mut rand::rng(), 24)
 }
 
-async fn stop(name: &str, json: bool) -> Result<()> {
+async fn stop(name: &str, version: Option<&str>, json: bool) -> Result<()> {
     server::validate_server_name(name)?;
     server::recover_current_project_servers();
+    let target = resolve_pg_target(name, version)?;
     if !json {
-        println!("Stopping Postgres '{}'...", name);
+        let display = format!(
+            "{} ({})",
+            user_name_from_key(&target.name),
+            target.version
+        );
+        println!("Stopping Postgres {}...", display);
     }
-    server::kill_server(name)?;
+    server::kill_server(&target.name)?;
     let out = output::ServerStopOutput {
-        name: name.to_string(),
+        name: user_name_from_key(&target.name).to_string(),
     };
     output::print_output(&out, json);
     Ok(())
@@ -357,28 +460,27 @@ async fn stop_all(json: bool) -> Result<()> {
     Ok(())
 }
 
-fn remove(name: &str, json: bool) -> Result<()> {
+fn remove(name: &str, version: Option<&str>, json: bool) -> Result<()> {
     server::validate_server_name(name)?;
     server::recover_current_project_servers();
-    if server::is_server_running(name) {
+
+    let target = resolve_pg_target(name, version)?;
+    let key = target.name.clone();
+    if server::is_server_running(&key) {
         return Err(Error::ServerAlreadyRunning(name.to_string()));
     }
 
-    // Tear down the stopped container (if any) before removing the data dir.
-    if let Some(info) = server::load_info(name)
-        && info.engine == Engine::Postgres
-        && let Some(cid) = info.container_id.as_deref()
-    {
+    if let Some(cid) = target.container_id.as_deref() {
         let _ = docker::stop_and_remove_blocking(cid);
     }
 
-    let data_dir = server::server_data_dir(name);
-    if !data_dir.exists() {
-        return Err(Error::ServerNotFound(name.to_string()));
+    // Postgres data dir lives at .clickhouse/servers/<key>/data/. Remove the
+    // <key>/ wrapper so the (name, version) pair leaves no on-disk state.
+    let pg_dir = server::servers_dir_join(&key);
+    if pg_dir.exists() {
+        std::fs::remove_dir_all(&pg_dir)?;
     }
-    let server_dir = data_dir.parent().unwrap();
-    std::fs::remove_dir_all(server_dir)?;
-    server::remove_server_info(name);
+    server::remove_server_info(&key);
     let out = output::ServerRemoveOutput {
         name: name.to_string(),
     };
@@ -389,14 +491,13 @@ fn remove(name: &str, json: bool) -> Result<()> {
 #[allow(clippy::too_many_arguments)]
 async fn client(
     name: Option<String>,
+    version: Option<String>,
     host: Option<String>,
     port: Option<u16>,
     query: Option<String>,
     queries_file: Option<String>,
     extra_args: Vec<String>,
 ) -> Result<()> {
-    let server_name = name.as_deref().unwrap_or("default").to_string();
-
     if host.is_some() || port.is_some() {
         // Direct connect — no server lookup; require host psql.
         let h = host.unwrap_or_else(|| "127.0.0.1".to_string());
@@ -405,24 +506,12 @@ async fn client(
     }
 
     server::recover_current_project_servers();
-    let entries = server::list_all_servers();
-    let entry = entries
-        .iter()
-        .find(|e| e.name == server_name)
-        .ok_or_else(|| Error::ServerNotFound(server_name.clone()))?;
-    let info = entry
-        .info
-        .as_ref()
-        .ok_or_else(|| Error::ServerNotRunning(server_name.clone()))?;
-    if info.engine != Engine::Postgres {
-        return Err(Error::Exec(format!(
-            "server '{}' is a {} server, not Postgres. Use `local client` for ClickHouse.",
-            server_name,
-            info.engine.as_str()
-        )));
+    let server_name = name.as_deref().unwrap_or("default");
+    let info = resolve_pg_target(server_name, version.as_deref())?;
+    if !server::is_server_running(&info.name) {
+        return Err(Error::ServerNotRunning(server_name.to_string()));
     }
 
-    // Read connection info from container env (POSTGRES_USER / DB).
     let docker = docker::connect().await?;
     let container_id = info
         .container_id
@@ -528,23 +617,17 @@ fn exec_host_psql(
     Err(Error::Exec(err.to_string()))
 }
 
-fn dotenv(name: Option<&str>, use_local: bool, json: bool) -> Result<()> {
+fn dotenv(
+    name: Option<&str>,
+    version: Option<&str>,
+    use_local: bool,
+    json: bool,
+) -> Result<()> {
+    server::recover_current_project_servers();
     let server_name = name.unwrap_or("default");
-    let entries = server::list_all_servers();
-    let entry = entries
-        .iter()
-        .find(|e| e.name == server_name)
-        .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
-    let info = entry
-        .info
-        .as_ref()
-        .ok_or_else(|| Error::ServerNotRunning(server_name.to_string()))?;
-    if info.engine != Engine::Postgres {
-        return Err(Error::Exec(format!(
-            "server '{}' is a {} server, not Postgres",
-            server_name,
-            info.engine.as_str()
-        )));
+    let info = resolve_pg_target(server_name, version)?;
+    if !server::is_server_running(&info.name) {
+        return Err(Error::ServerNotRunning(server_name.to_string()));
     }
 
     // Read user/password/db from the container env so we always emit accurate creds.

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -476,10 +476,11 @@ fn remove(name: &str, version: Option<&str>, json: bool) -> Result<()> {
 
     // Postgres data dir lives at .clickhouse/servers/<key>/data/. Remove the
     // <key>/ wrapper so the (name, version) pair leaves no on-disk state.
+    // On Linux the bind-mounted PGDATA contains files owned by uid 999, so
+    // a plain rm fails — `remove_host_dir_blocking` falls back to a
+    // privileged container in that case.
     let pg_dir = server::servers_dir_join(&key);
-    if pg_dir.exists() {
-        std::fs::remove_dir_all(&pg_dir)?;
-    }
+    docker::remove_host_dir_blocking(&pg_dir)?;
     server::remove_server_info(&key);
     let out = output::ServerRemoveOutput {
         name: name.to_string(),

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -15,6 +15,24 @@ use std::process::Command;
 const DEFAULT_PG_PORT: u16 = 5432;
 const DEFAULT_USER: &str = "postgres";
 const DEFAULT_DATABASE: &str = "postgres";
+/// Default image tag when `--version` is not given. Within the supported
+/// range; users can override with any 16/17/18 tag (`16`, `16-alpine`, etc).
+pub const DEFAULT_PG_TAG: &str = "18";
+
+/// Accept Postgres image tags whose major version is 16, 17, or 18 — anything
+/// else is unsupported for now. Examples that pass: `16`, `16-alpine`, `17.0`,
+/// `18-bookworm`, `16.4-alpine3.20`. Examples that fail: `latest`, `15`, `19`.
+pub(crate) fn validate_pg_tag(tag: &str) -> Result<()> {
+    let major: String = tag.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if !matches!(major.as_str(), "16" | "17" | "18") {
+        return Err(Error::Exec(format!(
+            "postgres version '{}' is not supported. Use a 16, 17, or 18 image tag \
+             (for example: 16, 16-alpine, 17.0, 18-bookworm).",
+            tag
+        )));
+    }
+    Ok(())
+}
 
 pub async fn run(cmd: PostgresCommands, json: bool) -> Result<()> {
     match cmd {
@@ -57,13 +75,58 @@ async fn start(
 
     let server_name = server::resolve_name(name.as_deref())?;
 
+    // Read prior metadata up-front so the cross-engine guard fires before
+    // any liveness side-effects (and before we touch Docker).
+    let prior = server::load_info(&server_name);
+    if let Some(p) = &prior
+        && p.engine != Engine::Postgres
+    {
+        return Err(Error::Exec(format!(
+            "name '{}' is already in use by a {} server. Use a different --name, \
+             or run `clickhousectl local server remove {}` first.",
+            server_name,
+            p.engine.as_str(),
+            server_name
+        )));
+    }
+
     if name.is_some() && server::is_server_running(&server_name) {
         return Err(Error::ServerAlreadyRunning(server_name));
     }
 
     let docker = docker::connect().await?;
 
-    let tag = version.as_deref().unwrap_or("latest");
+    let project_cwd = std::env::current_dir()
+        .and_then(|p| p.canonicalize())
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    // Resume path: prior Postgres metadata exists and the container is still
+    // on disk. Reuse the original credentials/version (PGDATA is already
+    // initialized for them; passing different values silently doesn't take).
+    if let Some(prior) = prior
+        && let Some(cid) = prior.container_id.as_deref()
+        && docker.inspect_container(cid, None).await.is_ok()
+    {
+        if version.is_some()
+            || port.is_some()
+            || user.is_some()
+            || password.is_some()
+            || database.is_some()
+            || !extra_env.is_empty()
+        {
+            eprintln!(
+                "Note: '{}' already exists; resuming with stored settings. \
+                 To change image/port/credentials, run `local postgres remove {}` first.",
+                server_name, server_name
+            );
+        }
+        return resume_existing(&docker, prior, json).await;
+    }
+
+    // Fresh-create path.
+    let tag = version.as_deref().unwrap_or(DEFAULT_PG_TAG);
+    validate_pg_tag(tag)?;
     if !docker::image_exists(&docker, tag).await? {
         eprintln!("Pulling postgres:{tag}...");
         docker::pull_image(&docker, tag).await?;
@@ -74,19 +137,11 @@ async fn start(
     server::ensure_server_data_dir(&server_name)?;
     let data_dir = server::server_data_dir(&server_name);
 
-    let project_cwd = std::env::current_dir()
-        .and_then(|p| p.canonicalize())
-        .map(|p| p.display().to_string())
-        .unwrap_or_default();
-
-    // Clear out any stale stopped container with the same name (only if we
-    // can prove we own it via labels) so create_container doesn't 409.
     docker::ensure_name_free(&docker, &server_name, &project_cwd).await?;
 
     let user = user.unwrap_or_else(|| DEFAULT_USER.to_string());
     let database = database.unwrap_or_else(|| DEFAULT_DATABASE.to_string());
 
-    // If POSTGRES_PASSWORD is in extra_env, prefer it; else use --password; else generate.
     let password_from_env = extra_env
         .iter()
         .find_map(|kv| kv.strip_prefix("POSTGRES_PASSWORD="))
@@ -122,13 +177,11 @@ async fn start(
     };
     server::save_server_info(&info)?;
 
-    // Health check: wait up to 3s for the container to be running.
     let healthy = wait_running(&docker, &container_id, 30).await;
     if !healthy {
         let logs = docker::container_logs_tail(&docker, &container_id, 50)
             .await
             .unwrap_or_default();
-        // Best-effort cleanup so we don't leave a broken container.
         let _ = docker::stop_container(&docker, &container_id).await;
         let _ = docker::remove_container(&docker, &container_id).await;
         server::remove_server_info(&server_name);
@@ -143,6 +196,50 @@ async fn start(
         container_id,
         image: format!("postgres:{tag}"),
         port: host_port,
+        user,
+        password,
+        database,
+    };
+    output::print_output(&out, json);
+    Ok(())
+}
+
+/// Resume an existing stopped Postgres container. Reads credentials from the
+/// container's persisted env (the source of truth — PGDATA was initialized
+/// for them) and refreshes the metadata.
+async fn resume_existing(
+    docker: &bollard::Docker,
+    prior: ServerInfo,
+    json: bool,
+) -> Result<()> {
+    let container_id = prior.container_id.clone().expect("checked by caller");
+
+    docker::start_existing_blocking(&container_id)?;
+
+    let healthy = wait_running(docker, &container_id, 30).await;
+    if !healthy {
+        let logs = docker::container_logs_tail(docker, &container_id, 50)
+            .await
+            .unwrap_or_default();
+        return Err(Error::DockerError(format!(
+            "Postgres container '{}' did not resume.\n--- container logs ---\n{}",
+            prior.name, logs
+        )));
+    }
+
+    let (user, password, database) = read_pg_env(docker, &container_id).await;
+
+    let info = ServerInfo {
+        started_at: server::now_timestamp(),
+        ..prior
+    };
+    server::save_server_info(&info)?;
+
+    let out = output::PostgresStartOutput {
+        name: info.name,
+        container_id,
+        image: info.version,
+        port: info.tcp_port,
         user,
         password,
         database,
@@ -254,6 +351,15 @@ fn remove(name: &str, json: bool) -> Result<()> {
     if server::is_server_running(name) {
         return Err(Error::ServerAlreadyRunning(name.to_string()));
     }
+
+    // Tear down the stopped container (if any) before removing the data dir.
+    if let Some(info) = server::load_info(name)
+        && info.engine == Engine::Postgres
+        && let Some(cid) = info.container_id.as_deref()
+    {
+        let _ = docker::stop_and_remove_blocking(cid);
+    }
+
     let data_dir = server::server_data_dir(name);
     if !data_dir.exists() {
         return Err(Error::ServerNotFound(name.to_string()));
@@ -326,7 +432,7 @@ async fn client(
         );
     }
 
-    // Build psql args for docker exec.
+    let one_shot = query.is_some() || queries_file.is_some();
     let mut psql_args: Vec<String> = vec![
         "-U".into(), user,
         "-d".into(), database,
@@ -341,7 +447,13 @@ async fn client(
     }
     psql_args.extend(extra_args);
 
-    docker::exec_psql_in_container(&docker, container_id, &psql_args).await
+    if one_shot {
+        // Non-interactive: no TTY, no raw mode, output goes to stdout/stderr
+        // so the caller can pipe / capture / redirect.
+        docker::exec_psql_one_shot(&docker, container_id, &psql_args).await
+    } else {
+        docker::exec_psql_in_container(&docker, container_id, &psql_args).await
+    }
 }
 
 /// Read POSTGRES_USER/PASSWORD/DB from the container's effective env so we
@@ -491,6 +603,20 @@ mod tests {
     fn resolve_port_passes_through_explicit_value() {
         // Use a port unlikely to be bound; we just want the passthrough path.
         assert_eq!(resolve_port(Some(54321)).unwrap(), 54321);
+    }
+
+    #[test]
+    fn validate_pg_tag_accepts_supported_majors() {
+        for tag in ["16", "17", "18", "16-alpine", "17.0", "18-bookworm", "16.4-alpine3.20"] {
+            assert!(validate_pg_tag(tag).is_ok(), "expected `{}` to be accepted", tag);
+        }
+    }
+
+    #[test]
+    fn validate_pg_tag_rejects_unsupported() {
+        for tag in ["latest", "15", "19", "14-alpine", "alpine", ""] {
+            assert!(validate_pg_tag(tag).is_err(), "expected `{}` to be rejected", tag);
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -101,27 +101,39 @@ async fn start(
         .map(|p| p.display().to_string())
         .unwrap_or_default();
 
-    // Resume path: prior Postgres metadata exists and the container is still
-    // on disk. Reuse the original credentials/version (PGDATA is already
-    // initialized for them; passing different values silently doesn't take).
-    if let Some(prior) = prior
-        && let Some(cid) = prior.container_id.as_deref()
-        && docker.inspect_container(cid, None).await.is_ok()
-    {
-        if version.is_some()
-            || port.is_some()
-            || user.is_some()
-            || password.is_some()
-            || database.is_some()
-            || !extra_env.is_empty()
-        {
-            eprintln!(
-                "Note: '{}' already exists; resuming with stored settings. \
-                 To change image/port/credentials, run `local postgres remove {}` first.",
-                server_name, server_name
-            );
+    if let Some(prior) = prior {
+        let cid = prior.container_id.as_deref().unwrap_or("");
+        let container_present =
+            !cid.is_empty() && docker.inspect_container(cid, None).await.is_ok();
+        if container_present {
+            // Resume the existing container with its persisted settings —
+            // PGDATA is already initdb'd against the original credentials,
+            // so passing different ones now silently wouldn't take.
+            if version.is_some()
+                || port.is_some()
+                || user.is_some()
+                || password.is_some()
+                || database.is_some()
+                || !extra_env.is_empty()
+            {
+                eprintln!(
+                    "Note: '{}' already exists; resuming with stored settings. \
+                     To change image/port/credentials, run `local postgres remove {}` first.",
+                    server_name, server_name
+                );
+            }
+            return resume_existing(&docker, prior, json).await;
         }
-        return resume_existing(&docker, prior, json).await;
+        // Metadata exists but the container is gone (e.g. external `docker rm`).
+        // Don't silently create a fresh container against the existing data dir
+        // — it would either fail (corrupt PGDATA) or come up with a password
+        // that doesn't match what we'd advertise. Force the user to choose.
+        return Err(Error::Exec(format!(
+            "Postgres '{name}' has metadata but the container is gone. Run \
+             `clickhousectl local postgres remove {name}` to clear the data dir \
+             and start fresh.",
+            name = server_name
+        )));
     }
 
     // Fresh-create path.

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use crate::init;
 use crate::local::discovery;
+use crate::local::docker;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -17,16 +18,50 @@ const NOUNS: &[&str] = &[
     "lynx", "moth", "newt", "orca", "puma", "seal", "swan", "wolf",
 ];
 
+/// Engine driving a server instance. ClickHouse is a managed binary process;
+/// Postgres is a managed Docker container.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Engine {
+    Clickhouse,
+    Postgres,
+}
+
+impl Engine {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Engine::Clickhouse => "clickhouse",
+            Engine::Postgres => "postgres",
+        }
+    }
+}
+
+fn default_engine() -> Engine {
+    Engine::Clickhouse
+}
+
 /// Metadata saved for each server instance.
+///
+/// `engine` and `container_id` are post-Postgres-support additions and default
+/// to ClickHouse + None so existing `.clickhouse/servers/*.json` files keep
+/// deserializing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerInfo {
     pub name: String,
+    /// Process PID for ClickHouse; 0 for Postgres (use `container_id` instead).
     pub pid: u32,
+    /// ClickHouse version like "25.12.5.44", or "postgres:<tag>" for Postgres.
     pub version: String,
+    /// Unused for Postgres (set to 0).
     pub http_port: u16,
+    /// TCP port for ClickHouse; mapped host port for Postgres.
     pub tcp_port: u16,
     pub started_at: String,
     pub cwd: String,
+    #[serde(default = "default_engine")]
+    pub engine: Engine,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
 }
 
 /// A server entry shown in list output — may or may not be running.
@@ -60,6 +95,12 @@ fn servers_dir() -> PathBuf {
 
 fn server_meta_path(name: &str) -> PathBuf {
     servers_dir().join(format!("{}.json", name))
+}
+
+/// Public alias used by `docker.rs` during orphan recovery — keeps the path
+/// computation in one place.
+pub fn server_meta_path_for_recovery(name: &str) -> PathBuf {
+    server_meta_path(name)
 }
 
 /// Data directory for a named server: .clickhouse/servers/<name>/data/
@@ -99,12 +140,23 @@ pub fn remove_server_info(name: &str) {
     let _ = std::fs::remove_file(server_meta_path(name));
 }
 
-/// Load server metadata if it exists and the process is alive.
+/// Engine-aware liveness check.
+fn is_alive(info: &ServerInfo) -> bool {
+    match info.engine {
+        Engine::Clickhouse => is_process_alive(info.pid),
+        Engine::Postgres => match info.container_id.as_deref() {
+            Some(id) => docker::is_container_running_blocking(id),
+            None => false,
+        },
+    }
+}
+
+/// Load server metadata if it exists and the underlying process/container is alive.
 fn load_running_info(name: &str) -> Option<ServerInfo> {
     let path = server_meta_path(name);
     let content = std::fs::read_to_string(&path).ok()?;
     let info: ServerInfo = serde_json::from_str(&content).ok()?;
-    if is_process_alive(info.pid) {
+    if is_alive(&info) {
         Some(info)
     } else {
         // Stale — clean up
@@ -222,11 +274,24 @@ fn kill_process(pid: u32) -> Result<()> {
     Ok(())
 }
 
-/// Kill a server by name.
+/// Kill a server by name. Dispatches based on engine: SIGTERM/SIGKILL for
+/// ClickHouse, `docker stop`+`docker rm` (via bollard) for Postgres.
 pub fn kill_server(name: &str) -> Result<()> {
     let info = load_running_info(name).ok_or_else(|| Error::ServerNotRunning(name.to_string()))?;
 
-    kill_process(info.pid)?;
+    match info.engine {
+        Engine::Clickhouse => kill_process(info.pid)?,
+        Engine::Postgres => {
+            let id = info
+                .container_id
+                .as_deref()
+                .ok_or_else(|| Error::DockerError(format!(
+                    "Postgres server '{}' has no container_id in metadata",
+                    name
+                )))?;
+            docker::stop_and_remove_blocking(id)?;
+        }
+    }
 
     remove_server_info(name);
     Ok(())
@@ -389,9 +454,14 @@ pub fn recover_current_project_servers() {
             tcp_port: proc.tcp_port.unwrap_or(0),
             started_at: "recovered".to_string(),
             cwd: current_dir.clone(),
+            engine: Engine::Clickhouse,
+            container_id: None,
         };
         let _ = save_server_info(&info);
     }
+
+    // Also recover orphaned Postgres containers belonging to this project.
+    docker::recover_project_postgres_blocking(&current_dir);
 }
 
 /// A server entry for global listing — always running (discovered via process inspection).
@@ -402,9 +472,13 @@ pub struct GlobalServerEntry {
     pub http_port: Option<u16>,
     pub tcp_port: Option<u16>,
     pub version: Option<String>,
+    pub engine: Engine,
+    pub container_id: Option<String>,
 }
 
 /// List all running ClickHouse servers across all projects via process discovery.
+/// (Postgres containers are not currently merged in — a future change will add
+/// `docker ps` based discovery here as well.)
 pub fn list_all_servers_global() -> Vec<GlobalServerEntry> {
     let processes = discovery::discover_clickhouse_processes();
     processes
@@ -416,6 +490,8 @@ pub fn list_all_servers_global() -> Vec<GlobalServerEntry> {
             http_port: p.http_port,
             tcp_port: p.tcp_port,
             version: p.version,
+            engine: Engine::Clickhouse,
+            container_id: None,
         })
         .collect()
 }
@@ -428,4 +504,52 @@ pub fn kill_server_by_pid(pid: u32) -> Result<()> {
     }
 
     kill_process(pid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_serializes_lowercase() {
+        assert_eq!(serde_json::to_string(&Engine::Clickhouse).unwrap(), "\"clickhouse\"");
+        assert_eq!(serde_json::to_string(&Engine::Postgres).unwrap(), "\"postgres\"");
+    }
+
+    #[test]
+    fn server_info_legacy_json_deserializes_as_clickhouse() {
+        // Legacy JSON written before the engine field existed.
+        let legacy = r#"{
+            "name": "default",
+            "pid": 12345,
+            "version": "25.12.5.44",
+            "http_port": 8123,
+            "tcp_port": 9000,
+            "started_at": "1700000000",
+            "cwd": "/tmp/proj"
+        }"#;
+        let info: ServerInfo = serde_json::from_str(legacy).expect("legacy JSON should parse");
+        assert_eq!(info.engine, Engine::Clickhouse);
+        assert!(info.container_id.is_none());
+    }
+
+    #[test]
+    fn server_info_postgres_round_trip() {
+        let info = ServerInfo {
+            name: "dev".into(),
+            pid: 0,
+            version: "postgres:16".into(),
+            http_port: 0,
+            tcp_port: 5432,
+            started_at: "1700000000".into(),
+            cwd: "/tmp/proj".into(),
+            engine: Engine::Postgres,
+            container_id: Some("abc123".into()),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        let parsed: ServerInfo = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.engine, Engine::Postgres);
+        assert_eq!(parsed.container_id.as_deref(), Some("abc123"));
+        assert!(json.contains("\"engine\":\"postgres\""));
+    }
 }

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -103,25 +103,53 @@ pub fn server_meta_path_for_recovery(name: &str) -> PathBuf {
     server_meta_path(name)
 }
 
-/// Data directory for a named server: .clickhouse/servers/<name>/data/
+/// Data directory for a ClickHouse server: .clickhouse/servers/<name>/data/.
 pub fn server_data_dir(name: &str) -> PathBuf {
     servers_dir().join(name).join("data")
 }
 
-/// Ensure the data directory for a named server exists.
-pub fn ensure_server_data_dir(name: &str) -> Result<()> {
+/// Disk identifier for a Postgres instance: `<name>-pg<major>`. Used in the
+/// metadata filename, the data dir name, and the container name so that
+/// distinct (name, major) pairs never share state.
+pub fn pg_instance_key(name: &str, major: &str) -> String {
+    format!("{}-pg{}", name, major)
+}
+
+/// Join a child name onto the servers directory. Exposed so handlers can
+/// remove a whole `<key>/` wrapper without poking at internals.
+pub fn servers_dir_join(child: &str) -> PathBuf {
+    servers_dir().join(child)
+}
+
+/// Data directory for a Postgres instance.
+pub fn pg_data_dir(name: &str, major: &str) -> PathBuf {
+    servers_dir().join(pg_instance_key(name, major)).join("data")
+}
+
+/// Ensure project-local servers dir + .gitignore exist. Idempotent.
+fn ensure_servers_dir() -> Result<()> {
     let dir = servers_dir();
     if !dir.exists() {
         std::fs::create_dir_all(&dir)?;
-        // Ensure parent .clickhouse has gitignore
-        let local = init::local_dir();
-        let gitignore = local.join(".gitignore");
+        let gitignore = init::local_dir().join(".gitignore");
         if !gitignore.exists() {
             let _ = std::fs::write(gitignore, "*\n");
         }
     }
-    let data = server_data_dir(name);
-    std::fs::create_dir_all(&data)?;
+    Ok(())
+}
+
+/// Ensure the data directory for a ClickHouse server exists.
+pub fn ensure_server_data_dir(name: &str) -> Result<()> {
+    ensure_servers_dir()?;
+    std::fs::create_dir_all(server_data_dir(name))?;
+    Ok(())
+}
+
+/// Ensure the data directory for a Postgres instance exists.
+pub fn ensure_pg_data_dir(name: &str, major: &str) -> Result<()> {
+    ensure_servers_dir()?;
+    std::fs::create_dir_all(pg_data_dir(name, major))?;
     Ok(())
 }
 
@@ -152,10 +180,48 @@ fn is_alive(info: &ServerInfo) -> bool {
 }
 
 /// Load server metadata regardless of liveness. Returns None if no metadata
-/// file exists or it can't be parsed.
+/// file exists or it can't be parsed. `name` is the disk identifier — for
+/// ClickHouse this is just the user-facing name, for Postgres it's
+/// `<name>-pg<major>` (use `pg_instance_key`).
 pub fn load_info(name: &str) -> Option<ServerInfo> {
     let content = std::fs::read_to_string(server_meta_path(name)).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+/// Find every Postgres instance whose user-facing name is `name`. Returns
+/// one entry per major version that has a metadata file on disk.
+pub fn find_pg_instances(name: &str) -> Vec<ServerInfo> {
+    let prefix = format!("{}-pg", name);
+    let dir = match std::fs::read_dir(servers_dir()) {
+        Ok(d) => d,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in dir.flatten() {
+        let fname = match entry.file_name().into_string() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let stem = match fname.strip_suffix(".json") {
+            Some(s) => s,
+            None => continue,
+        };
+        if !stem.starts_with(&prefix) {
+            continue;
+        }
+        // Major must be all digits to match — guards against e.g. `dev-pg-foo`
+        // matching when `name = "dev"`.
+        let major = &stem[prefix.len()..];
+        if major.is_empty() || !major.chars().all(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        if let Some(info) = load_info(stem)
+            && info.engine == Engine::Postgres
+        {
+            out.push(info);
+        }
+    }
+    out
 }
 
 /// Load server metadata only if the underlying process/container is alive.
@@ -169,8 +235,11 @@ fn load_running_info(name: &str) -> Option<ServerInfo> {
 }
 
 /// List all known servers (both running and stopped).
-/// Discovers servers by scanning data directories in .clickhouse/servers/.
-/// Also runs process discovery to recover any orphaned servers for the current project.
+///
+/// Scans `.clickhouse/servers/*.json` for metadata. Each metadata file is one
+/// entry — for ClickHouse the disk id is the user-facing name; for Postgres
+/// it's `<name>-pg<major>`. Also runs process/container discovery so
+/// orphaned instances reappear.
 pub fn list_all_servers() -> Vec<ServerEntry> {
     recover_current_project_servers();
 
@@ -184,35 +253,33 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
 
     for entry in dir_entries.flatten() {
         let path = entry.path();
-        if !path.is_dir() {
-            continue;
-        }
-        let name = match path.file_name().and_then(|n| n.to_str()) {
-            Some(n) => n.to_string(),
+        let fname = match entry.file_name().into_string() {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let stem = match fname.strip_suffix(".json") {
+            Some(s) => s,
             None => continue,
         };
-
-        if !server_data_dir(&name).exists() {
+        if !path.is_file() {
             continue;
         }
 
-        // Always read metadata if it exists, so the engine + saved version
-        // are visible even when the server is stopped (Postgres) or its
-        // process is gone (ClickHouse, until we GC the file).
-        let info = load_info(&name);
+        let info = load_info(stem);
         let running = match &info {
             Some(i) => is_alive(i),
             None => false,
         };
 
-        // GC stale ClickHouse metadata: process is gone for good.
+        // GC stale ClickHouse metadata: process is gone for good. Postgres
+        // entries stay so `start` can resume the existing container.
         if let Some(i) = &info
             && !running
             && i.engine == Engine::Clickhouse
         {
-            let _ = std::fs::remove_file(server_meta_path(&name));
+            let _ = std::fs::remove_file(server_meta_path(stem));
             entries.push(ServerEntry {
-                name,
+                name: stem.to_string(),
                 running: false,
                 info: None,
             });
@@ -220,7 +287,7 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
         }
 
         entries.push(ServerEntry {
-            name,
+            name: stem.to_string(),
             running,
             info,
         });

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -151,25 +151,27 @@ fn is_alive(info: &ServerInfo) -> bool {
     }
 }
 
-/// Load server metadata if it exists and the underlying process/container is alive.
+/// Load server metadata regardless of liveness. Returns None if no metadata
+/// file exists or it can't be parsed.
+pub fn load_info(name: &str) -> Option<ServerInfo> {
+    let content = std::fs::read_to_string(server_meta_path(name)).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Load server metadata only if the underlying process/container is alive.
+/// Does **not** auto-delete stale metadata — `list_all_servers` is the single
+/// place that GCs ClickHouse entries whose PID is gone, so callers like
+/// `is_server_running` and `resolve_name` can read the metadata without side
+/// effects.
 fn load_running_info(name: &str) -> Option<ServerInfo> {
-    let path = server_meta_path(name);
-    let content = std::fs::read_to_string(&path).ok()?;
-    let info: ServerInfo = serde_json::from_str(&content).ok()?;
-    if is_alive(&info) {
-        Some(info)
-    } else {
-        // Stale — clean up
-        let _ = std::fs::remove_file(&path);
-        None
-    }
+    let info = load_info(name)?;
+    if is_alive(&info) { Some(info) } else { None }
 }
 
 /// List all known servers (both running and stopped).
 /// Discovers servers by scanning data directories in .clickhouse/servers/.
 /// Also runs process discovery to recover any orphaned servers for the current project.
 pub fn list_all_servers() -> Vec<ServerEntry> {
-    // Recover any orphaned servers before listing
     recover_current_project_servers();
 
     let dir = servers_dir();
@@ -182,7 +184,6 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
 
     for entry in dir_entries.flatten() {
         let path = entry.path();
-        // Only look at directories (server data dirs), skip .json files
         if !path.is_dir() {
             continue;
         }
@@ -191,13 +192,32 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
             None => continue,
         };
 
-        // Check if this server has a data subdir (sanity check)
         if !server_data_dir(&name).exists() {
             continue;
         }
 
-        let info = load_running_info(&name);
-        let running = info.is_some();
+        // Always read metadata if it exists, so the engine + saved version
+        // are visible even when the server is stopped (Postgres) or its
+        // process is gone (ClickHouse, until we GC the file).
+        let info = load_info(&name);
+        let running = match &info {
+            Some(i) => is_alive(i),
+            None => false,
+        };
+
+        // GC stale ClickHouse metadata: process is gone for good.
+        if let Some(i) = &info
+            && !running
+            && i.engine == Engine::Clickhouse
+        {
+            let _ = std::fs::remove_file(server_meta_path(&name));
+            entries.push(ServerEntry {
+                name,
+                running: false,
+                info: None,
+            });
+            continue;
+        }
 
         entries.push(ServerEntry {
             name,
@@ -206,15 +226,15 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
         });
     }
 
-    // Sort: running first, then alphabetical
     entries.sort_by(|a, b| b.running.cmp(&a.running).then(a.name.cmp(&b.name)));
     entries
 }
 
-/// List only running servers.
+/// List only currently running servers.
 pub fn list_running_servers() -> Vec<ServerInfo> {
     list_all_servers()
         .into_iter()
+        .filter(|e| e.running)
         .filter_map(|e| e.info)
         .collect()
 }
@@ -274,26 +294,32 @@ fn kill_process(pid: u32) -> Result<()> {
     Ok(())
 }
 
-/// Kill a server by name. Dispatches based on engine: SIGTERM/SIGKILL for
-/// ClickHouse, `docker stop`+`docker rm` (via bollard) for Postgres.
+/// Stop a running server by name.
+///
+/// * ClickHouse: SIGTERM (then SIGKILL on timeout); metadata is removed
+///   because the process is gone for good.
+/// * Postgres: stops the container only — does **not** remove it, and keeps
+///   the metadata file so a subsequent `start` resumes the same container
+///   (preserving the password and any other PGDATA-encoded settings).
 pub fn kill_server(name: &str) -> Result<()> {
     let info = load_running_info(name).ok_or_else(|| Error::ServerNotRunning(name.to_string()))?;
 
     match info.engine {
-        Engine::Clickhouse => kill_process(info.pid)?,
+        Engine::Clickhouse => {
+            kill_process(info.pid)?;
+            remove_server_info(name);
+        }
         Engine::Postgres => {
-            let id = info
-                .container_id
-                .as_deref()
-                .ok_or_else(|| Error::DockerError(format!(
+            let id = info.container_id.as_deref().ok_or_else(|| {
+                Error::DockerError(format!(
                     "Postgres server '{}' has no container_id in metadata",
                     name
-                )))?;
-            docker::stop_and_remove_blocking(id)?;
+                ))
+            })?;
+            docker::stop_blocking(id)?;
+            // Metadata + container preserved so `start` can resume.
         }
     }
-
-    remove_server_info(name);
     Ok(())
 }
 

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Edge-case battery for `clickhousectl local postgres`. Runs each test in
+# isolation in a temp directory, prints PASS/FAIL, and continues on
+# failure so we get a full picture in one run.
+#
+# Requires:
+#   * a working Docker daemon
+#   * `jq` on PATH
+#
+# Usage:
+#   scripts/test-postgres-integration.sh [path/to/clickhousectl]
+#
+# If no argument is given, falls back to $CLICKHOUSECTL or the debug build
+# at target/debug/clickhousectl relative to the repo root.
+set -u
+
+CTL="${1:-${CLICKHOUSECTL:-}}"
+if [[ -z "$CTL" ]]; then
+    repo_root=$(cd "$(dirname "$0")/.." && pwd)
+    CTL="$repo_root/target/debug/clickhousectl"
+fi
+if [[ ! -x "$CTL" ]]; then
+    echo "clickhousectl binary not found at: $CTL" >&2
+    echo "Run 'cargo build -p clickhousectl' first, or pass the path as argument." >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required" >&2
+    exit 2
+fi
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker daemon is not reachable" >&2
+    exit 2
+fi
+
+PASS=0; FAIL=0
+FAILED_TESTS=()
+
+# Make a clean temp dir per test, run the body, then clean up containers
+# the test created.
+run_case() {
+    local name=$1; shift
+    local dir; dir=$(mktemp -d -t "pg-edge-$name.XXXX")
+    cd "$dir" || { echo "[FAIL] $name: tempdir"; FAIL=$((FAIL+1)); return; }
+    if "$@"; then
+        echo "[PASS] $name"
+        PASS=$((PASS+1))
+    else
+        echo "[FAIL] $name"
+        FAIL=$((FAIL+1))
+        FAILED_TESTS+=("$name")
+    fi
+    # Best-effort cleanup of any containers this test left behind
+    docker ps -a --filter "label=clickhousectl.project=$dir" -q 2>/dev/null \
+        | xargs -r docker rm -f >/dev/null 2>&1
+    cd /
+    rm -rf "$dir"
+}
+
+# Helper: fail the case
+die() { echo "    -> $*"; return 1; }
+
+# ── 1. Reuses existing container after stop/delete-metadata via discovery ──
+case_orphan_recovery() {
+    "$CTL" local postgres start --name a --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    local cid_before; cid_before=$(jq -r .container_id .clickhouse/servers/a.json)
+    "$CTL" local postgres stop a >/dev/null 2>&1 || { die "stop"; return 1; }
+    rm .clickhouse/servers/a.json
+    # Recovery should re-populate metadata from the container labels.
+    "$CTL" local server list 2>&1 | grep -q "^| a "  || { die "list did not see a"; return 1; }
+    [[ -f .clickhouse/servers/a.json ]] || { die "metadata not recovered"; return 1; }
+    local cid_after; cid_after=$(jq -r .container_id .clickhouse/servers/a.json)
+    [[ "$cid_before" == "$cid_after" ]] || { die "container id changed: $cid_before -> $cid_after"; return 1; }
+    "$CTL" local postgres remove a >/dev/null 2>&1 || { die "remove"; return 1; }
+}
+
+# ── 2. start with externally-removed container errors with recovery guidance ──
+case_externally_removed_container() {
+    "$CTL" local postgres start --name b --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    local cid; cid=$(jq -r .container_id .clickhouse/servers/b.json)
+    docker rm -f "$cid" >/dev/null 2>&1 || { die "docker rm failed"; return 1; }
+    # Metadata still references the dead id. Should error with explicit
+    # recovery guidance, not silently recreate against potentially-corrupt PGDATA.
+    local out; out=$("$CTL" local postgres start --name b --version 16-alpine 2>&1) || true
+    echo "$out" | grep -q "container is gone" || { die "no recovery message: $out"; return 1; }
+    # `local postgres remove` should clean it up.
+    "$CTL" local postgres remove b >/dev/null 2>&1 || { die "remove after orphan failed"; return 1; }
+    # Now start fresh should work.
+    "$CTL" local postgres start --name b --version 16-alpine >/dev/null 2>&1 || { die "fresh start after remove failed"; return 1; }
+    "$CTL" local postgres stop b >/dev/null 2>&1
+    "$CTL" local postgres remove b >/dev/null 2>&1
+}
+
+# ── 3. Two named postgres servers coexist on different ports ──
+case_two_concurrent_servers() {
+    "$CTL" local postgres start --name c1 --version 16-alpine >/dev/null 2>&1 || { die "start c1"; return 1; }
+    "$CTL" local postgres start --name c2 --version 16-alpine >/dev/null 2>&1 || { die "start c2"; return 1; }
+    local p1 p2
+    p1=$(jq -r .tcp_port .clickhouse/servers/c1.json)
+    p2=$(jq -r .tcp_port .clickhouse/servers/c2.json)
+    [[ "$p1" != "$p2" ]] || { die "ports collide: $p1 == $p2"; return 1; }
+    [[ "$p1" -gt 0 && "$p2" -gt 0 ]] || { die "ports invalid"; return 1; }
+    "$CTL" local postgres stop c1 >/dev/null 2>&1
+    "$CTL" local postgres stop c2 >/dev/null 2>&1
+    "$CTL" local postgres remove c1 >/dev/null 2>&1
+    "$CTL" local postgres remove c2 >/dev/null 2>&1
+}
+
+# ── 4. Restart with conflicting --version warns and uses stored version ──
+case_restart_ignores_changed_version() {
+    "$CTL" local postgres start --name d --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    "$CTL" local postgres stop d >/dev/null 2>&1
+    local out; out=$("$CTL" local postgres start --name d --version 17-alpine 2>&1)
+    echo "$out" | grep -q "resuming with stored settings" || { die "no resume warning"; return 1; }
+    local image; image=$(jq -r .version .clickhouse/servers/d.json)
+    [[ "$image" == "postgres:16-alpine" ]] || { die "image changed: $image"; return 1; }
+    "$CTL" local postgres stop d >/dev/null 2>&1
+    "$CTL" local postgres remove d >/dev/null 2>&1
+}
+
+# ── 5. dotenv reflects the actual container password (post-restart) ──
+case_dotenv_password_consistency() {
+    "$CTL" local postgres start --name e --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    local pw_meta; pw_meta=$("$CTL" local postgres dotenv --name e 2>/dev/null \
+        | grep POSTGRES_PASSWORD= | cut -d= -f2)
+    [[ -n "$pw_meta" ]] || { die "no password emitted"; return 1; }
+    "$CTL" local postgres stop e >/dev/null 2>&1
+    "$CTL" local postgres start --name e >/dev/null 2>&1 || { die "restart"; return 1; }
+    local pw_after; pw_after=$("$CTL" local postgres dotenv --name e 2>/dev/null \
+        | grep POSTGRES_PASSWORD= | cut -d= -f2)
+    [[ "$pw_meta" == "$pw_after" ]] || { die "password drifted: $pw_meta -> $pw_after"; return 1; }
+    "$CTL" local postgres stop e >/dev/null 2>&1
+    "$CTL" local postgres remove e >/dev/null 2>&1
+}
+
+# ── 6. Path-traversal server name rejected ──
+case_path_traversal_name() {
+    local out; out=$("$CTL" local postgres start --name "../etc" 2>&1) || true
+    echo "$out" | grep -qiE "invalid|name" || { die "no rejection: $out"; return 1; }
+}
+
+# ── 7. install postgres@latest rejected ──
+case_install_rejects_latest() {
+    local out; out=$("$CTL" local install postgres@latest 2>&1) || true
+    echo "$out" | grep -q "not supported" || { die "no rejection: $out"; return 1; }
+}
+
+# ── 8. Cross-engine guard: stopped CH default blocks postgres default ──
+case_cross_engine_blocks_postgres() {
+    mkdir -p .clickhouse/servers/x/data
+    cat > .clickhouse/servers/x.json <<EOF
+{"name":"x","pid":99999,"version":"25.12.5.44","http_port":8123,"tcp_port":9000,"started_at":"0","cwd":"$PWD","engine":"clickhouse"}
+EOF
+    local out; out=$("$CTL" local postgres start --name x 2>&1) || true
+    echo "$out" | grep -q "is already in use by a clickhouse server" || { die "no guard: $out"; return 1; }
+}
+
+# ── 9. Cross-engine guard: stopped Postgres blocks CH ──
+case_cross_engine_blocks_clickhouse() {
+    mkdir -p .clickhouse/servers/y/data
+    cat > .clickhouse/servers/y.json <<EOF
+{"name":"y","pid":0,"version":"postgres:16-alpine","http_port":0,"tcp_port":5432,"started_at":"0","cwd":"$PWD","engine":"postgres","container_id":"deadbeef"}
+EOF
+    local out; out=$("$CTL" local server start --name y 2>&1) || true
+    echo "$out" | grep -q "is already in use by a postgres server" || { die "no guard: $out"; return 1; }
+}
+
+# ── 10. local server stop-all leaves Postgres running ──
+case_stop_all_isolates_postgres() {
+    "$CTL" local postgres start --name p --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    "$CTL" local server stop-all >/dev/null 2>&1
+    "$CTL" local server list 2>&1 | grep -E "^\| p " | grep -q running || { die "postgres got stopped"; return 1; }
+    "$CTL" local postgres stop p >/dev/null 2>&1
+    "$CTL" local postgres remove p >/dev/null 2>&1
+}
+
+# ── 11. --port 0 rejected ──
+case_port_zero_rejected() {
+    local out; out=$("$CTL" local postgres start --name z --port 0 2>&1) || true
+    echo "$out" | grep -q -- "--port 0 is not allowed" || { die "no rejection: $out"; return 1; }
+}
+
+# ── 12. Non-TTY query path returns query result ──
+case_non_tty_query() {
+    "$CTL" local postgres start --name q --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    # Wait for pg to be query-ready (up to ~5s); the first start already waits
+    # for the container, but pg itself takes a moment to accept queries.
+    local cid; cid=$(jq -r .container_id .clickhouse/servers/q.json)
+    for _ in {1..30}; do
+        docker exec "$cid" pg_isready -U postgres >/dev/null 2>&1 && break
+        sleep 0.2
+    done
+    # Hide host psql to force the docker-exec fallback.
+    local out; out=$(PATH=/usr/bin:/bin "$CTL" local postgres client --name q --query "select 7 as seven" 2>&1)
+    echo "$out" | grep -q "7" || { die "query did not return 7: $out"; return 1; }
+    "$CTL" local postgres stop q >/dev/null 2>&1
+    "$CTL" local postgres remove q >/dev/null 2>&1
+}
+
+# ── 13. dotenv preserves unmanaged vars and replaces in-place ──
+case_dotenv_preserves_other_vars() {
+    "$CTL" local postgres start --name r --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    cat > .env <<EOF
+DATABASE_URL=postgres://existing
+CLICKHOUSE_HOST=ch.example.com
+EOF
+    "$CTL" local postgres dotenv --name r >/dev/null 2>&1 || { die "dotenv"; return 1; }
+    grep -q "DATABASE_URL=postgres://existing" .env || { die "lost DATABASE_URL"; return 1; }
+    grep -q "CLICKHOUSE_HOST=ch.example.com" .env || { die "lost CLICKHOUSE_HOST"; return 1; }
+    grep -q "POSTGRES_HOST=127.0.0.1" .env || { die "no POSTGRES_HOST"; return 1; }
+    "$CTL" local postgres stop r >/dev/null 2>&1
+    "$CTL" local postgres remove r >/dev/null 2>&1
+}
+
+# ── 14. remove of running postgres is rejected ──
+case_remove_running_rejected() {
+    "$CTL" local postgres start --name s --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+    local out; out=$("$CTL" local postgres remove s 2>&1) || true
+    echo "$out" | grep -qE "already running|running" || { die "no rejection: $out"; return 1; }
+    "$CTL" local postgres stop s >/dev/null 2>&1
+    "$CTL" local postgres remove s >/dev/null 2>&1
+}
+
+# ── 15a. Each supported major (16/17/18) starts and is query-ready ──
+case_majors_start_and_serve() {
+    local tag fail=0
+    for tag in 16 17 18; do
+        local n="m$tag"
+        if ! "$CTL" local postgres start --name "$n" --version "$tag" >/dev/null 2>&1; then
+            die "start postgres:$tag failed"
+            fail=1
+            continue
+        fi
+        local cid; cid=$(jq -r .container_id ".clickhouse/servers/$n.json")
+        local ready=0
+        for _ in {1..50}; do
+            if docker exec "$cid" pg_isready -U postgres >/dev/null 2>&1; then
+                ready=1
+                break
+            fi
+            sleep 0.2
+        done
+        if (( ready != 1 )); then
+            die "postgres:$tag not query-ready after 10s"
+            fail=1
+        fi
+        "$CTL" local postgres stop "$n" >/dev/null 2>&1
+        "$CTL" local postgres remove "$n" >/dev/null 2>&1
+    done
+    return $fail
+}
+
+# ── 16. validate_pg_tag rejects 19 and 14 ──
+case_unsupported_majors() {
+    local o14 o19
+    o14=$("$CTL" local postgres start --name t --version 14-alpine 2>&1) || true
+    o19=$("$CTL" local postgres start --name t --version 19 2>&1) || true
+    echo "$o14" | grep -q "not supported" || { die "14 not rejected: $o14"; return 1; }
+    echo "$o19" | grep -q "not supported" || { die "19 not rejected: $o19"; return 1; }
+}
+
+# ── Run all ──
+run_case orphan_recovery                case_orphan_recovery
+run_case externally_removed_container   case_externally_removed_container
+run_case two_concurrent_servers         case_two_concurrent_servers
+run_case restart_ignores_changed_version case_restart_ignores_changed_version
+run_case dotenv_password_consistency    case_dotenv_password_consistency
+run_case path_traversal_name            case_path_traversal_name
+run_case install_rejects_latest         case_install_rejects_latest
+run_case cross_engine_blocks_postgres   case_cross_engine_blocks_postgres
+run_case cross_engine_blocks_clickhouse case_cross_engine_blocks_clickhouse
+run_case stop_all_isolates_postgres     case_stop_all_isolates_postgres
+run_case port_zero_rejected             case_port_zero_rejected
+run_case non_tty_query                  case_non_tty_query
+run_case dotenv_preserves_other_vars    case_dotenv_preserves_other_vars
+run_case remove_running_rejected        case_remove_running_rejected
+run_case majors_start_and_serve         case_majors_start_and_serve
+run_case unsupported_majors             case_unsupported_majors
+
+echo
+echo "==== $PASS passed, $FAIL failed ===="
+if (( FAIL > 0 )); then
+    echo "failed: ${FAILED_TESTS[*]}"
+    exit 1
+fi

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -41,6 +41,9 @@ FAILED_TESTS=()
 run_case() {
     local name=$1; shift
     local dir; dir=$(mktemp -d -t "pg-edge-$name.XXXX")
+    # The CLI canonicalizes the project path before stamping it into
+    # container labels, so we match against the realpath here.
+    local real_dir; real_dir=$(cd "$dir" && pwd -P)
     cd "$dir" || { echo "[FAIL] $name: tempdir"; FAIL=$((FAIL+1)); return; }
     if "$@"; then
         echo "[PASS] $name"
@@ -50,8 +53,8 @@ run_case() {
         FAIL=$((FAIL+1))
         FAILED_TESTS+=("$name")
     fi
-    # Best-effort cleanup of any containers this test left behind
-    docker ps -a --filter "label=clickhousectl.project=$dir" -q 2>/dev/null \
+    # Best-effort cleanup of any containers this test left behind.
+    docker ps -a --filter "label=clickhousectl.project=$real_dir" -q 2>/dev/null \
         | xargs -r docker rm -f >/dev/null 2>&1
     cd /
     rm -rf "$dir"
@@ -63,13 +66,14 @@ die() { echo "    -> $*"; return 1; }
 # ── 1. Reuses existing container after stop/delete-metadata via discovery ──
 case_orphan_recovery() {
     "$CTL" local postgres start --name a --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
-    local cid_before; cid_before=$(jq -r .container_id .clickhouse/servers/a.json)
+    local meta=.clickhouse/servers/a-pg16.json
+    local cid_before; cid_before=$(jq -r .container_id "$meta")
     "$CTL" local postgres stop a >/dev/null 2>&1 || { die "stop"; return 1; }
-    rm .clickhouse/servers/a.json
+    rm "$meta"
     # Recovery should re-populate metadata from the container labels.
     "$CTL" local server list 2>&1 | grep -q "^| a "  || { die "list did not see a"; return 1; }
-    [[ -f .clickhouse/servers/a.json ]] || { die "metadata not recovered"; return 1; }
-    local cid_after; cid_after=$(jq -r .container_id .clickhouse/servers/a.json)
+    [[ -f "$meta" ]] || { die "metadata not recovered"; return 1; }
+    local cid_after; cid_after=$(jq -r .container_id "$meta")
     [[ "$cid_before" == "$cid_after" ]] || { die "container id changed: $cid_before -> $cid_after"; return 1; }
     "$CTL" local postgres remove a >/dev/null 2>&1 || { die "remove"; return 1; }
 }
@@ -77,7 +81,7 @@ case_orphan_recovery() {
 # ── 2. start with externally-removed container errors with recovery guidance ──
 case_externally_removed_container() {
     "$CTL" local postgres start --name b --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
-    local cid; cid=$(jq -r .container_id .clickhouse/servers/b.json)
+    local cid; cid=$(jq -r .container_id .clickhouse/servers/b-pg16.json)
     docker rm -f "$cid" >/dev/null 2>&1 || { die "docker rm failed"; return 1; }
     # Metadata still references the dead id. Should error with explicit
     # recovery guidance, not silently recreate against potentially-corrupt PGDATA.
@@ -96,8 +100,8 @@ case_two_concurrent_servers() {
     "$CTL" local postgres start --name c1 --version 16-alpine >/dev/null 2>&1 || { die "start c1"; return 1; }
     "$CTL" local postgres start --name c2 --version 16-alpine >/dev/null 2>&1 || { die "start c2"; return 1; }
     local p1 p2
-    p1=$(jq -r .tcp_port .clickhouse/servers/c1.json)
-    p2=$(jq -r .tcp_port .clickhouse/servers/c2.json)
+    p1=$(jq -r .tcp_port .clickhouse/servers/c1-pg16.json)
+    p2=$(jq -r .tcp_port .clickhouse/servers/c2-pg16.json)
     [[ "$p1" != "$p2" ]] || { die "ports collide: $p1 == $p2"; return 1; }
     [[ "$p1" -gt 0 && "$p2" -gt 0 ]] || { die "ports invalid"; return 1; }
     "$CTL" local postgres stop c1 >/dev/null 2>&1
@@ -106,16 +110,21 @@ case_two_concurrent_servers() {
     "$CTL" local postgres remove c2 >/dev/null 2>&1
 }
 
-# ── 4. Restart with conflicting --version warns and uses stored version ──
-case_restart_ignores_changed_version() {
-    "$CTL" local postgres start --name d --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
+# ── 4. Same name, two majors → two isolated instances ──
+case_per_version_isolation() {
+    "$CTL" local postgres start --name d --version 16-alpine >/dev/null 2>&1 || { die "start 16"; return 1; }
     "$CTL" local postgres stop d >/dev/null 2>&1
-    local out; out=$("$CTL" local postgres start --name d --version 17-alpine 2>&1)
-    echo "$out" | grep -q "resuming with stored settings" || { die "no resume warning"; return 1; }
-    local image; image=$(jq -r .version .clickhouse/servers/d.json)
-    [[ "$image" == "postgres:16-alpine" ]] || { die "image changed: $image"; return 1; }
-    "$CTL" local postgres stop d >/dev/null 2>&1
-    "$CTL" local postgres remove d >/dev/null 2>&1
+    "$CTL" local postgres start --name d --version 17-alpine >/dev/null 2>&1 || { die "start 17"; return 1; }
+    [[ -f .clickhouse/servers/d-pg16.json ]] || { die "16 metadata vanished"; return 1; }
+    [[ -f .clickhouse/servers/d-pg17.json ]] || { die "17 metadata not created"; return 1; }
+    [[ -d .clickhouse/servers/d-pg16/data ]] || { die "16 data dir vanished"; return 1; }
+    [[ -d .clickhouse/servers/d-pg17/data ]] || { die "17 data dir not created"; return 1; }
+    # Bare `local postgres stop d` should ask for --version since multiple match.
+    local out; out=$("$CTL" local postgres stop d 2>&1) || true
+    echo "$out" | grep -q "pass --version" || { die "no disambiguation message: $out"; return 1; }
+    "$CTL" local postgres stop d --version 17 >/dev/null 2>&1 || { die "versioned stop failed"; return 1; }
+    "$CTL" local postgres remove d --version 17 >/dev/null 2>&1
+    "$CTL" local postgres remove d --version 16 >/dev/null 2>&1
 }
 
 # ── 5. dotenv reflects the actual container password (post-restart) ──
@@ -145,24 +154,20 @@ case_install_rejects_latest() {
     echo "$out" | grep -q "not supported" || { die "no rejection: $out"; return 1; }
 }
 
-# ── 8. Cross-engine guard: stopped CH default blocks postgres default ──
-case_cross_engine_blocks_postgres() {
-    mkdir -p .clickhouse/servers/x/data
-    cat > .clickhouse/servers/x.json <<EOF
-{"name":"x","pid":99999,"version":"25.12.5.44","http_port":8123,"tcp_port":9000,"started_at":"0","cwd":"$PWD","engine":"clickhouse"}
+# ── 8. Cross-engine name reuse coexists (CH and PG can share a name) ──
+case_cross_engine_coexist() {
+    # Fake a stopped CH "shared" instance with metadata only.
+    mkdir -p .clickhouse/servers/shared/data
+    cat > .clickhouse/servers/shared.json <<EOF
+{"name":"shared","pid":99999,"version":"25.12.5.44","http_port":8123,"tcp_port":9000,"started_at":"0","cwd":"$PWD","engine":"clickhouse"}
 EOF
-    local out; out=$("$CTL" local postgres start --name x 2>&1) || true
-    echo "$out" | grep -q "is already in use by a clickhouse server" || { die "no guard: $out"; return 1; }
-}
-
-# ── 9. Cross-engine guard: stopped Postgres blocks CH ──
-case_cross_engine_blocks_clickhouse() {
-    mkdir -p .clickhouse/servers/y/data
-    cat > .clickhouse/servers/y.json <<EOF
-{"name":"y","pid":0,"version":"postgres:16-alpine","http_port":0,"tcp_port":5432,"started_at":"0","cwd":"$PWD","engine":"postgres","container_id":"deadbeef"}
-EOF
-    local out; out=$("$CTL" local server start --name y 2>&1) || true
-    echo "$out" | grep -q "is already in use by a postgres server" || { die "no guard: $out"; return 1; }
+    # Starting Postgres "shared" should succeed — CH and PG live in different files.
+    "$CTL" local postgres start --name shared --version 16-alpine >/dev/null 2>&1 \
+        || { die "postgres start with same name failed"; return 1; }
+    [[ -f .clickhouse/servers/shared.json ]] || { die "CH metadata clobbered"; return 1; }
+    [[ -f .clickhouse/servers/shared-pg16.json ]] || { die "PG metadata not created"; return 1; }
+    "$CTL" local postgres stop shared >/dev/null 2>&1
+    "$CTL" local postgres remove shared >/dev/null 2>&1
 }
 
 # ── 10. local server stop-all leaves Postgres running ──
@@ -185,9 +190,11 @@ case_non_tty_query() {
     "$CTL" local postgres start --name q --version 16-alpine >/dev/null 2>&1 || { die "start"; return 1; }
     # Wait for pg to be query-ready (up to ~5s); the first start already waits
     # for the container, but pg itself takes a moment to accept queries.
-    local cid; cid=$(jq -r .container_id .clickhouse/servers/q.json)
-    for _ in {1..30}; do
-        docker exec "$cid" pg_isready -U postgres >/dev/null 2>&1 && break
+    local cid; cid=$(jq -r .container_id .clickhouse/servers/q-pg16.json)
+    # `pg_isready` without -h checks a unix socket dir that may not exist in
+    # alpine builds yet; force TCP to wait for actual query readiness.
+    for _ in {1..50}; do
+        docker exec "$cid" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break
         sleep 0.2
     done
     # Hide host psql to force the docker-exec fallback.
@@ -231,10 +238,10 @@ case_majors_start_and_serve() {
             fail=1
             continue
         fi
-        local cid; cid=$(jq -r .container_id ".clickhouse/servers/$n.json")
+        local cid; cid=$(jq -r .container_id ".clickhouse/servers/$n-pg$tag.json")
         local ready=0
         for _ in {1..50}; do
-            if docker exec "$cid" pg_isready -U postgres >/dev/null 2>&1; then
+            if docker exec "$cid" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then
                 ready=1
                 break
             fi
@@ -263,12 +270,11 @@ case_unsupported_majors() {
 run_case orphan_recovery                case_orphan_recovery
 run_case externally_removed_container   case_externally_removed_container
 run_case two_concurrent_servers         case_two_concurrent_servers
-run_case restart_ignores_changed_version case_restart_ignores_changed_version
+run_case per_version_isolation          case_per_version_isolation
 run_case dotenv_password_consistency    case_dotenv_password_consistency
 run_case path_traversal_name            case_path_traversal_name
 run_case install_rejects_latest         case_install_rejects_latest
-run_case cross_engine_blocks_postgres   case_cross_engine_blocks_postgres
-run_case cross_engine_blocks_clickhouse case_cross_engine_blocks_clickhouse
+run_case cross_engine_coexist           case_cross_engine_coexist
 run_case stop_all_isolates_postgres     case_stop_all_isolates_postgres
 run_case port_zero_rejected             case_port_zero_rejected
 run_case non_tty_query                  case_non_tty_query

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -57,7 +57,13 @@ run_case() {
     docker ps -a --filter "label=clickhousectl.project=$real_dir" -q 2>/dev/null \
         | xargs -r docker rm -f >/dev/null 2>&1
     cd /
-    rm -rf "$dir"
+    # On Linux, residual postgres data dirs are owned by uid 999 (the
+    # postgres user inside the container), so a plain `rm` fails. Try
+    # host-side first; fall back to a privileged Alpine container.
+    if [[ -d "$dir" ]] && ! rm -rf "$dir" 2>/dev/null; then
+        docker run --rm -v "$(dirname "$dir"):/work" alpine:latest \
+            rm -rf "/work/$(basename "$dir")" >/dev/null 2>&1 || true
+    fi
 }
 
 # Helper: fail the case


### PR DESCRIPTION
## Summary

* Adds `clickhousectl local postgres start|stop|stop-all|remove|client|dotenv` as a sibling of `local server`. Each instance runs as a `postgres:<tag>` Docker container with data bind-mounted at `.clickhouse/servers/<name>/data/`. ClickHouse + Postgres share `local server list` (with an Engine column) but lifecycle commands stay engine-scoped.
* `local install postgres@<tag>` pre-pulls images. `local postgres client` prefers host `psql` and falls back to a Docker exec — interactive TTY for shells, non-TTY one-shot for `--query` / `--queries-file`.
* Restart-safe: `stop` keeps the container + metadata, `start` resumes via `docker start` so credentials encoded into PGDATA on first init are preserved across restarts.
* Engine-isolated: starting one engine on a name held by the other errors with a clear message instead of clobbering the other engine's data dir.
* Containers labeled `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`, `clickhousectl.project=<cwd>`, and `created_by=clickhousectl_<version>`. Discovery (orphan recovery in `local server list`) filters on engine + project so containers stay manageable across CLI upgrades.
* Postgres versions restricted to majors 16, 17, 18 (any sub-tag is accepted: `16-alpine`, `17.0`, `18-bookworm`, `16.4-alpine3.20`). Default is `18`.

## Test plan

- [x] `cargo build` and `cargo clippy` clean
- [x] `cargo test` — 247 passing (including new tests for `Engine` serde back-compat, dotenv prefix isolation, install spec parser, `validate_pg_tag`, `resolve_port`, `generate_password`)
- [x] Smoke: install → start → `server list` (combined view) → orphan recovery (delete metadata, list rebuilds it from container labels) → stop → start (container_id + password preserved) → remove
- [x] Smoke: cross-engine guard fires both directions with actionable error
- [x] Smoke: stale stopped container with our labels gets cleaned up before `create_container` (no 409)
- [x] Smoke: non-TTY `--query` path routes through `exec_psql_one_shot`
- [x] Smoke: unsupported version (`15`, `latest`) rejected with clear message
- [ ] CI green