### PR TITLE
Resolve OpenAPI drift and add scaling-schedule API coverage

### DIFF
--- a/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
+++ b/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
@@ -5,7 +5,7 @@
     "version": "1.0",
     "contact": {
       "name": "ClickHouse Support",
-      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-766864",
+      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-795280",
       "email": "support@clickhouse.com"
     }
   },
@@ -2212,7 +2212,7 @@
     "/v1/organizations/{organizationId}/services/{serviceId}/replicaScaling": {
       "patch": {
         "summary": "Update service auto scaling settings",
-        "description": "Updates minimum and maximum memory limits per replica and idle mode scaling behavior for the service. The memory settings are available only for \"production\" services and must be a multiple of 4 starting from 8GB. Please contact support to enable adjustment of numReplicas.",
+        "description": "Updates minimum and maximum memory limits per replica and idle mode scaling behavior for the service. Supports both vertical autoscaling (fixed replica count, variable memory) and horizontal autoscaling (variable replica count, fixed memory). The memory settings are available only for \"production\" services and must be a multiple of 4 starting from 8GB. For vertical autoscaling, please contact support to enable adjustment of numReplicas. For horizontal autoscaling (minReplicas/maxReplicas/replicaMemoryGb), contact support to enable the feature for your organization.",
         "operationId": "instanceReplicaScalingUpdate",
         "parameters": [
           {
@@ -2671,6 +2671,371 @@
         },
         "tags": [
           "Prometheus"
+        ]
+      }
+    },
+    "/v1/organizations/{organizationId}/services/{serviceId}/scalingSchedule": {
+      "get": {
+        "summary": "Get service autoscaling schedule",
+        "description": "**Disclaimer:** This beta endpoint is evolving; the API contract may change. <br /><br /> Returns the autoscaling schedule for a service. Returns 404 if no schedule has been configured or if the schedule was cleared. Requires the scheduled autoscaling feature to be enabled for the organization.",
+        "operationId": "scalingScheduleGet",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization that owns the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceId",
+            "description": "ID of the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ScalingSchedule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Service"
+        ],
+        "x-badges": [
+          {
+            "name": "Beta",
+            "position": "after"
+          }
+        ]
+      },
+      "post": {
+        "summary": "Create or replace service autoscaling schedule",
+        "description": "**Disclaimer:** This beta endpoint is evolving; the API contract may change. <br /><br /> Creates or fully replaces the autoscaling schedule for a service. Pass an empty `entries` array to clear the schedule — a subsequent GET will return 404, and the response will contain an empty `baseConfig` (all fields absent). The base scaling config (applied when no entry is active) is managed separately via the `replicaScaling` endpoint. Requires the scheduled autoscaling feature to be enabled for the organization.",
+        "operationId": "scalingScheduleUpsert",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization that owns the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceId",
+            "description": "ID of the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalingSchedulePostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ScalingSchedule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Service"
+        ],
+        "x-badges": [
+          {
+            "name": "Beta",
+            "position": "after"
+          }
+        ]
+      },
+      "patch": {
+        "summary": "Replace service autoscaling schedule",
+        "description": "**Disclaimer:** This beta endpoint is evolving; the API contract may change. <br /><br /> Fully replaces the autoscaling schedule for a service. Note: this is a full replacement — `entries` is required and partial updates (omitting `entries` to update only `baseConfig`) are not supported. Pass an empty `entries` array to clear the schedule — a subsequent GET will return 404, and the response will contain an empty `baseConfig` (all fields absent). Requires the scheduled autoscaling feature to be enabled for the organization.",
+        "operationId": "scalingScheduleReplace",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization that owns the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceId",
+            "description": "ID of the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScalingSchedulePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ScalingSchedule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Service"
+        ],
+        "x-badges": [
+          {
+            "name": "Beta",
+            "position": "after"
+          }
         ]
       }
     },
@@ -14160,6 +14525,254 @@
           "value": "staging"
         }
       },
