### PR TITLE
Flush stdout before slow stop in stop-all (fixes #256)

### DIFF
--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -11,6 +11,7 @@ use cli::{LocalCommands, ServerCommands};
 
 use crate::error::{Error, Result};
 use crate::{init, paths, version_manager};
+use std::io::Write;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 
@@ -820,6 +821,7 @@ fn stop_all_servers_local(json: bool) -> Result<()> {
     for s in &servers {
         if !json {
             print!("Stopping '{}'...", s.name);
+            let _ = std::io::stdout().flush();
         }
         match server::kill_server(&s.name) {
             Ok(()) => {
@@ -863,6 +865,7 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
     for s in &servers {
         if !json {
             print!("Stopping '{}' ({})...", s.name, s.project);
+            let _ = std::io::stdout().flush();
         }
         match server::kill_server_by_pid(s.pid) {
             Ok(()) => {


### PR DESCRIPTION
## Summary

Fixes #256 — `chctl local server stop-all` (and the global variant) showed no output for a few seconds, then `Stopping 'default'... stopped` appeared all at once, making it look like the app had frozen.

The two `stop-all` handlers in `local/mod.rs` printed the in-progress `Stopping '<name>'...` message with `print!` (no trailing newline) and then ran the graceful kill, which sleeps up to ~2.6s per server (SIGTERM wait + optional SIGKILL wait). With no newline, Rust's line-buffered stdout held the text until the trailing `println!(" stopped")` ran *after* the delay — so the whole line landed at once.

This flushes stdout immediately after the `print!` so the prompt is visible before the kill runs. The final output text is unchanged (`Stopping 'X'... stopped` on one line); only the timing changes — `Stopping 'X'...` now appears right away and ` stopped` is appended once the kill completes.

The single-server `stop` and `stop_server_global` paths already use `println!` (which flushes on the newline), so they were left unchanged.

## Testing

- `cargo build` and `cargo clippy` clean (no unused-import warning for `Write`).
- `--json` output path is unchanged (still behind the `if !json` guard).
- No automated test added: these handlers spawn/kill real processes and sleep, the existing suite has no coverage for them, and flush behaviour isn't observable via unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only UX timing change with no effect on kill logic, JSON output, or server lifecycle.
> 
> **Overview**
> Fixes **#256**: `chctl local server stop-all` (project-scoped and `--global`) looked frozen because the `Stopping '…'...` line used `print!` without a newline and only appeared once the trailing ` stopped` ran after **~2.6s** graceful kill per server.
> 
> Both **`stop_all_servers_local`** and **`stop_all_servers_global`** now call **`stdout().flush()`** immediately after the `print!`, so the in-progress text shows before **`kill_server`** / **`kill_server_by_pid`**. Final line text is unchanged; **`--json`** paths are untouched. Single-server stop paths already use **`println!`** and were not modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6543c0c4710c70afa2a707d23b5513127af320f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->