### PR TITLE
Move OAuth tokens to global ~/.clickhouse/tokens.json (fixes #277)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The user-facing CLI surface. Contains all logic for local commands, wraps `click
 
 Use `--help` to learn the current command surface.
 
-Project-local data lives in `.clickhouse/`. Globally installed ClickHouse binaries live in `~/.clickhouse/`.
+Project-local data lives in `.clickhouse/`. Globally installed ClickHouse binaries live in `~/.clickhouse/`. OAuth tokens (`~/.clickhouse/tokens.json`) are the exception — they're global user identity, not project-scoped.
 
 The CLI does not need to have 100% coverage of endpoints exposed by the API library: be intentional about what is exposed to users.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ If you don't have a ClickHouse Cloud account yet, `clickhousectl cloud auth sign
 clickhousectl cloud auth login
 ```
 
-This opens your browser for authentication via the OAuth device flow. Tokens are saved to `.clickhouse/tokens.json` (project-local).
+This opens your browser for authentication via the OAuth device flow. Tokens are saved to `~/.clickhouse/tokens.json` (global, shared across all directories).
 
 > **Note:** OAuth tokens provide **read-only** access. You can list and inspect resources (organizations, services, backups, etc.) but cannot create, modify, or delete them. For write operations, use API key authentication. `cloud service query` works under OAuth too, running SQL as your own identity with **read-only** access — see [Query API auth modes](#query-api-auth-modes).
 
@@ -302,7 +302,7 @@ clickhousectl cloud auth login --api-key YOUR_KEY --api-secret YOUR_SECRET
 clickhousectl cloud auth login --interactive
 ```
 
-Credentials are saved to `.clickhouse/credentials.json` (project-local).
+Credentials are saved to `.clickhouse/credentials.json` (project-local). API keys are org-scoped, so they stay per-project; OAuth tokens represent your user identity and are stored globally in `~/.clickhouse/tokens.json`.
 
 You can also use environment variables, either exported in your session:
 ```bash

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -96,37 +96,86 @@ struct TokenErrorResponse {
     error_description: Option<String>,
 }
 
-pub fn tokens_path() -> PathBuf {
+/// Global OAuth token store: `~/.clickhouse/tokens.json`.
+///
+/// OAuth login is user identity (not org-scoped like API keys), so tokens live
+/// in the CLI's global home alongside installed versions and configs, rather
+/// than per-project under `./.clickhouse/`.
+pub fn tokens_path() -> Result<PathBuf, crate::error::Error> {
+    Ok(crate::paths::base_dir()?.join("tokens.json"))
+}
+
+/// Legacy per-project token store: `<cwd>/.clickhouse/tokens.json`.
+///
+/// Earlier versions wrote OAuth tokens here (per-project). `load_tokens`
+/// migrates a legacy file to the global path on first sight, and
+/// `clear_tokens` removes both so logging out from an old project dir doesn't
+/// leave a file that re-migrates.
+fn legacy_tokens_path() -> PathBuf {
     crate::init::local_dir().join("tokens.json")
 }
 
 pub fn load_tokens() -> Option<TokenStore> {
-    let path = tokens_path();
-    let data = std::fs::read_to_string(path).ok()?;
-    serde_json::from_str(&data).ok()
+    let global = tokens_path().ok()?;
+    let legacy = legacy_tokens_path();
+    load_tokens_from(&global, &legacy)
+}
+
+/// Path-injected core of [`load_tokens`]. Reads the global token file first;
+/// if absent/unreadable, attempts a one-time migration from `legacy_path`
+/// (write the global copy, best-effort delete the legacy file).
+fn load_tokens_from(global_path: &std::path::Path, legacy_path: &std::path::Path) -> Option<TokenStore> {
+    if let Ok(data) = std::fs::read_to_string(global_path)
+        && let Ok(tokens) = serde_json::from_str::<TokenStore>(&data)
+    {
+        return Some(tokens);
+    }
+
+    // Global file missing or unreadable — try a one-time migration from the
+    // legacy cwd-based path. Best-effort: write the global copy, then delete
+    // the legacy file so it can't re-migrate on the next command.
+    if let Ok(data) = std::fs::read_to_string(legacy_path)
+        && let Ok(tokens) = serde_json::from_str::<TokenStore>(&data)
+    {
+        if save_tokens_to(global_path, &tokens).is_ok() {
+            let _ = std::fs::remove_file(legacy_path);
+        }
+        return Some(tokens);
+    }
+
+    None
 }
 
 pub fn save_tokens(tokens: &TokenStore) -> Result<(), Box<dyn std::error::Error>> {
-    let path = tokens_path();
+    let path = tokens_path()?;
+    save_tokens_to(&path, tokens)
+}
+
+fn save_tokens_to(
+    path: &std::path::Path,
+    tokens: &TokenStore,
+) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
     let json = serde_json::to_string_pretty(tokens)?;
-    std::fs::write(&path, &json)?;
+    std::fs::write(path, &json)?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
     }
 
     Ok(())
 }
 
 pub fn clear_tokens() {
-    let path = tokens_path();
-    let _ = std::fs::remove_file(path);
+    if let Ok(path) = tokens_path() {
+        let _ = std::fs::remove_file(path);
+    }
+    let _ = std::fs::remove_file(legacy_tokens_path());
 }
 
 pub fn is_token_valid(tokens: &TokenStore) -> bool {
@@ -413,8 +462,110 @@ mod tests {
 
     #[test]
     fn test_tokens_path() {
-        let path = tokens_path();
-        assert!(path.ends_with(".clickhouse/tokens.json"));
+        // Tokens live in the global ~/.clickhouse/ home, not the cwd, so the
+        // path must end with .clickhouse/tokens.json under the home directory
+        // and be independent of the current working directory.
+        let path = tokens_path().expect("home dir should be resolvable");
+        assert!(
+            path.ends_with(".clickhouse/tokens.json"),
+            "expected path to end with .clickhouse/tokens.json, got {}",
+            path.display()
+        );
+        let home = dirs::home_dir().expect("home dir should be resolvable");
+        assert!(
+            path.starts_with(home.join(".clickhouse")),
+            "expected path under {}/.clickhouse, got {}",
+            home.display(),
+            path.display()
+        );
+    }
+
+    fn sample_tokens() -> TokenStore {
+        TokenStore {
+            access_token: "a".into(),
+            refresh_token: "r".into(),
+            expires_at: chrono::Utc::now().timestamp() + 3600,
+            api_url: DEFAULT_API_URL.into(),
+        }
+    }
+
+    #[test]
+    fn load_tokens_migrates_legacy_file_when_global_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global/.clickhouse/tokens.json");
+        let legacy = tmp.path().join("legacy/.clickhouse/tokens.json");
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+
+        let tokens = sample_tokens();
+        std::fs::write(&legacy, serde_json::to_string_pretty(&tokens).unwrap()).unwrap();
+
+        let loaded = load_tokens_from(&global, &legacy).expect("legacy file should migrate");
+        assert_eq!(loaded.access_token, "a");
+
+        // Migration writes the global copy and deletes the legacy file.
+        assert!(global.exists(), "global tokens file should be created");
+        assert!(
+            std::fs::read_to_string(&global)
+                .unwrap()
+                .contains("\"access_token\": \"a\""),
+            "global file should hold the migrated tokens"
+        );
+        assert!(!legacy.exists(), "legacy file should be deleted");
+    }
+
+    #[test]
+    fn load_tokens_prefers_global_over_legacy() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global/.clickhouse/tokens.json");
+        let legacy = tmp.path().join("legacy/.clickhouse/tokens.json");
+        std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+
+        let mut global_tokens = sample_tokens();
+        global_tokens.access_token = "global-wins".into();
+        std::fs::write(&global, serde_json::to_string_pretty(&global_tokens).unwrap()).unwrap();
+
+        let mut legacy_tokens = sample_tokens();
+        legacy_tokens.access_token = "legacy-ignored".into();
+        std::fs::write(&legacy, serde_json::to_string_pretty(&legacy_tokens).unwrap()).unwrap();
+
+        let loaded = load_tokens_from(&global, &legacy).expect("global file should load");
+        assert_eq!(loaded.access_token, "global-wins");
+        assert!(legacy.exists(), "legacy file must not be touched");
+    }
+
+    #[test]
+    fn load_tokens_returns_none_when_both_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global/.clickhouse/tokens.json");
+        let legacy = tmp.path().join("legacy/.clickhouse/tokens.json");
+        assert!(load_tokens_from(&global, &legacy).is_none());
+    }
+
+    #[test]
+    fn load_tokens_returns_none_when_both_unparseable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global = tmp.path().join("global/.clickhouse/tokens.json");
+        let legacy = tmp.path().join("legacy/.clickhouse/tokens.json");
+        std::fs::create_dir_all(global.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(legacy.parent().unwrap()).unwrap();
+        std::fs::write(&global, b"not json").unwrap();
+        std::fs::write(&legacy, b"also not json").unwrap();
+        assert!(load_tokens_from(&global, &legacy).is_none());
+    }
+
+    #[test]
+    fn save_tokens_creates_parent_dirs_and_sets_permissions() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested/dir/tokens.json");
+        save_tokens_to(&path, &sample_tokens()).unwrap();
+        assert!(path.exists());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "tokens file should be 0o600");
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -60,7 +60,7 @@ pub enum AuthSource {
     CredentialsFile,
     /// `CLICKHOUSE_CLOUD_API_KEY` / `CLICKHOUSE_CLOUD_API_SECRET` env vars
     EnvVars,
-    /// OAuth tokens saved by `cloud auth login` (`.clickhouse/tokens.json`)
+    /// OAuth tokens saved by `cloud auth login` (`~/.clickhouse/tokens.json`)
     OAuthTokens,
 }
 
@@ -98,7 +98,7 @@ fn real_env_lookup(key: &str) -> Option<String> {
 /// the env tier these tests are exercising.
 type CredentialsLookup<'a> = &'a dyn Fn() -> Option<crate::cloud::credentials::Credentials>;
 
-/// Loader for the OAuth token tier (`.clickhouse/tokens.json`). Injected for
+/// Loader for the OAuth token tier (`~/.clickhouse/tokens.json`). Injected for
 /// the same reason as `CredentialsLookup`.
 type TokensLookup<'a> = &'a dyn Fn() -> Option<crate::cloud::auth::TokenStore>;
 
@@ -140,7 +140,8 @@ fn resolve_auth(
 /// `env_lookup`, `load_credentials`, and `load_tokens` are the injection
 /// points that let tests feed a controlled snapshot of every source without
 /// mutating the process environment or reading the real `.clickhouse/` files
-/// under the (un-isolated) test cwd.
+/// (credentials.json under cwd, tokens.json under the home dir) that `cargo
+/// test` does not isolate.
 fn resolve_auth_with_sources(
     api_key: Option<&str>,
     api_secret: Option<&str>,
@@ -299,7 +300,9 @@ impl AuthSource {
             }
             AuthSource::OAuthTokens => format!(
                 "OAuth tokens ({})",
-                crate::cloud::auth::tokens_path().display()
+                crate::cloud::auth::tokens_path()
+                    .map(|p| p.display().to_string())
+                    .unwrap_or_else(|_| "~/.clickhouse/tokens.json".to_string())
             ),
         }
     }

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -151,7 +151,9 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                         .map_err(|e| Error::Cloud(e.to_string()))?;
                     cloud::auth::save_tokens(&tokens).map_err(|e| Error::Cloud(e.to_string()))?;
                     println!("Logged in successfully.");