+      "ScalingScheduleEntry": {
+        "properties": {
+          "id": {
+            "description": "Unique identifier for this schedule entry.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "description": "Human-readable label for this schedule entry.",
+            "type": "string"
+          },
+          "weekdays": {
+            "type": "array",
+            "description": "Days of the week this entry applies to. 0 = Sunday, 1 = Monday, …, 6 = Saturday.",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "startHourUtc": {
+            "description": "UTC hour (0–23) when this entry becomes active (inclusive).",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23
+          },
+          "endHourUtc": {
+            "description": "UTC hour (1–24) when this entry deactivates (exclusive). Must differ from startHourUtc. Set to 24 to end at midnight. Values less than startHourUtc create an overnight window spanning midnight.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24
+          },
+          "minReplicaMemoryGb": {
+            "description": "Minimum memory per replica (Gb) during this window.",
+            "type": "number"
+          },
+          "maxReplicaMemoryGb": {
+            "description": "Maximum memory per replica (Gb) during this window.",
+            "type": "number"
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas during this window. Must equal maxReplicas — schedule entries specify a fixed replica count per window.",
+            "type": "integer"
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas during this window. Must equal minReplicas — schedule entries specify a fixed replica count per window.",
+            "type": "integer"
+          },
+          "idleScaling": {
+            "description": "Whether idle scaling is enabled during this window.",
+            "type": "boolean"
+          },
+          "idleTimeoutMinutes": {
+            "description": "Idle timeout in minutes during this window.",
+            "type": "integer"
+          },
+          "isActiveNow": {
+            "description": "Whether this entry is currently active. Scheduled times are indicative — actions are applied on a best-effort basis and may be delayed by a few minutes.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "weekdays",
+          "startHourUtc",
+          "endHourUtc",
+          "isActiveNow"
+        ]
+      },
+      "ScalingScheduleBaseConfig": {
+        "properties": {
+          "minReplicaMemoryGb": {
+            "description": "Minimum memory per replica (Gb) when no schedule entry is active.",
+            "type": "number"
+          },
+          "maxReplicaMemoryGb": {
+            "description": "Maximum memory per replica (Gb) when no schedule entry is active.",
+            "type": "number"
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas when no schedule entry is active.",
+            "type": "integer"
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas when no schedule entry is active.",
+            "type": "integer"
+          },
+          "idleScaling": {
+            "description": "Whether idle scaling is enabled when no schedule entry is active.",
+            "type": "boolean"
+          },
+          "idleTimeoutMinutes": {
+            "description": "Idle timeout in minutes when no schedule entry is active.",
+            "type": "integer"
+          }
+        }
+      },
+      "ScalingSchedule": {
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "List of schedule entries.",
+            "items": {
+              "$ref": "#/components/schemas/ScalingScheduleEntry"
+            }
+          },
+          "baseConfig": {
+            "$ref": "#/components/schemas/ScalingScheduleBaseConfig"
+          },
+          "activeEntryId": {
+            "description": "ID of the currently-active schedule entry. Absent when no entry is active and the base config is in effect.",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "entries",
+          "baseConfig"
+        ]
+      },
+      "ScalingScheduleEntryRequest": {
+        "properties": {
+          "name": {
+            "description": "Human-readable label for this schedule entry.",
+            "type": "string",
+            "example": "Business hours"
+          },
+          "weekdays": {
+            "type": "array",
+            "description": "Days of the week this entry applies to. 0 = Sunday, 1 = Monday, …, 6 = Saturday.",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "startHourUtc": {
+            "description": "UTC hour (0–23) when this entry becomes active (inclusive).",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 23,
+            "example": 9
+          },
+          "endHourUtc": {
+            "description": "UTC hour (1–24) when this entry deactivates (exclusive). Must differ from startHourUtc. Set to 24 to end at midnight. Values less than startHourUtc create an overnight window spanning midnight.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 24,
+            "example": 17
+          },
+          "minReplicaMemoryGb": {
+            "description": "Minimum memory per replica (Gb) during this window.",
+            "type": "number"
+          },
+          "maxReplicaMemoryGb": {
+            "description": "Maximum memory per replica (Gb) during this window.",
+            "type": "number"
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas during this window.",
+            "type": "integer"
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas during this window.",
+            "type": "integer"
+          },
+          "idleScaling": {
+            "description": "Whether idle scaling is enabled during this window.",
+            "type": "boolean"
+          },
+          "idleTimeoutMinutes": {
+            "description": "Idle timeout in minutes during this window.",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name",
+          "weekdays",
+          "startHourUtc",
+          "endHourUtc"
+        ]
+      },
+      "ScalingSchedulePostRequest": {
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "List of schedule entries. Pass an empty array to clear the schedule.",
+            "items": {
+              "$ref": "#/components/schemas/ScalingScheduleEntryRequest"
+            }
+          }
+        },
+        "required": [
+          "entries"
+        ]
+      },
+      "ScalingSchedulePatchRequest": {
+        "properties": {
+          "entries": {
+            "type": "array",
+            "description": "Full list of schedule entries. Replaces any existing schedule. Pass an empty array to clear the schedule.",
+            "items": {
+              "$ref": "#/components/schemas/ScalingScheduleEntryRequest"
+            }
+          }
+        },
+        "required": [
+          "entries"
+        ]
+      },
+      "CurrentScaling": {
+        "properties": {
+          "effectiveAutoscalingMode": {
+            "description": "Autoscaling mode currently in effect on the running service. May diverge from the configured baseline mode while a schedule entry is active.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ]
+          },
+          "effectiveMinReplicaMemoryGb": {
+            "description": "Minimum memory per replica (Gb) currently applied to the running service. May diverge from the top-level `minReplicaMemoryGb` baseline while a schedule entry is active.",
+            "type": "number"
+          },
+          "effectiveMaxReplicaMemoryGb": {
+            "description": "Maximum memory per replica (Gb) currently applied to the running service. May diverge from the top-level `maxReplicaMemoryGb` baseline while a schedule entry is active. In horizontal autoscaling mode equals `effectiveMinReplicaMemoryGb`.",
+            "type": "number"
+          },
+          "effectiveMinReplicas": {
+            "description": "Minimum number of replicas currently applied to the running service. May diverge from the baseline while a schedule entry is active. In vertical autoscaling mode equals `effectiveMaxReplicas` (vertical mode runs a fixed replica count).",
+            "type": "integer"
+          },
+          "effectiveMaxReplicas": {
+            "description": "Maximum number of replicas currently applied to the running service. May diverge from the baseline while a schedule entry is active.",
+            "type": "integer"
+          },
+          "effectiveIdleScaling": {
+            "description": "Whether idle scaling is currently in effect on the service. May diverge from the top-level `idleScaling` baseline while a schedule entry is active.",
+            "type": "boolean"
+          },
+          "effectiveIdleTimeoutMinutes": {
+            "description": "Idle timeout in minutes currently in effect on the service. May diverge from the top-level `idleTimeoutMinutes` baseline while a schedule entry is active.",
+            "type": "integer"
+          },
+          "activeEntryId": {
+            "description": "ID of the schedule entry whose values are currently applied to the service. Absent when no entry is active.",
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
       "ServiceEndpoint": {
         "properties": {
           "protocol": {
@@ -14302,7 +14915,7 @@
             "deprecated": true
           },
           "minTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -14311,7 +14924,7 @@
             "deprecated": true
           },
           "maxTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -14336,11 +14949,33 @@
             "example": 120
           },
           "numReplicas": {
-            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers.",
+            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers. Present only when the service uses vertical autoscaling. For horizontal autoscaling, use minReplicas and maxReplicas instead.",
             "type": "number",
             "minimum": 1,
             "maximum": 20,
             "example": 3
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas for horizontal autoscaling. Present only when the service uses horizontal autoscaling.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 1
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas for horizontal autoscaling. Present only when the service uses horizontal autoscaling.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 5
+          },
+          "replicaMemoryGb": {
+            "description": "Fixed memory per replica in Gb for horizontal autoscaling. Present only when the service uses horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services.",
+            "type": "number",
+            "minimum": 8,
+            "maximum": 356,
+            "multipleOf": 4,
+            "example": 32
           },
           "idleScaling": {
             "description": "When set to true the service is allowed to scale down to zero when idle. True by default.",
@@ -14455,8 +15090,17 @@
           "enableCoreDumps": {
             "description": "True if the service's underline infra is enabled for collecting core dumps. This is an experimental feature",
             "type": "boolean"
+          },
+          "scalingSchedule": {
+            "$ref": "#/components/schemas/ScalingSchedule"
+          },
+          "currentScaling": {
+            "$ref": "#/components/schemas/CurrentScaling"
           }
-        }
+        },
+        "required": [
+          "currentScaling"
+        ]
       },
       "PrivateEndpointConfig": {
         "properties": {
@@ -21723,7 +22367,7 @@
             }
           },
           "minTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -21732,7 +22376,7 @@
             "deprecated": true
           },
           "maxTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -21757,7 +22401,7 @@
             "example": 120
           },
           "numReplicas": {
-            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers.",
+            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers. Present only when the service uses vertical autoscaling. For horizontal autoscaling, use minReplicas and maxReplicas instead.",
             "type": "number",
             "minimum": 1,
             "maximum": 20,
@@ -21920,7 +22564,7 @@
       "ServiceScalingPatchRequest": {
         "properties": {
           "minTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -21929,7 +22573,7 @@
             "deprecated": true
           },
           "maxTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -22055,7 +22699,7 @@
             "deprecated": true
           },
           "minTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `minReplicaMemoryGb` instead. Minimum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and greater than or equal to 24. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -22064,7 +22708,7 @@
             "deprecated": true
           },
           "maxTotalMemoryGb": {
-            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services.",
+            "description": "DEPRECATED - inaccurate for services with non-default numbers of replicas. Use `maxReplicaMemoryGb` instead. Maximum memory of three workers during auto-scaling in Gb. Available only for 'production' services. Must be a multiple of 12 and lower than or equal to 360 for non paid services or 1068 for paid services. Always absent for horizontal-autoscaling services (replica count is variable).",
             "type": "number",
             "minimum": 24,
             "maximum": 1068,
@@ -22073,7 +22717,7 @@
             "deprecated": true
           },
           "minReplicaMemoryGb": {
-            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8.",
+            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. Present only when the service uses vertical autoscaling.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -22081,7 +22725,7 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum auto-scaling memory in Gb for a single replica . Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services.",
+            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. Present only when the service uses vertical autoscaling.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -22089,11 +22733,33 @@
             "example": 120
           },
           "numReplicas": {
-            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers.",
+            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers. Present only when the service uses vertical autoscaling. For horizontal autoscaling, use minReplicas and maxReplicas instead.",
             "type": "number",
             "minimum": 1,
             "maximum": 20,
             "example": 3
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas for horizontal autoscaling. Present only when the service uses horizontal autoscaling.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 1
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas for horizontal autoscaling. Present only when the service uses horizontal autoscaling.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 5
+          },
+          "replicaMemoryGb": {
+            "description": "Fixed memory per replica in Gb for horizontal autoscaling. Present only when the service uses horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services.",
+            "type": "number",
+            "minimum": 8,
+            "maximum": 356,
+            "multipleOf": 4,
+            "example": 32
           },
           "idleScaling": {
             "description": "When set to true the service is allowed to scale down to zero when idle. True by default.",
@@ -22208,13 +22874,22 @@
           "enableCoreDumps": {
             "description": "True if the service's underline infra is enabled for collecting core dumps. This is an experimental feature",
             "type": "boolean"
+          },
+          "scalingSchedule": {
+            "$ref": "#/components/schemas/ScalingSchedule"
+          },
+          "currentScaling": {
+            "$ref": "#/components/schemas/CurrentScaling"
           }
-        }
+        },
+        "required": [
+          "currentScaling"
+        ]
       },
       "ServiceReplicaScalingPatchRequest": {
         "properties": {
           "minReplicaMemoryGb": {
-            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8.",
+            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. Used for vertical autoscaling. Mutually exclusive with replicaMemoryGb.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -22222,7 +22897,7 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum auto-scaling memory in Gb for a single replica . Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services.",
+            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. Used for vertical autoscaling. Mutually exclusive with replicaMemoryGb.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -22230,11 +22905,33 @@
             "example": 120
           },
           "numReplicas": {
-            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers.",
+            "description": "Fixed replica count for vertical autoscaling. Mutually exclusive with minReplicas/maxReplicas. Please contact support to enable adjustment of numReplicas. When switching from horizontal autoscaling mode the existing replica memory is preserved as the new vertical min/max range; include minReplicaMemoryGb/maxReplicaMemoryGb in the same request to set an explicit range.",
             "type": "number",
             "minimum": 1,
             "maximum": 20,
             "example": 3
+          },
+          "minReplicas": {
+            "description": "Minimum number of replicas for horizontal autoscaling. Must be provided together with maxReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 1
+          },
+          "maxReplicas": {
+            "description": "Maximum number of replicas for horizontal autoscaling. Must be provided together with minReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service.",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 20,
+            "example": 5
+          },
+          "replicaMemoryGb": {
+            "description": "Fixed memory per replica in Gb for horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services. Mutually exclusive with minReplicaMemoryGb/maxReplicaMemoryGb. Requires horizontal autoscaling to be enabled for the service.",
+            "type": "number",
+            "minimum": 8,
+            "maximum": 356,
+            "multipleOf": 4,
+            "example": 32
           },
           "idleScaling": {
             "description": "When set to true the service is allowed to scale down to zero when idle. True by default.",

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -2293,6 +2293,79 @@ impl Client {
         Ok(serde_json::from_str(&body_text)?)
     }
 
+    /// Get service autoscaling schedule
+    pub async fn scaling_schedule_get(
+        &self,
+        organization_id: &str,
+        service_id: &str,
+    ) -> Result<ApiResponse<ScalingSchedule>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let req = self.request(reqwest::Method::GET, &path);
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
+    /// Create or replace service autoscaling schedule
+    pub async fn scaling_schedule_upsert(
+        &self,
+        organization_id: &str,
+        service_id: &str,
+        body: &ScalingSchedulePostRequest,
+    ) -> Result<ApiResponse<ScalingSchedule>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let mut req = self.request(reqwest::Method::POST, &path);
+        req = req.json(body);
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
+    /// Replace service autoscaling schedule
+    pub async fn scaling_schedule_replace(
+        &self,
+        organization_id: &str,
+        service_id: &str,
+        body: &ScalingSchedulePatchRequest,
+    ) -> Result<ApiResponse<ScalingSchedule>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let mut req = self.request(reqwest::Method::PATCH, &path);
+        req = req.json(body);
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
     /// Get the service query endpoint for a given instance
     pub async fn instance_query_endpoint_get(
         &self,

--- a/crates/clickhouse-cloud-api/src/lib.rs
+++ b/crates/clickhouse-cloud-api/src/lib.rs
@@ -18,9 +18,11 @@
 
 pub mod client;
 pub mod error;
+pub mod meta;
 #[allow(non_camel_case_types)]
 pub mod models;
 
 pub use client::Client;
 pub use error::Error;
+pub use meta::{is_beta_operation, BETA_OPERATIONS};
 pub use models::*;

--- a/crates/clickhouse-cloud-api/src/meta.rs
+++ b/crates/clickhouse-cloud-api/src/meta.rs
@@ -1,0 +1,91 @@
+//! Operation stability metadata.
+//!
+//! `BETA_OPERATIONS` mirrors `x-badges` entries on operations in the ClickHouse
+//! Cloud OpenAPI spec. The list is kept sorted so [`is_beta_operation`] can use
+//! `binary_search` and snapshot diffs stay readable.
+//!
+//! Consumers — including this crate's own CLI — can use [`is_beta_operation`]
+//! to render a "(Beta)" affordance derived from the spec rather than maintained
+//! by hand.
+//!
+//! Regenerate from the snapshot with:
+//!
+//! ```text
+//! python3 scripts/regenerate-beta-lists.py
+//! ```
+//!
+//! The `beta_operations_match_spec` test in `tests/spec_coverage_test.rs` fails
+//! if this list drifts from the spec.
+
+/// Snake-case operation IDs (matching [`crate::client::Client`] method names)
+/// that the OpenAPI spec marks Beta via `x-badges`.
+pub const BETA_OPERATIONS: &[&str] = &[
+    "backup_bucket_create",
+    "backup_bucket_delete",
+    "backup_bucket_get",
+    "backup_bucket_update",
+    "click_stack_create_alert",
+    "click_stack_create_dashboard",
+    "click_stack_delete_alert",
+    "click_stack_delete_dashboard",
+    "click_stack_get_alert",
+    "click_stack_get_dashboard",
+    "click_stack_list_alerts",
+    "click_stack_list_dashboards",
+    "click_stack_list_sources",
+    "click_stack_list_webhooks",
+    "click_stack_update_alert",
+    "click_stack_update_dashboard",
+    "postgres_instance_config_get",
+    "postgres_instance_config_patch",
+    "postgres_instance_config_post",
+    "postgres_instance_create_read_replica",
+    "postgres_instance_restore",
+    "postgres_service_certs_get",
+    "postgres_service_create",
+    "postgres_service_delete",
+    "postgres_service_get",
+    "postgres_service_get_list",
+    "postgres_service_patch",
+    "postgres_service_patch_state",
+    "postgres_service_set_password",
+    "scaling_schedule_get",
+    "scaling_schedule_replace",
+    "scaling_schedule_upsert",
+    "service_clickhouse_setting_get",
+    "service_clickhouse_settings_list_get",
+    "service_clickhouse_settings_schema_get",
+    "service_clickhouse_settings_update",
+];
+
+/// Returns `true` if `name` matches a client method backed by a Beta endpoint.
+///
+/// `name` is the snake-case method name (e.g. `"postgres_service_get_list"`).
+pub fn is_beta_operation(name: &str) -> bool {
+    BETA_OPERATIONS.binary_search(&name).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_is_sorted_and_unique() {
+        for pair in BETA_OPERATIONS.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "BETA_OPERATIONS must be sorted and unique; {:?} >= {:?}",
+                pair[0],
+                pair[1],
+            );
+        }
+    }
+
+    #[test]
+    fn is_beta_operation_matches_constant() {
+        assert!(is_beta_operation("scaling_schedule_get"));
+        assert!(is_beta_operation("postgres_service_get_list"));
+        assert!(!is_beta_operation("services_list"));
+        assert!(!is_beta_operation("not_a_real_op"));
+    }
+}

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -4919,6 +4919,29 @@ impl std::fmt::Display for CreateReversePrivateEndpointType {
     }
 }
 
+/// Inline enum for `CurrentScaling.effectiveAutoscalingMode`.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum CurrentScalingEffectiveautoscalingmode {
+    #[serde(rename = "vertical")]
+    #[default]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+    /// Catch-all for unknown or newly-added values.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+impl std::fmt::Display for CurrentScalingEffectiveautoscalingmode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// Inline enum for `GcpBackupBucket.bucketProvider`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum GcpBackupBucketBucketprovider {
@@ -9426,6 +9449,27 @@ pub struct CreateReversePrivateEndpoint {
     pub vpc_resource_share_arn: Option<String>,
 }
 
+/// `CurrentScaling` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct CurrentScaling {
+    #[serde(rename = "activeEntryId", default)]
+    pub active_entry_id: uuid::Uuid,
+    #[serde(rename = "effectiveAutoscalingMode", default)]
+    pub effective_autoscaling_mode: CurrentScalingEffectiveautoscalingmode,
+    #[serde(rename = "effectiveIdleScaling", default)]
+    pub effective_idle_scaling: bool,
+    #[serde(rename = "effectiveIdleTimeoutMinutes", default)]
+    pub effective_idle_timeout_minutes: i64,
+    #[serde(rename = "effectiveMaxReplicaMemoryGb", default)]
+    pub effective_max_replica_memory_gb: f64,
+    #[serde(rename = "effectiveMaxReplicas", default)]
+    pub effective_max_replicas: i64,
+    #[serde(rename = "effectiveMinReplicaMemoryGb", default)]
+    pub effective_min_replica_memory_gb: f64,
+    #[serde(rename = "effectiveMinReplicas", default)]
+    pub effective_min_replicas: i64,
+}
+
 /// `GcpBackupBucket` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GcpBackupBucket {
