### PR TITLE
Add custom config files for local servers (#226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ EOF
 clickhousectl local server start --config-file analytics    # Start a server with it
 ```
 
-The named file is **overlaid on top of ClickHouse's built-in defaults** (it is staged into the server's `config.d/` directory), so it only needs to contain the settings you want to change — you don't have to reproduce a full config. Files may be `.xml`, `.yaml`, or `.yml`; reference them by name with or without the extension (e.g. `--config-file analytics` or `--config-file analytics.xml`).
+The named file is **overlaid on top of ClickHouse's built-in defaults** (it is staged into the server's `config.d/` directory), so it only needs to contain the settings you want to change — you don't have to reproduce a full config. Files may be `.xml`, `.yaml`, or `.yml`; reference them by name with or without the extension (e.g. `--config-file analytics` or `--config-file analytics.xml`). `--config-file` takes a name within `~/.clickhouse/configs/` **not a path**.
 
 The managed data directory (`.clickhouse/servers/<name>/data/`) and the HTTP/TCP ports are always forced as command-line overrides, which take precedence over the config file. This means a custom config can never break the managed server lifecycle (`list`, `stop`, `remove`, `dotenv`) regardless of its contents. Starting a server again without `--config-file` reverts it to plain defaults.
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ clickhousectl local server start --name dev               # Named "dev"
 clickhousectl local server start --version stable         # Use a specific version (installs if needed, doesn't change default)
 clickhousectl local server start --foreground             # Run in foreground (-F / --fg)
 clickhousectl local server start --http-port 8124 --tcp-port 9001  # Explicit ports
-clickhousectl local server start -- --config-file=/path/to/config.xml
+clickhousectl local server start --config-file analytics  # Apply a custom config (see "Custom config files" below)
+
+# List custom config files available to --config-file
+clickhousectl local server configs
 
 # List all servers (running and stopped)
 clickhousectl local server list
@@ -185,6 +188,31 @@ clickhousectl local server dotenv --user default --password secret --database my
 **Orphaned server recovery:** If server metadata files are lost while the ClickHouse process is still running, the CLI automatically recovers them via process discovery. Running `server list`, `server start`, or any server command will detect orphaned processes belonging to the current project and bring them back under management.
 
 **Global server management:** Use `--global` with `list`, `stop`, and `stop-all` to operate across all projects system-wide. `server list --global` shows all running ClickHouse servers with a Project column indicating which directory each belongs to.
+
+#### Custom config files
+
+Drop ClickHouse config files into `~/.clickhouse/configs/` and apply one by name when starting a server:
+
+```bash
+mkdir -p ~/.clickhouse/configs
+cat > ~/.clickhouse/configs/analytics.xml <<'EOF'
+<clickhouse>
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+    </query_log>
+</clickhouse>
+EOF
+
+clickhousectl local server configs                          # List available config files
+clickhousectl local server start --config-file analytics    # Start a server with it
+```
+
+The named file is **overlaid on top of ClickHouse's built-in defaults** (it is staged into the server's `config.d/` directory), so it only needs to contain the settings you want to change — you don't have to reproduce a full config. Files may be `.xml`, `.yaml`, or `.yml`; reference them by name with or without the extension (e.g. `--config-file analytics` or `--config-file analytics.xml`).
+
+The managed data directory (`.clickhouse/servers/<name>/data/`) and the HTTP/TCP ports are always forced as command-line overrides, which take precedence over the config file. This means a custom config can never break the managed server lifecycle (`list`, `stop`, `remove`, `dotenv`) regardless of its contents. Starting a server again without `--config-file` reverts it to plain defaults.
+
+> Passing `-- --config-file=...` through the trailing args is rejected — use `--config-file <NAME>` instead so the overlay and the managed data directory stay consistent.
 
 #### Local Postgres (Docker-backed)
 

--- a/README.md
+++ b/README.md
@@ -203,16 +203,13 @@ cat > ~/.clickhouse/configs/analytics.xml <<'EOF'
     </query_log>
 </clickhouse>
 EOF
-
-clickhousectl local server configs                          # List available config files
+                      # List available config files
 clickhousectl local server start --config-file analytics    # Start a server with it
 ```
 
 The named file is **overlaid on top of ClickHouse's built-in defaults** (it is staged into the server's `config.d/` directory), so it only needs to contain the settings you want to change — you don't have to reproduce a full config. Files may be `.xml`, `.yaml`, or `.yml`; reference them by name with or without the extension (e.g. `--config-file analytics` or `--config-file analytics.xml`).
 
 The managed data directory (`.clickhouse/servers/<name>/data/`) and the HTTP/TCP ports are always forced as command-line overrides, which take precedence over the config file. This means a custom config can never break the managed server lifecycle (`list`, `stop`, `remove`, `dotenv`) regardless of its contents. Starting a server again without `--config-file` reverts it to plain defaults.
