### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -40,7 +40,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.2.4", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.3.0", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
Closes #244

Bumps all versioned artifacts to 0.3.0 in lockstep:

- `crates/clickhousectl/Cargo.toml` — `version` and the `clickhouse-cloud-api` dependency version
- `crates/clickhouse-cloud-api/Cargo.toml`
- `npm/package.json`
- `Cargo.lock` refreshed via `cargo build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata changes with no runtime or API logic modified in this diff.
> 
> **Overview**
> **Bumps the monorepo release from `0.2.4` to `0.3.0`** across the Rust crates and npm wrapper so published artifacts stay aligned.
> 
> Updates `version` in `clickhouse-cloud-api` and `clickhousectl`, sets the path dependency on `clickhouse-cloud-api` to `0.3.0`, mirrors the same version in `npm/package.json`, and refreshes `Cargo.lock` for the workspace packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f218498f33f314acdbc63ea0bf5f9a4e3c1242. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->