@@ -9971,6 +10015,102 @@ pub struct RoleUpdateRequest {
     pub name: String,
     #[serde(default)]
     pub policies: Vec<RBACPolicyCreateRequest>,
+}
+
+/// `ScalingSchedule` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingSchedule {
+    #[serde(rename = "activeEntryId", skip_serializing_if = "Option::is_none", default)]
+    pub active_entry_id: Option<uuid::Uuid>,
+    #[serde(rename = "baseConfig", default)]
+    pub base_config: ScalingScheduleBaseConfig,
+    #[serde(default)]
+    pub entries: Vec<ScalingScheduleEntry>,
+}
+
+/// `ScalingScheduleBaseConfig` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingScheduleBaseConfig {
+    #[serde(rename = "idleScaling", default)]
+    pub idle_scaling: bool,
+    #[serde(rename = "idleTimeoutMinutes", default)]
+    pub idle_timeout_minutes: i64,
+    #[serde(rename = "maxReplicaMemoryGb", default)]
+    pub max_replica_memory_gb: f64,
+    #[serde(rename = "maxReplicas", default)]
+    pub max_replicas: i64,
+    #[serde(rename = "minReplicaMemoryGb", default)]
+    pub min_replica_memory_gb: f64,
+    #[serde(rename = "minReplicas", default)]
+    pub min_replicas: i64,
+}
+
+/// `ScalingScheduleEntry` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingScheduleEntry {
+    #[serde(rename = "endHourUtc", default)]
+    pub end_hour_utc: i64,
+    #[serde(default)]
+    pub id: uuid::Uuid,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    pub idle_scaling: Option<bool>,
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    pub idle_timeout_minutes: Option<i64>,
+    #[serde(rename = "isActiveNow", default)]
+    pub is_active_now: bool,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub max_replicas: Option<i64>,
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub min_replicas: Option<i64>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(rename = "startHourUtc", default)]
+    pub start_hour_utc: i64,
+    #[serde(default)]
+    pub weekdays: Vec<i64>,
+}
+
+/// `ScalingScheduleEntryRequest` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingScheduleEntryRequest {
+    #[serde(rename = "endHourUtc", default)]
+    pub end_hour_utc: i64,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    pub idle_scaling: Option<bool>,
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    pub idle_timeout_minutes: Option<i64>,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub max_replicas: Option<i64>,
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub min_replicas: Option<i64>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(rename = "startHourUtc", default)]
+    pub start_hour_utc: i64,
+    #[serde(default)]
+    pub weekdays: Vec<i64>,
+}
+
+/// `ScalingSchedulePatchRequest` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingSchedulePatchRequest {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub entries: Option<Vec<ScalingScheduleEntryRequest>>,
+}
+
+/// `ScalingSchedulePostRequest` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ScalingSchedulePostRequest {
+    #[serde(default)]
+    pub entries: Vec<ScalingScheduleEntryRequest>,
 }
 
 /// `ScimEnterpriseManager` from the ClickHouse Cloud API.