-
-> Passing `-- --config-file=...` through the trailing args is rejected — use `--config-file <NAME>` instead so the overlay and the managed data directory stay consistent.
 
 #### Local Postgres (Docker-backed)
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -64,6 +64,9 @@ pub enum Error {
     #[error("{0}")]
     ConfigNotFound(String),
 
+    #[error("Invalid config name '{0}': must be a file in the configs dir, not a path (no '/', '\\', or '..')")]
+    InvalidConfigName(String),
+
     #[error("--json and --foreground cannot be used together")]
     JsonForegroundConflict,
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -61,6 +61,9 @@ pub enum Error {
     #[error("Invalid server name '{0}': must not contain path separators or '..'")]
     InvalidServerName(String),
 
+    #[error("{0}")]
+    ConfigNotFound(String),
+
     #[error("--json and --foreground cannot be used together")]
     JsonForegroundConflict,
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -165,6 +165,11 @@ CONTEXT FOR AGENTS:
   Runs in background by default. Use --foreground (-F / --fg) to run in foreground.
   If --name is given and that server is already running, the command will error.
   Shows count of already-running servers before starting.
+  Use --config-file <NAME> to apply a custom ClickHouse config file from ~/.clickhouse/configs/
+  (see `clickhousectl local server configs`). The file is merged as an overlay on top of
+  ClickHouse's built-in defaults (via config.d), so it can contain just the settings you want
+  to change (e.g. <query_log>). The data directory and ports stay managed regardless of the
+  file's contents (they are forced as command-line overrides).
   Related: `clickhousectl local server list` to see servers, `clickhousectl local server stop <name>` to stop one.")]
     Start {
         /// Server name (default: \"default\", or random if default is already running)
@@ -187,10 +192,26 @@ CONTEXT FOR AGENTS:
         #[arg(long, alias = "fg", short = 'F')]
         foreground: bool,
 
+        /// Overlay a named config file from ~/.clickhouse/configs/ on top of the defaults (see `server configs`)
+        #[arg(long, value_name = "NAME")]
+        config_file: Option<String>,
+
         /// Arguments to pass to clickhouse-server
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
         args: Vec<String>,
     },
+
+    /// List custom config files available to `server start --config-file`
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Lists ClickHouse config files in ~/.clickhouse/configs/ and prints that directory's path.
+  Drop a config file there (e.g. analytics.xml) and start a server with it via
+  `clickhousectl local server start --config-file analytics`. The file is overlaid on top of
+  ClickHouse's built-in defaults (config.d merge), so it only needs the settings you want to
+  change. Files may be .xml, .yaml, or .yml; reference them by name with or without the
+  extension.
+  Related: `clickhousectl local server start --config-file <NAME>`.")]
+    Configs,
 
     /// List all server instances (running and stopped)
     #[command(after_help = "\
@@ -410,4 +431,54 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         local: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use clap::Parser;
+
+    fn local_command(args: &[&str]) -> LocalCommands {
+        let mut argv = vec!["clickhousectl", "local"];
+        argv.extend_from_slice(args);
+        let cli = Cli::try_parse_from(argv).unwrap();
+        let Commands::Local(local) = cli.command else {
+            panic!("expected local command");
+        };
+        local.command
+    }
+
+    #[test]
+    fn parses_server_start_config_file() {
+        let LocalCommands::Server {
+            command: ServerCommands::Start { config_file, .. },
+        } = local_command(&["server", "start", "--config-file", "analytics"])
+        else {
+            panic!("expected server start");
+        };
+        assert_eq!(config_file.as_deref(), Some("analytics"));
+    }
+
+    #[test]
+    fn server_start_config_file_defaults_to_none() {
+        let LocalCommands::Server {
+            command: ServerCommands::Start { config_file, args, .. },
+        } = local_command(&["server", "start"])
+        else {
+            panic!("expected server start");
+        };
+        assert_eq!(config_file, None);
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn parses_server_configs() {
+        let LocalCommands::Server {
+            command: ServerCommands::Configs,
+        } = local_command(&["server", "configs"])
+        else {
+            panic!("expected server configs");
+        };
+    }
 }

--- a/crates/clickhousectl/src/local/config.rs
+++ b/crates/clickhousectl/src/local/config.rs
@@ -51,12 +51,35 @@ pub fn list_configs_in(dir: &Path) -> Vec<String> {
     names
 }
 
+/// Rejects config names that would resolve outside `dir`.
+///
+/// A named config is, by design, a file living directly in the configs store.
+/// Without this guard `dir.join(name)` would let an absolute path or `..`
+/// segments escape the store (`Path::join` replaces the base on an absolute
+/// argument), copying arbitrary files into the server overlay. Mirrors
+/// `server::validate_server_name`.
+fn validate_config_name(name: &str) -> Result<()> {
+    if name.is_empty()
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains('\0')
+        || name == "."
+        || name == ".."
+    {
+        return Err(Error::InvalidConfigName(name.to_string()));
+    }
+    Ok(())
+}
+
 /// Resolves a config `name` to a file path within `dir`.
 ///
 /// If `name` already carries a recognized extension, that exact file must
 /// exist. Otherwise each known extension is tried; exactly one match must be
-/// found. Missing or ambiguous names produce a helpful error.
+/// found. Missing or ambiguous names produce a helpful error. Names that would
+/// escape `dir` (path separators or `..`) are rejected.
 pub fn resolve_config_in(dir: &Path, name: &str) -> Result<PathBuf> {
+    validate_config_name(name)?;
+
     if has_config_ext(name) {
         let path = dir.join(name);
         if path.is_file() {
@@ -214,6 +237,60 @@ mod tests {
         assert!(msg.contains("ambiguous"), "got: {msg}");
         assert!(msg.contains("shared.xml"));
         assert!(msg.contains("shared.yaml"));
+    }
+
+    #[test]
+    fn rejects_parent_dir_escape() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A real file outside the configs dir that an escape could target.
+        let outside = tmp.path().join("outside.xml");
+        std::fs::write(&outside, "<clickhouse/>").unwrap();
+        let configs = tmp.path().join("configs");
+        std::fs::create_dir(&configs).unwrap();
+
+        let err = resolve_config_in(&configs, "../outside").unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidConfigName(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_parent_dir_escape_with_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside.xml");
+        std::fs::write(&outside, "<clickhouse/>").unwrap();
+        let configs = tmp.path().join("configs");
+        std::fs::create_dir(&configs).unwrap();
+
+        let err = resolve_config_in(&configs, "../outside.xml").unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidConfigName(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "dev.xml");
+        // Absolute path would make `dir.join` discard the configs dir entirely.
+        let abs = tmp.path().join("dev.xml");
+        let err = resolve_config_in(tmp.path(), abs.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidConfigName(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_dotdot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_config_in(tmp.path(), "..").unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidConfigName(_)),
+            "got: {err:?}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/config.rs
+++ b/crates/clickhousectl/src/local/config.rs
@@ -1,0 +1,305 @@
+//! Resolution and listing of custom server config files.
+//!
+//! Users drop named ClickHouse config files into `~/.clickhouse/configs/` and
+//! reference them by name with `clickhousectl local server start --config-file
+//! <NAME>`. The file is passed to ClickHouse as `--config-file`; the launcher
+//! still forces `--path=./` and the ports as command-line overrides (which beat
+//! config-file values), so the managed server lifecycle is preserved regardless
+//! of what the config file contains.
+
+use crate::error::{Error, Result};
+use crate::paths;
+use std::path::{Path, PathBuf};
+
+/// Recognized config file extensions, in resolution priority order.
+const CONFIG_EXTS: [&str; 3] = ["xml", "yaml", "yml"];
+
+/// Filename stem for the chctl-managed `config.d` overlay file.
+const OVERLAY_STEM: &str = "chctl-config";
+
+/// Returns true if `name` already ends in a recognized config extension.
+fn has_config_ext(name: &str) -> bool {
+    Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| CONFIG_EXTS.contains(&e))
+        .unwrap_or(false)
+}
+
+/// Lists the names of config files in `dir` (those with a recognized
+/// extension), sorted. Returns an empty vec if the directory does not exist.
+pub fn list_configs_in(dir: &Path) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<String> = entries
+        .flatten()
+        .filter(|e| e.path().is_file())
+        .filter_map(|e| {
+            let path = e.path();
+            let ext = path.extension().and_then(|e| e.to_str())?;
+            if CONFIG_EXTS.contains(&ext) {
+                path.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    names.sort();
+    names
+}
+
+/// Resolves a config `name` to a file path within `dir`.
+///
+/// If `name` already carries a recognized extension, that exact file must
+/// exist. Otherwise each known extension is tried; exactly one match must be
+/// found. Missing or ambiguous names produce a helpful error.
+pub fn resolve_config_in(dir: &Path, name: &str) -> Result<PathBuf> {
+    if has_config_ext(name) {
+        let path = dir.join(name);
+        if path.is_file() {
+            return Ok(path);
+        }
+        return Err(not_found_error(dir, name));
+    }
+
+    let matches: Vec<PathBuf> = CONFIG_EXTS
+        .iter()
+        .map(|ext| dir.join(format!("{name}.{ext}")))
+        .filter(|p| p.is_file())
+        .collect();
+
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().unwrap()),
+        0 => Err(not_found_error(dir, name)),
+        _ => {
+            let exts = matches
+                .iter()
+                .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(Error::ConfigNotFound(format!(
+                "config '{name}' is ambiguous in {} ({exts}); specify the file extension",
+                dir.display()
+            )))
+        }
+    }
+}
+
+fn not_found_error(dir: &Path, name: &str) -> Error {
+    let available = list_configs_in(dir);
+    let avail = if available.is_empty() {
+        "none".to_string()
+    } else {
+        available.join(", ")
+    };
+    Error::ConfigNotFound(format!(
+        "config '{name}' not found in {} (available: {avail})",
+        dir.display()
+    ))
+}
+
+/// Resolves a named config from `~/.clickhouse/configs/` to its absolute path.
+pub fn resolve_config(name: &str) -> Result<PathBuf> {
+    resolve_config_in(&paths::configs_dir()?, name)
+}
+
+/// Lists the available config file names in `~/.clickhouse/configs/`.
+pub fn list_configs() -> Result<Vec<String>> {
+    Ok(list_configs_in(&paths::configs_dir()?))
+}
+
+/// Stages (or clears) the chctl-managed config overlay in `<data_dir>/config.d/`.
+///
+/// ClickHouse merges files in the `config.d/` directory next to its working
+/// directory with its built-in defaults, so a partial override file takes
+/// effect without replacing the whole config. We own a single file there named
+/// `chctl-config.<ext>`; any previously staged overlay (in any recognized
+/// extension) is removed first, so restarting a server without `--config-file`
+/// reverts cleanly to plain defaults.
+pub fn apply_config_overlay(data_dir: &Path, source: Option<&Path>) -> Result<()> {
+    let config_d = data_dir.join("config.d");
+
+    // Drop any overlay we previously staged before applying the new state.
+    for ext in CONFIG_EXTS {
+        let stale = config_d.join(format!("{OVERLAY_STEM}.{ext}"));
+        if stale.exists() {
+            std::fs::remove_file(&stale)?;
+        }
+    }
+
+    let Some(source) = source else {
+        return Ok(());
+    };
+
+    // Preserve the source extension so ClickHouse parses XML vs YAML correctly.
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .filter(|e| CONFIG_EXTS.contains(e))
+        .unwrap_or("xml");
+    std::fs::create_dir_all(&config_d)?;
+    std::fs::copy(source, config_d.join(format!("{OVERLAY_STEM}.{ext}")))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_file(dir: &Path, name: &str) {
+        std::fs::write(dir.join(name), "<clickhouse/>").unwrap();
+    }
+
+    #[test]
+    fn resolves_by_bare_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "analytics.xml");
+        let path = resolve_config_in(tmp.path(), "analytics").unwrap();
+        assert_eq!(path, tmp.path().join("analytics.xml"));
+    }
+
+    #[test]
+    fn resolves_yaml_by_bare_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "prod.yaml");
+        let path = resolve_config_in(tmp.path(), "prod").unwrap();
+        assert_eq!(path, tmp.path().join("prod.yaml"));
+    }
+
+    #[test]
+    fn resolves_with_explicit_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "dev.xml");
+        let path = resolve_config_in(tmp.path(), "dev.xml").unwrap();
+        assert_eq!(path, tmp.path().join("dev.xml"));
+    }
+
+    #[test]
+    fn explicit_extension_missing_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_config_in(tmp.path(), "dev.xml").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("not found"), "got: {msg}");
+    }
+
+    #[test]
+    fn not_found_lists_available() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "dev.xml");
+        write_file(tmp.path(), "prod.yaml");
+        let err = resolve_config_in(tmp.path(), "missing").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing"), "got: {msg}");
+        assert!(msg.contains("dev.xml"), "got: {msg}");
+        assert!(msg.contains("prod.yaml"), "got: {msg}");
+    }
+
+    #[test]
+    fn not_found_reports_none_when_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = resolve_config_in(tmp.path(), "missing").unwrap_err();
+        assert!(err.to_string().contains("available: none"));
+    }
+
+    #[test]
+    fn ambiguous_bare_name_errors() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "shared.xml");
+        write_file(tmp.path(), "shared.yaml");
+        let err = resolve_config_in(tmp.path(), "shared").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("ambiguous"), "got: {msg}");
+        assert!(msg.contains("shared.xml"));
+        assert!(msg.contains("shared.yaml"));
+    }
+
+    #[test]
+    fn list_filters_and_sorts() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_file(tmp.path(), "prod.yaml");
+        write_file(tmp.path(), "dev.xml");
+        write_file(tmp.path(), "notes.txt");
+        std::fs::create_dir(tmp.path().join("subdir.xml")).unwrap();
+        let configs = list_configs_in(tmp.path());
+        assert_eq!(configs, vec!["dev.xml", "prod.yaml"]);
+    }
+
+    #[test]
+    fn list_nonexistent_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(list_configs_in(&missing).is_empty());
+    }
+
+    #[test]
+    fn overlay_stages_file_with_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.xml");
+        std::fs::write(&src, "<clickhouse><a>1</a></clickhouse>").unwrap();
+        let data_dir = tmp.path().join("data");
+        std::fs::create_dir(&data_dir).unwrap();
+
+        apply_config_overlay(&data_dir, Some(&src)).unwrap();
+
+        let staged = data_dir.join("config.d").join("chctl-config.xml");
+        assert!(staged.is_file());
+        assert_eq!(
+            std::fs::read_to_string(&staged).unwrap(),
+            "<clickhouse><a>1</a></clickhouse>"
+        );
+    }
+
+    #[test]
+    fn overlay_preserves_yaml_extension() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.yaml");
+        std::fs::write(&src, "a: 1").unwrap();
+        let data_dir = tmp.path().join("data");
+
+        apply_config_overlay(&data_dir, Some(&src)).unwrap();
+
+        assert!(data_dir.join("config.d").join("chctl-config.yaml").is_file());
+    }
+
+    #[test]
+    fn overlay_none_clears_previous() {
+        let tmp = tempfile::tempdir().unwrap();
+        let src = tmp.path().join("src.xml");
+        std::fs::write(&src, "<clickhouse/>").unwrap();
+        let data_dir = tmp.path().join("data");
+
+        apply_config_overlay(&data_dir, Some(&src)).unwrap();
+        assert!(data_dir.join("config.d").join("chctl-config.xml").is_file());
+
+        apply_config_overlay(&data_dir, None).unwrap();
+        assert!(!data_dir.join("config.d").join("chctl-config.xml").exists());
+    }
+
+    #[test]
+    fn overlay_switching_extension_removes_old() {
+        let tmp = tempfile::tempdir().unwrap();
+        let xml = tmp.path().join("a.xml");
+        std::fs::write(&xml, "<clickhouse/>").unwrap();
+        let yaml = tmp.path().join("b.yaml");
+        std::fs::write(&yaml, "a: 1").unwrap();
+        let data_dir = tmp.path().join("data");
+
+        apply_config_overlay(&data_dir, Some(&xml)).unwrap();
+        apply_config_overlay(&data_dir, Some(&yaml)).unwrap();
+
+        let config_d = data_dir.join("config.d");
+        assert!(!config_d.join("chctl-config.xml").exists());
+        assert!(config_d.join("chctl-config.yaml").is_file());
+    }
+
+    #[test]
+    fn overlay_none_on_empty_is_noop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let data_dir = tmp.path().join("data");
+        // Should not error even though config.d does not exist.
+        apply_config_overlay(&data_dir, None).unwrap();
+    }
+}

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod config;
 pub mod discovery;
 pub mod docker;
 pub mod output;
