### PR TITLE
Add bug report issue template (#197)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a problem with clickhousectl (chctl)
+title: "[bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the sections below so we can reproduce and fix the issue.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen instead.
+      placeholder: When I run `clickhousectl ...`, I expected ... but instead ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The exact commands you ran, in order. Include relevant flags and config.
+      placeholder: |
+        1. `clickhousectl local server start ...`
+        2. `clickhousectl ...`
+        3. ...
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: clickhousectl version
+      description: Output of `clickhousectl --version`.
+      placeholder: clickhousectl 0.2.4
+    validations:
+      required: true
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation method
+      description: How did you install clickhousectl?
+      options:
+        - Quick install script (curl ... | sh)
+        - cargo binstall
+        - npm
+        - pip / pipx / uv (PyPI)
+        - cargo install (crates.io)
+        - Built from source
+        - Other (describe in "What happened?")
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS (Apple Silicon)
+        - macOS (Intel)
+        - Linux (x86_64)
+        - Linux (aarch64)
+        - Windows
+        - Other (describe in "What happened?")
+    validations:
+      required: true
+  - type: input
+    id: os-version
+    attributes:
+      label: OS version
+      description: e.g. macOS 15.5, Ubuntu 24.04, Debian 12.
+      placeholder: macOS 15.5
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste any error messages or command output. This will be rendered as code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -49,7 +49,7 @@ body:
         - Built from source
         - Other (describe in "What happened?")
     validations:
-      required: true
+      required: false
   - type: dropdown
     id: os
     attributes:


### PR DESCRIPTION
Closes #197

Adds a GitHub issue form (`.github/ISSUE_TEMPLATE/bug_report.yml`) for bug reports. It captures the details we need to reproduce issues:

- **What happened** and **steps to reproduce** (required)
- **clickhousectl version** (`--version` output, required)
- **Installation method** — dropdown covering quick install script, cargo binstall, npm, PyPI (pip/pipx/uv), cargo install, source, other (optional)
- **Operating system** + OS version (required dropdown / optional input)
- **Relevant logs or output** (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to GitHub issue templates; no application or runtime code is modified.
> 
> **Overview**
> Adds a **GitHub issue form** at `.github/ISSUE_TEMPLATE/bug_report.yml` so reporters file structured **bug** issues for `clickhousectl` (chctl).
> 
> New issues get the `bug` label and a `[bug]: ` title prefix. The form requires **what happened**, **steps to reproduce**, **`clickhousectl --version`**, and **operating system**; it optionally collects **installation method** (script, binstall, npm, PyPI, cargo, source, etc.), **OS version**, and **logs/output** (shell-rendered).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b7a99dc7237b1d33f96d9d2af45f1ca3e19a81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->