@@ -10592,6 +10732,8 @@ pub struct Service {
     pub compliance_type: ServiceCompliancetype,
     #[serde(rename = "createdAt", default)]
     pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(rename = "currentScaling", default)]
+    pub current_scaling: CurrentScaling,
     #[serde(rename = "dataWarehouseId", default)]
     pub data_warehouse_id: String,
     #[serde(rename = "enableCoreDumps", default)]
@@ -10622,10 +10764,14 @@ pub struct Service {
     pub is_readonly: bool,
     #[serde(rename = "maxReplicaMemoryGb", default)]
     pub max_replica_memory_gb: f64,
+    #[serde(rename = "maxReplicas", default)]
+    pub max_replicas: f64,
     #[serde(rename = "maxTotalMemoryGb", default)]
     pub max_total_memory_gb: f64,
     #[serde(rename = "minReplicaMemoryGb", default)]
     pub min_replica_memory_gb: f64,
+    #[serde(rename = "minReplicas", default)]
+    pub min_replicas: f64,
     #[serde(rename = "minTotalMemoryGb", default)]
     pub min_total_memory_gb: f64,
     #[serde(default)]
@@ -10642,6 +10788,10 @@ pub struct Service {
     pub region: ServiceRegion,
     #[serde(rename = "releaseChannel", default)]
     pub release_channel: ServiceReleasechannel,
+    #[serde(rename = "replicaMemoryGb", default)]
+    pub replica_memory_gb: f64,
+    #[serde(rename = "scalingSchedule", default)]
+    pub scaling_schedule: ScalingSchedule,
     #[serde(default)]
     pub state: ServiceState,
     #[serde(default)]
@@ -10875,10 +11025,16 @@ pub struct ServiceReplicaScalingPatchRequest {
     pub idle_timeout_minutes: Option<f64>,
     #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
     pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub max_replicas: Option<f64>,
     #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
     pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    pub min_replicas: Option<f64>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
     pub num_replicas: Option<f64>,
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    pub replica_memory_gb: Option<f64>,
 }
 
 /// `ServiceScalingPatchRequest` from the ClickHouse Cloud API.
@@ -10909,6 +11065,8 @@ pub struct ServiceScalingPatchResponse {
     pub compliance_type: ServiceScalingPatchResponseCompliancetype,
     #[serde(rename = "createdAt", default)]
     pub created_at: chrono::DateTime<chrono::Utc>,
+    #[serde(rename = "currentScaling", default)]
+    pub current_scaling: CurrentScaling,
     #[serde(rename = "dataWarehouseId", default)]
     pub data_warehouse_id: String,
     #[serde(rename = "enableCoreDumps", default)]
@@ -10939,10 +11097,14 @@ pub struct ServiceScalingPatchResponse {
     pub is_readonly: bool,
     #[serde(rename = "maxReplicaMemoryGb", default)]
     pub max_replica_memory_gb: f64,
+    #[serde(rename = "maxReplicas", default)]
+    pub max_replicas: f64,
     #[serde(rename = "maxTotalMemoryGb", default)]
     pub max_total_memory_gb: f64,
     #[serde(rename = "minReplicaMemoryGb", default)]
     pub min_replica_memory_gb: f64,
+    #[serde(rename = "minReplicas", default)]
+    pub min_replicas: f64,
     #[serde(rename = "minTotalMemoryGb", default)]
     pub min_total_memory_gb: f64,
     #[serde(default)]
@@ -10959,6 +11121,10 @@ pub struct ServiceScalingPatchResponse {
     pub region: ServiceScalingPatchResponseRegion,
     #[serde(rename = "releaseChannel", default)]
     pub release_channel: ServiceScalingPatchResponseReleasechannel,
+    #[serde(rename = "replicaMemoryGb", default)]
+    pub replica_memory_gb: f64,
+    #[serde(rename = "scalingSchedule", default)]
+    pub scaling_schedule: ScalingSchedule,
     #[serde(default)]
     pub state: ServiceScalingPatchResponseState,
     #[serde(default)]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -542,8 +542,11 @@ fn serialize_service_state_patch_request_stop() {
 fn serialize_service_replica_scaling_patch_request() {
     let req = ServiceReplicaScalingPatchRequest {
         num_replicas: Some(5.0),
+        min_replicas: None,
+        max_replicas: None,
         min_replica_memory_gb: Some(16.0),
         max_replica_memory_gb: Some(64.0),
+        replica_memory_gb: None,
         idle_scaling: Some(true),
         idle_timeout_minutes: Some(10.0),
     };

--- a/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
+++ b/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 
+use clickhouse_cloud_api::BETA_OPERATIONS;
 use serde_json::Value;
 
 const SPEC_JSON: &str = include_str!("../clickhouse_cloud_openapi.json");
@@ -629,4 +630,65 @@ fn extract_serde_rename(serde_line: &str) -> Option<&str> {
     let value_start = start + "rename = \"".len();
     let end = serde_line[value_start..].find('"')? + value_start;
     Some(&serde_line[value_start..end])
+}
+
+// ---------------------------------------------------------------------------
+// Beta status (x-badges) coverage
+// ---------------------------------------------------------------------------
+
+#[test]
+fn beta_operations_match_spec() {
+    assert_beta_operations_match(&serde_json::from_str(SPEC_JSON).unwrap());
+}
+
+#[tokio::test]
+#[ignore = "hits the live published ClickHouse OpenAPI spec"]
+async fn beta_operations_match_live_spec() {
+    let spec = load_live_spec().await;
+    assert_beta_operations_match(&spec);
+}
+
+fn assert_beta_operations_match(spec: &Value) {
+    let spec_beta: BTreeSet<String> = spec_beta_operation_ids(spec);
+    let declared: BTreeSet<String> =
+        BETA_OPERATIONS.iter().map(|s| (*s).to_string()).collect();
+
+    let missing: Vec<_> = spec_beta.difference(&declared).cloned().collect();
+    let extra: Vec<_> = declared.difference(&spec_beta).cloned().collect();
+
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "BETA_OPERATIONS drifted from the OpenAPI spec.\n\
+         New beta ops in spec, missing from meta.rs: {:?}\n\
+         No longer beta in spec, still in meta.rs: {:?}\n\
+         Regenerate with: python3 scripts/regenerate-beta-lists.py",
+        missing,
+        extra,
+    );
+}
+
+fn spec_beta_operation_ids(spec: &Value) -> BTreeSet<String> {
+    let mut ids = BTreeSet::new();
+    for path_item in spec["paths"].as_object().unwrap().values() {
+        for (method, operation) in path_item.as_object().unwrap() {
+            if !matches!(
+                method.as_str(),
+                "get" | "put" | "post" | "delete" | "patch" | "options" | "head" | "trace"
+            ) {
+                continue;
+            }
+            let Some(badges) = operation.get("x-badges").and_then(Value::as_array) else {
+                continue;
+            };
+            let is_beta = badges
+                .iter()
+                .any(|b| b.get("name").and_then(Value::as_str) == Some("Beta"));
+            if is_beta {
+                ids.insert(camel_to_snake(
+                    operation["operationId"].as_str().unwrap(),
+                ));
+            }
+        }
+    }
+    ids
 }

--- a/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
+++ b/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
@@ -460,12 +460,25 @@ fn assert_field_coverage(spec: &Value) {
     );
 }
 
+/// Schemas where the spec's `required` array lists only newly-added fields;
+/// older fields on the same schema still rely on the description heuristic.
+/// For these we union `required[]` with the description heuristic instead of
+/// treating `required[]` as exclusive.
+///
+/// Remove an entry once the spec is corrected upstream. `PARTIAL_REQUIRED_SCHEMAS`
+/// is mirrored in `scripts/resolve-field-requirements.py`.
+const PARTIAL_REQUIRED_SCHEMAS: &[&str] = &[
+    "Service",
+    "ServiceScalingPatchResponse",
+];
+
 /// Determine which fields in a schema are required AND non-nullable.
 ///
 /// Resolution strategy:
-/// 1. PATCH request schemas (name contains "Patch" and ends with "Request") → all optional
-/// 2. If schema has a `required` array → use it
-/// 3. Otherwise → fields whose description does NOT start with "Optional" are required
+/// 1. PATCH request schemas (name contains "Patch" and ends with "Request") → all optional.
+/// 2. Schemas in `PARTIAL_REQUIRED_SCHEMAS` → required = `required[]` ∪ description heuristic.
+/// 3. Schemas with a `required` array → use it.
+/// 4. Otherwise → fields whose description does NOT start with "Optional" are required.
 ///
 /// Nullable fields (type: ["string", "null"] or oneOf/anyOf with null) are excluded.
 fn resolve_required_fields<'a>(schema_name: &str, schema: &'a Value) -> BTreeSet<&'a str> {
@@ -479,10 +492,24 @@ fn resolve_required_fields<'a>(schema_name: &str, schema: &'a Value) -> BTreeSet
         return BTreeSet::new();
     }
 
-    let required_names: BTreeSet<&str> = if let Some(required) = schema.get("required").and_then(Value::as_array) {
+    let is_partial = PARTIAL_REQUIRED_SCHEMAS.contains(&schema_name);
+
+    let required_names: BTreeSet<&str> = if is_partial {
+        let mut names: BTreeSet<&str> = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|arr| arr.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        for (name, prop) in props {
+            let desc = prop.get("description").and_then(Value::as_str).unwrap_or("");
+            if !desc.starts_with("Optional") {
+                names.insert(name.as_str());
+            }
+        }
+        names
+    } else if let Some(required) = schema.get("required").and_then(Value::as_array) {
         required.iter().filter_map(Value::as_str).collect()
     } else {
-        // Description heuristic for legacy schemas
         props
             .iter()
             .filter(|(_, prop)| {

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -176,7 +176,7 @@ CONTEXT FOR AGENTS:
         command: ActivityCommands,
     },
 
-    /// Manage ClickHouse Cloud Postgres services (beta)
+    /// Manage ClickHouse Cloud Postgres services (Beta)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Manage ClickHouse Cloud managed Postgres services. Subcommands cover CRUD, lifecycle
@@ -1631,5 +1631,39 @@ mod tests {
         assert_write(&["clickhousectl", "cloud", "postgres", "restart", "pg-1"], true);
         assert_write(&["clickhousectl", "cloud", "postgres", "promote", "pg-1"], true);
         assert_write(&["clickhousectl", "cloud", "postgres", "switchover", "pg-1"], true);
+    }
+
+    /// The `(Beta)` suffix on the Postgres subcommand must agree with the
+    /// library's spec-derived beta metadata. If postgres ever graduates, the
+    /// daily drift check flags it; we then drop the suffix and this test still
+    /// passes (both sides become false).
+    #[test]
+    fn postgres_label_matches_library_beta_status() {
+        use clap::CommandFactory;
+
+        let cmd = Cli::command();
+        let cloud = cmd
+            .find_subcommand("cloud")
+            .expect("cloud subcommand present");
+        let postgres = cloud
+            .find_subcommand("postgres")
+            .expect("postgres subcommand present");
+        let about = postgres
+            .get_about()
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+
+        let label_says_beta = about.contains("(Beta)");
+        let spec_says_beta =
+            clickhouse_cloud_api::is_beta_operation("postgres_service_get_list");
+
+        assert_eq!(
+            label_says_beta, spec_says_beta,
+            "Postgres `--help` says Beta={} but the OpenAPI spec (via meta.rs) \
+             says Beta={}. Update the `Postgres` doc comment in cli.rs or \
+             regenerate BETA_OPERATIONS with `python3 scripts/regenerate-beta-lists.py`. \
+             Current `about`: {about:?}",
+            label_says_beta, spec_says_beta,
+        );
     }
 }

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -176,7 +176,7 @@ CONTEXT FOR AGENTS:
         command: ActivityCommands,
     },
 
-    /// Manage ClickHouse Cloud Postgres services (Beta)
+    /// Manage ClickHouse Cloud Postgres services (beta)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Manage ClickHouse Cloud managed Postgres services. Subcommands cover CRUD, lifecycle
@@ -1631,39 +1631,5 @@ mod tests {
         assert_write(&["clickhousectl", "cloud", "postgres", "restart", "pg-1"], true);
         assert_write(&["clickhousectl", "cloud", "postgres", "promote", "pg-1"], true);
         assert_write(&["clickhousectl", "cloud", "postgres", "switchover", "pg-1"], true);
-    }
-
-    /// The `(Beta)` suffix on the Postgres subcommand must agree with the
-    /// library's spec-derived beta metadata. If postgres ever graduates, the
-    /// daily drift check flags it; we then drop the suffix and this test still
-    /// passes (both sides become false).
-    #[test]
-    fn postgres_label_matches_library_beta_status() {
-        use clap::CommandFactory;
-
-        let cmd = Cli::command();
-        let cloud = cmd
-            .find_subcommand("cloud")
-            .expect("cloud subcommand present");
-        let postgres = cloud
-            .find_subcommand("postgres")
-            .expect("postgres subcommand present");
-        let about = postgres
-            .get_about()
-            .map(|s| s.to_string())
-            .unwrap_or_default();
-
-        let label_says_beta = about.contains("(Beta)");
-        let spec_says_beta =
-            clickhouse_cloud_api::is_beta_operation("postgres_service_get_list");
-
-        assert_eq!(
-            label_says_beta, spec_says_beta,
-            "Postgres `--help` says Beta={} but the OpenAPI spec (via meta.rs) \
-             says Beta={}. Update the `Postgres` doc comment in cli.rs or \
-             regenerate BETA_OPERATIONS with `python3 scripts/regenerate-beta-lists.py`. \
-             Current `about`: {about:?}",
-            label_says_beta, spec_says_beta,
-        );
     }
 }

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -1149,6 +1149,9 @@ pub async fn service_scale(
     let request = ServiceReplicaScalingPatchRequest {
         min_replica_memory_gb: opts.min_replica_memory_gb.map(f64::from),
         max_replica_memory_gb: opts.max_replica_memory_gb.map(f64::from),
+        min_replicas: None,
+        max_replicas: None,
+        replica_memory_gb: None,
         num_replicas: opts.num_replicas.map(f64::from),
         idle_scaling: opts.idle_scaling,
         idle_timeout_minutes: opts.idle_timeout_minutes.map(f64::from),

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -27,6 +27,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CLIENT_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "src" / "client.rs"
 MODELS_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "src" / "models.rs"
+SPEC_COVERAGE_TEST_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "tests" / "spec_coverage_test.rs"
 SNAPSHOT_JSON = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "clickhouse_cloud_openapi.json"
 LIVE_SPEC_URL = os.environ.get(
     "CLICKHOUSE_OPENAPI_SPEC_URL", "https://api.clickhouse.cloud/v1"
@@ -100,6 +101,48 @@ def client_method_names() -> set[str]:
     """Extract all pub async fn names from client.rs."""
     source = CLIENT_RS.read_text()
     return public_items(source, "pub async fn ")
+
+
+def parse_non_openapi_client_methods() -> set[str]:
+    """Parse `NON_OPENAPI_CLIENT_METHODS` from spec_coverage_test.rs.
+
+    The Rust test exempts these client methods from operation coverage because
+    they intentionally back endpoints outside the control-plane OpenAPI spec
+    (e.g. the `queries.clickhouse.cloud` Query API). Re-use the same list here
+    so the drift report does not re-flag them.
+    """
+    if not SPEC_COVERAGE_TEST_RS.exists():
+        return set()
+    source = SPEC_COVERAGE_TEST_RS.read_text()
+    match = re.search(
+        r"const\s+NON_OPENAPI_CLIENT_METHODS\s*:\s*&\[&str\]\s*=\s*&\[(.*?)\];",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        return set()
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def parse_optionality_exemptions() -> set[tuple[str, str]]:
+    """Parse `OPTIONALITY_EXEMPTIONS` from spec_coverage_test.rs.
+
+    The Rust test deliberately diverges from the spec for these (struct, field)
+    pairs — the API behaves differently from what the spec declares (e.g.
+    rejecting zero-value defaults the spec implies are required). Re-use the
+    same list so the drift report stays in sync with the test.
+    """
+    if not SPEC_COVERAGE_TEST_RS.exists():
+        return set()
+    source = SPEC_COVERAGE_TEST_RS.read_text()
+    match = re.search(
+        r"const\s+OPTIONALITY_EXEMPTIONS\s*:\s*&\[\(&str,\s*&str\)\]\s*=\s*&\[(.*?)\];",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        return set()
+    return set(re.findall(r'\("([^"]+)",\s*"([^"]+)"\)', match.group(1)))
 
 
 def model_type_names() -> set[str]:
@@ -255,11 +298,13 @@ def parse_model_fields(source: str) -> dict[str, dict[str, bool]]:
 def check_field_optionality(
     spec: dict,
     model_fields: dict[str, dict[str, bool]],
+    exemptions: set[tuple[str, str]] | None = None,
 ) -> list[dict]:
     """Compare field optionality between spec and models.rs.
 
     Returns list of mismatches: [{schema, field, expected, actual}]
     """
+    exemptions = exemptions or set()
     mismatches = []
     schemas = spec.get("components", {}).get("schemas", {})
 
@@ -277,6 +322,9 @@ def check_field_optionality(
 
         for prop_name in props:
             if prop_name not in fields:
+                continue
+
+            if (pascal_name, prop_name) in exemptions:
                 continue
 
             is_required = prop_name in required_fields
@@ -640,8 +688,9 @@ def main():
     live_ops = spec_operations(live_spec)
     spec_method_names = set(live_ops.keys())
 
+    non_openapi_methods = parse_non_openapi_client_methods()
     missing_op_names = spec_method_names - client_methods
-    extra_op_names = client_methods - spec_method_names
+    extra_op_names = client_methods - spec_method_names - non_openapi_methods
 
     missing_ops = {name: live_ops[name] for name in missing_op_names}
 
@@ -655,7 +704,8 @@ def main():
     # Compare fields
     models_source = MODELS_RS.read_text()
     model_fields = parse_model_fields(models_source)
-    field_mismatches = check_field_optionality(live_spec, model_fields)
+    optionality_exemptions = parse_optionality_exemptions()
+    field_mismatches = check_field_optionality(live_spec, model_fields, optionality_exemptions)
     missing_fields = check_missing_fields(live_spec, model_fields)
 
     # Check committed snapshot staleness

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -27,6 +27,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CLIENT_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "src" / "client.rs"
 MODELS_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "src" / "models.rs"
+META_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "src" / "meta.rs"
 SPEC_COVERAGE_TEST_RS = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "tests" / "spec_coverage_test.rs"
 SNAPSHOT_JSON = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "clickhouse_cloud_openapi.json"
 LIVE_SPEC_URL = os.environ.get(
@@ -122,6 +123,38 @@ def parse_non_openapi_client_methods() -> set[str]:
     if not match:
         return set()
     return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def parse_beta_operations() -> set[str]:
+    """Parse `BETA_OPERATIONS` from meta.rs.
+
+    The list mirrors `x-badges` Beta markers in the OpenAPI spec and is the
+    consumer-facing declaration of which client methods back beta endpoints.
+    """
+    if not META_RS.exists():
+        return set()
+    source = META_RS.read_text()
+    match = re.search(
+        r"pub\s+const\s+BETA_OPERATIONS\s*:\s*&\[&str\]\s*=\s*&\[(.*?)\];",
+        source,
+        re.DOTALL,
+    )
+    if not match:
+        return set()
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def spec_beta_operations(spec: dict) -> set[str]:
+    """Extract snake_case operationIds that are tagged Beta via `x-badges`."""
+    beta = set()
+    for path_item in spec.get("paths", {}).values():
+        for method, op in path_item.items():
+            if method not in HTTP_METHODS or not isinstance(op, dict):
+                continue
+            badges = op.get("x-badges") or []
+            if any(b.get("name") == "Beta" for b in badges):
+                beta.add(camel_to_snake(op["operationId"]))
+    return beta
 
 
 def parse_optionality_exemptions() -> set[tuple[str, str]]:
@@ -464,9 +497,13 @@ def build_issue_body(
     field_mismatches: list[dict] | None = None,
     missing_fields: list[dict] | None = None,
     snapshot_staleness: dict | None = None,
+    beta_status_changes: dict | None = None,
 ) -> str:
     snap = snapshot_staleness or {}
     snap_total = sum(len(snap.get(k, set())) for k in ("added_ops", "removed_ops", "added_schemas", "removed_schemas"))
+
+    beta = beta_status_changes or {}
+    beta_total = len(beta.get("newly_beta", set())) + len(beta.get("graduated", set()))
 
     lines = [
         "The live ClickHouse Cloud OpenAPI spec has operations or schemas that the",
@@ -475,6 +512,7 @@ def build_issue_body(
         f"- **Live spec:** `{LIVE_SPEC_URL}`",
         f"- **Client:** `crates/clickhouse-cloud-api/src/client.rs`",
         f"- **Models:** `crates/clickhouse-cloud-api/src/models.rs`",
+        f"- **Beta metadata:** `crates/clickhouse-cloud-api/src/meta.rs`",
         "",
         "## Summary",
         "",
@@ -485,6 +523,7 @@ def build_issue_body(
         f"| Missing model types | {len(missing_types)} |",
         f"| Missing struct fields | {len(missing_fields or [])} |",
         f"| Field optionality mismatches | {len(field_mismatches or [])} |",
+        f"| Beta status changes | {beta_total} |",
         f"| Stale snapshot changes | {snap_total} |",
         "",
     ]
@@ -600,6 +639,35 @@ def build_issue_body(
             )
         lines.append("")
 
+    # ---- Beta status changes ----
+    if beta_total > 0:
+        lines += [
+            "## Beta Status Changes",
+            "",
+            "The live spec's `x-badges` Beta markers have drifted from",
+            "`BETA_OPERATIONS` in `crates/clickhouse-cloud-api/src/meta.rs`.",
+            "Consumers of the typed client (including this CLI) read that constant",
+            "to render `(Beta)` affordances and gate stability-sensitive code paths.",
+            "",
+        ]
+        if beta.get("newly_beta"):
+            lines.append("**Newly Beta in live spec (add to `BETA_OPERATIONS`):**")
+            for name in sorted(beta["newly_beta"]):
+                lines.append(f"- `{name}`")
+            lines.append("")
+        if beta.get("graduated"):
+            lines.append("**Graduated out of Beta in live spec (remove from `BETA_OPERATIONS`):**")
+            for name in sorted(beta["graduated"]):
+                lines.append(f"- `{name}`")
+            lines.append("")
+        lines += [
+            "Regenerate the list with:",
+            "```bash",
+            "python3 scripts/regenerate-beta-lists.py",
+            "```",
+            "",
+        ]
+
     # ---- Stale snapshot ----
     if snap_total > 0:
         lines += [
@@ -712,8 +780,25 @@ def main():
     snapshot_staleness = check_snapshot_staleness(live_spec)
     snap_total = sum(len(v) for v in snapshot_staleness.values())
 
+    # Compare beta status: spec x-badges vs meta.rs BETA_OPERATIONS
+    declared_beta = parse_beta_operations()
+    live_beta = spec_beta_operations(live_spec)
+    beta_status_changes = {
+        "newly_beta": live_beta - declared_beta,
+        "graduated": declared_beta - live_beta,
+    }
+    beta_total = sum(len(v) for v in beta_status_changes.values())
+
     # Report
-    total = len(missing_ops) + len(extra_op_names) + len(missing_types) + len(field_mismatches) + len(missing_fields) + snap_total
+    total = (
+        len(missing_ops)
+        + len(extra_op_names)
+        + len(missing_types)
+        + len(field_mismatches)
+        + len(missing_fields)
+        + beta_total
+        + snap_total
+    )
 
     print(f"Live spec:       {len(spec_method_names)} operations, {len(spec_type_names)} schemas", file=sys.stderr)
     print(f"client.rs:       {len(client_methods)} pub async fn methods", file=sys.stderr)
@@ -724,13 +809,23 @@ def main():
     print(f"Missing types:   {len(missing_types)}", file=sys.stderr)
     print(f"Missing fields:  {len(missing_fields)}", file=sys.stderr)
     print(f"Field mismatches:{len(field_mismatches)}", file=sys.stderr)
+    print(f"Beta changes:    {beta_total}", file=sys.stderr)
     print(f"Stale snapshot:  {snap_total}", file=sys.stderr)
 
     if total == 0:
         print("\nNo drift. Library fully covers the live spec.", file=sys.stderr)
         return
 
-    body = build_issue_body(missing_ops, extra_op_names, missing_types, live_schemas, field_mismatches, missing_fields, snapshot_staleness)
+    body = build_issue_body(
+        missing_ops,
+        extra_op_names,
+        missing_types,
+        live_schemas,
+        field_mismatches,
+        missing_fields,
+        snapshot_staleness,
+        beta_status_changes,
+    )
 
     if args.dry_run:
         print("\n--- Issue body (dry run) ---\n", file=sys.stderr)

--- a/scripts/regenerate-beta-lists.py
+++ b/scripts/regenerate-beta-lists.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Print the BETA_OPERATIONS list for crates/clickhouse-cloud-api/src/meta.rs,
+sourced from `x-badges` entries in the committed OpenAPI snapshot.
+
+Run this whenever the snapshot is refreshed. Paste the output into meta.rs.
+The `beta_operations_match_spec` test will fail until the constant matches.
+
+Usage:
+    python3 scripts/regenerate-beta-lists.py
+"""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SNAPSHOT = REPO_ROOT / "crates" / "clickhouse-cloud-api" / "clickhouse_cloud_openapi.json"
+HTTP_METHODS = {"get", "put", "post", "delete", "patch", "options", "head", "trace"}
+
+
+def camel_to_snake(name: str) -> str:
+    out = []
+    prev = None
+    for ch in name:
+        if ch.isupper():
+            if prev and (prev.islower() or prev.isdigit()):
+                out.append("_")
+            out.append(ch.lower())
+        else:
+            out.append(ch)
+        prev = ch
+    return "".join(out)
+
+
+def beta_operation_ids(spec: dict) -> list[str]:
+    ids = []
+    for path_item in spec.get("paths", {}).values():
+        for method, op in path_item.items():
+            if method not in HTTP_METHODS or not isinstance(op, dict):
+                continue
+            badges = op.get("x-badges") or []
+            if any(b.get("name") == "Beta" for b in badges):
+                ids.append(camel_to_snake(op["operationId"]))
+    return sorted(set(ids))
+
+
+def main():
+    spec = json.loads(SNAPSHOT.read_text())
+    ops = beta_operation_ids(spec)
+    print(f"// {len(ops)} beta operations extracted from x-badges in")
+    print(f"// crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json")
+    print(f"// Regenerate with: python3 scripts/regenerate-beta-lists.py")
+    print("pub const BETA_OPERATIONS: &[&str] = &[")
+    for op in ops:
+        print(f'    "{op}",')
+    print("];")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/resolve-field-requirements.py
+++ b/scripts/resolve-field-requirements.py
@@ -7,6 +7,11 @@ OpenAPI spec. Handles two conventions:
 2. Schemas without `required` — optional fields have descriptions starting
    with "Optional" (legacy GA endpoints)
 
+A subset of schemas (PARTIAL_REQUIRED_SCHEMAS) have a `required` array that
+only lists newly-added fields; older fields on the same schema still rely on
+the description heuristic. For those, the description heuristic also applies
+as a fallback for fields absent from `required[]`.
+
 PATCH request schemas are always treated as all-optional (partial update
 semantics).
 
@@ -47,13 +52,28 @@ def is_patch_schema(schema_name: str) -> bool:
     return "Patch" in schema_name and schema_name.endswith("Request")
 
 
+# Schemas where the spec's `required` array lists only newly-added fields;
+# older fields on the same schema still rely on the description heuristic.
+# Adding a schema here makes its resolution use the union of `required[]`
+# and the description heuristic instead of treating `required[]` as exclusive.
+#
+# Remove an entry once the spec is corrected upstream (the `required[]` array
+# becomes comprehensive for the schema). The Rust test mirrors this list in
+# `tests/spec_coverage_test.rs` and asserts on stale entries.
+PARTIAL_REQUIRED_SCHEMAS: set[str] = {
+    "Service",
+    "ServiceScalingPatchResponse",
+}
+
+
 def resolve_required_fields(schema_name: str, schema: dict) -> tuple[set[str], str]:
     """Returns (set of required non-nullable field names, resolution method).
 
     Resolution strategy:
-    1. PATCH request schemas -> all fields optional
-    2. If schema has a 'required' array -> use it (standard OpenAPI)
-    3. Otherwise -> field is required if description does NOT start with 'Optional'
+    1. PATCH request schemas -> all fields optional.
+    2. If schema is in PARTIAL_REQUIRED_SCHEMAS -> required = (required[] ∪ description heuristic).
+    3. If schema has a `required` array -> use it (standard OpenAPI).
+    4. Otherwise -> field is required if description does NOT start with "Optional".
 
     In all cases, nullable fields are excluded from the required set.
     """
@@ -62,13 +82,20 @@ def resolve_required_fields(schema_name: str, schema: dict) -> tuple[set[str], s
     if is_patch_schema(schema_name):
         return set(), "patch_schema"
 
-    if "required" in schema:
+    if schema_name in PARTIAL_REQUIRED_SCHEMAS:
+        required_names = set(schema.get("required", []))
+        for name, field in props.items():
+            desc = field.get("description", "") or ""
+            if not desc.startswith("Optional"):
+                required_names.add(name)
+        method = "partial_required"
+    elif "required" in schema:
         required_names = set(schema["required"])
         method = "required_array"
     else:
         required_names = set()
         for name, field in props.items():
-            desc = field.get("description", "")
+            desc = field.get("description", "") or ""
             if not desc.startswith("Optional"):
                 required_names.add(name)
         method = "description_heuristic"


### PR DESCRIPTION
## Summary

Resolves the daily OpenAPI drift report in #149 by:

- Refreshing the committed OpenAPI snapshot.
- Adding **7 new model types** for the ClickHouse Cloud horizontal-autoscaling / scaling-schedule feature (`CurrentScaling`, `ScalingSchedule`, `ScalingScheduleBaseConfig`, `ScalingScheduleEntry`, `ScalingScheduleEntryRequest`, `ScalingSchedulePatchRequest`, `ScalingSchedulePostRequest`).
- Adding **13 new struct fields** to `Service` / `ServiceScalingPatchResponse` / `ServiceReplicaScalingPatchRequest` (`currentScaling`, `scalingSchedule`, `minReplicas`, `maxReplicas`, `replicaMemoryGb`).
- Adding **3 new client methods**: `scaling_schedule_get`, `scaling_schedule_upsert`, `scaling_schedule_replace`.

## Resolver fix

The drift report also surfaced **86 field optionality mismatches** caused by a recent spec convention shift: the OpenAPI team is now adding `required[]` arrays to schemas but **only listing newly-introduced fields**, leaving older fields to the existing \"description doesn't start with 'Optional'\" heuristic. Our previous resolver treated `required[]` as exclusive when present, which mis-classified every other field on `Service` and `ServiceScalingPatchResponse` as optional.

This PR introduces a `PARTIAL_REQUIRED_SCHEMAS` list (mirrored in both `scripts/resolve-field-requirements.py` and `tests/spec_coverage_test.rs`). Schemas in this list fall back to the description heuristic for fields absent from `required[]`. Currently `Service` and `ServiceScalingPatchResponse`. Other schemas with comprehensive `required[]` arrays (e.g. `Scim*`) keep the exclusive interpretation.

The Python drift checker now also parses `NON_OPENAPI_CLIENT_METHODS` and `OPTIONALITY_EXEMPTIONS` directly from `spec_coverage_test.rs`, so the daily report stays in sync with the Rust test's intentional divergences without a second source of truth.

> [!NOTE]
> Stacked on #148 so it merges clean once that lands. Retarget to \`main\` after #148 (and #146) merge.

Closes #149.

## Test plan

- [x] \`cargo build\` (workspace, macOS)
- [x] \`cargo test --workspace\` — 86 lib tests + 5 spec coverage tests + 249 CLI tests pass
- [x] \`cargo clippy --workspace --all-targets\` — no new warnings (pre-existing warnings in \`spec_coverage_test.rs\` are on lines untouched by this PR)
- [x] \`python3 scripts/check-openapi-drift.py --dry-run\` reports 0 drift
- [x] \`python3 scripts/resolve-field-requirements.py --summary\` shows 2 \`partial_required\` schemas
- [ ] Cloud integration workflow run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)