@@ -265,12 +266,14 @@ fn run_client(
     Err(Error::Exec(err.to_string()))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_server(
     name: Option<String>,
     version_spec: Option<String>,
     http_port: Option<u16>,
     tcp_port: Option<u16>,
     foreground: bool,
+    config_file: Option<String>,
     args: Vec<String>,
     json: bool,
 ) -> Result<()> {
@@ -319,29 +322,49 @@ async fn start_server(
             http_port, tcp_port
         );
     }
-    // Reject --config-file / -C in passthrough args. A custom config file
-    // redirects where ClickHouse stores data, which breaks the managed
-    // server lifecycle (list, stop, remove, dotenv all rely on the data
-    // directory living under .clickhouse/servers/<name>/). Individual
-    // --setting=value flags are fine — they don't change the data directory.
-    // Users who need a fully custom config should run `clickhouse server` directly.
+    // Reject --config-file / -C in passthrough args. Passing a raw config path
+    // here would bypass the managed `--config-file` handling below and could
+    // redirect where ClickHouse stores data, breaking the managed server
+    // lifecycle (list, stop, remove, dotenv all rely on the data directory
+    // living under .clickhouse/servers/<name>/). Individual --setting=value
+    // flags are fine — they don't change the data directory.
     if args
         .iter()
         .any(|a| a.starts_with("--config-file") || a.starts_with("-C"))
     {
         return Err(Error::Exec(
-            "--config-file / -C cannot be passed through to managed servers. \
-             Individual --setting=value flags are supported. \
-             For a fully custom config, run `clickhouse server` directly."
+            "--config-file / -C cannot be passed through in trailing args. \
+             Use `--config-file <NAME>` with a file in ~/.clickhouse/configs/ \
+             (see `clickhousectl local server configs`). \
+             Individual --setting=value flags are supported."
                 .into(),
         ));
     }
+
+    // Resolve a named config file before any process is spawned, so a bad name
+    // fails fast with a helpful error.
+    let resolved_config = match &config_file {
+        Some(name) => Some(config::resolve_config(name)?),
+        None => None,
+    };
 
     let mut cmd = Command::new(&binary);
     cmd.arg("server");
 
     server::ensure_server_data_dir(&server_name)?;
-    cmd.current_dir(server::server_data_dir(&server_name));
+    let data_dir = server::server_data_dir(&server_name);
+
+    // Stage the named config as a config.d overlay inside the data dir. With no
+    // --config-file, ClickHouse uses its built-in defaults and merges any
+    // config.d/ next to its working directory, so a partial override file (e.g.
+    // just <query_log>) takes effect without replacing the whole config.
+    // Passing it as --config-file instead would replace the embedded defaults
+    // and a partial file would fail to start. The forced --path=./ and port
+    // flags below are command-line overrides that still win over the file, so
+    // the managed lifecycle is preserved regardless of the file's contents.
+    config::apply_config_overlay(&data_dir, resolved_config.as_deref())?;
+
+    cmd.current_dir(&data_dir);
     cmd.args(init::server_flags());
 
     cmd.args(server::port_flags(http_port, tcp_port));
@@ -414,6 +437,16 @@ async fn start_server(
         }
         Ok(())
     }
