### PR TITLE
ci: declare contents:read on test-install workflow

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -9,6 +9,9 @@ on:
       - "crates/clickhousectl/Cargo.toml"
       - ".github/workflows/test-install.yml"
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The job here only checks out the repository and runs its tests / validation; no GitHub API call beyond the initial checkout is needed.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` supply-chain compromise) is the canonical motivation: a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Per-workflow caps bound that runtime authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's Token-Permissions check (which only credits explicit per-workflow declarations).

YAML validated locally with `yaml.safe_load`.
