### PR TITLE
Use underscores in integration-test tag keys and values

### DIFF
--- a/crates/clickhouse-cloud-api/tests/integration/support.rs
+++ b/crates/clickhouse-cloud-api/tests/integration/support.rs
@@ -90,15 +90,15 @@ impl TestContext {
     pub fn run_tags(&self) -> Vec<ResourceTagsV1> {
         vec![
             ResourceTagsV1 {
-                key: "managed-by".to_string(),
-                value: Some("clickhousectl-it".to_string()),
+                key: "managed_by".to_string(),
+                value: Some("clickhousectl_it".to_string()),
             },
             ResourceTagsV1 {
                 key: "suite".to_string(),
-                value: Some("service-crud".to_string()),
+                value: Some("service_crud".to_string()),
             },
             ResourceTagsV1 {
-                key: "run-id".to_string(),
+                key: "run_id".to_string(),
                 value: Some(self.run_id.clone()),
             },
         ]
@@ -106,9 +106,9 @@ impl TestContext {
 
     pub fn run_tag_filters(&self) -> Vec<String> {
         vec![
-            "tag:managed-by=clickhousectl-it".to_string(),
-            "tag:suite=service-crud".to_string(),
-            format!("tag:run-id={}", self.run_id),
+            "tag:managed_by=clickhousectl_it".to_string(),
+            "tag:suite=service_crud".to_string(),
+            format!("tag:run_id={}", self.run_id),
         ]
     }
 
@@ -119,15 +119,15 @@ impl TestContext {
     pub fn postgres_run_tags(&self) -> Vec<ResourceTagsV1> {
         vec![
             ResourceTagsV1 {
-                key: "managed-by".to_string(),
-                value: Some("clickhousectl-it".to_string()),
+                key: "managed_by".to_string(),
+                value: Some("clickhousectl_it".to_string()),
             },
             ResourceTagsV1 {
                 key: "suite".to_string(),
-                value: Some("postgres-crud".to_string()),
+                value: Some("postgres_crud".to_string()),
             },
             ResourceTagsV1 {
-                key: "run-id".to_string(),
+                key: "run_id".to_string(),
                 value: Some(self.run_id.clone()),
             },
         ]
@@ -135,9 +135,9 @@ impl TestContext {
 
     pub fn postgres_run_tag_filters(&self) -> Vec<String> {
         vec![
-            "tag:managed-by=clickhousectl-it".to_string(),
-            "tag:suite=postgres-crud".to_string(),
-            format!("tag:run-id={}", self.run_id),
+            "tag:managed_by=clickhousectl_it".to_string(),
+            "tag:suite=postgres_crud".to_string(),
+            format!("tag:run_id={}", self.run_id),
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Switch integration-test resource tag keys (`managed-by` → `managed_by`, `run-id` → `run_id`) and the associated values (`clickhousectl-it`, `service-crud`, `postgres-crud`) from dashes to underscores in `tests/integration/support.rs`.
- The matching `tag:KEY=VALUE` filter strings (used by pre-create sweeps and `CleanupRegistry`) are updated in lockstep so listing and cleanup keep working.
- Service names stay with dashes — those are DNS-style identifiers, not tags.

The `phase=patched` tag in the Postgres PATCH test never had a dash, so no change there. The only place tag literals live is `support.rs`; the workflow file (`.github/workflows/cloud-integration.yml`) does not reference tag keys/values, so no CI changes are needed.

## Test plan
- [x] `cargo build -p clickhouse-cloud-api --tests` passes locally
- [ ] Cloud Integration workflow run on this PR (provisions services, applies the new underscore tags, and tears them down via the matching filters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)