### PR TITLE
Fix README drift found in pre-0.3.0 audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,20 @@ cargo install --path crates/clickhousectl
 
 ### Direct download
 
-Prebuilt archives for each release are hosted at `https://builds.clickhouse.com/clickhousectl/`. Archives are named `clickhousectl-{target}-v{version}.tar.gz` and contain a single directory of the same name with the `clickhousectl` binary inside. Supported targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`. Example: `https://builds.clickhouse.com/clickhousectl/clickhousectl-aarch64-apple-darwin-v0.2.2.tar.gz`.
+Prebuilt archives for each release are hosted at `https://builds.clickhouse.com/clickhousectl/`. Archives are named `clickhousectl-{target}-v{version}.tar.gz` and contain a single directory of the same name with the `clickhousectl` binary inside. Supported targets: `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, `x86_64-apple-darwin`, `aarch64-apple-darwin`. Example: `https://builds.clickhouse.com/clickhousectl/clickhousectl-aarch64-apple-darwin-v0.3.0.tar.gz`.
 
 ## Local
 
 ### Installing and managing ClickHouse versions
 
-`clickhousectl` downloads ClickHouse binaries from [GitHub releases](https://github.com/ClickHouse/ClickHouse/releases).
+`clickhousectl` downloads ClickHouse binaries from `builds.clickhouse.com`, falling back to `packages.clickhouse.com` (Linux) or [GitHub releases](https://github.com/ClickHouse/ClickHouse/releases) (macOS) when a build isn't available there.
 
 ```bash
 # Install a version
+clickhousectl local install latest          # Latest master build
 clickhousectl local install stable          # Latest stable release
 clickhousectl local install lts             # Latest LTS release
+clickhousectl local install 25              # Latest 25.x.x.x
 clickhousectl local install 25.12           # Latest 25.12.x.x
 clickhousectl local install 25.12.5.44      # Exact version
 
@@ -209,7 +211,7 @@ cat > ~/.clickhouse/configs/analytics.xml <<'EOF'
     </query_log>
 </clickhouse>
 EOF
-                      # List available config files
+clickhousectl local server configs                          # List available config files
 clickhousectl local server start --config-file analytics    # Start a server with it
 ```
 
@@ -244,6 +246,7 @@ clickhousectl local postgres dotenv --name dev
 # Stop / remove. Pass --version when more than one major shares a name.
 clickhousectl local postgres stop dev
 clickhousectl local postgres stop dev --version 17        # disambiguate
+clickhousectl local postgres stop-all                     # Stop all Postgres instances in this project
 clickhousectl local postgres remove dev
 ```
 
@@ -271,6 +274,8 @@ Each named server has its own data directory, so servers are fully isolated from
 ## Authentication
 
 Authenticate to ClickHouse Cloud using OAuth (browser-based) or API keys. OAuth provides **read-only** access; API keys provide full **read/write** access.
+
+If you don't have a ClickHouse Cloud account yet, `clickhousectl cloud auth signup` opens the sign-up page in your browser.
 
 ### OAuth login (read-only)
 
@@ -403,6 +408,8 @@ clickhousectl cloud service stop <service-id>
 # Run SQL over HTTP via the Query API (no local clickhouse binary needed)
 clickhousectl cloud service query --name my-service --query "SELECT 1"
 clickhousectl cloud service query --id <service-id> --query "SELECT count() FROM system.tables" --format JSONEachRow
+clickhousectl cloud service query --name my-service --queries-file schema.sql   # "-" reads from stdin
+clickhousectl cloud service query --name my-service --database mydb --query "SHOW TABLES"
 echo "SELECT 1+1" | clickhousectl cloud service query --name my-service
 
 # Update service metadata and patches


### PR DESCRIPTION
## Summary

Audited the README against the current CLI surface (built the binary, dumped `--help` for every command, and verified claims against the source) ahead of the 0.3.0 release. Most of the README is accurate — including all the recently-landed areas (`.env` credentials, exit codes, agent auto-JSON, Postgres 16/storageSize removal). This PR fixes what drifted:

- **Wrong download source**: the versions section claimed binaries come from GitHub releases; the primary source is `builds.clickhouse.com`, with `packages.clickhouse.com` (Linux) / GitHub releases (macOS) as fallbacks (`version_manager/resolve.rs`).
- **Broken example line**: the "Custom config files" snippet lost its `clickhousectl local server configs` command, leaving an orphaned comment.
- **Stale example URL**: direct-download example bumped from v0.2.2 to v0.3.0.
- **Undocumented commands/flags**: `cloud auth signup`, `local postgres stop-all`, `local install latest` and bare-major specs (`25`), and `cloud service query --queries-file` (with `-` for stdin) / `--database`.

Doc-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **README-only** alignment with the 0.3.0 CLI surface after an audit against `--help` and source.
> 
> **Local versions:** Documents that ClickHouse binaries are fetched from `builds.clickhouse.com` first, with Linux/macOS fallbacks, and adds install examples for `latest` and bare major `25`.
> 
> **Examples & snippets:** Bumps the direct-download `clickhousectl` archive example to **v0.3.0**; restores the missing `clickhousectl local server configs` line in the custom-config bash block; documents `local postgres stop-all`.
> 
> **Cloud:** Notes `cloud auth signup` for new accounts and expands `cloud service query` with `--queries-file` (including stdin via `-`) and `--database`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed10ad50423c9994f72208c91f1655e2029e8e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->