### PR TITLE
Bare `local server start` bootstraps `latest` when nothing is set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ clickhousectl local client --host remote-host --port 9000  # Connect to a specif
 
 Start and manage ClickHouse server instances. Each server gets its own isolated data directory at `.clickhouse/servers/<name>/data/`.
 
-A bare `clickhousectl local server start` bootstraps from zero: if no version is installed and no default is set, it installs `latest` and starts with it (it does not set a default, so you keep tracking `latest` on subsequent starts). Pin a version with `--version`, or set a default with `local use`, to opt out.
+A bare `clickhousectl local server start` bootstraps from zero: if no version is installed and no default is set, it installs `latest` and starts with it (it does not set a default, so you keep tracking `latest` on subsequent starts). Pin a version with `--version`, or set a default with `local use`, to opt out. Because `latest` tracks the rolling master build, repeat `latest` installs/starts do a cheap `HEAD` against `builds.clickhouse.com` and skip the ~150 MB re-download when master hasn't changed (the build's `etag` is cached in `~/.clickhouse/versions/.master-builds.json`).
 
 ```bash
 # Start a server (runs in background by default)

--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ clickhousectl local list                    # Installed versions
 clickhousectl local list --remote           # Available for download
 
 # Manage default version
-clickhousectl local use stable              # Latest stable (installs if needed)
+clickhousectl local use latest              # Latest master build (installs if needed)
 clickhousectl local use lts                 # Latest LTS (installs if needed)
 clickhousectl local use 25.12               # Latest 25.12.x.x (installs if needed)
 clickhousectl local use 25.12.5.44          # Exact version
-clickhousectl local use stable --no-global  # Set default but don't touch ~/.local/bin/clickhouse
+clickhousectl local use latest --no-global  # Set default but don't touch ~/.local/bin/clickhouse
 clickhousectl local which                   # Show current default
 
 # Remove a version
@@ -159,11 +159,13 @@ clickhousectl local client --host remote-host --port 9000  # Connect to a specif
 
 Start and manage ClickHouse server instances. Each server gets its own isolated data directory at `.clickhouse/servers/<name>/data/`.
 
+A bare `clickhousectl local server start` bootstraps from zero: if no version is installed and no default is set, it installs `latest` and starts with it (it does not set a default, so you keep tracking `latest` on subsequent starts). Pin a version with `--version`, or set a default with `local use`, to opt out.
+
 ```bash
 # Start a server (runs in background by default)
-clickhousectl local server start                          # Named "default"
+clickhousectl local server start                          # Named "default" (installs latest if nothing is set up yet)
 clickhousectl local server start --name dev               # Named "dev"
-clickhousectl local server start --version stable         # Use a specific version (installs if needed, doesn't change default)
+clickhousectl local server start --version latest         # Use a specific version (installs if needed, doesn't change default)
 clickhousectl local server start --foreground             # Run in foreground (-F / --fg)
 clickhousectl local server start --http-port 8124 --tcp-port 9001  # Explicit ports
 clickhousectl local server start --config-file analytics  # Apply a custom config (see "Custom config files" below)

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -31,7 +31,7 @@ CONTEXT FOR AGENTS:
 
   `clickhousectl skills`
 
