### PR TITLE
Download release artifacts from builds.clickhouse.com; bump to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64",
  "bollard",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The install script will download the correct version for your OS and install to 
 
 ### `cargo binstall`
 
-If you already have [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall), this pulls the prebuilt binary from GitHub Releases:
+If you already have [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall), this pulls the prebuilt binary from `builds.clickhouse.com`:
 
 ```bash
 cargo binstall clickhousectl
@@ -40,7 +40,7 @@ cargo binstall clickhousectl
 npm install -g clickhousectl
 ```
 
-This installs an npm wrapper package that downloads the matching prebuilt binary from GitHub Releases at install time. Both `clickhousectl` and `chctl` are exposed as commands. If you use `npm install --ignore-scripts`, the download is skipped — fall back to one of the other install paths.
+This installs an npm wrapper package that downloads the matching prebuilt binary from `builds.clickhouse.com` at install time. Both `clickhousectl` and `chctl` are exposed as commands. If you use `npm install --ignore-scripts`, the download is skipped — fall back to one of the other install paths.
 
 ### From crates.io
 
@@ -58,7 +58,7 @@ cargo install --path crates/clickhousectl
 
 ### Direct download
 
-Prebuilt archives for each release are attached to the [GitHub release](https://github.com/ClickHouse/clickhousectl/releases). Archives are named `clickhousectl-{target}-v{version}.tar.gz` and contain a single directory of the same name with the `clickhousectl` binary inside. Supported targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`.
+Prebuilt archives for each release are hosted at `https://builds.clickhouse.com/clickhousectl/`. Archives are named `clickhousectl-{target}-v{version}.tar.gz` and contain a single directory of the same name with the `clickhousectl` binary inside. Supported targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`. Example: `https://builds.clickhouse.com/clickhousectl/clickhousectl-aarch64-apple-darwin-v0.2.2.tar.gz`.
 
 ## Local
 

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ categories = ["command-line-utilities", "database"]
 readme = "../../README.md"
 
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+pkg-url = "https://builds.clickhouse.com/clickhousectl/{ name }-{ target }-v{ version }{ archive-suffix }"
 pkg-fmt = "tgz"
 bin-dir = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }"
 
@@ -34,7 +34,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.2.2", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.2.3", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 base64 = "0.22.1"

--- a/crates/clickhousectl/src/update.rs
+++ b/crates/clickhousectl/src/update.rs
@@ -9,29 +9,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tar::Archive;
 
 const GITHUB_REPO: &str = "ClickHouse/clickhousectl";
+const BUILDS_BASE_URL: &str = "https://builds.clickhouse.com/clickhousectl";
 const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60; // 24 hours
 
 #[derive(Deserialize)]
 struct GitHubRelease {
     tag_name: String,
-    assets: Vec<GitHubAsset>,
 }
 
