### PR TITLE
Cover postgres_instance_create_read_replica

### DIFF
--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -132,6 +132,10 @@ impl TestContext {
         format!("clickhousectl-it-pg-{}", self.run_id)
     }
 
+    pub fn postgres_replica_name(&self) -> String {
+        format!("clickhousectl-it-pgrr-{}", self.run_id)
+    }
+
     pub fn postgres_run_tags(&self) -> Vec<ResourceTagsV1> {
         vec![
             ResourceTagsV1 {
@@ -366,6 +370,12 @@ impl FailureRecorder {
 pub struct CleanupRegistry {
     service_ids: Vec<String>,
     postgres_ids: Vec<String>,
+    // Read replicas are tracked separately from primary postgres services so
+    // we can guarantee they are torn down first. The ClickHouse Cloud API
+    // refuses to delete a primary that still has live replicas, so cleanup
+    // order matters when a test fails mid-way and the on-success teardown
+    // never runs.
+    postgres_replica_ids: Vec<String>,
     clickpipes: Vec<(String, String)>,
     /// `default.<table>` names to DROP during teardown. Only relevant when
     /// the service is NOT being deleted (attach mode); when the service is
@@ -393,6 +403,23 @@ impl CleanupRegistry {
             .retain(|registered| registered != postgres_id);
     }
 
+    /// Register a Postgres read-replica id for cleanup.
+    ///
+    /// Replicas registered here are torn down before any primary Postgres
+    /// service registered via [`Self::register_postgres`], because the live
+    /// API rejects deleting a primary while replicas still reference it.
+    /// Always register the replica immediately after the create call
+    /// returns its id, before any further interaction, so a mid-test
+    /// failure cannot leak the replica and break the primary delete.
+    pub fn register_postgres_replica(&mut self, replica_id: impl Into<String>) {
+        self.postgres_replica_ids.push(replica_id.into());
+    }
+
+    pub fn unregister_postgres_replica(&mut self, replica_id: &str) {
+        self.postgres_replica_ids
+            .retain(|registered| registered != replica_id);
+    }
+
     pub fn register_clickpipe(
         &mut self,
         service_id: impl Into<String>,
@@ -414,6 +441,7 @@ impl CleanupRegistry {
     pub fn merge_from(&mut self, mut other: CleanupRegistry) {
         self.service_ids.append(&mut other.service_ids);
         self.postgres_ids.append(&mut other.postgres_ids);
+        self.postgres_replica_ids.append(&mut other.postgres_replica_ids);
         self.clickpipes.append(&mut other.clickpipes);
         self.tables.append(&mut other.tables);
         self.api_key_ids.append(&mut other.api_key_ids);
@@ -493,6 +521,18 @@ impl CleanupRegistry {
         while let Some(service_id) = self.service_ids.pop() {
             if let Err(error) = ensure_service_gone(client, org_id, &service_id, delete_timeout, poll_interval).await {
                 failures.push(format!("{service_id}: {error}"));
+            }
+        }
+
+        // Replicas MUST be deleted before primaries. The live API will
+        // refuse a primary delete that still has replicas attached, which
+        // would then leak the primary too.
+        while let Some(replica_id) = self.postgres_replica_ids.pop() {
+            if let Err(error) =
+                ensure_postgres_gone(client, org_id, &replica_id, delete_timeout, poll_interval)
+                    .await
+            {
+                failures.push(format!("postgres replica {replica_id}: {error}"));
             }
         }
 

--- a/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
@@ -354,6 +354,305 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             })
             .await?;
 
+        // ── Read Replica ────────────────────────────────────────────
+        //
+        // Cleanup-order note: the live API refuses to delete a primary while
+        // any read replica still references it, so the replica MUST be torn
+        // down BEFORE the primary. We rely on two complementary mechanisms:
+        //
+        //   1. `CleanupRegistry::register_postgres_replica` below — invoked
+        //      *immediately* after create returns the id. The cleanup phase
+        //      deletes registered replicas before registered primaries, so
+        //      a mid-test panic between create and the in-body teardown
+        //      cannot leak the replica and brick the primary delete.
+        //   2. An explicit in-body teardown of the replica that runs before
+        //      the primary Delete phase below, plus
+        //      `unregister_postgres_replica` to keep the registry tidy on
+        //      the happy path.
+
+        log_phase("Read Replica");
+
+        let replica_tags = {
+            let mut t = ctx.postgres_run_tags();
+            t.push(ResourceTagsV1 {
+                key: "phase".to_string(),
+                value: Some("read_replica".to_string()),
+            });
+            t
+        };
+
+        let replica = failures
+            .run(
+                &ctx,
+                StepKind::Blocking,
+                "create postgres read replica",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let postgres_id = postgres_id.clone();
+                    let body = PostgresServiceReadReplicaRequest {
+                        name: ctx.postgres_replica_name(),
+                        tags: Some(replica_tags.clone()),
+                        ..Default::default()
+                    };
+                    async move {
+                        let resp = client
+                            .postgres_instance_create_read_replica(
+                                &org_id,
+                                &postgres_id,
+                                &body,
+                            )
+                            .await?;
+                        resp.result.ok_or_else(|| {
+                            "postgres read replica create returned no result".into()
+                        })
+                    }
+                },
+            )
+            .await?
+            .expect("blocking steps always return a value");
+
+        let replica_id = replica.id.to_string();
+        eprintln!("postgres_replica_id: <redacted>");
+        // Register before any further interaction so a panic in a later
+        // step cannot leak the replica.
+        cleanup.register_postgres_replica(replica_id.clone());
+
+        // The create response should mark the new service as a replica.
+        // Soft-assert via the FailureRecorder so spec drift on this single
+        // field doesn't take the whole run down.
+        let replica_was_primary_on_create = replica.is_primary;
+        let replica_name_on_create = replica.name.clone();
+        failures
+            .run(
+                &ctx,
+                StepKind::NonBlocking,
+                "verify replica create response marks is_primary=false",
+                || async move {
+                    if replica_was_primary_on_create {
+                        return Err(format!(
+                            "expected replica `{replica_name_on_create}` to have isPrimary=false on create response"
+                        )
+                        .into());
+                    }
+                    Ok(())
+                },
+            )
+            .await?;
+
+        let replica_ready = failures
+            .run(
+                &ctx,
+                StepKind::Blocking,
+                "wait for postgres read replica running",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let replica_id = replica_id.clone();
+                    async move {
+                        poll_until(
+                            "postgres replica running state",
+                            ctx.steady_state_timeout,
+                            ctx.poll_interval,
+                            || {
+                                let client = client.clone();
+                                let org_id = org_id.clone();
+                                let replica_id = replica_id.clone();
+                                async move {
+                                    let resp = client
+                                        .postgres_service_get(&org_id, &replica_id)
+                                        .await?;
+                                    let svc = resp
+                                        .result
+                                        .ok_or("postgres replica get returned no result")?;
+                                    if svc.state.to_string() == "running" {
+                                        Ok(Some(svc))
+                                    } else {
+                                        Ok(None)
+                                    }
+                                }
+                            },
+                        )
+                        .await
+                    }
+                },
+            )
+            .await?
+            .expect("blocking steps always return a value");
+
+        assert_eq!(replica_ready.name, ctx.postgres_replica_name());
+        assert!(
+            !replica_ready.is_primary,
+            "running read replica reported isPrimary=true"
+        );
+        assert!(
+            !replica_ready.hostname.is_empty(),
+            "running postgres replica returned empty hostname"
+        );
+        assert!(
+            !replica_ready.connection_string.is_empty(),
+            "running postgres replica returned empty connection string"
+        );
+
+        failures
+            .run(
+                &ctx,
+                StepKind::NonBlocking,
+                "verify replica appears in postgres_service_get_list alongside primary",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let primary_id = postgres_id.clone();
+                    let replica_id = replica_id.clone();
+                    async move {
+                        let resp = client.postgres_service_get_list(&org_id).await?;
+                        let services = resp
+                            .result
+                            .ok_or("postgres list returned no result")?;
+                        let primary_seen =
+                            services.iter().any(|s| s.id.to_string() == primary_id);
+                        let replica_entry = services
+                            .iter()
+                            .find(|s| s.id.to_string() == replica_id);
+                        if !primary_seen {
+                            return Err(
+                                "primary postgres service no longer visible in list after replica create"
+                                    .into(),
+                            );
+                        }
+                        let Some(replica_entry) = replica_entry else {
+                            return Err(
+                                "created read replica was not visible in postgres_service_get_list"
+                                    .into(),
+                            );
+                        };
+                        if replica_entry.is_primary {
+                            return Err(
+                                "replica entry in list reported isPrimary=true".into(),
+                            );
+                        }
+                        Ok(())
+                    }
+                },
+            )
+            .await?;
+
+        failures
+            .run(
+                &ctx,
+                StepKind::NonBlocking,
+                "verify postgres_service_get on replica returns expected primary reference",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let replica_id = replica_id.clone();
+                    let expected_provider = ctx.provider.clone();
+                    let expected_region = ctx.region.clone();
+                    async move {
+                        let resp = client
+                            .postgres_service_get(&org_id, &replica_id)
+                            .await?;
+                        let svc = resp
+                            .result
+                            .ok_or("postgres replica get returned no result")?;
+                        if svc.is_primary {
+                            return Err(
+                                "GET on replica id returned isPrimary=true".into(),
+                            );
+                        }
+                        // A read replica inherits provider+region from its
+                        // primary. These are the closest "primary reference"
+                        // signals the current API surface exposes on the
+                        // PostgresService model.
+                        if svc.provider.to_string() != expected_provider {
+                            return Err(format!(
+                                "replica provider `{}` did not match primary `{}`",
+                                svc.provider, expected_provider
+                            )
+                            .into());
+                        }
+                        if svc.region != expected_region {
+                            return Err(format!(
+                                "replica region `{}` did not match primary `{}`",
+                                svc.region, expected_region
+                            )
+                            .into());
+                        }
+                        Ok(())
+                    }
+                },
+            )
+            .await?;
+
+        // Explicit replica teardown BEFORE the primary Delete phase. This is
+        // Blocking: if it fails the primary delete will fail too, which is
+        // a cleanup-order failure that would leak resources. The replica is
+        // also tracked by the cleanup registry as a safety net.
+        failures
+            .run(
+                &ctx,
+                StepKind::Blocking,
+                "delete postgres read replica before primary",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let replica_id = replica_id.clone();
+                    async move {
+                        client
+                            .postgres_service_delete(&org_id, &replica_id)
+                            .await?;
+                        Ok(())
+                    }
+                },
+            )
+            .await?;
+
+        failures
+            .run(
+                &ctx,
+                StepKind::Blocking,
+                "confirm postgres read replica is gone after delete",
+                || {
+                    let client = client.clone();
+                    let org_id = ctx.org_id.clone();
+                    let replica_id = replica_id.clone();
+                    let timeout = ctx.delete_timeout;
+                    let interval = ctx.poll_interval;
+                    async move {
+                        poll_until("postgres replica deletion", timeout, interval, || {
+                            let client = client.clone();
+                            let org_id = org_id.clone();
+                            let replica_id = replica_id.clone();
+                            async move {
+                                match client
+                                    .postgres_service_get(&org_id, &replica_id)
+                                    .await
+                                {
+                                    Ok(_) => Ok(None),
+                                    Err(clickhouse_cloud_api::Error::Api {
+                                        status: 404, ..
+                                    }) => Ok(Some(())),
+                                    Err(e) => {
+                                        let message = e.to_string();
+                                        if message.contains("404")
+                                            || message.contains("not found")
+                                        {
+                                            Ok(Some(()))
+                                        } else {
+                                            Err(e.into())
+                                        }
+                                    }
+                                }
+                            }
+                        })
+                        .await?;
+                        Ok(())
+                    }
+                },
+            )
+            .await?;
+        cleanup.unregister_postgres_replica(&replica_id);
+
         // ── Delete ──────────────────────────────────────────────────
 
         log_phase("Delete");


### PR DESCRIPTION
## Summary

- Extends `integration_postgres_test.rs` with a Read Replica phase that exercises `postgres_instance_create_read_replica` end-to-end (create, poll-to-running, list+get verification including primary reference, explicit delete) before the primary Delete phase.
- Adds replica-id tracking to `CleanupRegistry` (`register_postgres_replica` / `unregister_postgres_replica`); the cleanup pass deletes registered replicas before registered primaries, since the live API refuses to delete a primary while a replica still references it.
- Replica is registered in the cleanup registry immediately on create so a panic between create and the in-body teardown cannot leak the replica and break the primary delete.

## Cleanup ordering

Two complementary mechanisms keep replicas torn down before primaries:

1. **`CleanupRegistry`** — the cleanup pass iterates `postgres_replica_ids` to deletion before iterating `postgres_ids`. Registration happens immediately after the create call returns the id.
2. **Explicit in-body teardown** — the Read Replica phase deletes its replica and waits for 404 before the primary Delete phase runs. `unregister_postgres_replica` keeps the registry tidy on the happy path.

Both paths are documented in code comments (`CleanupRegistry` doc-comment and the Read Replica phase header in the test).

## Test plan

- [x] `cargo build -p clickhouse-cloud-api`
- [x] `cargo clippy -p clickhouse-cloud-api --tests -- -D warnings` (only pre-existing errors in `spec_coverage_test.rs` and `integration_test.rs` remain; nothing in files touched by this PR)
- [x] `cargo test -p clickhouse-cloud-api` (86 unit + 6 spec-coverage tests pass; integration_postgres test is `#[ignore]` per existing suite policy)
- [ ] Live cloud-integration run via PR CI to exercise the new phase end-to-end against production.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)