### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -40,7 +40,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.3.0", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.3.1", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.2.1"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
Bumps `crates/clickhousectl`, `crates/clickhouse-cloud-api`, and `npm/package.json` to 0.3.1 in lockstep, plus the `clickhouse-cloud-api` dependency version in the CLI crate and `Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release metadata with no runtime or API logic changes.
> 
> **Overview**
> Releases **0.3.1** across the Rust workspace and npm wrapper with no functional code changes.
> 
> `clickhouse-cloud-api` and `clickhousectl` crate versions move to **0.3.1**, the CLI’s path dependency on the API crate is updated to match, and `Cargo.lock` is refreshed for the new crate versions. The npm `clickhousectl` package version is bumped to **0.3.1** so published binaries stay aligned with the Rust release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c304b7dcf8de2c20df0778bdebda9d64f14446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->