### PR TITLE
Bump clickhouse-cloud-api to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "reqwest",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "MIT"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -22,7 +22,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.1.0", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.2.0", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 bollard = "0.21.0"


### PR DESCRIPTION
## Summary
- Bumps the `clickhouse-cloud-api` library crate version from 0.1.0 to 0.2.0
- Updates the `clickhousectl` dependency reference to match
- Refreshes `Cargo.lock`

## Test plan
- [x] `cargo build` passes on the full workspace