### PR TITLE
Harden GitHub Actions workflows per zizmor audit

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -35,7 +35,9 @@ jobs:
       RUST_TEST_THREADS: 1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Resolve test run label
         run: |
@@ -52,7 +54,7 @@ jobs:
           esac
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Run cloud integration suite
         run: cargo test -p clickhouse-cloud-api --test integration_test -- --ignored --nocapture

--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -35,7 +35,7 @@ jobs:
       RUST_TEST_THREADS: 1
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -15,7 +15,9 @@ jobs:
     name: Check for OpenAPI spec drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Check for drift and create issue
         env:

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check for OpenAPI spec drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -31,10 +31,12 @@ jobs:
             cross: false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
         with:
           targets: ${{ matrix.target }}
 
@@ -67,7 +69,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/clickhousectl clickhousectl-${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: clickhousectl-${{ matrix.target }}
           path: clickhousectl-${{ matrix.target }}
@@ -98,7 +100,7 @@ jobs:
             artifact: clickhousectl-x86_64-unknown-linux-musl
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: ${{ matrix.artifact }}
 
@@ -114,11 +116,15 @@ jobs:
     name: Create Release
     needs: [build, smoke-test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe #v2
-        with:
-          generate_release_notes: true
-          files: release/*
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: gh release create "$TAG" --generate-notes release/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             cross: false
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -69,7 +69,7 @@ jobs:
         run: cp target/${{ matrix.target }}/release/clickhousectl clickhousectl-${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: clickhousectl-${{ matrix.target }}
           path: clickhousectl-${{ matrix.target }}
@@ -100,7 +100,7 @@ jobs:
             artifact: clickhousectl-x86_64-unknown-linux-musl
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.artifact }}
 
@@ -119,12 +119,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -16,10 +16,12 @@ jobs:
     name: Test clickhousectl
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Build
         run: cargo build -p clickhousectl

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -16,7 +16,7 @@ jobs:
     name: Test clickhousectl
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-cloud-api.yml
+++ b/.github/workflows/test-cloud-api.yml
@@ -16,10 +16,12 @@ jobs:
     name: Test clickhouse-cloud-api
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Build
         run: cargo build -p clickhouse-cloud-api

--- a/.github/workflows/test-cloud-api.yml
+++ b/.github/workflows/test-cloud-api.yml
@@ -16,7 +16,7 @@ jobs:
     name: Test clickhouse-cloud-api
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -17,7 +17,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
@@ -93,7 +93,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -9,13 +9,18 @@ on:
       - "crates/clickhousectl/Cargo.toml"
       - ".github/workflows/test-install.yml"
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
       - run: cargo test
 
   url-probing:
@@ -88,9 +93,11 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Build CLI
         run: cargo build

--- a/.github/workflows/test-postgres-integration.yml
+++ b/.github/workflows/test-postgres-integration.yml
@@ -18,7 +18,7 @@ jobs:
     name: local postgres edge cases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/test-postgres-integration.yml
+++ b/.github/workflows/test-postgres-integration.yml
@@ -18,13 +18,15 @@ jobs:
     name: local postgres edge cases
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Cache cargo build
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
 
       - name: Build clickhousectl
         run: cargo build -p clickhousectl


### PR DESCRIPTION
## Summary

Runs `zizmor` over `.github/workflows/` and addresses every finding. No functional CI changes — purely supply-chain hardening.

- **SHA-pin every third-party action** to the latest tagged release. The tag is preserved as a trailing comment so future bumps stay reviewable:
  - `actions/checkout` → `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2)
  - `actions/upload-artifact` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1)
  - `actions/download-artifact` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1)
  - `Swatinem/rust-cache` → `e18b497796c12c097a38f9edb9d0641fb99eee32` (v2.9.1)
  - `dtolnay/rust-toolchain` → `29eef336d9b2848a0b548edc03f92a220660cdb8` (stable branch @ 2026-03-27)
- **Drop `softprops/action-gh-release`** in favour of a `gh release create` script step. `gh` is pre-installed on every GitHub-hosted runner, so removing the third-party action shrinks the release path's external dependency surface. Tag and token are passed via env vars rather than direct `${{ }}` expression expansion to keep us out of the template-injection class of issues.
- **`persist-credentials: false`** on every `actions/checkout` invocation. None of these jobs push via the default `GITHUB_TOKEN`, so leaving it in the worktree only widens the blast radius if a later step is compromised.
- **`release.yml`**: drop workflow-level `contents: write` to `contents: read`; grant `contents: write` only on the `release` job that publishes.
- **`test-install.yml`**: add an explicit workflow-level `permissions: contents: read` block — previously the workflow inherited overly broad default token permissions.

The `checkout` v6 / `upload-artifact` v7 / `download-artifact` v7+ majors all require Actions Runner ≥ 2.327.1 (Node.js 24); GitHub-hosted runners satisfy this. `download-artifact` v8 also now defaults to erroring on artifact hash mismatch, which is the secure default we want.

## zizmor result after this PR

```
No findings to report. Good job! (34 suppressed)
```

## Merge cleanliness with open PRs

Only three open PRs touch any workflow file, and all touch only `cloud-integration.yml`:

- **#130 (clickpipes)** — merges cleanly.
- **#173 (org integration)** — workflow file merges cleanly (only adds a new env var + a new step on lines this PR doesn't touch).
- **#144 (clickstack)** — has a pre-existing conflict in `cloud-integration.yml` against `main` (predates this PR); this hardening does not introduce any additional workflow conflict.

The other 12 open PRs don't touch `.github/workflows/` at all.

## Test plan

- [ ] `zizmor .github/workflows` reports zero findings on the branch
- [ ] All non-release CI workflows still pass on this PR (they exercise the pinned versions of every touched action)
- [ ] `release.yml` is verified by the next tag push; behavioural changes are (a) the permissions split (`release` job retains `contents: write`) and (b) `gh release create` replacing `softprops/action-gh-release` — same inputs (auto-generated notes + `release/*` files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)