+}
+
+fn list_configs(json: bool) -> Result<()> {
+    let dir = paths::configs_dir()?;
+    let out = output::ServerConfigsOutput {
+        dir: dir.display().to_string(),
+        configs: config::list_configs()?,
+    };
+    output::print_output(&out, json);
+    Ok(())
 }
 
 fn dotenv_server(
@@ -566,8 +599,22 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             http_port,
             tcp_port,
             foreground,
+            config_file,
             args,
-        } => start_server(name, version, http_port, tcp_port, foreground, args, json).await,
+        } => {
+            start_server(
+                name,
+                version,
+                http_port,
+                tcp_port,
+                foreground,
+                config_file,
+                args,
+                json,
+            )
+            .await
+        }
+        ServerCommands::Configs => list_configs(json),
         ServerCommands::List { global } => {
             if global {
                 list_servers_global(json)
@@ -860,7 +907,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_start_rejects_json_with_foreground() {
-        let result = start_server(None, None, None, None, true, vec![], true).await;
+        let result = start_server(None, None, None, None, true, None, vec![], true).await;
         let err = result.unwrap_err();
         assert!(
             matches!(err, Error::JsonForegroundConflict),

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -173,6 +173,36 @@ impl fmt::Display for InitOutput {
     }
 }
 
+// ── server configs ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerConfigsOutput {
+    pub dir: String,
+    pub configs: Vec<String>,
+}
+
+impl fmt::Display for ServerConfigsOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.configs.is_empty() {
+            writeln!(f, "No config files in {}", self.dir)?;
+            write!(
+                f,
+                "Drop a ClickHouse config file there, then start with: \
+                 clickhousectl local server start --config-file <NAME>"
+            )?;
+            return Ok(());
+        }
+        writeln!(f, "Config files in {}:", self.dir)?;
+        for name in &self.configs {
+            writeln!(f, "  {name}")?;
+        }
+        write!(
+            f,
+            "Use with: clickhousectl local server start --config-file <NAME>"
+        )
+    }
+}
+
 // ── server start ────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize)]
