### PR TITLE
Bump version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.2.3", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.2.4", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
## Summary
- Bumps `clickhousectl`, `clickhouse-cloud-api`, and `npm/package.json` to 0.2.4
- Updates the workspace `clickhouse-cloud-api` dep version to match
- Refreshes `Cargo.lock`

## Test plan
- [x] `cargo build` passes
- [ ] After merge, tag `v0.2.4` to trigger the release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)