-                    println!("Tokens saved to {}", cloud::auth::tokens_path().display());
+                    let tokens_path = cloud::auth::tokens_path()
+                        .map_err(|e| Error::Cloud(e.to_string()))?;
+                    println!("Tokens saved to {}", tokens_path.display());
                     Ok(())
                 }
             }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1299,10 +1299,11 @@ async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
     let query_host = start_mock_query_host().await;
 
     // OAuth tokens are the lowest-precedence credential tier, so clear the
-    // API key env vars and run in a temp dir whose .clickhouse/tokens.json
-    // is the only credential source.
+    // API key env vars. Tokens now live in the global ~/.clickhouse/tokens.json
+    // (issue #277), so point HOME at a temp dir and write them there.
     let dir = tempfile::tempdir().unwrap();
-    let ch_dir = dir.path().join(".clickhouse");
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
     std::fs::create_dir_all(&ch_dir).unwrap();
     let tokens = serde_json::json!({
         "access_token": "test-bearer-token",
@@ -1332,6 +1333,7 @@ async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
             "SELECT 1",
         ])
         .current_dir(dir.path())
+        .env("HOME", &home_dir)
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
@@ -1465,8 +1467,9 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
 // header (waking the service, like the SQL console does after prompting);
 // for `Service is stopped` it must fail with a hint to start the service.
 