@@ -784,6 +814,42 @@ mod tests {
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
         assert_eq!(json["servers"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn server_configs_json() {
+        let output = ServerConfigsOutput {
+            dir: "/home/user/.clickhouse/configs".to_string(),
+            configs: vec!["dev.xml".to_string(), "prod.yaml".to_string()],
+        };
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
+        assert_eq!(json["dir"], "/home/user/.clickhouse/configs");
+        assert_eq!(json["configs"][0], "dev.xml");
+        assert_eq!(json["configs"][1], "prod.yaml");
+        assert_eq!(json["configs"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn server_configs_display_empty() {
+        let output = ServerConfigsOutput {
+            dir: "/home/user/.clickhouse/configs".to_string(),
+            configs: vec![],
+        };
+        let text = output.to_string();
+        assert!(text.contains("No config files"));
+        assert!(text.contains("--config-file"));
+    }
+
+    #[test]
+    fn server_configs_display_with_entries() {
+        let output = ServerConfigsOutput {
+            dir: "/home/user/.clickhouse/configs".to_string(),
+            configs: vec!["dev.xml".to_string()],
+        };
+        let text = output.to_string();
+        assert!(text.contains("dev.xml"));
+        assert!(text.contains("Use with:"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/paths.rs
+++ b/crates/clickhousectl/src/paths.rs
@@ -32,6 +32,11 @@ pub fn default_file() -> Result<PathBuf> {
     Ok(base_dir()?.join("default"))
 }
 
+/// Returns the custom server configs directory (~/.clickhouse/configs/)
+pub fn configs_dir() -> Result<PathBuf> {
+    Ok(base_dir()?.join("configs"))
+}
+
 /// Ensures all necessary directories exist
 pub fn ensure_dirs() -> Result<()> {
     let versions = versions_dir()?;


### PR DESCRIPTION
Closes #226.

## What

Adds support for custom ClickHouse config files for locally-managed servers:

- A global config store at `~/.clickhouse/configs/`. Drop named config files there.
- `clickhousectl local server start --config-file <NAME>` applies one by name.
- `clickhousectl local server configs` lists what's available (and prints the dir). Supports `--json`.

```bash
mkdir -p ~/.clickhouse/configs
cat > ~/.clickhouse/configs/analytics.xml <<'XML'
<clickhouse>
    <query_log><database>system</database><table>query_log</table></query_log>
</clickhouse>
XML

clickhousectl local server configs
clickhousectl local server start --config-file analytics
```

## How it works (and why not literal `--config-file`)

The original code rejected `--config-file` because a custom config could redirect the data directory and break the managed lifecycle. While implementing this I verified ClickHouse's behaviour empirically:

- Passing a **partial** file as `--config-file` **replaces** the embedded defaults — the server exits (code 180) because required sections are missing. So the intuitive "partial files merge" assumption does *not* hold for `--config-file`.
- ClickHouse **does** merge a `config.d/` directory found next to its working dir on top of its built-in defaults.

So the named file is **staged into the server's `config.d/`** (as `chctl-config.<ext>`) instead of being passed as `--config-file`. This gives the intended DX — a file with just `<query_log>` takes effect without reproducing a whole config — while the forced `--path=./` and port flags stay as command-line overrides that win over the file. The managed lifecycle (`list`/`stop`/`remove`/`dotenv`) is preserved regardless of the file's contents. Restarting without `--config-file` clears the overlay and reverts to plain defaults.

Name-only resolution (`.xml`/`.yaml`/`.yml`, extension optional, ambiguous/missing names error helpfully). The trailing `-- --config-file=...` passthrough stays rejected and now points users at the new flag.

## Tests

- `src/local/config.rs`: pure-logic unit tests for resolution (bare name, explicit ext, not-found, ambiguous) and overlay staging (extension preservation, clear-on-None, switch extension).
- `src/local/cli.rs`: `Cli::try_parse_from` tests for `--config-file` and the `configs` subcommand.
- `src/local/output.rs`: JSON + display tests for the new output type.
- Manually verified end-to-end against ClickHouse 26.6: overlay merges (`displayName()` reflects the override), defaults remain intact, data stays under `.clickhouse/servers/<name>/data/`, and restart-without-flag reverts.

`cargo build`, `cargo test`, and `cargo clippy --workspace --all-targets` all pass.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to local server startup and config file staging under ~/.clickhouse, with path validation and preserved managed data/ports; no cloud or auth impact.
> 
> **Overview**
> Adds **named custom ClickHouse configs** for locally managed servers via a global store at `~/.clickhouse/configs/`.
> 
> **`clickhousectl local server start --config-file <NAME>`** resolves a name (optional `.xml`/`.yaml`/`.yml`, with clear errors for missing or ambiguous names) and **stages** the file into the server data dir as `config.d/chctl-config.<ext>` so partial overrides merge with built-in defaults. **Data path and ports** stay forced on the command line so `list`/`stop`/`remove`/`dotenv` behavior is unchanged; restarting without the flag clears the overlay.
> 
> New **`clickhousectl local server configs`** lists available files and the configs directory (supports `--json`). Trailing `-- --config-file=...` remains rejected, with messaging pointing at the new flag. Adds `paths::configs_dir()`, `ConfigNotFound` / `InvalidConfigName` errors, and path-traversal checks on config names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90455ca1e677676b2bd608007f785c8d2e992b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->