### PR TITLE
Release prep: bump to 0.2.2 in lockstep; document lockstep policy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ cargo add -p clickhouse-cloud-api url
 - If the user references a GitHub issue (e.g. "work on issue 3"), use `gh issue view 3` to get the details, then create a branch like `issue-3-short-description`.
 - Update `README.md` and any relevant documentation as part of the change — PRs should include doc updates for new or changed functionality.
 - Commit to the branch, push, and create a PR with `gh pr create`.
-- Releases are done by tagging `main` (e.g. `git tag v0.1.4 && git push origin v0.1.4`), which triggers the GitHub Actions release workflow. Bump `version` in `crates/clickhousectl/Cargo.toml` (always) and `crates/clickhouse-cloud-api/Cargo.toml` (only when the API client changed; publish step skips if unchanged). `npm/package.json` is bumped automatically by the workflow. Release-time secrets: `CARGO_REGISTRY_TOKEN` for crates.io; npm uses OIDC trusted publishing (configured one-time on npmjs.com against this repo, `release.yml`, and the `publish-npm` job).
+- Releases are done by tagging `main` (e.g. `git tag v0.1.4 && git push origin v0.1.4`), which triggers the GitHub Actions release workflow. Bump all of these to the same version in lockstep: `crates/clickhousectl/Cargo.toml` (`version` and the `clickhouse-cloud-api` dep version), `crates/clickhouse-cloud-api/Cargo.toml`, and `npm/package.json`. The workflow also re-aligns `npm/package.json` to the tag at publish time, but bump it in the repo too so the source-of-truth matches. Release-time secrets: `CARGO_REGISTRY_TOKEN` for crates.io; npm uses OIDC trusted publishing (configured one-time on npmjs.com against this repo, `release.yml`, and the `publish-npm` job).
 
 ## Testing locally
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.2.1", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.2.2", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
## Summary

- Bump `clickhousectl`, `clickhouse-cloud-api`, the dep reference between them, and `npm/package.json` to **0.2.2** in lockstep, ready for release.
- `CLAUDE.md`: update the release section to require lockstep bumps across both crates and the npm package on every release, replacing the prior rules ("only when API client changed" for `clickhouse-cloud-api`, "auto-bumped by the workflow" for npm).

Stacked on #198, which contains the actual `chctl update` fix that the 0.2.2 release exists to ship. Tag `v0.2.2` once both this and #198 are merged.

> Existing 0.2.1 installs will still need a one-time manual reinstall (`npm i -g clickhousectl` / `cargo binstall` / direct binary) — the broken update command on those installs can't self-heal.

## Test plan

- [x] `cargo build --workspace` passes with the new versions
- [ ] After tag `v0.2.2`: from a fresh 0.2.1 install (post-reinstall), confirm `chctl update` upgrades cleanly to 0.2.2
- [ ] Confirm crates.io shows `clickhousectl@0.2.2` + `clickhouse-cloud-api@0.2.2`, and npm shows `clickhousectl@0.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)