### PR TITLE
Remove beta notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # clickhousectl
 
-> **Beta:** `clickhousectl` is currently in beta. Features and behavior may change.
-
 `clickhousectl` is the CLI for ClickHouse: local and cloud.
 
 With `clickhousectl` you can:


### PR DESCRIPTION
Removes the top-level beta notice from the README, since clickhousectl is no longer in beta.

The "Postgres (beta)" label further down is left untouched, since Postgres support is still beta.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)