-  Typical local workflow: `clickhousectl local install stable && clickhousectl local use stable && clickhousectl local server start`.")]
+  Typical local workflow: `clickhousectl local server start` (bootstraps from zero — installs `latest` if nothing is set up).")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
@@ -43,7 +43,7 @@ pub enum Commands {
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Manage local ClickHouse installations: install versions, run queries, manage servers.
-  Typical workflow: `clickhousectl local install stable && clickhousectl local use stable && clickhousectl local server start`.
+  Typical workflow: `clickhousectl local server start` (bootstraps from zero — installs `latest` if nothing is set up).
   Use `clickhousectl local <command> --help` for details on each subcommand.
   For a local Postgres instance via Docker, see `clickhousectl local postgres --help`.")]
     Local(LocalArgs),

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -167,6 +167,8 @@ CONTEXT FOR AGENTS:
   Use --name to give a server a stable identity (e.g., --name dev, --name test).
   Use --version (-v) to run a specific ClickHouse version without changing the default.
   Accepts same specs as install/use: \"latest\" (recommended), stable, lts, 25.12, etc. Installs if needed.
+  With no --version and no default set, a bare start bootstraps by installing \"latest\" (without
+  setting it as the default, so you keep tracking latest on later starts).
   Ports default to 8123 (HTTP) and 9000 (TCP). If they're in use, free ports are auto-assigned.
   Use --http-port and --tcp-port to set explicit ports.
   Runs in background by default. Use --foreground (-F / --fg) to run in foreground.

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -332,7 +332,10 @@ async fn start_server(
                 // otherwise it pulls the newer master build.
                 let spec = version_manager::parse_version_spec("latest")?;
                 let platform = version_manager::platform::Platform::detect()?;
-                eprintln!("No version specified and no default set; installing latest...");
+                // Says "using", not "installing": on repeat starts the build is
+                // usually already installed and nothing is downloaded. The install
+                // path prints its own Resolving/Downloading/up-to-date messages.
+                eprintln!("No version specified and no default set; using latest");
                 version_manager::install::ensure_installed_local_first(&spec, &platform).await?
             }
             // A default pointing at a removed binary stays an error.

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -321,7 +321,23 @@ async fn start_server(
         let platform = version_manager::platform::Platform::detect()?;
         version_manager::install::ensure_installed_local_first(&spec, &platform).await?
     } else {
-        version_manager::get_default_version()?
+        match version_manager::get_default_version() {
+            Ok(v) => v,
+            Err(Error::NoDefaultVersion) => {
+                // No version specified and no default set: bootstrap `latest`.
+                // Deliberately do NOT set it as the default, so unpinned users keep
+                // tracking latest on each start. This branch is therefore hit on every
+                // subsequent bare start too; `ensure_installed_local_first` returns the
+                // already-installed build silently if `latest` still resolves to it,
+                // otherwise it pulls the newer master build.
+                let spec = version_manager::parse_version_spec("latest")?;
+                let platform = version_manager::platform::Platform::detect()?;
+                eprintln!("No version specified and no default set; installing latest...");
+                version_manager::install::ensure_installed_local_first(&spec, &platform).await?
+            }
+            // A default pointing at a removed binary stays an error.
+            Err(e) => return Err(e),
+        }
     };
     let binary = paths::binary_path(&version)?;
 

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -218,6 +218,15 @@ fn remove(version: &str, force: bool, json: bool) -> Result<()> {
     }
 
     std::fs::remove_dir_all(&version_dir)?;
+
+    // If the removed dir was recorded as the installed master build, clear the
+    // master sidecar record so a later `latest` resolve doesn't see a stale
+    // entry pointing at a now-deleted binary. Best-effort, like the install
+    // overwrite path: a sidecar failure must not fail a successful removal.
+    if let Ok(platform) = version_manager::platform::Platform::detect() {
+        let _ = version_manager::master::clear_record_for_version(&platform, version);
+    }
+
     let out = output::RemoveOutput {
         version: version.to_string(),
     };

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -165,8 +165,16 @@ pub async fn ensure_installed(resolved: &ResolvedVersion, platform: &Platform) -
         }
     }
 
-    // Not installed — delegate to install_resolved
-    install_resolved(resolved, platform, false).await
+    // Not installed (or a master/`latest` build whose exact version we can only
+    // learn after downloading) — delegate to install_resolved. For master builds
+    // try_resolve_local always returns None and the exact version isn't known
+    // upfront, so install_resolved downloads, detects the version, and may find it
+    // already installed. That's a success for the "ensure" contract, not an error:
+    // map VersionAlreadyInstalled back to the existing version.
+    match install_resolved(resolved, platform, false).await {
+        Err(Error::VersionAlreadyInstalled(version)) => Ok(version),
+        other => other,
+    }
 }
 
 /// Detect the version of a clickhouse binary by running `./clickhouse --version`

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -2,6 +2,7 @@ use crate::error::{Error, Result};
 use crate::paths;
 use crate::version_manager::download::download_from_source;
 use crate::version_manager::list::list_installed_versions;
