### PR TITLE
Bump is-ai-agent to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,9 +2085,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is-ai-agent"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9848cf556ca7b76f8e28f386a76deab397c60ef815f124f54f5c59016b1586f0"
+checksum = "b942aa58ac9280e0e7018e08500d77175efce90d9dee68a8e7e593b2a2c80d67"
 
 [[package]]
 name = "is-docker"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -42,7 +42,7 @@ url = "2.5.8"
 tabled = "0.20.0"
 clickhouse-cloud-api = { version = "0.3.1", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
-is-ai-agent = "0.4.0"
+is-ai-agent = "0.5.0"
 base64 = "0.22.1"
 bollard = "0.21.0"
 crossterm = "0.29.0"


### PR DESCRIPTION
Bumps the `is-ai-agent` dependency from 0.4.0 to 0.5.0 in `crates/clickhousectl/Cargo.toml` and updates `Cargo.lock`.