### PR TITLE
Fix local remove deleting a version in use by a running server

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,12 @@ clickhousectl local which                   # Show current default
 
 # Remove a version
 clickhousectl local remove 25.12.5.44
+clickhousectl local remove 25.12.5.44 --force   # Stop running servers on this version first
 ```
 
 `local use` also creates a symlink at `~/.local/bin/clickhouse` pointing to the selected version's binary, so the plain `clickhouse` command (e.g. `clickhouse local`, `clickhouse client`) is on PATH. Pass `--no-global` to skip. If a regular file already exists at that path it is left alone with a warning. `local remove` of the active default version also clears the symlink.
+
+`local remove` refuses to delete a version while a local server is running on it (it would leave the server pointing at a deleted binary), failing with the running server names. Stop the server first, or pass `--force` to stop the running server(s) and then remove the version.
 
 #### ClickHouse binary storage
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -25,6 +25,9 @@ pub enum Error {
     #[error("Version {0} is already installed")]
     VersionAlreadyInstalled(String),
 
+    #[error("Version {version} is in use by running server(s): {servers}. Stop them first, or pass --force.")]
+    VersionInUse { version: String, servers: String },
+
     #[error("Unsupported platform: {os}/{arch}")]
     UnsupportedPlatform { os: String, arch: String },
 
@@ -114,5 +117,13 @@ mod tests {
         assert_eq!(Error::Cloud("boom".into()).exit_code(), 1);
         assert_eq!(Error::NoVersionsInstalled.exit_code(), 1);
         assert_eq!(Error::VersionNotFound("25.12".into()).exit_code(), 1);
+        assert_eq!(
+            Error::VersionInUse {
+                version: "25.12".into(),
+                servers: "default".into(),
+            }
+            .exit_code(),
+            1
+        );
     }
 }

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -61,10 +61,16 @@ CONTEXT FOR AGENTS:
   Removes an installed ClickHouse version from ~/.clickhouse/versions/.
   Takes an exact version string as shown by `clickhousectl local list` (e.g., \"25.12.5.44\").
   Does NOT accept keywords like \"stable\" — use the exact version number.
+  Fails if a local server is currently running on this version; stop it first, or pass
+  --force to stop the running server(s) before removing.
   Related: `clickhousectl local list` to see installed versions.")]
     Remove {
         /// Version to remove
         version: String,
+
+        /// Stop any running servers using this version, then remove it
+        #[arg(long)]
+        force: bool,
     },
 
     /// Show the current default version
@@ -448,6 +454,27 @@ mod tests {
             panic!("expected local command");
         };
         local.command
+    }
+
+    #[test]
+    fn parses_remove_without_force() {
+        let LocalCommands::Remove { version, force } = local_command(&["remove", "25.12.5.44"])
+        else {
+            panic!("expected remove");
+        };
+        assert_eq!(version, "25.12.5.44");
+        assert!(!force);
+    }
+
+    #[test]
+    fn parses_remove_with_force() {
+        let LocalCommands::Remove { version, force } =
+            local_command(&["remove", "25.12.5.44", "--force"])
+        else {
+            panic!("expected remove");
+        };
+        assert_eq!(version, "25.12.5.44");
+        assert!(force);
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -25,7 +25,7 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
             }
         }
         LocalCommands::Use { version, no_global } => use_version(&version, no_global, json).await,
-        LocalCommands::Remove { version } => remove(&version, json),
+        LocalCommands::Remove { version, force } => remove(&version, force, json),
         LocalCommands::Which => which(json),
         LocalCommands::Init => {
             init::init()?;
@@ -175,11 +175,35 @@ async fn use_version(version_spec: &str, no_global: bool, json: bool) -> Result<
     Ok(())
 }
 
-fn remove(version: &str, json: bool) -> Result<()> {
+fn remove(version: &str, force: bool, json: bool) -> Result<()> {
     let version_dir = paths::version_dir(version)?;
 
     if !version_dir.exists() {
         return Err(Error::VersionNotFound(version.to_string()));
+    }
+
+    // Recover orphaned servers so we detect a running process even when its
+    // metadata file is missing, then refuse to pull the binary out from under
+    // a server running on this version.
+    server::recover_current_project_servers();
+    let in_use: Vec<String> = server::list_running_servers()
+        .into_iter()
+        .filter(|i| i.version == version)
+        .map(|i| i.name)
+        .collect();
+    if !in_use.is_empty() {
+        if !force {
+            return Err(Error::VersionInUse {
+                version: version.to_string(),
+                servers: in_use.join(", "),
+            });
+        }
+        for name in &in_use {
+            server::kill_server(name)?;
+            if !json {
+                println!("Stopped server '{}'", name);
+            }
+        }
     }
 
     // Check if this is the default version


### PR DESCRIPTION
Fixes #257.

## Problem

`chctl local remove <version>` deleted the installed binary directory unconditionally. If a local server was running on that version, the binary was pulled out from under it — `local remove` reported success while `local server list` still showed the server running, now pointing at a deleted binary.

## Fix

`local remove <version>` now:

- Recovers orphaned servers, then refuses to delete a version that a running server is using, failing with a new `VersionInUse` error that lists the running server name(s): _"Version X is in use by running server(s): default. Stop them first, or pass --force."_ (exit code 1, nothing deleted).
- Accepts `--force` to stop the running server(s) first (printing `Stopped server '<name>'`), then proceed with the existing default-version/symlink cleanup and removal.

Reuses the same guard pattern as `server remove` (`recover_current_project_servers`, `list_running_servers`, `kill_server`). Detection/stop is current-project scoped, consistent with those helpers, which covers the reported in-project bug.

## Changes

- `src/error.rs` — new `VersionInUse { version, servers }` variant (+ exit-code test).
- `src/local/cli.rs` — `--force` flag on `Remove`, updated help text, two parse tests.
- `src/local/mod.rs` — running-server guard in `remove()`.
- `README.md` — documented the guard and `--force`.

## Verification

- `cargo build` and `cargo clippy` clean (no warnings).
- `cargo test -p clickhousectl` — all passing, including the new parse and exit-code tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized CLI safety change around version removal; reuses existing server stop/discovery helpers with tests and docs.
> 
> **Overview**
> **`clickhousectl local remove`** no longer deletes an installed ClickHouse binary if a local server in the current project is still running on that version. It recovers orphaned servers, lists matching running instances, and fails with **`VersionInUse`** (exit 1) naming those servers unless you stop them first.
> 
> Adds **`--force`** on **`local remove`** to stop those servers via the existing **`kill_server`** path, print **`Stopped server '<name>'`**, then run the usual default-version / symlink cleanup and directory removal. CLI help, README, a new error variant (+ exit-code test), and **`Remove`** parse tests document and cover the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5ef18a2e9e95df22e74e9555fd3832bb7d506b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->