### PR TITLE
Surface "latest" first as recommended version in local --help

### DIFF
--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -17,7 +17,7 @@ pub enum LocalCommands {
 CONTEXT FOR AGENTS:
   `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
     Install {
-        /// Version to install (e.g., latest, stable, lts, 25, 25.12, 25.12.9.61)
+        /// Version to install. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.9.61".
         version: String,
 
         /// Force re-install even if version is already installed
@@ -42,12 +42,12 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Sets the default ClickHouse version used by `clickhousectl local client` and `clickhousectl local server`.
-  Accepts version specs: \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
+  Accepts version specs: \"latest\" (recommended), \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
   Auto-installs the version if not already present.
   Also creates `~/.local/bin/clickhouse` as a symlink to the version's binary so the `clickhouse` command is on PATH. Pass --no-global to skip.
   Related: `clickhousectl local which` to verify, `clickhousectl local server start` to start a server.")]
     Use {
-        /// Version to use as default
+        /// Version to use as default. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.5.44".
         version: String,
 
         /// Do not create or update the ~/.local/bin/clickhouse symlink
@@ -160,7 +160,7 @@ CONTEXT FOR AGENTS:
   a random name is generated (e.g., \"bold-crane\").
   Use --name to give a server a stable identity (e.g., --name dev, --name test).
   Use --version (-v) to run a specific ClickHouse version without changing the default.
-  Accepts same specs as install/use: stable, lts, latest, 25.12, etc. Installs if needed.
+  Accepts same specs as install/use: \"latest\" (recommended), stable, lts, 25.12, etc. Installs if needed.
   Ports default to 8123 (HTTP) and 9000 (TCP). If they're in use, free ports are auto-assigned.
   Use --http-port and --tcp-port to set explicit ports.
   Runs in background by default. Use --foreground (-F / --fg) to run in foreground.
@@ -177,7 +177,7 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         name: Option<String>,
 
-        /// ClickHouse version to use (e.g. stable, lts, latest, 25.12). Installs if needed. Does not change the default version.
+        /// ClickHouse version to use (e.g. "latest" (recommended), stable, lts, 25.12). Installs if needed. Does not change the default version.
         #[arg(long, short = 'v')]
         version: Option<String>,
 


### PR DESCRIPTION
Closes #265.

For local commands, the `--help` text enumerating version specs now lists `latest` **first** and marks it as **recommended**.

## Changes

All in `crates/clickhousectl/src/local/cli.rs`:

- `local install` — `<VERSION>` arg help now reads `"latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.9.61"`.
- `local use` — both the `<VERSION>` arg help and the `after_help` spec enumeration now lead with `"latest" (recommended)`.
- `local server start` — the `--version`/`-v` flag help and the `after_help` ("Accepts same specs as install/use…") now lead with `"latest" (recommended)`.

## Testing

- `cargo build`, `cargo clippy`, and `cargo test --bins` all clean.
- Manually verified rendered `--help` output for `local use`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to clap help strings; no runtime or version-resolution behavior is modified.
> 
> **Overview**
> Updates **`clickhousectl local`** CLI help so version specs consistently list **`"latest" (recommended)`** first wherever users pick a ClickHouse version.
> 
> **`local install`** and **`local use`** argument help, plus **`local use`** and **`local server start`** `after_help` text, now enumerate `latest` before `stable`, `lts`, partial, and exact versions. The **`server start --version` / `-v`** flag help matches the same ordering and wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e0c931464df0f167fb430f8fbf62d02f1c9324. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->