### PR TITLE
Make update notice prominent on every non-JSON command (#269)

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ clickhousectl update
 clickhousectl update --check
 ```
 
-The CLI also checks for updates in the background (at most once per 24 hours) and displays a notice when a newer version is available.
+The CLI checks for updates in the background (at most once per 24 hours) and caches the result. When a newer version is available, a one-line notice is printed to stderr at the end of every command that produces human-readable output. JSON output (`--json` or a detected coding agent) is never affected, so machine consumers stay clean. Running `clickhousectl update` clears the cached notice.
 
 ## Cloud integration testing
 

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -34,24 +34,39 @@ async fn main() {
     let cli = match Cli::try_parse() {
         Ok(cli) => cli,
         Err(e) => {
-            // For --help and --version, show the update notice after the output
-            if e.kind() == ErrorKind::DisplayHelp || e.kind() == ErrorKind::DisplayVersion {
-                e.print().expect("failed to print output");
-                update::print_cached_update_notice();
-                std::process::exit(0);
+            match e.kind() {
+                // --version always hits the network to refresh the cache + timer,
+                // then prints the notice from the freshly-updated cache.
+                ErrorKind::DisplayVersion => {
+                    e.print().expect("failed to print output");
+                    update::force_refresh_update_cache().await;
+                    update::print_cached_update_notice();
+                    std::process::exit(0);
+                }
+                // --help shows the notice from cache (no blocking network call).
+                ErrorKind::DisplayHelp => {
+                    e.print().expect("failed to print output");
+                    update::print_cached_update_notice();
+                    std::process::exit(0);
+                }
+                _ => e.exit(),
             }
-            e.exit();
         }
     };
 
-    // Spawn a background task to refresh the update cache for non-update commands.
-    // The notice itself is only shown on --help (above), not during normal execution.
+    // Spawn a background task to refresh the update cache for non-update
+    // commands. The refresh is gated to one network call per 24h; the notice
+    // below is driven off whatever the cache currently holds.
     let is_update_cmd = matches!(cli.command, Commands::Update(_));
     let cache_refresh = if !is_update_cmd {
         Some(tokio::spawn(update::refresh_update_cache()))
     } else {
         None
     };
+
+    // Decide whether to surface the update notice before `run` consumes the
+    // command. Shown on every command that does not emit machine-readable JSON.
+    let show_notice = should_show_update_notice(&cli.command);
 
     let result = run(cli.command).await;
 
@@ -62,9 +77,43 @@ async fn main() {
         let _ = tokio::time::timeout(std::time::Duration::from_millis(500), handle).await;
     }
 
-    if let Err(e) = result {
-        eprintln!("Error: {}", e);
-        std::process::exit(e.exit_code());
+    let exit_code = match result {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            e.exit_code()
+        }
+    };
+
+    // Always print the notice at the very end, after the command's own output
+    // (stdout) and any error message.
+    if show_notice {
+        update::print_cached_update_notice();
+    }
+
+    std::process::exit(exit_code);
+}
+
+/// The explicit `--json` flag for a command, or `None` for commands that never
+/// surface the update notice (the `update` command itself). `Skills` has no
+/// `--json` flag, so it reports `false`. Kept separate from agent detection so
+/// the mapping is deterministic and unit-testable regardless of environment.
+fn command_json_flag(cmd: &Commands) -> Option<bool> {
+    match cmd {
+        Commands::Update(_) => None,
+        Commands::Local(args) => Some(args.json),
+        Commands::Cloud(args) => Some(args.json),
+        Commands::Skills(_) => Some(false),
+    }
+}
+
+/// Whether to surface the cached update notice for this invocation. Shown for
+/// every command that does not emit machine-readable JSON (`--json` or a
+/// detected coding agent both suppress it), except the `update` command itself.
+fn should_show_update_notice(cmd: &Commands) -> bool {
+    match command_json_flag(cmd) {
+        None => false,
+        Some(flag) => !json_output(flag),
     }
 }
 
@@ -1226,6 +1275,69 @@ mod tests {
     #[test]
     fn json_output_true_when_flag_set() {
         assert!(json_output(true));
+    }
+
+    fn parse(args: &[&str]) -> Commands {
+        Cli::try_parse_from(args).unwrap().command
+    }
+
+    #[test]
+    fn command_json_flag_tracks_each_command() {
+        // Human-readable commands report an explicit `false` flag.
+        assert_eq!(
+            command_json_flag(&parse(&["clickhousectl", "cloud", "service", "list"])),
+            Some(false)
+        );
+        assert_eq!(
+            command_json_flag(&parse(&["clickhousectl", "local", "list"])),
+            Some(false)
+        );
+        // --json is picked up on both cloud and local (global flag).
+        assert_eq!(
+            command_json_flag(&parse(&[
+                "clickhousectl",
+                "cloud",
+                "--json",
+                "service",
+                "list"
+            ])),
+            Some(true)
+        );
+        assert_eq!(
+            command_json_flag(&parse(&["clickhousectl", "local", "--json", "list"])),
+            Some(true)
+        );
+        // Skills has no --json flag, so it always reports `false`.
+        assert_eq!(
+            command_json_flag(&parse(&["clickhousectl", "skills"])),
+            Some(false)
+        );
+        // The update command never surfaces the notice.
+        assert_eq!(command_json_flag(&parse(&["clickhousectl", "update"])), None);
+    }
+
+    #[test]
+    fn update_notice_suppressed_for_json_and_update() {
+        // --json suppresses the notice so machine output stays clean,
+        // regardless of agent detection.
+        assert!(!should_show_update_notice(&parse(&[
+            "clickhousectl",
+            "cloud",
+            "--json",
+            "service",
+            "list"
+        ])));
+        assert!(!should_show_update_notice(&parse(&[
+            "clickhousectl",
+            "local",
+            "--json",
+            "list"
+        ])));
+        // The update command never nags about itself.
+        assert!(!should_show_update_notice(&parse(&[
+            "clickhousectl",
+            "update"
+        ])));
     }
 
     #[test]

--- a/crates/clickhousectl/src/update.rs
+++ b/crates/clickhousectl/src/update.rs
@@ -143,6 +143,9 @@ pub async fn perform_update() -> Result<()> {
     if !is_newer(current, latest) {
         let display = latest.strip_prefix('v').unwrap_or(latest);
         println!("Already up to date (v{}).", display);
+        // Refresh the cache with the network truth so a stale "update available"
+        // notice can't keep nagging after the user explicitly checked.
+        let _ = save_update_check(display);
         return Ok(());
     }
 

--- a/crates/clickhousectl/src/update.rs
+++ b/crates/clickhousectl/src/update.rs
@@ -121,9 +121,13 @@ pub async fn check_for_update() -> Result<Option<(String, String)>> {
     let current = env!("CARGO_PKG_VERSION");
     let release = fetch_latest_release(EXPLICIT_TIMEOUT).await?;
     let latest = &release.tag_name;
+    let display = latest.strip_prefix('v').unwrap_or(latest);
+
+    // An explicit check always refreshes the cache and resets the staleness
+    // timer, so subsequent commands reflect what we just learned.
+    let _ = save_update_check(display);
 
     if is_newer(current, latest) {
-        let display = latest.strip_prefix('v').unwrap_or(latest);
         Ok(Some((current.to_string(), display.to_string())))
     } else {
         Ok(None)
@@ -206,8 +210,8 @@ pub async fn perform_update() -> Result<()> {
     })?;
 
     println!("Updated clickhousectl: v{} → v{}", current, display);
-    // Save the check cache so we don't nag right after updating
-    let _ = save_update_check(display);
+    // Clear the check cache so the update notice disappears immediately.
+    let _ = clear_update_check();
     Ok(())
 }
 
@@ -245,6 +249,27 @@ fn read_update_check() -> Option<(u64, String)> {
     Some((ts, version))
 }
 
+/// Remove the cached update check. Used after a successful self-update so the
+/// notice disappears immediately. Missing file is not an error.
+fn clear_update_check() -> Result<()> {
+    let path = update_check_path()?;
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(Error::Io(e)),
+    }
+}
+
+/// Whether the cache is stale enough to warrant a network refresh. A missing
+/// cache is always stale; a present one is stale once it is older than the
+/// check interval.
+fn cache_is_stale(cache: Option<(u64, String)>, now: u64) -> bool {
+    match cache {
+        Some((ts, _)) => now.saturating_sub(ts) >= CHECK_INTERVAL_SECS,
+        None => true,
+    }
+}
+
 /// Print an update notice from cached data only. No network, no async.
 /// Called synchronously before the command runs so output never interleaves.
 pub fn print_cached_update_notice() {
@@ -252,40 +277,49 @@ pub fn print_cached_update_notice() {
         let current = env!("CARGO_PKG_VERSION");
         if is_newer(current, &cached_version) {
             eprintln!(
-                "\nA new version of clickhousectl is available: v{} (current: v{})",
-                cached_version, current
+                "\nThere is a new version of clickhousectl. Update with `clickhousectl update`."
             );
-            eprintln!("Run `clickhousectl update` to upgrade.\n");
         }
     }
 }
 
-/// Refresh the update cache in the background if stale. Never prints.
-/// On any failure (timeout, network error, etc.), writes the current version
-/// to the cache so we don't retry for another 24 hours.
-pub async fn refresh_update_cache() {
-    // Only hit the network if cache is stale or missing
-    let needs_refresh = match read_update_check() {
-        Some((ts, _)) => now_secs().saturating_sub(ts) >= CHECK_INTERVAL_SECS,
-        None => true,
-    };
-    if !needs_refresh {
-        return;
-    }
-
+/// Hit the network, refresh the cache, and reset the staleness timer. Never
+/// prints. On any failure (timeout, network error, etc.) the timestamp is still
+/// reset so we back off for another 24h, but a previously-cached "update
+/// available" version is preserved so we don't hide a known update.
+async fn do_refresh_update_cache(timeout: std::time::Duration) {
     let current = env!("CARGO_PKG_VERSION");
-    let release = fetch_latest_release(BACKGROUND_TIMEOUT).await;
-    match release {
+    match fetch_latest_release(timeout).await {
         Ok(r) => {
             let latest = r.tag_name;
             let display = latest.strip_prefix('v').unwrap_or(&latest);
             let _ = save_update_check(display);
         }
         Err(_) => {
-            // Failed or timed out — write current version so we back off for 24h
-            let _ = save_update_check(current);
+            // Preserve any previously-cached latest version; fall back to the
+            // current version when there is nothing cached yet.
+            let version = read_update_check()
+                .map(|(_, v)| v)
+                .unwrap_or_else(|| current.to_string());
+            let _ = save_update_check(&version);
         }
     }
+}
+
+/// Refresh the update cache in the background if stale. Never prints. Skips the
+/// network entirely when the cache is still fresh (within 24h).
+pub async fn refresh_update_cache() {
+    if !cache_is_stale(read_update_check(), now_secs()) {
+        return;
+    }
+    do_refresh_update_cache(BACKGROUND_TIMEOUT).await;
+}
+
+/// Force a network check and refresh the cache + timer regardless of staleness.
+/// Used by explicit user actions (e.g. `--version`) that should always reflect
+/// the freshest state. Uses the longer explicit timeout. Never prints.
+pub async fn force_refresh_update_cache() {
+    do_refresh_update_cache(EXPLICIT_TIMEOUT).await;
 }
 
 #[cfg(test)]
@@ -309,6 +343,30 @@ mod tests {
         assert!(!is_newer("0.1.17", "0.1.17"));
         assert!(!is_newer("0.1.17", "0.1.16"));
         assert!(!is_newer("0.2.0", "0.1.99"));
+    }
+
+    #[test]
+    fn test_cache_is_stale() {
+        let now = 1_000_000;
+        // Missing cache is always stale.
+        assert!(cache_is_stale(None, now));
+        // Fresh cache (just written) is not stale.
+        assert!(!cache_is_stale(Some((now, "0.2.0".into())), now));
+        // Cache one second short of the interval is not stale.
+        assert!(!cache_is_stale(
+            Some((now - (CHECK_INTERVAL_SECS - 1), "0.2.0".into())),
+            now
+        ));
+        // Cache exactly at the interval is stale.
+        assert!(cache_is_stale(
+            Some((now - CHECK_INTERVAL_SECS, "0.2.0".into())),
+            now
+        ));
+        // Older cache is stale.
+        assert!(cache_is_stale(
+            Some((now - 2 * CHECK_INTERVAL_SECS, "0.2.0".into())),
+            now
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Closes #269

## Problem

Users weren't updating clickhousectl because the update notice was barely surfaced — it only printed on `--help`/`--version`, never during normal command execution.

## What changed

- **Show the notice on every non-`--json` command.** The cached update notice now prints to **stderr at the very end** of every command that produces human-readable output. `--json` and detected coding agents continue to suppress it, so machine/agent consumers are unaffected.
- **New single-line message:**
  > There is a new version of clickhousectl. Update with `clickhousectl update`.
- **`--version` always checks the network**, refreshes the cache, and resets the staleness timer, then prints the notice from the fresh cache.
- **`update --check`** now also writes the cache and resets the timer on every run.
- **Successful `update`** clears the cache so the notice disappears immediately.
- **Kept the 24h background-refresh gate** for normal commands (one network call per day). On network failure we now preserve any previously-cached "update available" version instead of clobbering it with the current version, so a known update is never hidden.

## Tests

- `cache_is_stale` boundary cases (`update.rs`).
- `command_json_flag` mapping + `--json`/`update` suppression (`main.rs`).
- All 353 tests pass; clippy clean.

## Manual verification (live network, current latest `0.3.1`)

| Scenario | Result |
|---|---|
| `--version`, seeded stale cache | Hit network, cache rewritten to `0.3.1`, timer reset |
| `--version` on a temp `v0.0.1` build | Printed version, then the notice |
| `update --check`, seeded wrong cache | `Update available: v0.0.1 → v0.3.1`; cache rewritten, timer reset |
| Normal human command, newer cache | Notice prints at the very end after output |
| Same command with `--json` / under agent detection | Notice suppressed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)