### PR TITLE
Cover query endpoint GET + DELETE in service suite

### DIFF
--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -372,6 +372,10 @@ pub struct CleanupRegistry {
     /// being deleted, table drops are redundant but harmless.
     tables: Vec<String>,
     api_key_ids: Vec<String>,
+    // Query endpoint bindings reference an API key; they must be deleted
+    // before the key they point to, otherwise we can't distinguish "binding
+    // cleanup works" from "API key was already gone."
+    query_endpoint_service_ids: Vec<String>,
 }
 
 impl CleanupRegistry {
@@ -433,6 +437,15 @@ impl CleanupRegistry {
             .retain(|registered| registered != key_id);
     }
 
+    pub fn register_query_endpoint(&mut self, service_id: impl Into<String>) {
+        self.query_endpoint_service_ids.push(service_id.into());
+    }
+
+    pub fn unregister_query_endpoint(&mut self, service_id: &str) {
+        self.query_endpoint_service_ids
+            .retain(|registered| registered != service_id);
+    }
+
     pub async fn cleanup(
         &mut self,
         client: &Client,
@@ -443,8 +456,19 @@ impl CleanupRegistry {
     ) -> Result<(), String> {
         let mut failures = Vec::new();
 
-        // API keys are cleaned up first; they belong to the org, not a
-        // specific service, so they outlive service deletion if leaked.
+        // Query endpoint bindings reference an API key, so drop them first.
+        // The service itself may still be around; that's fine — we're just
+        // removing the binding so the API key can be deleted cleanly next.
+        while let Some(service_id) = self.query_endpoint_service_ids.pop() {
+            match client.instance_query_endpoint_delete(org_id, &service_id).await {
+                Ok(_) => {}
+                Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {}
+                Err(e) => failures.push(format!("query endpoint on {service_id}: {e}")),
+            }
+        }
+
+        // API keys are cleaned up before services; they belong to the org,
+        // not a specific service, so they outlive service deletion if leaked.
         while let Some(key_id) = self.api_key_ids.pop() {
             match client.openapi_key_delete(org_id, &key_id).await {
                 Ok(_) => {}

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -357,6 +357,65 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             )
             .await?
             .expect("blocking steps always return a value");
+        // Register the binding for cleanup BEFORE doing anything else with it.
+        // The registry deletes query endpoints before API keys, so a panic
+        // mid-phase still leaves the org tidy.
+        cleanup.register_query_endpoint(service_id.clone());
+
+        // GET the binding back and assert it matches the upsert. Catches
+        // regressions where the control plane stores something different from
+        // what we sent (roles silently demoted, openApiKeys dropped, etc).
+        failures
+            .run(
+                &ctx,
+                StepKind::NonBlocking,
+                "get query endpoint matches upsert",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let service_id = service_id.clone();
+                    let api_key_uuid = api_key_uuid.clone();
+                    let initial_endpoint = initial_endpoint.clone();
+                    async move {
+                        let resp = client
+                            .instance_query_endpoint_get(&org_id, &service_id)
+                            .await?;
+                        let endpoint = resp
+                            .result
+                            .ok_or("query endpoint get returned no result")?;
+                        if endpoint.id != initial_endpoint.id {
+                            return Err(format!(
+                                "get returned different endpoint id: {} (upsert) vs {} (get)",
+                                initial_endpoint.id, endpoint.id
+                            )
+                            .into());
+                        }
+                        if !endpoint.roles.iter().any(|r| r == "sql_console_admin") {
+                            return Err(format!(
+                                "get missing sql_console_admin role: {:?}",
+                                endpoint.roles
+                            )
+                            .into());
+                        }
+                        if !endpoint.open_api_keys.contains(&api_key_uuid) {
+                            return Err(format!(
+                                "get missing our key from openApiKeys: {:?}",
+                                endpoint.open_api_keys
+                            )
+                            .into());
+                        }
+                        if endpoint.allowed_origins != "*" {
+                            return Err(format!(
+                                "get returned unexpected allowedOrigins: {:?}",
+                                endpoint.allowed_origins
+                            )
+                            .into());
+                        }
+                        Ok(())
+                    }
+                },
+            )
+            .await?;
 
         // Endpoint propagation can lag a few seconds behind the upsert; poll
         // for the first successful query rather than asserting on the first
@@ -602,6 +661,65 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 "unexpected query response after re-upsert: {trimmed:?}"
                             )
                             .into())
+                        }
+                    }
+                },
+            )
+            .await?;
+
+        // Delete the binding BEFORE the API key so we can distinguish
+        // "binding cleanup works" from "API key was already gone."
+        failures
+            .run(&ctx, StepKind::NonBlocking, "delete query endpoint", || {
+                let client = client.clone();
+                let org_id = ctx.org_id.clone();
+                let service_id = service_id.clone();
+                async move {
+                    client
+                        .instance_query_endpoint_delete(&org_id, &service_id)
+                        .await?;
+                    Ok(())
+                }
+            })
+            .await?;
+        cleanup.unregister_query_endpoint(&service_id);
+
+        // GET must now report the binding is gone. The control plane returns
+        // 404 once the binding is deleted; accept any 4xx in case the exact
+        // status drifts, but require an error rather than a stale 200.
+        failures
+            .run(
+                &ctx,
+                StepKind::NonBlocking,
+                "get query endpoint after delete returns 4xx",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let service_id = service_id.clone();
+                    async move {
+                        match client
+                            .instance_query_endpoint_get(&org_id, &service_id)
+                            .await
+                        {
+                            Ok(resp) => {
+                                Err(format!(
+                                    "expected 4xx after delete, got 200 with result: {:?}",
+                                    resp.result
+                                )
+                                .into())
+                            }
+                            Err(clickhouse_cloud_api::Error::Api { status, message })
+                                if (400..500).contains(&status) =>
+                            {
+                                eprintln!(
+                                    "  query endpoint correctly absent after delete: {status}: {message}"
+                                );
+                                Ok(())
+                            }
+                            Err(e) => Err(format!(
+                                "expected 4xx after delete, got unexpected error: {e}"
+                            )
+                            .into()),
                         }
                     }
                 },


### PR DESCRIPTION
## Summary

- Adds an `instance_query_endpoint_get` step after the upsert that asserts the binding stored matches what we sent (id, roles, openApiKeys, allowedOrigins).
- Adds an `instance_query_endpoint_delete` step before the API key delete, followed by a GET that must return 4xx — so the test can distinguish binding cleanup working from the API key being gone.
- Extends `CleanupRegistry` with a query endpoint slot that is cleaned up before API keys on the failure path, preserving the same ordering invariant on panic/early-exit.

Closes #158.

## Test plan
- [x] `cargo build -p clickhouse-cloud-api`
- [x] `cargo test -p clickhouse-cloud-api` (live tests remain `#[ignore]`; non-live suite passes)
- [ ] Live `cloud_service_crud_lifecycle` run in CI exercises the new GET + DELETE steps end-to-end