+use crate::version_manager::master;
 use crate::version_manager::platform::{DownloadSource, Platform};
 use crate::version_manager::resolve::{ResolvedVersion, resolve, try_resolve_local};
 use crate::version_manager::spec::VersionSpec;
@@ -54,6 +55,27 @@ pub async fn install_resolved(
     force: bool,
 ) -> Result<String> {
     paths::ensure_dirs()?;
+
+    // The floating `latest`/master build has no version upfront and a stable
+    // URL whose content moves. Use the HTTP etag to skip the ~153MB download
+    // when master hasn't changed since the installed build.
+    let is_master = matches!(
+        resolved.source,
+        DownloadSource::Builds { ref version_path } if version_path == "master"
+    );
+    let mut master_head = None;
+    if is_master {
+        master_head = master::head_info(platform).await;
+        if !force
+            && let Some(version) = master::reuse_if_unchanged(platform, master_head.as_ref())
+        {
+            eprintln!(
+                "latest is up to date (master build unchanged); using {}",
+                version
+            );
+            return Ok(version);
+        }
+    }
 
     // If we know the exact version upfront, check if already installed
     if let Some(ref version) = resolved.exact_version {
@@ -115,9 +137,12 @@ pub async fn install_resolved(
         detect_binary_version(&binary_path)?
     };
 
-    // Check if this exact version is already installed (post-detection check for builds source)
+    // Check if this exact version is already installed (post-detection check for builds source).
+    // Skipped for master: a master build's version string is shared across commits, so an
+    // existing dir doesn't mean the content matches — we got here because the etag changed
+    // (or there was no record), so overwrite the stale binary in place.
     let version_dir = paths::version_dir(&exact_version)?;
-    if version_dir.exists() && !force {
+    if version_dir.exists() && !force && !is_master {
         let _ = std::fs::remove_dir_all(&temp_dir);
         return Err(Error::VersionAlreadyInstalled(exact_version));
     }
@@ -131,6 +156,15 @@ pub async fn install_resolved(
 
     // Clean up temp dir
     let _ = std::fs::remove_dir_all(&temp_dir);
+
+    // Record the master etag so a later `latest` resolve can skip the download
+    // when master is unchanged. Best-effort: a sidecar write failure must not
+    // fail an otherwise-successful install.
+    if is_master
+        && let Some(head) = &master_head
+    {
+        let _ = master::record(platform, head, &exact_version);
+    }
 
     let channel_suffix = match resolved.channel {
         Some(ch) => format!(" ({})", ch),

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -140,7 +140,8 @@ pub async fn install_resolved(
     // Check if this exact version is already installed (post-detection check for builds source).
     // Skipped for master: a master build's version string is shared across commits, so an
     // existing dir doesn't mean the content matches — we got here because the etag changed
-    // (or there was no record), so overwrite the stale binary in place.
+    // (or there was no record), so overwrite the existing binary in place and adopt the dir
+    // as the master install (the record write below re-points the master record at it).
     let version_dir = paths::version_dir(&exact_version)?;
     if version_dir.exists() && !force && !is_master {
         let _ = std::fs::remove_dir_all(&temp_dir);
@@ -148,11 +149,21 @@ pub async fn install_resolved(
     }
 
     // Move to final location
-    if version_dir.exists() {
+    let replaced_existing = version_dir.exists();
+    if replaced_existing {
         std::fs::remove_dir_all(&version_dir)?;
     }
     std::fs::create_dir_all(&version_dir)?;
     std::fs::rename(&binary_path, version_dir.join("clickhouse"))?;
+
+    // Replacing a build on disk never affects already-running servers (they keep
+    // executing the old binary) — just say so, so the swap isn't silent.
+    if is_master && replaced_existing && version_in_use_by_running_server(&exact_version) {
+        eprintln!(
+            "Note: running servers keep using the previous {} build until restarted",
+            exact_version
+        );
+    }
 
     // Clean up temp dir
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -160,10 +171,16 @@ pub async fn install_resolved(
     // Record the master etag so a later `latest` resolve can skip the download
     // when master is unchanged. Best-effort: a sidecar write failure must not
     // fail an otherwise-successful install.
-    if is_master
-        && let Some(head) = &master_head
-    {
-        let _ = master::record(platform, head, &exact_version);
+    if is_master {
+        if let Some(head) = &master_head {
+            let _ = master::record(platform, head, &exact_version);
+        }
+    } else {
+        // A non-master install just wrote versions/<exact_version>/. If the
+        // sidecar recorded that dir as the installed master build, the record
+        // is now stale and would make a later `latest` resolve reuse this
+        // binary as if it were master. Best-effort, like `record`.
+        let _ = master::clear_record_for_version(platform, &exact_version);
     }
 
     let channel_suffix = match resolved.channel {
@@ -209,6 +226,16 @@ pub async fn ensure_installed(resolved: &ResolvedVersion, platform: &Platform) -
         Err(Error::VersionAlreadyInstalled(version)) => Ok(version),
         other => other,
     }
+}
+
+/// Whether a running managed server (in the current project) was started from
+/// this version. Recovers orphans first (like `local remove`) so a server that
+/// lost its metadata file is still counted.
+fn version_in_use_by_running_server(version: &str) -> bool {
+    crate::local::server::recover_current_project_servers();
+    crate::local::server::list_running_servers()
+        .iter()
+        .any(|s| s.version == version)
 }
 
 /// Detect the version of a clickhouse binary by running `./clickhouse --version`
@@ -322,4 +349,5 @@ mod tests {
     fn test_parse_version_output_empty() {
         assert!(parse_version_output("").is_err());
     }
+
 }

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -69,6 +69,33 @@ fn load_record(platform: &Platform) -> Option<MasterRecord> {
     load_sidecar().builds.remove(platform.builds_path())
 }
 
+/// Pure core of [`clear_record_for_version`]: drop the platform's record iff it
+/// records exactly `version`. Returns whether the sidecar changed.
+fn clear_version_from(sidecar: &mut Sidecar, platform_key: &str, version: &str) -> bool {
+    if sidecar
+        .builds
+        .get(platform_key)
+        .is_some_and(|r| r.version == version)
+    {
+        sidecar.builds.remove(platform_key);
+        true
+    } else {
+        false
+    }
+}
+
+/// Invalidate the record when a non-master install overwrites `versions/<version>/`:
+/// the recorded etag no longer describes the binary on disk, and a stale match
+/// would make a later `latest` resolve silently reuse the wrong build.
+pub fn clear_record_for_version(platform: &Platform, version: &str) -> Result<()> {
+    let mut sidecar = load_sidecar();
+    if clear_version_from(&mut sidecar, platform.builds_path(), version) {
+        let json = serde_json::to_vec_pretty(&sidecar)?;
+        std::fs::write(sidecar_path()?, json)?;
+    }
+    Ok(())
+}
+
 /// Persist the master state for this platform, merging into any existing
 /// sidecar so other platforms' records are preserved.
 pub fn record(platform: &Platform, head: &HeadInfo, version: &str) -> Result<()> {
@@ -220,5 +247,46 @@ mod tests {
     fn corrupt_sidecar_deserializes_to_default() {
         let back: Sidecar = serde_json::from_slice(b"not json").unwrap_or_default();
         assert!(back.builds.is_empty());
+    }
+
+    #[test]
+    fn clear_version_removes_matching_record() {
+        let mut sidecar = Sidecar::default();
+        sidecar
+            .builds
+            .insert("macos-aarch64".to_string(), rec("\"x-1\"", "26.5.1.1"));
+        assert!(clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
+        assert!(!sidecar.builds.contains_key("macos-aarch64"));
+    }
+
+    #[test]
+    fn clear_version_keeps_record_for_other_version() {
+        // The record points at a different version dir than the one being
+        // overwritten — it still describes the binary on disk, keep it.
+        let mut sidecar = Sidecar::default();
+        sidecar
+            .builds
+            .insert("macos-aarch64".to_string(), rec("\"x-1\"", "26.5.1.1"));
+        assert!(!clear_version_from(&mut sidecar, "macos-aarch64", "25.12.9.61"));
+        assert!(sidecar.builds.contains_key("macos-aarch64"));
+    }
+
+    #[test]
+    fn clear_version_keeps_other_platforms() {
+        let mut sidecar = Sidecar::default();
+        sidecar
+            .builds
+            .insert("amd64".to_string(), rec("\"x-1\"", "26.5.1.1"));
+        sidecar
+            .builds
+            .insert("macos-aarch64".to_string(), rec("\"y-2\"", "26.5.1.1"));
+        assert!(clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
+        assert!(sidecar.builds.contains_key("amd64"));
+    }
+
+    #[test]
+    fn clear_version_no_record_is_noop() {
+        let mut sidecar = Sidecar::default();
+        assert!(!clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
     }
 }

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -1,0 +1,224 @@
+//! Change detection for the floating `latest`/`master` build.
+//!
+//! `builds.clickhouse.com/master/...` is a single, stable URL whose *content*
+//! changes as master moves. The binary carries no externally-readable version
+//! (the `--version` string is shared across many master commits, and sibling
+//! metadata files 403), so the only cheap change-detection key is the HTTP
+//! `etag` (an S3 content hash) exposed on a HEAD request.
+//!
+//! We record the etag of the installed master build in a small sidecar next to
+//! the versions directory. On a later `latest` resolve we do a ~50ms HEAD and
+//! compare: unchanged -> reuse the installed binary and skip the ~153MB download
+//! *and* the post-download version detection; changed (or no record, or the
+//! recorded binary is missing) -> download afresh and re-record.
+
+use crate::error::Result;
+use crate::paths;
+use crate::version_manager::platform::{DownloadSource, Platform};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// One installed master build's change-detection state, per platform.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MasterRecord {
+    /// HTTP `etag` of the master binary at install time.
+    pub etag: String,
+    /// HTTP `last-modified` at install time (informational; etag is the key).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
+    /// The detected version string the binary was installed as (the
+    /// `versions/<version>/` directory it lives in).
+    pub version: String,
+}
+
+/// Change-detection headers from a HEAD request to the master URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeadInfo {
+    pub etag: String,
+    pub last_modified: Option<String>,
+}
+
+/// The whole sidecar: platform segment (e.g. "macos-aarch64") -> record.
+/// Keyed by platform so a shared `~/.clickhouse` survives moving between
+/// architectures without a stale-etag false match.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct Sidecar {
+    #[serde(default)]
+    builds: BTreeMap<String, MasterRecord>,
+}
+
+/// Path to the sidecar file (`~/.clickhouse/versions/.master-builds.json`).
+fn sidecar_path() -> Result<std::path::PathBuf> {
+    Ok(paths::versions_dir()?.join(".master-builds.json"))
+}
+
+fn load_sidecar() -> Sidecar {
+    let Ok(path) = sidecar_path() else {
+        return Sidecar::default();
+    };
+    let Ok(bytes) = std::fs::read(&path) else {
+        return Sidecar::default();
+    };
+    // A corrupt/old-format sidecar is treated as absent -- worst case is one
+    // extra download that rewrites it.
+    serde_json::from_slice(&bytes).unwrap_or_default()
+}
+
+/// Load the recorded master state for this platform, if any.
+fn load_record(platform: &Platform) -> Option<MasterRecord> {
+    load_sidecar().builds.remove(platform.builds_path())
+}
+
+/// Persist the master state for this platform, merging into any existing
+/// sidecar so other platforms' records are preserved.
+pub fn record(platform: &Platform, head: &HeadInfo, version: &str) -> Result<()> {
+    let mut sidecar = load_sidecar();
+    sidecar.builds.insert(
+        platform.builds_path().to_string(),
+        MasterRecord {
+            etag: head.etag.clone(),
+            last_modified: head.last_modified.clone(),
+            version: version.to_string(),
+        },
+    );
+    let path = sidecar_path()?;
+    let json = serde_json::to_vec_pretty(&sidecar)?;
+    std::fs::write(&path, json)?;
+    Ok(())
+}
+
+/// HEAD the master URL and pull the change-detection headers.
+/// Best-effort: returns `None` on any network/build error, so callers fall
+/// back to an unconditional download rather than failing.
+pub async fn head_info(platform: &Platform) -> Option<HeadInfo> {
+    let url = DownloadSource::Builds {
+        version_path: "master".to_string(),
+    }
+    .url(platform);
+
+    let client = reqwest::Client::builder()
+        .user_agent(crate::user_agent::user_agent())
+        .build()
+        .ok()?;
+
+    let resp = client.head(&url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let header = |name: reqwest::header::HeaderName| {
+        resp.headers()
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+    };
+    let etag = header(reqwest::header::ETAG)?;
+    let last_modified = header(reqwest::header::LAST_MODIFIED);
+    Some(HeadInfo { etag, last_modified })
+}
+
+/// Pure reuse decision: reuse the recorded build only when we have a record,
+/// a remote etag, they match, and the recorded binary still exists on disk.
+fn should_reuse(
+    record: Option<&MasterRecord>,
+    remote_etag: Option<&str>,
+    binary_exists: bool,
+) -> bool {
+    match (record, remote_etag) {
+        (Some(rec), Some(etag)) => rec.etag == etag && binary_exists,
+        _ => false,
+    }
+}
+
+/// If the installed master build is unchanged from the remote, return the
+/// version to reuse (download can be skipped). Otherwise `None`.
+///
+/// `head` is the result of [`head_info`]; pass it through so the same HEAD
+/// result drives both the reuse check and the post-download [`record`].
+pub fn reuse_if_unchanged(platform: &Platform, head: Option<&HeadInfo>) -> Option<String> {
+    let record = load_record(platform)?;
+    let binary_exists = paths::binary_path(&record.version)
+        .map(|p| p.exists())
+        .unwrap_or(false);
+    if should_reuse(Some(&record), head.map(|h| h.etag.as_str()), binary_exists) {
+        Some(record.version)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(etag: &str, version: &str) -> MasterRecord {
+        MasterRecord {
+            etag: etag.to_string(),
+            last_modified: None,
+            version: version.to_string(),
+        }
+    }
+
+    #[test]
+    fn reuse_when_etag_matches_and_binary_present() {
+        assert!(should_reuse(
+            Some(&rec("\"abc-1\"", "26.5.1.1")),
+            Some("\"abc-1\""),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_reuse_when_etag_differs() {
+        assert!(!should_reuse(
+            Some(&rec("\"abc-1\"", "26.5.1.1")),
+            Some("\"def-2\""),
+            true
+        ));
+    }
+
+    #[test]
+    fn no_reuse_when_binary_missing() {
+        // etag recorded but the installed binary was removed
+        assert!(!should_reuse(
+            Some(&rec("\"abc-1\"", "26.5.1.1")),
+            Some("\"abc-1\""),
+            false
+        ));
+    }
+
+    #[test]
+    fn no_reuse_when_no_record() {
+        assert!(!should_reuse(None, Some("\"abc-1\""), true));
+    }
+
+    #[test]
+    fn no_reuse_when_head_failed() {
+        // HEAD returned nothing (network error) -- never reuse blindly
+        assert!(!should_reuse(
+            Some(&rec("\"abc-1\"", "26.5.1.1")),
+            None,
+            true
+        ));
+    }
+
+    #[test]
+    fn sidecar_round_trips_and_preserves_other_platforms() {
+        let mut sidecar = Sidecar::default();
+        sidecar
+            .builds
+            .insert("amd64".to_string(), rec("\"x-1\"", "26.5.1.1"));
+        sidecar
+            .builds
+            .insert("macos-aarch64".to_string(), rec("\"y-2\"", "26.5.1.1"));
+        let json = serde_json::to_vec_pretty(&sidecar).unwrap();
+        let back: Sidecar = serde_json::from_slice(&json).unwrap();
+        assert_eq!(back.builds.get("amd64").unwrap().etag, "\"x-1\"");
+        assert_eq!(back.builds.get("macos-aarch64").unwrap().etag, "\"y-2\"");
+    }
+
+    #[test]
+    fn corrupt_sidecar_deserializes_to_default() {
+        let back: Sidecar = serde_json::from_slice(b"not json").unwrap_or_default();
+        assert!(back.builds.is_empty());
+    }
+}

--- a/crates/clickhousectl/src/version_manager/mod.rs
+++ b/crates/clickhousectl/src/version_manager/mod.rs
@@ -1,6 +1,7 @@
 pub mod download;
 pub mod install;
 pub mod list;
+pub mod master;
 pub mod platform;
 pub mod resolve;
 pub mod spec;


### PR DESCRIPTION
Closes #264.

## Summary

Running `clickhousectl local server start` with no installed version, no default set, and no `--version` flag now bootstraps automatically: it installs `latest` and starts with it, instead of failing with `NoDefaultVersion` and exit code 1.

- If a default exists → use it (unchanged).
- If no default is set (`NoDefaultVersion`) → resolve `latest`, install if missing, and start. We deliberately **do not** set it as the default, so unpinned users keep tracking `latest` on later starts. A note is printed to stderr so the auto-download isn't silent.
- A `VersionNotFound` default (file points at a removed binary) stays an error — only the *no default at all* case bootstraps.

## Changes

- **`start_server` (`src/local/mod.rs`)** — the bare-start branch matches on `get_default_version()` and handles `NoDefaultVersion` by bootstrapping `latest`. Message: `No version specified and no default set; installing latest...`.
- **`ensure_installed` (`src/version_manager/install.rs`)** — bug fix required for the feature. For `latest`/master builds the exact version is only known after download, so `install_resolved` returned `VersionAlreadyInstalled`, breaking `ensure_installed`'s "return existing, don't error" contract. Because bare start never sets a default, *every* repeat start hits this path and would fail. Now maps `VersionAlreadyInstalled` → `Ok(version)`. This also fixes the pre-existing `server start --version latest`-on-repeat failure.
- **Docs / help text** — README server section and `server start` help document the bootstrap; the "typical workflow" help text drops the three-step `install stable && use stable && start` dance in favour of a bare `server start`; `stable`-as-tag examples switched to `latest` (the install keyword catalog keeps `stable` documented).

## Skip re-downloading master when unchanged (etag change detection)

Because bare start never sets a default, every repeat re-entered the `latest` path and re-downloaded the full ~153MB master binary (then re-ran `clickhouse --version`), even when master hadn't moved. This PR now short-circuits that.

Master exposes no readable version (the `--version` string is shared across many commits, sibling metadata files 403), but `builds.clickhouse.com` returns a stable, content-keyed `etag` on a HEAD request (~50ms, no body). We use it as a change-detection key:

- **New `src/version_manager/master.rs`** — a per-platform sidecar (`~/.clickhouse/versions/.master-builds.json`) recording each installed master build's `etag` + version; a best-effort `head_info()` HEAD helper; a pure `should_reuse`/`reuse_if_unchanged` decision; and a `record()` writer.
- **`install_resolved`** — for the master source, HEAD-and-compare before downloading. Etag match + binary present → reuse the installed build, skipping the download *and* version detection. Otherwise download and re-record. Handles "etag recorded but binary missing" by falling through to download. Applies to both `install latest` and `server start --version latest` / bare start (shared path).

This also fixes a **latent bug**: because a master build's detected version string is shared across commits, the old code would re-download a moved master, detect the same version, hit `VersionAlreadyInstalled`, and discard the fresh binary — paying the full download cost yet keeping the stale build. Reuse/overwrite now key on the etag, so a changed master correctly overwrites in place.

## Verification

Manual end-to-end in an isolated `HOME` (no installs, no default):

- Bare `server start` → message prints, `latest` downloads, server starts, exit 0, **no `default` file created**. ✅
- Second bare `server start` → reuses the installed build, starts, exit 0 (previously errored). ✅
- Default pointing at a removed binary → `Error: Version <x> not found`, exit 1. ✅

Etag change detection, against the live CDN with the built binary:

- First `install latest` → downloads master, writes the sidecar with the build's `etag`. **~12.4s**. ✅
- Second `install latest` → `latest is up to date (master build unchanged); using <v>`, single HEAD, no download. **~0.14s**. ✅
- 7 new unit tests cover the reuse decision (etag match/mismatch, missing binary, no record, failed HEAD) and sidecar round-trip.

- `cargo build`, `cargo clippy` (clean), `cargo test` (all pass). ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)