### PR TITLE
Create postgres project scaffold on local init

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ clickhouse/
 ├── materialized_views/     # Materialized view definitions
 ├── queries/                # Saved queries
 └── seed/                   # Seed data / INSERT statements
+postgres/
+├── tables/                 # Table definitions (CREATE TABLE ...)
+├── materialized_views/     # Materialized view definitions
+├── queries/                # Saved queries
+└── seed/                   # Seed data / INSERT statements
 ```
 
 ### Running queries

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ clickhouse/
 └── seed/                   # Seed data / INSERT statements
 postgres/
 ├── tables/                 # Table definitions (CREATE TABLE ...)
-├── materialized_views/     # Materialized view definitions
+├── views/                  # View definitions (CREATE VIEW ...)
+├── functions/              # Function / procedure definitions (CREATE FUNCTION ...)
 ├── queries/                # Saved queries
 └── seed/                   # Seed data / INSERT statements
 ```

--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -40,7 +40,7 @@ pub fn init() -> Result<()> {
     )?;
     create_project_scaffold(
         postgres_project_dir(),
-        &["tables", "materialized_views", "queries", "seed"],
+        &["tables", "views", "functions", "queries", "seed"],
     )?;
 
     Ok(())

--- a/crates/clickhousectl/src/init.rs
+++ b/crates/clickhousectl/src/init.rs
@@ -13,6 +13,12 @@ pub fn project_dir() -> PathBuf {
         .join("clickhouse")
 }
 
+pub fn postgres_project_dir() -> PathBuf {
+    std::env::current_dir()
+        .expect("failed to get current directory")
+        .join("postgres")
+}
+
 pub fn is_initialized() -> bool {
     local_dir().exists()
 }
@@ -28,17 +34,21 @@ pub fn init() -> Result<()> {
         eprintln!("Initialized ClickHouse project in {}", dir.display());
     }
 
-    create_project_scaffold()?;
+    create_project_scaffold(
+        project_dir(),
+        &["tables", "materialized_views", "queries", "seed"],
+    )?;
+    create_project_scaffold(
+        postgres_project_dir(),
+        &["tables", "materialized_views", "queries", "seed"],
+    )?;
 
     Ok(())
 }
 
-fn create_project_scaffold() -> Result<()> {
-    let dir = project_dir();
-    let subdirs = ["tables", "materialized_views", "queries", "seed"];
-
+fn create_project_scaffold(dir: PathBuf, subdirs: &[&str]) -> Result<()> {
     let mut created = false;
-    for subdir in &subdirs {
+    for subdir in subdirs {
         let path = dir.join(subdir);
         if !path.exists() {
             std::fs::create_dir_all(&path)?;
@@ -49,8 +59,9 @@ fn create_project_scaffold() -> Result<()> {
 
     if created {
         eprintln!(
-            "Created project scaffold in {}/ (tables, materialized_views, queries, seed)",
-            dir.display()
+            "Created project scaffold in {}/ ({})",
+            dir.display(),
+            subdirs.join(", ")
         );
     }
 
@@ -60,4 +71,41 @@ fn create_project_scaffold() -> Result<()> {
 /// Returns CLI flags that point ClickHouse data into the current directory.
 pub fn server_flags() -> Vec<String> {
     vec!["--".into(), "--path=./".into()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_creates_subdirs_with_gitkeep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("postgres");
+        let subdirs = ["tables", "materialized_views", "queries", "seed"];
+
+        create_project_scaffold(dir.clone(), &subdirs).unwrap();
+
+        for subdir in &subdirs {
+            let path = dir.join(subdir);
+            assert!(path.is_dir(), "{} should be a directory", path.display());
+            assert!(
+                path.join(".gitkeep").is_file(),
+                "{}/.gitkeep should exist",
+                path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn scaffold_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("clickhouse");
+        let subdirs = ["tables", "queries"];
+
+        create_project_scaffold(dir.clone(), &subdirs).unwrap();
+        // Running again over an existing scaffold must not error.
+        create_project_scaffold(dir.clone(), &subdirs).unwrap();
+
+        assert!(dir.join("tables").join(".gitkeep").is_file());
+    }
 }

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -78,9 +78,10 @@ CONTEXT FOR AGENTS:
     /// Initialize a project-local ClickHouse configuration
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Creates a .clickhouse/ directory (runtime data, git-ignored) and a clickhouse/ project
-  scaffold with subdirs: tables/, materialized_views/, queries/, seed/ (each with .gitkeep).
-  The clickhouse/ directory is meant to be committed — organize your SQL files there.
+  Creates a .clickhouse/ directory (runtime data, git-ignored) plus clickhouse/ and postgres/
+  project scaffolds, each with subdirs: tables/, materialized_views/, queries/, seed/ (each
+  with .gitkeep). The clickhouse/ and postgres/ directories are meant to be committed —
+  organize your SQL files there.
   Related: `clickhousectl local server start` to start a server with project-local data.")]
     Init,
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -79,9 +79,9 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Creates a .clickhouse/ directory (runtime data, git-ignored) plus clickhouse/ and postgres/
-  project scaffolds, each with subdirs: tables/, materialized_views/, queries/, seed/ (each
-  with .gitkeep). The clickhouse/ and postgres/ directories are meant to be committed —
-  organize your SQL files there.
+  project scaffolds (each subdir has a .gitkeep). clickhouse/: tables/, materialized_views/,
+  queries/, seed/. postgres/: tables/, views/, functions/, queries/, seed/. The clickhouse/ and
+  postgres/ directories are meant to be committed — organize your SQL files there.
   Related: `clickhousectl local server start` to start a server with project-local data.")]
     Init,
 


### PR DESCRIPTION
## Summary

Closes #221.

`local init` previously only created the `clickhouse/` project scaffold. It now also creates a `postgres/` scaffold so Postgres project files have a home.

The Postgres scaffold is PG-native rather than a mirror of the ClickHouse one: plain `views/` and `functions/` (procedures) are far more central to a Postgres project than ClickHouse-style materialized views — in Postgres a materialized view is just a manually-refreshed query snapshot, not an insert-time pipeline.

```
clickhouse/
├── tables/
├── materialized_views/
├── queries/
└── seed/
postgres/
├── tables/
├── views/
├── functions/
├── queries/
└── seed/
```

Each subdir gets a `.gitkeep`.

## Changes

- `init.rs`: added `postgres_project_dir()`; generalized `create_project_scaffold` to take an explicit target dir + subdirs and call it for both engines.
- Added unit tests covering scaffold creation (dirs + `.gitkeep`) and idempotency.
- Updated the `local init` agent help text and `README.md`.

## Testing

- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Filesystem-only init scaffolding and docs; no runtime server, auth, or data-path behavior changes.
> 
> **Overview**
> **`clickhousectl local init`** now scaffolds a committed **`postgres/`** tree alongside the existing **`clickhouse/`** layout, so Postgres SQL assets have a standard home next to ClickHouse project files.
> 
> Scaffold creation is refactored: **`create_project_scaffold`** takes a target directory and subdirectory list and is invoked twice—**`clickhouse/`** keeps `tables`, `materialized_views`, `queries`, `seed`; **`postgres/`** gets `tables`, `views`, `functions`, `queries`, `seed` (each with `.gitkeep`). **`postgres_project_dir()`** was added for the new root. Unit tests cover directory/`.gitkeep` creation and idempotent re-runs. **README** and **`local init`** agent help text document both trees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54d974b26dba80e00d241577c94680d22f7c7bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->