### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -40,7 +40,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.3.1", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.4.0", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.4.0"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
Prep for 0.4.0 release. Bumps version in lockstep across:

- `crates/clickhouse-cloud-api/Cargo.toml`
- `crates/clickhousectl/Cargo.toml` (version + `clickhouse-cloud-api` dep)
- `npm/package.json`
- `Cargo.lock`

`pypi/pyproject.toml` pulls its version dynamically from the CLI Cargo.toml, so no manual bump needed there.