### PR TITLE
Fix npm OIDC publish: drop registry-url, upgrade npm to 11.5.1+

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,11 +209,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # Deliberately omit `registry-url:` — setup-node would write
+      # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} into .npmrc and
+      # set NODE_AUTH_TOKEN to a placeholder, which makes npm authenticate
+      # with that placeholder instead of falling through to OIDC. The default
+      # registry is registry.npmjs.org anyway, so no .npmrc is needed.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
+
+      # npm trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Align package version with tag
         working-directory: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,19 +209,16 @@ jobs:
         with:
           persist-credentials: false
 
-      # Deliberately omit `registry-url:` — setup-node would write
-      # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} into .npmrc and
-      # set NODE_AUTH_TOKEN to a placeholder, which makes npm authenticate
-      # with that placeholder instead of falling through to OIDC. The default
-      # registry is registry.npmjs.org anyway, so no .npmrc is needed.
+      # Node 24 LTS ships npm 11.x, which is required for trusted publishing
+      # (>= 11.5.1). Deliberately omit `registry-url:` — when given one,
+      # setup-node writes //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+      # into .npmrc and exports NODE_AUTH_TOKEN as a placeholder, making npm
+      # auth with the placeholder instead of falling through to OIDC. The
+      # default registry is registry.npmjs.org anyway, so no .npmrc is needed.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
-
-      # npm trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
-      - name: Upgrade npm
-        run: npm install -g npm@latest
+          node-version: '24'
 
       - name: Align package version with tag
         working-directory: npm


### PR DESCRIPTION
v0.2.0 release: crates.io publish succeeded, npm publish failed with `E404 PUT registry.npmjs.org/clickhousectl` despite a successful provenance signing.

## Root cause

Decoding the [sigstore transparency log entry](https://search.sigstore.dev/?logIndex=1570191743) for the failed attempt confirmed the OIDC subject claim matched the trusted publisher config (org=`ClickHouse`, repo=`clickhousectl`, workflow path=`.github/workflows/release.yml`, ref=`refs/tags/v0.2.0`). So the trusted publisher itself is configured correctly — the failure was purely on the auth path.

Two compounding bugs in our `publish-npm` job:

1. **`actions/setup-node` injected a placeholder `NODE_AUTH_TOKEN`.** When given `registry-url:` without an explicit token, setup-node still writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `.npmrc` and exports `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX`. npm then auths with that placeholder instead of falling through to OIDC. Visible in the failing run's env block:
   ```
   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
   ```
   Issue #188 called out the empty-token gotcha; I missed that setup-node injects a non-empty placeholder when you don't supply one. Fix: drop `registry-url:` entirely. The default registry is `registry.npmjs.org` anyway, so no `.npmrc` is needed.

2. **npm 10.9.7 is too old for trusted publishing.** Trusted publishing requires npm ≥ 11.5.1; Node 22 ships npm 10.x. Fix: `npm install -g npm@latest` before the publish step.

## Test plan

- [ ] Delete the broken v0.2.0 npm publish state isn't possible (no version got published). After merge, re-tag (either delete + recreate `v0.2.0`, or bump to `v0.2.1`) and confirm the npm package page shows the new version with a provenance badge.

Note that `clickhousectl@0.2.0` was successfully published to crates.io on the previous run, so reusing `v0.2.0` requires `cargo yank --version 0.2.0` first (or bumping to `v0.2.1`, which is cleaner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)