-/// Write an OAuth tokens.json into `ch_dir` so the binary authenticates with
-/// a bearer token against the given control plane.
+/// Write an OAuth tokens.json into `ch_dir` (the caller's `$HOME/.clickhouse`)
+/// so the binary authenticates with a bearer token against the given control
+/// plane. Callers must also set `HOME` to the parent of `ch_dir`.
 fn write_oauth_tokens(ch_dir: &std::path::Path, control_uri: &str) {
     let tokens = serde_json::json!({
         "access_token": "test-bearer-token",
@@ -1506,7 +1509,8 @@ async fn service_query_resends_with_wake_header_when_service_is_idle() {
         .await;
 
     let dir = tempfile::tempdir().unwrap();
-    let ch_dir = dir.path().join(".clickhouse");
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
     std::fs::create_dir_all(&ch_dir).unwrap();
     write_oauth_tokens(&ch_dir, &control.uri());
 
@@ -1526,6 +1530,7 @@ async fn service_query_resends_with_wake_header_when_service_is_idle() {
             "SELECT 1",
         ])
         .current_dir(dir.path())
+        .env("HOME", &home_dir)
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
@@ -1568,7 +1573,8 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
         .await;
 
     let dir = tempfile::tempdir().unwrap();
-    let ch_dir = dir.path().join(".clickhouse");
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
     std::fs::create_dir_all(&ch_dir).unwrap();
     write_oauth_tokens(&ch_dir, &control.uri());
 
@@ -1588,6 +1594,7 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
             "SELECT 1",
         ])
         .current_dir(dir.path())
+        .env("HOME", &home_dir)
         .env_remove("CLICKHOUSE_CLOUD_API_KEY")
         .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())


### PR DESCRIPTION
OAuth `cloud auth login` / `auth status` read and wrote `<cwd>/.clickhouse/tokens.json`, so logging in from one directory left you logged out everywhere else (#277). Tokens now live at `~/.clickhouse/tokens.json` alongside versions/configs via the existing `paths::base_dir()` helper. `load_tokens()` does a one-time best-effort migration from a legacy cwd-based file (copy global, delete legacy); `clear_tokens()` removes both so logout in an old project dir doesn't leave a file that re-migrates. `credentials.json` (API keys) stays project-local — org-scoped per-project — so the asymmetry is deliberate.

Behavioral note: with a single global store, logging into staging now overwrites a prod login (the token records its `api_url`, so it's self-consistent, but juggling environments via separate dirs no longer works). A per-host keyed store could be a follow-up.