### PR TITLE
Wire publish-crates into release-publishing environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
+    environment: release-publishing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Fixes the empty-token failure from the v0.2.0 release run.

`CARGO_REGISTRY_TOKEN` is stored in the `release-publishing` environment. Environment-scoped secrets are only exposed to jobs that declare `environment: <name>`, so without this line `${{ secrets.CARGO_REGISTRY_TOKEN }}` resolves to empty string and `cargo publish` errors out with "no token configured".

`publish-npm` deliberately stays out of the environment — adding it would change the OIDC subject claim and break the npm trusted publisher match.

## Test plan
- [ ] Re-tag (either delete + recreate `v0.2.0`, or bump to `v0.2.1`) and confirm `publish-crates` reads the token and publishes both crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)