-#[derive(Deserialize)]
-struct GitHubAsset {
-    name: String,
-    browser_download_url: String,
-}
-
-/// The asset name suffix for this platform's binary in GitHub Releases.
-fn asset_name() -> Result<&'static str> {
+/// The platform target triple used in release artifact names.
+fn target_triple() -> Result<&'static str> {
     let os = std::env::consts::OS;
     let arch = std::env::consts::ARCH;
     match (os, arch) {
-        ("macos", "x86_64") => Ok("clickhousectl-x86_64-apple-darwin"),
-        ("macos", "aarch64") => Ok("clickhousectl-aarch64-apple-darwin"),
-        ("linux", "x86_64") => Ok("clickhousectl-x86_64-unknown-linux-musl"),
-        ("linux", "aarch64") => Ok("clickhousectl-aarch64-unknown-linux-musl"),
+        ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
+        ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
+        ("linux", "x86_64") => Ok("x86_64-unknown-linux-musl"),
+        ("linux", "aarch64") => Ok("aarch64-unknown-linux-musl"),
         _ => Err(Error::UnsupportedPlatform {
             os: os.to_string(),
             arch: arch.to_string(),
@@ -148,18 +142,9 @@ pub async fn perform_update() -> Result<()> {
         return Ok(());
     }
 
-    let asset_prefix = asset_name()?;
-    let expected_asset = format!("{}-{}.tar.gz", asset_prefix, latest);
-    let asset = release
-        .assets
-        .iter()
-        .find(|a| a.name == expected_asset)
-        .ok_or_else(|| {
-            Error::Download(format!(
-                "No compatible binary found for this platform (expected {})",
-                expected_asset
-            ))
-        })?;
+    let target = target_triple()?;
+    let archive_name = format!("clickhousectl-{}-{}.tar.gz", target, latest);
+    let download_url = format!("{}/{}", BUILDS_BASE_URL, archive_name);
 
     let display = latest.strip_prefix('v').unwrap_or(latest);
     println!("Downloading clickhousectl v{}...", display);
@@ -170,7 +155,7 @@ pub async fn perform_update() -> Result<()> {
         .build()?;
 
     let response = client
-        .get(&asset.browser_download_url)
+        .get(&download_url)
         .send()
         .await?
         .error_for_status()
@@ -327,10 +312,10 @@ mod tests {
     }
 
     #[test]
-    fn test_asset_name() {
+    fn test_target_triple() {
         // Should return something valid on macOS/Linux test hosts
-        let name = asset_name().unwrap();
-        assert!(name.starts_with("clickhousectl-"));
+        let target = target_triple().unwrap();
+        assert!(target.contains('-'));
     }
 
     fn build_release_archive(inner_dir: &str, binary_bytes: &[u8]) -> Vec<u8> {

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,7 @@ echo "Latest release: $LATEST"
 
 # Download archive
 ARCHIVE_NAME="clickhousectl-${TARGET}-${LATEST}.tar.gz"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST}/${ARCHIVE_NAME}"
+DOWNLOAD_URL="https://builds.clickhouse.com/clickhousectl/${ARCHIVE_NAME}"
 echo "Downloading ${DOWNLOAD_URL}..."
 
 mkdir -p "$INSTALL_DIR"

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -14,7 +14,7 @@ if (!fs.existsSync(binaryPath)) {
     `clickhousectl: binary not found at ${binaryPath}.\n` +
     `The postinstall step may have been skipped (e.g. npm --ignore-scripts) ` +
     `or failed. Reinstall with scripts enabled, or download manually from ` +
-    `https://github.com/ClickHouse/clickhousectl/releases`
+    `https://builds.clickhouse.com/clickhousectl/`
   );
   process.exit(1);
 }

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Downloads the platform-appropriate clickhousectl binary from the matching
-// GitHub release and places it next to bin/clickhousectl. Invoked as the
-// package's postinstall script.
+// Downloads the platform-appropriate clickhousectl binary from
+// builds.clickhouse.com and places it next to bin/clickhousectl. Invoked as
+// the package's postinstall script.
 
 const fs = require('fs');
 const path = require('path');
@@ -9,7 +9,7 @@ const https = require('https');
 const { URL } = require('url');
 const { spawnSync } = require('child_process');
 
-const REPO = 'ClickHouse/clickhousectl';
+const BUILDS_BASE_URL = 'https://builds.clickhouse.com/clickhousectl';
 const PLATFORM_MAP = {
   'linux-x64': 'x86_64-unknown-linux-musl',
   'linux-arm64': 'aarch64-unknown-linux-musl',
@@ -67,7 +67,7 @@ async function main() {
   const version = pkg.version;
   const target = resolveTarget();
   const archiveName = `clickhousectl-${target}-v${version}.tar.gz`;
-  const url = `https://github.com/${REPO}/releases/download/v${version}/${archiveName}`;
+  const url = `${BUILDS_BASE_URL}/${archiveName}`;
 
   const vendorDir = path.join(__dirname, 'vendor');
   fs.mkdirSync(vendorDir, { recursive: true });

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
## Summary

- Switch every release-download path from GitHub Releases to `https://builds.clickhouse.com/clickhousectl/`: the self-`update` command, `install.sh`, the npm postinstall script, and the `cargo-binstall` metadata.
- The "what is the latest version" lookup still hits the GitHub releases API — `builds.clickhouse.com` has no listing/`latest` endpoint, so we use GH for discovery and pull the actual artifact from CDN.
- Lockstep version bump to 0.2.3 across `crates/clickhousectl/Cargo.toml` (incl. `clickhouse-cloud-api` dep), `crates/clickhouse-cloud-api/Cargo.toml`, and `npm/package.json`. README updated to point at the new artifact host.

## Test plan

- [x] `cargo build` / `cargo clippy -p clickhousectl` clean
- [x] `cargo test -p clickhousectl update::` (unit tests for version parsing + archive extraction)
- [x] Local smoke test of `clickhousectl update` with a spoofed-older version, confirming the binary is fetched from `builds.clickhouse.com`
- [x] `sh -x install.sh` shows the new download URL
- [x] `node npm/install.js` downloads and extracts the binary
- [ ] After tagging, confirm the release workflow still publishes to both GH Releases (for the version-discovery API) and builds.clickhouse.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)