### PR TITLE
Fix OpenAPI drift: 36 gaps between live spec and library (#298)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,10 @@ Add an exemption only for intentional, verified runtime behavior, with a nearby 
 
 Enum values and struct fields are checked bidirectionally. Enum mapping is structural: named schemas resolve to model types; properties, array items, compositions, and operation parameters resolve through their Rust field/argument type. Serde container/variant renames determine wire values. Catch-alls are recognized through `untagged`/`other` attributes, never variant names; a genuine unit variant named `Unknown` remains a value. Numeric, mixed, and scalar-backed enum constraints are reported explicitly as unsupported rather than silently skipped.
 
+##### `VALUES` const checking
+
+Enums that the CLI validates against declare `pub const VALUES: &'static [&'static str]` in an `impl` block — a hand-written literal slice of the enum's non-catch-all wire values. The analyzer verifies that any enum with a `VALUES` const has it exactly equal (as a set) to its variant wire values; a mismatch produces `FindingKind::EnumValuesMismatch`. This is opt-in: enums without a `VALUES` const are not checked. When adding a new enum value to a `VALUES`-bearing enum, update both the variant and the const or CI will fail.
+
 ##### Deprecated field hiding
 
 Every spec-deprecated request or response field belongs in `meta.rs::DEPRECATED_FIELDS` and carries `#[cfg(feature = "deprecated-fields")]` on the `models.rs` field. It is therefore absent from the public model by default. Request fields that must be gated out but resolve as required are `Option<T>` with a documented optionality exemption. Update CLI code that directly accesses or constructs an affected model so both feature configurations compile.

--- a/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
+++ b/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
@@ -5,13 +5,53 @@
     "version": "1.0",
     "contact": {
       "name": "ClickHouse Support",
-      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-897534",
+      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-909980",
       "email": "support@clickhouse.com"
     }
   },
   "servers": [
     {
       "url": "https://api.clickhouse.cloud"
+    }
+  ],
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Organization"
+    },
+    {
+      "name": "User management"
+    },
+    {
+      "name": "Billing"
+    },
+    {
+      "name": "Role Management"
+    },
+    {
+      "name": "Service"
+    },
+    {
+      "name": "Backup"
+    },
+    {
+      "name": "OpenAPI"
+    },
+    {
+      "name": "Prometheus"
+    },
+    {
+      "name": "ClickPipes"
+    },
+    {
+      "name": "ClickStack"
+    },
+    {
+      "name": "Postgres"
     }
   ],
   "paths": {
@@ -2212,7 +2252,7 @@
     "/v1/organizations/{organizationId}/services/{serviceId}/replicaScaling": {
       "patch": {
         "summary": "Update service auto scaling settings",
-        "description": "Updates minimum and maximum memory limits per replica and idle mode scaling behavior for the service. Supports both vertical autoscaling (fixed replica count, variable memory) and horizontal autoscaling (variable replica count, fixed memory). The memory settings are available only for \"production\" services and must be a multiple of 4 starting from 8GB. For vertical autoscaling, please contact support to enable adjustment of numReplicas. For horizontal autoscaling (minReplicas/maxReplicas/replicaMemoryGb), contact support to enable the feature for your organization.",
+        "description": "Updates minimum and maximum memory limits per replica and idle mode scaling behavior for the service. Supports both vertical autoscaling (fixed replica count, variable memory) and horizontal autoscaling (variable replica count, fixed memory). The memory settings are available only for \"production\" services and must be a multiple of 4 starting from 8GB. For vertical autoscaling, please contact support to enable adjustment of numReplicas. For horizontal autoscaling (autoscalingMode \"horizontal\" with minReplicas/maxReplicas), contact support to enable the feature for your organization.",
         "operationId": "instanceReplicaScalingUpdate",
         "parameters": [
           {
@@ -7535,6 +7575,132 @@
         },
         "tags": [
           "ClickPipes"
+        ]
+      }
+    },
+    "/v1/organizations/{organizationId}/services/{serviceId}/clickpipes/schemaDiscovery": {
+      "post": {
+        "summary": "Discover ClickPipe source schema",
+        "description": "**This endpoint is in beta.** API contract is stable, and no breaking changes are expected in the future. <br /><br /> Infers the schema (field names and ClickHouse data types) of a streaming ClickPipe source without creating a pipe. Supported for Kafka and Kinesis sources.",
+        "operationId": "clickPipeSchemaDiscovery",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organizationId",
+            "description": "ID of the organization that owns the service.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "serviceId",
+            "description": "ID of the service to run schema discovery against.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClickPipeSchemaDiscoveryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 200
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    },
+                    "result": {
+                      "$ref": "#/components/schemas/ClickPipeSchemaDiscoveryResponse"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request cannot be processed due to a client error. Please verify your request parameters and try again.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "number",
+                      "description": "HTTP status code.",
+                      "example": 400
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An internal server error has occurred. If this issue persists, please contact ClickHouse Cloud support for assistance.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "integer",
+                      "description": "HTTP status code.",
+                      "example": 500
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Detailed error description."
+                    },
+                    "requestId": {
+                      "type": "string",
+                      "description": "Unique id assigned to every request. UUIDv4",
+                      "format": "uuid"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "ClickPipes"
+        ],
+        "x-badges": [
+          {
+            "name": "Beta",
+            "position": "after"
+          }
         ]
       }
     },
@@ -14580,6 +14746,13 @@
             "type": "boolean",
             "example": false
           },
+          "serverId": {
+            "description": "Optional MySQL server_id the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned automatically.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295,
+            "example": 4242
+          },
           "settings": {
             "$ref": "#/components/schemas/ClickPipeMySQLPipeSettings"
           },
@@ -14666,6 +14839,13 @@
             "description": "Skip TLS certificate verification for the MySQL connection. Use with caution in production environments.",
             "type": "boolean",
             "example": false
+          },
+          "serverId": {
+            "description": "Optional MySQL server_id the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned automatically.",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 4294967295,
+            "example": 4242
           },
           "tableMappings": {
             "type": "array",
@@ -14757,6 +14937,16 @@
               "null"
             ],
             "example": false
+          },
+          "serverId": {
+            "description": "Optional MySQL server_id the pipe declares itself as in the MySQL replication topology. Must be unique across replicas connected to the source. If omitted, one is assigned automatically.",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 1,
+            "maximum": 4294967295,
+            "example": 4242
           },
           "settings": {
             "$ref": "#/components/schemas/ClickPipePatchMySQLPipeSettings"
@@ -16245,28 +16435,28 @@
             "minimum": 1,
             "maximum": 24
           },
+          "autoscalingMode": {
+            "description": "Autoscaling mode for this entry. \"vertical\" runs a fixed replica count while memory scales; \"horizontal\" scales the replica count at a fixed per-replica memory. Defaults to \"vertical\" for entries persisted before the mode was exposed.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ]
+          },
           "minReplicaMemoryGb": {
-            "description": "Minimum memory per replica (Gb) during this window. Present only for vertical entries; horizontal entries use replicaMemoryGb instead.",
+            "description": "Minimum memory per replica (Gb) during this window. A range in vertical; in horizontal it equals maxReplicaMemoryGb (memory is fixed while the replica count scales).",
             "type": "number"
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum memory per replica (Gb) during this window. Present only for vertical entries; horizontal entries use replicaMemoryGb instead.",
+            "description": "Maximum memory per replica (Gb) during this window. A range in vertical; in horizontal it equals minReplicaMemoryGb (memory is fixed while the replica count scales).",
             "type": "number"
-          },
-          "replicaMemoryGb": {
-            "description": "Fixed memory per replica (Gb) during this window. Present only for horizontal entries; vertical entries use minReplicaMemoryGb/maxReplicaMemoryGb instead.",
-            "type": "number"
-          },
-          "numReplicas": {
-            "description": "Fixed replica count for a vertical entry. Responses express the fixed count as equal minReplicas and maxReplicas rather than numReplicas.",
-            "type": "integer"
           },
           "minReplicas": {
-            "description": "Number of replicas during this window. For a horizontal entry the replica count scales from minReplicas up to maxReplicas; for a vertical entry both equal the fixed count.",
+            "description": "Minimum number of replicas during this window. For a horizontal entry the replica count scales between minReplicas and maxReplicas; for a vertical entry minReplicas and maxReplicas are equal and report the fixed replica count (both omitted when the entry stored no count).",
             "type": "integer"
           },
           "maxReplicas": {
-            "description": "Maximum replicas during this window for a horizontal entry; equal to the fixed count for a vertical entry.",
+            "description": "Maximum number of replicas during this window. For a horizontal entry the replica count scales between minReplicas and maxReplicas; for a vertical entry minReplicas and maxReplicas are equal and report the fixed replica count (both omitted when the entry stored no count).",
             "type": "integer"
           },
           "idleScaling": {
@@ -16288,11 +16478,20 @@
           "weekdays",
           "startHourUtc",
           "endHourUtc",
+          "autoscalingMode",
           "isActiveNow"
         ]
       },
       "ScalingScheduleBaseConfig": {
         "properties": {
+          "autoscalingMode": {
+            "description": "Autoscaling mode applied when no schedule entry is active. \"vertical\" runs a fixed replica count while memory scales; \"horizontal\" scales the replica count at a fixed per-replica memory.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ]
+          },
           "minReplicaMemoryGb": {
             "description": "Minimum memory per replica (Gb) when no schedule entry is active.",
             "type": "number"
@@ -16378,22 +16577,25 @@
             "maximum": 24,
             "example": 17
           },
+          "autoscalingMode": {
+            "description": "Autoscaling mode for this entry. \"vertical\" (the default when omitted) runs a fixed replica count while memory scales between minReplicaMemoryGb and maxReplicaMemoryGb; \"horizontal\" scales the replica count between minReplicas and maxReplicas at a fixed per-replica memory (minReplicaMemoryGb equal to maxReplicaMemoryGb). Horizontal requires the feature to be enabled for the organization.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "example": "vertical"
+          },
           "minReplicaMemoryGb": {
-            "description": "Minimum memory per replica (Gb) for a vertical entry. Mutually exclusive with replicaMemoryGb. The upper bound is tier-dependent (lower for non-paid organizations) and enforced when the entry is applied.",
+            "description": "Minimum memory per replica (Gb). Optional for vertical entries — provide both bounds for a memory range, or omit both to inherit memory from the base scaling config. Required for horizontal (both bounds, equal to maxReplicaMemoryGb — memory is fixed while the replica count scales). The upper bound is tier-dependent (lower for non-paid organizations) and enforced when the entry is applied.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
-            "multipleOf": 4
+            "multipleOf": 4,
+            "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum memory per replica (Gb) for a vertical entry. Mutually exclusive with replicaMemoryGb. The upper bound is tier-dependent (lower for non-paid organizations) and enforced when the entry is applied.",
-            "type": "number",
-            "minimum": 8,
-            "maximum": 356,
-            "multipleOf": 4
-          },
-          "replicaMemoryGb": {
-            "description": "Fixed memory per replica (Gb) for a horizontal entry. A horizontal entry requires both this field and a minReplicas/maxReplicas range. Mutually exclusive with minReplicaMemoryGb/maxReplicaMemoryGb and numReplicas. Requires horizontal autoscaling to be enabled for the organization. The upper bound is tier-dependent (lower for non-paid organizations) and enforced when the entry is applied.",
+            "description": "Maximum memory per replica (Gb). Optional for vertical entries — provide both bounds for a memory range, or omit both to inherit memory from the base scaling config. Required for horizontal (both bounds, equal to minReplicaMemoryGb — memory is fixed while the replica count scales). The upper bound is tier-dependent (lower for non-paid organizations) and enforced when the entry is applied.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -16401,20 +16603,22 @@
             "example": 16
           },
           "numReplicas": {
-            "description": "Fixed replica count for a vertical entry. Used for vertical autoscaling (fixed replica count, variable memory). Mutually exclusive with minReplicas/maxReplicas and replicaMemoryGb. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
+            "description": "Fixed replica count for a vertical entry (autoscalingMode \"vertical\" or omitted). Mutually exclusive with minReplicas/maxReplicas. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
             "type": "integer",
             "minimum": 1,
             "example": 3
           },
           "minReplicas": {
-            "description": "Minimum number of replicas for a horizontal entry, where the replica count scales between minReplicas and maxReplicas. Must be provided together with maxReplicas. Mutually exclusive with numReplicas. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
+            "description": "Minimum number of replicas. A minReplicas/maxReplicas band scales the replica count in a horizontal entry (autoscalingMode \"horizontal\"); when autoscalingMode is omitted or \"vertical\", an equal band (minReplicas === maxReplicas) is instead an accepted vertical fixed count and needs no horizontal entitlement. Must be provided together with maxReplicas. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "example": 2
           },
           "maxReplicas": {
-            "description": "Maximum number of replicas for a horizontal entry, where the replica count scales between minReplicas and maxReplicas. Must be provided together with minReplicas. Mutually exclusive with numReplicas. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
+            "description": "Maximum number of replicas. A minReplicas/maxReplicas band scales the replica count in a horizontal entry (autoscalingMode \"horizontal\"); when autoscalingMode is omitted or \"vertical\", an equal band (minReplicas === maxReplicas) is instead an accepted vertical fixed count and needs no horizontal entitlement. Must be provided together with minReplicas. The per-service replica maximum is variable (tier-dependent, configurable per service) and enforced when the entry is applied, not at request time.",
             "type": "integer",
-            "minimum": 1
+            "minimum": 1,
+            "example": 3
           },
           "idleScaling": {
             "description": "Whether idle scaling is enabled during this window.",
@@ -16461,11 +16665,11 @@
             "type": "number"
           },
           "effectiveMaxReplicaMemoryGb": {
-            "description": "Maximum memory per replica (Gb) currently applied to the running service. May diverge from the top-level `maxReplicaMemoryGb` baseline while a schedule entry is active. In horizontal autoscaling mode equals `effectiveMinReplicaMemoryGb`.",
+            "description": "Maximum memory per replica (Gb) currently applied to the running service. May diverge from the top-level `maxReplicaMemoryGb` baseline while a schedule entry is active. Reflects the stored value: normally equal to `effectiveMinReplicaMemoryGb` in horizontal mode, but a legacy service stored with an unequal memory range reports the stored bounds as-is.",
             "type": "number"
           },
           "effectiveMinReplicas": {
-            "description": "Minimum number of replicas currently applied to the running service. May diverge from the baseline while a schedule entry is active. In vertical autoscaling mode equals `effectiveMaxReplicas` (vertical mode runs a fixed replica count).",
+            "description": "Minimum number of replicas currently applied to the running service. May diverge from the baseline while a schedule entry is active. Reflects the stored value: normally equal to `effectiveMaxReplicas` in vertical mode (a fixed replica count), but a legacy service stored with an unequal replica range reports the stored bounds as-is.",
             "type": "integer"
           },
           "effectiveMaxReplicas": {
@@ -16559,6 +16763,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -16647,7 +16852,7 @@
             "deprecated": true
           },
           "minReplicaMemoryGb": {
-            "description": "Minimum total memory of each replica during auto-scaling in Gb. Must be a multiple of 4 and greater than or equal to 8.",
+            "description": "Minimum total memory of each replica during auto-scaling in Gb. A range in vertical autoscaling; equal to maxReplicaMemoryGb in horizontal (memory is fixed while the replica count scales). Must be a multiple of 4 and greater than or equal to 8.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -16655,7 +16860,7 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum total memory of each replica during auto-scaling in Gb.  Must be a multiple of 4 and lower than or equal to 120* for non paid services or 356* for paid services.* - maximum replica size subject to cloud provider hardware availability in your selected region. ",
+            "description": "Maximum total memory of each replica during auto-scaling in Gb. A range in vertical autoscaling; equal to minReplicaMemoryGb in horizontal (memory is fixed while the replica count scales). Must be a multiple of 4 and lower than or equal to 120* for non paid services or 356* for paid services.* - maximum replica size subject to cloud provider hardware availability in your selected region. ",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -16682,6 +16887,15 @@
             "minimum": 1,
             "maximum": 20,
             "example": 5
+          },
+          "autoscalingMode": {
+            "description": "Configured autoscaling mode. \"vertical\" runs a fixed replica count while memory scales between minReplicaMemoryGb and maxReplicaMemoryGb; \"horizontal\" scales the replica count between minReplicas and maxReplicas at a fixed per-replica memory. This is the baseline configuration; the mode currently applied (which may differ while a schedule entry is active) is currentScaling.effectiveAutoscalingMode.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "example": "vertical"
           },
           "replicaMemoryGb": {
             "description": "Fixed memory per replica in Gb for horizontal autoscaling. Present only when the service uses horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services.",
@@ -16814,6 +17028,7 @@
           }
         },
         "required": [
+          "autoscalingMode",
           "currentScaling"
         ]
       },
@@ -16959,6 +17174,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -17119,6 +17335,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -17169,6 +17386,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -17276,6 +17494,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -17515,7 +17734,7 @@
       "CustomPrivateDnsMapping": {
         "properties": {
           "privateDnsName": {
-            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nCurrently, available in Private Preview for Google Private Service Connect (PSC) forwarding rules.\nSupports exact names and leading wildcard names such as *.example.com",
+            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nGenerally available for Google Private Service Connect (PSC). For AWS PrivateLink (VPC endpoint service and VPC resource), available in Private Preview; contact ClickHouse support to enable it for your service. Not supported for MSK multi-VPC.\nSupports exact names and leading wildcard names such as *.example.com",
             "type": "string",
             "example": "*.my-service.example.com"
           }
@@ -17593,7 +17812,7 @@
           },
           "customPrivateDnsMappings": {
             "type": "array",
-            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nCurrently, available in Private Preview for Google Private Service Connect (PSC) forwarding rules.\nSupports exact names and leading wildcard names such as *.example.com",
+            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nGenerally available for Google Private Service Connect (PSC). For AWS PrivateLink (VPC endpoint service and VPC resource), available in Private Preview; contact ClickHouse support to enable it for your service. Not supported for MSK multi-VPC.\nSupports exact names and leading wildcard names such as *.example.com",
             "items": {
               "$ref": "#/components/schemas/CustomPrivateDnsMapping"
             },
@@ -17612,7 +17831,7 @@
         "properties": {
           "customPrivateDnsMappings": {
             "type": "array",
-            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nCurrently, available in Private Preview for Google Private Service Connect (PSC) forwarding rules.\nSupports exact names and leading wildcard names such as *.example.com",
+            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nGenerally available for Google Private Service Connect (PSC). For AWS PrivateLink (VPC endpoint service and VPC resource), available in Private Preview; contact ClickHouse support to enable it for your service. Not supported for MSK multi-VPC.\nSupports exact names and leading wildcard names such as *.example.com",
             "items": {
               "$ref": "#/components/schemas/CustomPrivateDnsMapping"
             },
@@ -17699,7 +17918,7 @@
           },
           "customPrivateDnsMappings": {
             "type": "array",
-            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nCurrently, available in Private Preview for Google Private Service Connect (PSC) forwarding rules.\nSupports exact names and leading wildcard names such as *.example.com",
+            "description": "Optional private DNS names for Reverse Private Endpoint. Can be used as data source destination address. Must be unique across the ClickHouse service.\nGenerally available for Google Private Service Connect (PSC). For AWS PrivateLink (VPC endpoint service and VPC resource), available in Private Preview; contact ClickHouse support to enable it for your service. Not supported for MSK multi-VPC.\nSupports exact names and leading wildcard names such as *.example.com",
             "items": {
               "$ref": "#/components/schemas/CustomPrivateDnsMapping"
             },
@@ -17763,6 +17982,62 @@
               "Expired"
             ],
             "example": "Ready"
+          }
+        }
+      },
+      "ClickPipeSchemaDiscoverySource": {
+        "properties": {
+          "kafka": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ClickPipePostKafkaSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "kinesis": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ClickPipePostKinesisSource"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "ClickPipeSchemaDiscoveryField": {
+        "properties": {
+          "name": {
+            "description": "Name of the inferred field.",
+            "type": "string",
+            "example": "user_id"
+          },
+          "type": {
+            "description": "Inferred ClickHouse data type of the field.",
+            "type": "string",
+            "example": "Int64"
+          },
+          "optional": {
+            "description": "Whether the field is optional (nullable) in the source.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      },
+      "ClickPipeSchemaDiscoveryResponse": {
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Inferred schema fields with their ClickHouse data types.",
+            "items": {
+              "$ref": "#/components/schemas/ClickPipeSchemaDiscoveryField"
+            }
           }
         }
       },
@@ -24274,6 +24549,7 @@
           "restoring_backup",
           "finalizing_restore",
           "unavailable",
+          "stopped",
           "deleting"
         ]
       },
@@ -25144,6 +25420,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -25207,8 +25484,17 @@
             "example": 360,
             "deprecated": true
           },
+          "autoscalingMode": {
+            "description": "Autoscaling mode. \"vertical\" (the default when omitted) runs a fixed replica count while memory scales between minReplicaMemoryGb and maxReplicaMemoryGb; \"horizontal\" scales the replica count between minReplicas and maxReplicas at a fixed per-replica memory (minReplicaMemoryGb equal to maxReplicaMemoryGb). Horizontal requires the feature to be enabled for the organization.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "example": "vertical"
+          },
           "minReplicaMemoryGb": {
-            "description": "Minimum total memory of each replica during auto-scaling in Gb. Must be a multiple of 4 and greater than or equal to 8.",
+            "description": "Minimum total memory of each replica during auto-scaling in Gb. A range in vertical autoscaling; equal to maxReplicaMemoryGb in horizontal (memory is fixed while the replica count scales). Must be a multiple of 4 and greater than or equal to 8.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -25216,7 +25502,7 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum total memory of each replica during auto-scaling in Gb.  Must be a multiple of 4 and lower than or equal to 120* for non paid services or 356* for paid services.* - maximum replica size subject to cloud provider hardware availability in your selected region. ",
+            "description": "Maximum total memory of each replica during auto-scaling in Gb. A range in vertical autoscaling; equal to minReplicaMemoryGb in horizontal (memory is fixed while the replica count scales). Must be a multiple of 4 and lower than or equal to 120* for non paid services or 356* for paid services.* - maximum replica size subject to cloud provider hardware availability in your selected region. ",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -25224,33 +25510,25 @@
             "example": 120
           },
           "numReplicas": {
-            "description": "Number of replicas for the service. The number of replicas must be between 2 and 20 for the first service in a warehouse. Services that are created in an existing warehouse can have a number of replicas as low as 1. Further restrictions may apply based on your organization's tier. It defaults to 1 for the BASIC tier and 3 for the SCALE and ENTERPRISE tiers. Present only when the service uses vertical autoscaling. For horizontal autoscaling, use minReplicas and maxReplicas instead.",
+            "description": "Fixed replica count for vertical autoscaling (autoscalingMode \"vertical\" or omitted). Mutually exclusive with minReplicas/maxReplicas.",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 3
           },
           "minReplicas": {
-            "description": "Minimum number of replicas for horizontal autoscaling. Must be provided together with maxReplicas and replicaMemoryGb. Mutually exclusive with numReplicas, minReplicaMemoryGb/maxReplicaMemoryGb, and minTotalMemoryGb/maxTotalMemoryGb. Requires horizontal autoscaling to be enabled for the organization.",
+            "description": "Minimum number of replicas. A minReplicas/maxReplicas band scales the replica count in horizontal autoscaling (autoscalingMode \"horizontal\"). Must be provided together with maxReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the organization, unless autoscalingMode is omitted or \"vertical\" and minReplicas equals maxReplicas (an equal band is then an accepted vertical fixed count and needs no horizontal entitlement).",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 1
           },
           "maxReplicas": {
-            "description": "Maximum number of replicas for horizontal autoscaling. Must be provided together with minReplicas and replicaMemoryGb. Mutually exclusive with numReplicas, minReplicaMemoryGb/maxReplicaMemoryGb, and minTotalMemoryGb/maxTotalMemoryGb. Requires horizontal autoscaling to be enabled for the organization.",
+            "description": "Maximum number of replicas. A minReplicas/maxReplicas band scales the replica count in horizontal autoscaling (autoscalingMode \"horizontal\"). Must be provided together with minReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the organization, unless autoscalingMode is omitted or \"vertical\" and minReplicas equals maxReplicas (an equal band is then an accepted vertical fixed count and needs no horizontal entitlement).",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 5
-          },
-          "replicaMemoryGb": {
-            "description": "Fixed memory per replica in Gb for horizontal autoscaling. Must be provided together with minReplicas/maxReplicas. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services. Mutually exclusive with minReplicaMemoryGb/maxReplicaMemoryGb and minTotalMemoryGb/maxTotalMemoryGb. Requires horizontal autoscaling to be enabled for the organization.",
-            "type": "number",
-            "minimum": 8,
-            "maximum": 356,
-            "multipleOf": 4,
-            "example": 32
           },
           "idleScaling": {
             "description": "When set to true the service is allowed to scale down to zero when idle. True by default.",
@@ -25475,6 +25753,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -25563,7 +25842,7 @@
             "deprecated": true
           },
           "minReplicaMemoryGb": {
-            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. Present only when the service uses vertical autoscaling.",
+            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. A range in vertical autoscaling; equal to maxReplicaMemoryGb in horizontal (memory is fixed while the replica count scales).",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -25571,7 +25850,7 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. Present only when the service uses vertical autoscaling.",
+            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. A range in vertical autoscaling; equal to minReplicaMemoryGb in horizontal (memory is fixed while the replica count scales).",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -25598,6 +25877,15 @@
             "minimum": 1,
             "maximum": 20,
             "example": 5
+          },
+          "autoscalingMode": {
+            "description": "Configured autoscaling mode. \"vertical\" runs a fixed replica count while memory scales between minReplicaMemoryGb and maxReplicaMemoryGb; \"horizontal\" scales the replica count between minReplicas and maxReplicas at a fixed per-replica memory. This is the baseline configuration; the mode currently applied (which may differ while a schedule entry is active) is currentScaling.effectiveAutoscalingMode.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "example": "vertical"
           },
           "replicaMemoryGb": {
             "description": "Fixed memory per replica in Gb for horizontal autoscaling. Present only when the service uses horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services.",
@@ -25730,13 +26018,14 @@
           }
         },
         "required": [
+          "autoscalingMode",
           "currentScaling"
         ]
       },
       "ServiceReplicaScalingPatchRequest": {
         "properties": {
           "minReplicaMemoryGb": {
-            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. Used for vertical autoscaling. Mutually exclusive with replicaMemoryGb.",
+            "description": "Minimum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and greater than or equal to 8. A range in vertical autoscaling; equal to maxReplicaMemoryGb in horizontal.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
@@ -25744,41 +26033,42 @@
             "example": 16
           },
           "maxReplicaMemoryGb": {
-            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. Used for vertical autoscaling. Mutually exclusive with replicaMemoryGb.",
+            "description": "Maximum auto-scaling memory in Gb for a single replica. Available only for 'production' services. Must be a multiple of 4 and lower than or equal to 120 for non paid services or 356 for paid services. A range in vertical autoscaling; equal to minReplicaMemoryGb in horizontal.",
             "type": "number",
             "minimum": 8,
             "maximum": 356,
             "multipleOf": 4,
             "example": 120
           },
+          "autoscalingMode": {
+            "description": "Target autoscaling mode. Omit to keep the service on its current mode. \"vertical\" runs a fixed replica count while memory scales between minReplicaMemoryGb and maxReplicaMemoryGb; \"horizontal\" scales the replica count between minReplicas and maxReplicas at a fixed per-replica memory (minReplicaMemoryGb equal to maxReplicaMemoryGb). Switching to horizontal requires the feature to be enabled for the organization.",
+            "type": "string",
+            "enum": [
+              "vertical",
+              "horizontal"
+            ],
+            "example": "vertical"
+          },
           "numReplicas": {
-            "description": "Fixed replica count for vertical autoscaling. Mutually exclusive with minReplicas/maxReplicas. Please contact support to enable adjustment of numReplicas. When switching from horizontal autoscaling mode the existing replica memory is preserved as the new vertical min/max range; include minReplicaMemoryGb/maxReplicaMemoryGb in the same request to set an explicit range.",
+            "description": "Fixed replica count for vertical autoscaling (autoscalingMode \"vertical\"). Mutually exclusive with minReplicas/maxReplicas. When switching to vertical (autoscalingMode \"vertical\") with numReplicas and no memory, the service's stored baseline per-replica memory is kept as the new vertical range. Please contact support to enable adjustment of numReplicas.",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 3
           },
           "minReplicas": {
-            "description": "Minimum number of replicas for horizontal autoscaling. Must be provided together with maxReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service.",
+            "description": "Minimum number of replicas. A minReplicas/maxReplicas band scales the replica count in horizontal autoscaling (autoscalingMode \"horizontal\"). Must be provided together with maxReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service, unless autoscalingMode is omitted or \"vertical\" and minReplicas equals maxReplicas (an equal band is then an accepted vertical fixed count and needs no horizontal entitlement).",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 1
           },
           "maxReplicas": {
-            "description": "Maximum number of replicas for horizontal autoscaling. Must be provided together with minReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service.",
+            "description": "Maximum number of replicas. A minReplicas/maxReplicas band scales the replica count in horizontal autoscaling (autoscalingMode \"horizontal\"). Must be provided together with minReplicas. Mutually exclusive with numReplicas. Requires horizontal autoscaling to be enabled for the service, unless autoscalingMode is omitted or \"vertical\" and minReplicas equals maxReplicas (an equal band is then an accepted vertical fixed count and needs no horizontal entitlement).",
             "type": "integer",
             "minimum": 1,
             "maximum": 20,
             "example": 5
-          },
-          "replicaMemoryGb": {
-            "description": "Fixed memory per replica in Gb for horizontal autoscaling. Must be a multiple of 4, at least 8 Gb, and at most 120 Gb for non paid services or 356 Gb for paid services. Mutually exclusive with minReplicaMemoryGb/maxReplicaMemoryGb. Requires horizontal autoscaling to be enabled for the service.",
-            "type": "number",
-            "minimum": 8,
-            "maximum": 356,
-            "multipleOf": 4,
-            "example": 32
           },
           "idleScaling": {
             "description": "When set to true the service is allowed to scale down to zero when idle. True by default.",
@@ -26044,6 +26334,13 @@
           }
         }
       },
+      "ClickPipeSchemaDiscoveryRequest": {
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/ClickPipeSchemaDiscoverySource"
+          }
+        }
+      },
       "ClickPipePatchRequest": {
         "properties": {
           "name": {
@@ -26177,6 +26474,7 @@
               "ap-south-1",
               "ap-southeast-1",
               "ap-southeast-2",
+              "ca-central-1",
               "eu-central-1",
               "eu-west-1",
               "eu-west-2",
@@ -26243,46 +26541,6 @@
       }
     }
   },
-  "security": [
-    {
-      "basicAuth": []
-    }
-  ],
-  "tags": [
-    {
-      "name": "Organization"
-    },
-    {
-      "name": "User management"
-    },
-    {
-      "name": "Billing"
-    },
-    {
-      "name": "Role Management"
-    },
-    {
-      "name": "Service"
-    },
-    {
-      "name": "Backup"
-    },
-    {
-      "name": "OpenAPI"
-    },
-    {
-      "name": "Prometheus"
-    },
-    {
-      "name": "ClickPipes"
-    },
-    {
-      "name": "ClickStack"
-    },
-    {
-      "name": "Postgres"
-    }
-  ],
   "x-tagGroups": [
     {
       "name": "Organization",

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -2223,6 +2223,31 @@ impl Client {
         Ok(serde_json::from_str(&body_text)?)
     }
 
+    /// Discover ClickPipe source schema (Beta).
+    pub async fn click_pipe_schema_discovery(
+        &self,
+        organization_id: &str,
+        service_id: &str,
+        body: &ClickPipeSchemaDiscoveryRequest,
+    ) -> Result<ApiResponse<ClickPipeSchemaDiscoveryResponse>, Error> {
+        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/schemaDiscovery");
+        let mut req = self.request(reqwest::Method::POST, &path);
+        req = req.json(body);
+        let resp = req.send().await?;
+        let status = resp.status();
+        let body_text = resp.text().await?;
+        if !status.is_success() {
+            return Err(Error::Api {
+                status: status.as_u16(),
+                message: serde_json::from_str::<ApiResponse<serde_json::Value>>(&body_text)
+                    .ok()
+                    .and_then(|r| r.error)
+                    .unwrap_or(body_text.clone()),
+            });
+        }
+        Ok(serde_json::from_str(&body_text)?)
+    }
+
     /// ClickStack: List Alerts
     pub async fn click_stack_list_alerts(
         &self,

--- a/crates/clickhouse-cloud-api/src/meta.rs
+++ b/crates/clickhouse-cloud-api/src/meta.rs
@@ -24,6 +24,7 @@ pub const BETA_OPERATIONS: &[&str] = &[
     "backup_bucket_delete",
     "backup_bucket_get",
     "backup_bucket_update",
+    "click_pipe_schema_discovery",
     "click_stack_create_alert",
     "click_stack_create_dashboard",
     "click_stack_delete_alert",

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -331,6 +331,8 @@ pub enum PgStateProperty {
     Finalizing_restore,
     #[serde(rename = "unavailable")]
     Unavailable,
+    #[serde(rename = "stopped")]
+    Stopped,
     #[serde(rename = "deleting")]
     Deleting,
     /// Catch-all for unknown or newly-added values.
@@ -348,6 +350,7 @@ impl std::fmt::Display for PgStateProperty {
             Self::Restoring_backup => write!(f, "restoring_backup"),
             Self::Finalizing_restore => write!(f, "finalizing_restore"),
             Self::Unavailable => write!(f, "unavailable"),
+            Self::Stopped => write!(f, "stopped"),
             Self::Deleting => write!(f, "deleting"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
@@ -953,6 +956,8 @@ pub enum ByocConfigRegionid {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -1002,6 +1007,7 @@ impl std::fmt::Display for ByocConfigRegionid {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -1065,6 +1071,8 @@ pub enum ByocInfrastructurePostRequestRegionid {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -1114,6 +1122,7 @@ impl std::fmt::Display for ByocInfrastructurePostRequestRegionid {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -5153,6 +5162,33 @@ impl std::fmt::Display for CreateReversePrivateEndpointType {
     }
 }
 
+/// `autoscalingMode` enum from the ClickHouse Cloud API.
+///
+/// Used by `Service`, `ServicePostRequest`, `ServiceReplicaScalingPatchRequest`,
+/// `ServiceScalingPatchResponse`, `ScalingScheduleBaseConfig`,
+/// `ScalingScheduleEntry`, and `ScalingScheduleEntryRequest`.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub enum AutoscalingMode {
+    #[serde(rename = "vertical")]
+    #[default]
+    Vertical,
+    #[serde(rename = "horizontal")]
+    Horizontal,
+    /// Catch-all for unknown or newly-added values.
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+impl std::fmt::Display for AutoscalingMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Vertical => write!(f, "vertical"),
+            Self::Horizontal => write!(f, "horizontal"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// Inline enum for `CurrentScaling.effectiveAutoscalingMode`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum CurrentScalingEffectiveautoscalingmode {
@@ -5292,6 +5328,8 @@ pub enum InstancePrivateEndpointRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -5341,6 +5379,7 @@ impl std::fmt::Display for InstancePrivateEndpointRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -5496,6 +5535,8 @@ pub enum OrganizationPatchPrivateEndpointRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -5545,6 +5586,7 @@ impl std::fmt::Display for OrganizationPatchPrivateEndpointRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -5608,6 +5650,8 @@ pub enum OrganizationPrivateEndpointRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -5657,6 +5701,7 @@ impl std::fmt::Display for OrganizationPrivateEndpointRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -5997,6 +6042,8 @@ pub enum ServiceRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -6046,6 +6093,7 @@ impl std::fmt::Display for ServiceRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -6374,6 +6422,8 @@ pub enum ServicePostRequestRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -6423,6 +6473,7 @@ impl std::fmt::Display for ServicePostRequestRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -6620,6 +6671,8 @@ pub enum ServiceScalingPatchResponseRegion {
     Ap_southeast_1,
     #[serde(rename = "ap-southeast-2")]
     Ap_southeast_2,
+    #[serde(rename = "ca-central-1")]
+    Ca_central_1,
     #[serde(rename = "eu-central-1")]
     Eu_central_1,
     #[serde(rename = "eu-west-1")]
@@ -6669,6 +6722,7 @@ impl std::fmt::Display for ServiceScalingPatchResponseRegion {
             Self::Ap_south_1 => write!(f, "ap-south-1"),
             Self::Ap_southeast_1 => write!(f, "ap-southeast-1"),
             Self::Ap_southeast_2 => write!(f, "ap-southeast-2"),
+            Self::Ca_central_1 => write!(f, "ca-central-1"),
             Self::Eu_central_1 => write!(f, "eu-central-1"),
             Self::Eu_west_1 => write!(f, "eu-west-1"),
             Self::Eu_west_2 => write!(f, "eu-west-2"),
@@ -8135,6 +8189,8 @@ pub struct ClickPipeMutateMySQLSource {
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
     pub port: i64,
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    pub server_id: Option<i64>,
     pub settings: ClickPipeMySQLPipeSettings,
     #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
     pub skip_cert_verification: Option<bool>,
@@ -8244,6 +8300,8 @@ pub struct ClickPipeMySQLSource {
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
     pub port: i64,
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    pub server_id: Option<i64>,
     pub settings: ClickPipeMySQLPipeSettings,
     #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
     pub skip_cert_verification: Option<bool>,
@@ -8408,6 +8466,8 @@ pub struct ClickPipePatchMySQLSource {
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
     pub port: Option<i64>,
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    pub server_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settings: Option<ClickPipePatchMySQLPipeSettings>,
     #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
@@ -8592,6 +8652,40 @@ pub struct ClickPipePostKinesisSource {
     pub timestamp: Option<i64>,
     #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none", default)]
     pub use_enhanced_fan_out: Option<bool>,
+}
+
+/// `ClickPipeSchemaDiscoveryField` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeSchemaDiscoveryField {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub optional: Option<bool>,
+}
+
+/// `ClickPipeSchemaDiscoveryRequest` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeSchemaDiscoveryRequest {
+    #[serde(default)]
+    pub source: ClickPipeSchemaDiscoverySource,
+}
+
+/// `ClickPipeSchemaDiscoveryResponse` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeSchemaDiscoveryResponse {
+    #[serde(default)]
+    pub fields: Vec<ClickPipeSchemaDiscoveryField>,
+}
+
+/// `ClickPipeSchemaDiscoverySource` from the ClickHouse Cloud API.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeSchemaDiscoverySource {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub kafka: Option<ClickPipePostKafkaSource>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub kinesis: Option<ClickPipePostKinesisSource>,
 }
 
 /// `ClickPipePostObjectStorageSource` from the ClickHouse Cloud API.
@@ -10843,6 +10937,8 @@ pub struct ScalingSchedule {
 /// `ScalingScheduleBaseConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleBaseConfig {
+    #[serde(rename = "autoscalingMode", default)]
+    pub autoscaling_mode: AutoscalingMode,
     #[serde(rename = "idleScaling", default)]
     pub idle_scaling: bool,
     #[serde(rename = "idleTimeoutMinutes", default)]
@@ -10860,6 +10956,8 @@ pub struct ScalingScheduleBaseConfig {
 /// `ScalingScheduleEntry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleEntry {
+    #[serde(rename = "autoscalingMode", default)]
+    pub autoscaling_mode: AutoscalingMode,
     #[serde(rename = "endHourUtc", default)]
     pub end_hour_utc: i64,
     #[serde(default)]
@@ -10880,10 +10978,6 @@ pub struct ScalingScheduleEntry {
     pub min_replicas: Option<i64>,
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
-    pub num_replicas: Option<i64>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
-    pub replica_memory_gb: Option<f64>,
     #[serde(rename = "startHourUtc", default)]
     pub start_hour_utc: i64,
     #[serde(default)]
@@ -10893,6 +10987,8 @@ pub struct ScalingScheduleEntry {
 /// `ScalingScheduleEntryRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleEntryRequest {
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    pub autoscaling_mode: Option<AutoscalingMode>,
     #[serde(rename = "endHourUtc", default)]
     pub end_hour_utc: i64,
     #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
@@ -10911,8 +11007,6 @@ pub struct ScalingScheduleEntryRequest {
     pub name: String,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
     pub num_replicas: Option<i64>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
-    pub replica_memory_gb: Option<f64>,
     #[serde(rename = "startHourUtc", default)]
     pub start_hour_utc: i64,
     #[serde(default)]
@@ -11535,6 +11629,8 @@ pub struct ServicPrivateEndpointePostRequest {
 pub struct Service {
     #[serde(rename = "availablePrivateEndpointIds", default)]
     pub available_private_endpoint_ids: Vec<String>,
+    #[serde(rename = "autoscalingMode", default)]
+    pub autoscaling_mode: AutoscalingMode,
     #[serde(rename = "byocId", default)]
     pub byoc_id: String,
     #[serde(rename = "clickhouseVersion", default)]
@@ -11752,6 +11848,8 @@ pub struct ServicePatchRequest {
 /// `ServicePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePostRequest {
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    pub autoscaling_mode: Option<AutoscalingMode>,
     #[serde(rename = "backupId", skip_serializing_if = "Option::is_none", default)]
     pub backup_id: Option<uuid::Uuid>,
     #[serde(rename = "byocId", skip_serializing_if = "Option::is_none", default)]
@@ -11809,8 +11907,6 @@ pub struct ServicePostRequest {
     pub region: ServicePostRequestRegion,
     #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none", default)]
     pub release_channel: Option<ServicePostRequestReleasechannel>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
-    pub replica_memory_gb: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<ResourceTagsV1>>,
     #[cfg(feature = "deprecated-fields")]
@@ -11843,6 +11939,8 @@ pub struct ServiceQueryAPIEndpoint {
 /// `ServiceReplicaScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceReplicaScalingPatchRequest {
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    pub autoscaling_mode: Option<AutoscalingMode>,
     #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
     pub idle_scaling: Option<bool>,
     #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
@@ -11857,8 +11955,6 @@ pub struct ServiceReplicaScalingPatchRequest {
     pub min_replicas: Option<f64>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
     pub num_replicas: Option<f64>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
-    pub replica_memory_gb: Option<f64>,
 }
 
 /// `ServiceScalingPatchRequest` from the ClickHouse Cloud API.
@@ -11883,6 +11979,8 @@ pub struct ServiceScalingPatchRequest {
 pub struct ServiceScalingPatchResponse {
     #[serde(rename = "availablePrivateEndpointIds", default)]
     pub available_private_endpoint_ids: Vec<String>,
+    #[serde(rename = "autoscalingMode", default)]
+    pub autoscaling_mode: AutoscalingMode,
     #[serde(rename = "byocId", default)]
     pub byoc_id: String,
     #[serde(rename = "clickhouseVersion", default)]

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -30,6 +30,11 @@ impl std::fmt::Display for PgHaType {
     }
 }
 
+impl PgHaType {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["none", "async", "sync"];
+}
+
 /// `pgProvider` enum from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum PgProvider {
@@ -48,6 +53,11 @@ impl std::fmt::Display for PgProvider {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl PgProvider {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["aws"];
 }
 
 /// `pgSize` enum from the ClickHouse Cloud API.
@@ -378,6 +388,11 @@ impl std::fmt::Display for PgVersion {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl PgVersion {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["18", "17"];
 }
 
 /// Inline enum for `Activity.actorType`.
@@ -6324,6 +6339,11 @@ impl std::fmt::Display for ServicePatchRequestReleasechannel {
     }
 }
 
+impl ServicePatchRequestReleasechannel {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["slow", "default", "fast"];
+}
+
 /// Inline enum for `ServicePostRequest.complianceType`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ServicePostRequestCompliancetype {
@@ -6345,6 +6365,11 @@ impl std::fmt::Display for ServicePostRequestCompliancetype {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl ServicePostRequestCompliancetype {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["hipaa", "pci"];
 }
 
 /// Inline enum for `ServicePostRequest.profile`.
@@ -6382,6 +6407,18 @@ impl std::fmt::Display for ServicePostRequestProfile {
     }
 }
 
+impl ServicePostRequestProfile {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &[
+        "v1-default",
+        "v1-highmem-xs",
+        "v1-highmem-s",
+        "v1-highmem-m",
+        "v1-highmem-l",
+        "v1-highmem-xl",
+    ];
+}
+
 /// Inline enum for `ServicePostRequest.provider`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ServicePostRequestProvider {
@@ -6406,6 +6443,11 @@ impl std::fmt::Display for ServicePostRequestProvider {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl ServicePostRequestProvider {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["aws", "gcp", "azure"];
 }
 
 /// Inline enum for `ServicePostRequest.region`.
@@ -6497,6 +6539,36 @@ impl std::fmt::Display for ServicePostRequestRegion {
     }
 }
 
+impl ServicePostRequestRegion {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &[
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "il-central-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-2",
+        "us-east1",
+        "us-central1",
+        "europe-west2",
+        "europe-west4",
+        "asia-southeast1",
+        "asia-northeast1",
+        "eastus",
+        "eastus2",
+        "westus3",
+        "germanywestcentral",
+        "centralus",
+    ];
+}
+
 /// Inline enum for `ServicePostRequest.releaseChannel`.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ServicePostRequestReleasechannel {
@@ -6521,6 +6593,11 @@ impl std::fmt::Display for ServicePostRequestReleasechannel {
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
+}
+
+impl ServicePostRequestReleasechannel {
+    /// Wire values accepted by the API, excluding the catch-all.
+    pub const VALUES: &'static [&'static str] = &["slow", "default", "fast"];
 }
 
 /// Inline enum for `ServicePostRequest.tier`.

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1546,6 +1546,48 @@ async fn update_click_pipe_settings() {
 }
 
 // ===========================================================================
+// ClickPipes Schema Discovery (Beta)
+// ===========================================================================
+
+#[tokio::test]
+async fn click_pipe_schema_discovery_kafka() {
+    let (s, c) = setup().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/schemaDiscovery"))
+        .and(body_partial_json(serde_json::json!({
+            "source": {"kafka": {"brokers": "broker1:9092"}}
+        })))
+        .respond_with(ok_json(serde_json::json!({
+            "fields": [
+                {"name": "user_id", "type": "Int64", "optional": false},
+                {"name": "event", "type": "String", "optional": true}
+            ]
+        })))
+        .mount(&s)
+        .await;
+
+    let body = ClickPipeSchemaDiscoveryRequest {
+        source: ClickPipeSchemaDiscoverySource {
+            kafka: Some(ClickPipePostKafkaSource {
+                brokers: "broker1:9092".to_string(),
+                ..Default::default()
+            }),
+            kinesis: None,
+        },
+    };
+    let resp = c
+        .click_pipe_schema_discovery("org-1", "svc-1", &body)
+        .await
+        .unwrap();
+    let result = resp.result.unwrap();
+    assert_eq!(result.fields.len(), 2);
+    assert_eq!(result.fields[0].name, "user_id");
+    assert_eq!(result.fields[0].r#type, "Int64");
+    assert_eq!(result.fields[1].optional, Some(true));
+}
+
+// ===========================================================================
 // ClickPipes CDC Scaling
 // ===========================================================================
 

--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -906,6 +906,7 @@ pub fn scaling_schedule_entry_to_request(
     entry: &ScalingScheduleEntry,
 ) -> ScalingScheduleEntryRequest {
     ScalingScheduleEntryRequest {
+        autoscaling_mode: Some(entry.autoscaling_mode.clone()),
         end_hour_utc: entry.end_hour_utc,
         idle_scaling: entry.idle_scaling,
         idle_timeout_minutes: entry.idle_timeout_minutes,
@@ -914,8 +915,7 @@ pub fn scaling_schedule_entry_to_request(
         min_replica_memory_gb: entry.min_replica_memory_gb,
         min_replicas: entry.min_replicas,
         name: entry.name.clone(),
-        num_replicas: entry.num_replicas,
-        replica_memory_gb: entry.replica_memory_gb,
+        num_replicas: None,
         start_hour_utc: entry.start_hour_utc,
         weekdays: entry.weekdays.clone(),
     }

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -2035,7 +2035,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 // Vertical entry expressed as equal min/max; the fixed-count
                 // and horizontal-autoscaling forms need org-level enablement.
                 num_replicas: None,
-                replica_memory_gb: None,
+                ..Default::default()
             };
 
             let upserted = failures

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -155,22 +155,22 @@ fn serialize_service_post_request() {
 fn serialize_service_post_request_horizontal_autoscaling() {
     let req = ServicePostRequest {
         name: "horizontal-service".to_string(),
+        autoscaling_mode: Some(AutoscalingMode::Horizontal),
         min_replicas: Some(1.0),
         max_replicas: Some(5.0),
-        replica_memory_gb: Some(32.0),
         ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
+    assert_eq!(json["autoscalingMode"], "horizontal");
     assert_eq!(json["minReplicas"], 1.0);
     assert_eq!(json["maxReplicas"], 5.0);
-    assert_eq!(json["replicaMemoryGb"], 32.0);
 
     // Omitted entirely when unset — mutually exclusive with the vertical
     // scaling fields, so they must not serialize as null/defaults.
     let json = serde_json::to_value(ServicePostRequest::default()).unwrap();
     assert!(json.get("minReplicas").is_none());
     assert!(json.get("maxReplicas").is_none());
-    assert!(json.get("replicaMemoryGb").is_none());
+    assert!(json.get("autoscalingMode").is_none());
 }
 
 #[test]
@@ -576,9 +576,9 @@ fn serialize_service_replica_scaling_patch_request() {
         max_replicas: None,
         min_replica_memory_gb: Some(16.0),
         max_replica_memory_gb: Some(64.0),
-        replica_memory_gb: None,
         idle_scaling: Some(true),
         idle_timeout_minutes: Some(10.0),
+        ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
     assert_eq!(json["numReplicas"], 5.0);
@@ -901,25 +901,29 @@ fn deserialize_scaling_schedule_entry_fixed_scaling_fields() {
         "startHourUtc": 8,
         "endHourUtc": 18,
         "isActiveNow": false,
-        "numReplicas": 3,
-        "replicaMemoryGb": 16
+        "autoscalingMode": "vertical",
+        "minReplicaMemoryGb": 16,
+        "maxReplicaMemoryGb": 32
     }"#;
     let entry: ScalingScheduleEntry = serde_json::from_str(json).unwrap();
-    assert_eq!(entry.num_replicas, Some(3));
-    assert_eq!(entry.replica_memory_gb, Some(16.0));
+    assert_eq!(entry.autoscaling_mode, AutoscalingMode::Vertical);
+    assert_eq!(entry.min_replica_memory_gb, Some(16.0));
+    assert_eq!(entry.max_replica_memory_gb, Some(32.0));
 
     let req = ScalingScheduleEntryRequest {
         name: entry.name.clone(),
         weekdays: entry.weekdays.clone(),
         start_hour_utc: entry.start_hour_utc,
         end_hour_utc: entry.end_hour_utc,
-        num_replicas: entry.num_replicas,
-        replica_memory_gb: entry.replica_memory_gb,
+        autoscaling_mode: Some(entry.autoscaling_mode.clone()),
+        min_replica_memory_gb: entry.min_replica_memory_gb,
+        max_replica_memory_gb: entry.max_replica_memory_gb,
         ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
-    assert_eq!(json["numReplicas"], 3);
-    assert_eq!(json["replicaMemoryGb"], 16.0);
+    assert_eq!(json["autoscalingMode"], "vertical");
+    assert_eq!(json["minReplicaMemoryGb"], 16.0);
+    assert_eq!(json["maxReplicaMemoryGb"], 32.0);
 }
 
 #[test]
@@ -1614,4 +1618,128 @@ fn deserialize_clickstack_alert_with_note() {
     // its skip_serializing_if=None gate must let Some(_) through).
     let v = serde_json::to_value(&alert).unwrap();
     assert_eq!(v["note"], "investigate runaway queries");
+}
+
+#[test]
+fn autoscaling_mode_round_trip() {
+    let v = serde_json::to_value(AutoscalingMode::Vertical).unwrap();
+    assert_eq!(v, "vertical");
+    let v = serde_json::to_value(AutoscalingMode::Horizontal).unwrap();
+    assert_eq!(v, "horizontal");
+    let parsed: AutoscalingMode = serde_json::from_str("\"vertical\"").unwrap();
+    assert_eq!(parsed, AutoscalingMode::Vertical);
+    let parsed: AutoscalingMode = serde_json::from_str("\"horizontal\"").unwrap();
+    assert_eq!(parsed, AutoscalingMode::Horizontal);
+    assert_eq!(AutoscalingMode::default(), AutoscalingMode::Vertical);
+    assert_eq!(AutoscalingMode::Vertical.to_string(), "vertical");
+    assert_eq!(AutoscalingMode::Horizontal.to_string(), "horizontal");
+}
+
+#[test]
+fn autoscaling_mode_unknown_catch_all() {
+    let parsed: AutoscalingMode = serde_json::from_str("\"crystal\"").unwrap();
+    assert_eq!(parsed, AutoscalingMode::Unknown("crystal".to_string()));
+    assert_eq!(parsed.to_string(), "crystal");
+}
+
+#[test]
+fn pg_state_property_stopped() {
+    let parsed: PgStateProperty = serde_json::from_str("\"stopped\"").unwrap();
+    assert_eq!(parsed, PgStateProperty::Stopped);
+    assert_eq!(parsed.to_string(), "stopped");
+}
+
+#[test]
+fn service_region_ca_central_1() {
+    let parsed: ServiceRegion = serde_json::from_str("\"ca-central-1\"").unwrap();
+    assert_eq!(parsed, ServiceRegion::Ca_central_1);
+    assert_eq!(parsed.to_string(), "ca-central-1");
+}
+
+#[test]
+fn byoc_config_regionid_ca_central_1() {
+    let parsed: ByocConfigRegionid = serde_json::from_str("\"ca-central-1\"").unwrap();
+    assert_eq!(parsed, ByocConfigRegionid::Ca_central_1);
+    assert_eq!(parsed.to_string(), "ca-central-1");
+}
+
+#[test]
+fn click_pipe_schema_discovery_response_round_trip() {
+    let json = r#"{
+        "fields": [
+            {"name": "user_id", "type": "Int64", "optional": false},
+            {"name": "event", "type": "String", "optional": true}
+        ]
+    }"#;
+    let resp: ClickPipeSchemaDiscoveryResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(resp.fields.len(), 2);
+    assert_eq!(resp.fields[0].name, "user_id");
+    assert_eq!(resp.fields[0].r#type, "Int64");
+    assert_eq!(resp.fields[0].optional, Some(false));
+    assert_eq!(resp.fields[1].optional, Some(true));
+
+    let v = serde_json::to_value(&resp).unwrap();
+    assert_eq!(v["fields"][0]["name"], "user_id");
+    assert_eq!(v["fields"][0]["type"], "Int64");
+    assert_eq!(v["fields"][1]["optional"], true);
+}
+
+#[test]
+fn click_pipe_schema_discovery_request_kafka_source() {
+    let req = ClickPipeSchemaDiscoveryRequest {
+        source: ClickPipeSchemaDiscoverySource {
+            kafka: Some(ClickPipePostKafkaSource::default()),
+            kinesis: None,
+        },
+    };
+    let v = serde_json::to_value(&req).unwrap();
+    assert!(v["source"]["kafka"].is_object());
+    assert!(v["source"].get("kinesis").is_none());
+}
+
+#[test]
+fn click_pipe_schema_discovery_request_default_omits_sources() {
+    let v = serde_json::to_value(ClickPipeSchemaDiscoveryRequest::default()).unwrap();
+    assert!(v["source"].get("kafka").is_none());
+    assert!(v["source"].get("kinesis").is_none());
+}
+
+#[test]
+fn click_pipe_schema_discovery_field_nullable_optional() {
+    let json = r#"{"name": "col", "type": "Nullable(String)", "optional": null}"#;
+    let field: ClickPipeSchemaDiscoveryField = serde_json::from_str(json).unwrap();
+    assert_eq!(field.optional, None);
+    let v = serde_json::to_value(&field).unwrap();
+    assert!(v.get("optional").is_none());
+}
+
+#[test]
+fn mysql_source_server_id_optional() {
+    let json = r#"{"host": "h", "port": 3306, "settings": {"replicationMode": "gtid"}, "tableMappings": [], "serverId": 4242}"#;
+    let src: ClickPipeMySQLSource = serde_json::from_str(json).unwrap();
+    assert_eq!(src.server_id, Some(4242));
+
+    let json = r#"{"host": "h", "port": 3306, "settings": {"replicationMode": "gtid"}, "tableMappings": []}"#;
+    let src: ClickPipeMySQLSource = serde_json::from_str(json).unwrap();
+    assert_eq!(src.server_id, None);
+
+    let v = serde_json::to_value(ClickPipeMySQLSource {
+        server_id: Some(99),
+        ..Default::default()
+    })
+    .unwrap();
+    assert_eq!(v["serverId"], 99);
+    let v = serde_json::to_value(ClickPipeMySQLSource::default()).unwrap();
+    assert!(v.get("serverId").is_none());
+}
+
+#[test]
+fn mysql_patch_source_server_id_nullable() {
+    let json = r#"{"serverId": null}"#;
+    let src: ClickPipePatchMySQLSource = serde_json::from_str(json).unwrap();
+    assert_eq!(src.server_id, None);
+
+    let json = r#"{"serverId": 100}"#;
+    let src: ClickPipePatchMySQLSource = serde_json::from_str(json).unwrap();
+    assert_eq!(src.server_id, Some(100));
 }

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -438,6 +438,71 @@ fn compare_enums(
             .detail("key", pointer),
         );
     }
+
+    compare_enum_values_consts(rust, report);
+}
+
+fn compare_enum_values_consts(rust: &RustInventory, report: &mut DriftReport) {
+    for (name, info) in &rust.enums {
+        let Some(values_const) = &info.values_const else {
+            continue;
+        };
+        let rust_values = &info.values;
+        let missing: Vec<&String> = rust_values.difference(values_const).collect();
+        let extra: Vec<&String> = values_const.difference(rust_values).collect();
+        if missing.is_empty() && extra.is_empty() {
+            continue;
+        }
+        let mut parts = Vec::new();
+        if !missing.is_empty() {
+            let list = missing
+                .iter()
+                .map(|v| format!("{v:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!("missing {list}"));
+        }
+        if !extra.is_empty() {
+            let list = extra
+                .iter()
+                .map(|v| format!("{v:?}"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            parts.push(format!("extra {list}"));
+        }
+        let rust_item = format!("models.rs::{name}::VALUES");
+        let finding = Finding::new(
+            FindingKind::EnumValuesMismatch,
+            format!("{name}::VALUES does not match enum wire values: {}", parts.join("; ")),
+        )
+        .at_rust(&rust_item)
+        .detail("enum", name);
+        let finding = if !missing.is_empty() {
+            finding.detail(
+                "missing",
+                missing
+                    .iter()
+                    .map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        } else {
+            finding
+        };
+        let finding = if !extra.is_empty() {
+            finding.detail(
+                "extra",
+                extra
+                    .iter()
+                    .map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        } else {
+            finding
+        };
+        report.findings.push(finding);
+    }
 }
 
 fn mapping_rust_item(mapping: &EnumMapping) -> Option<String> {
@@ -993,5 +1058,125 @@ mod tests {
                 "missing fixture coverage for {expected:?}"
             );
         }
+    }
+
+    #[test]
+    fn enum_values_const_matching_produces_no_finding() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+            impl Color {
+                pub const VALUES: &'static [&'static str] = &["red", "blue"];
+            }
+        "#;
+        let report = analyze_fixture(
+            models,
+            serde_json::json!({"type": "string", "enum": ["red", "blue"]}),
+            AnalyzerConfig::default(),
+        );
+        let mismatch = report
+            .findings
+            .iter()
+            .find(|f| f.kind == FindingKind::EnumValuesMismatch);
+        assert!(
+            mismatch.is_none(),
+            "unexpected EnumValuesMismatch: {:?}",
+            mismatch
+        );
+    }
+
+    #[test]
+    fn enum_values_const_missing_value_reports_mismatch() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(rename = "green")]
+                Green,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+            impl Color {
+                pub const VALUES: &'static [&'static str] = &["red", "blue"];
+            }
+        "#;
+        let report = analyze_fixture(
+            models,
+            serde_json::json!({"type": "string", "enum": ["red", "blue", "green"]}),
+            AnalyzerConfig::default(),
+        );
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.kind == FindingKind::EnumValuesMismatch)
+            .expect("expected EnumValuesMismatch finding");
+        assert_eq!(finding.details.get("enum"), Some(&"Color".to_string()));
+        assert_eq!(finding.details.get("missing"), Some(&"green".to_string()));
+        assert!(
+            finding.rust_item.as_deref() == Some("models.rs::Color::VALUES"),
+            "unexpected rust_item: {:?}",
+            finding.rust_item
+        );
+    }
+
+    #[test]
+    fn enum_values_const_extra_value_reports_mismatch() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+            impl Color {
+                pub const VALUES: &'static [&'static str] = &["red", "blue", "green"];
+            }
+        "#;
+        let report = analyze_fixture(
+            models,
+            serde_json::json!({"type": "string", "enum": ["red", "blue"]}),
+            AnalyzerConfig::default(),
+        );
+        let finding = report
+            .findings
+            .iter()
+            .find(|f| f.kind == FindingKind::EnumValuesMismatch)
+            .expect("expected EnumValuesMismatch finding");
+        assert_eq!(finding.details.get("enum"), Some(&"Color".to_string()));
+        assert_eq!(finding.details.get("extra"), Some(&"green".to_string()));
+    }
+
+    #[test]
+    fn enum_without_values_const_produces_no_mismatch_finding() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+        "#;
+        let report = analyze_fixture(
+            models,
+            serde_json::json!({"type": "string", "enum": ["red", "blue"]}),
+            AnalyzerConfig::default(),
+        );
+        let mismatch = report
+            .findings
+            .iter()
+            .find(|f| f.kind == FindingKind::EnumValuesMismatch);
+        assert!(mismatch.is_none());
     }
 }

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -38,6 +38,7 @@ pub fn clickhouse_cloud_config() -> AnalyzerConfig {
 const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     // The legacy service-create schema marks almost every property required,
     // but the API requires only name/provider/region and rejects many defaults.
+    ("ServicePostRequest", "autoscalingMode"),
     ("ServicePostRequest", "byocId"),
     ("ServicePostRequest", "complianceType"),
     ("ServicePostRequest", "dataWarehouseId"),
@@ -54,7 +55,6 @@ const OPTIONALITY_EXEMPTIONS: &[(&str, &str)] = &[
     ("ServicePostRequest", "numReplicas"),
     ("ServicePostRequest", "maxReplicas"),
     ("ServicePostRequest", "minReplicas"),
-    ("ServicePostRequest", "replicaMemoryGb"),
     ("ServicePostRequest", "privateEndpointIds"),
     ("ServicePostRequest", "privatePreviewTermsChecked"),
     ("ServicePostRequest", "profile"),

--- a/crates/clickhouse-openapi-analyzer/src/report.rs
+++ b/crates/clickhouse-openapi-analyzer/src/report.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-pub const REPORT_SCHEMA_VERSION: u32 = 1;
+pub const REPORT_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -22,6 +22,7 @@ pub enum FindingKind {
     StrayDeprecatedMarker,
     MissingEnumValue,
     ExtraEnumValue,
+    EnumValuesMismatch,
     SnapshotAddedOperation,
     SnapshotRemovedOperation,
     SnapshotAddedSchema,

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -250,31 +250,38 @@ impl RustInventory {
                     self.model_types.insert(name.clone());
                     self.aliases.insert(name, TypeNode::from_syn(&item_type.ty));
                 }
-                Item::Impl(item_impl) => {
-                    let Type::Path(self_type) = item_impl.self_ty.as_ref() else {
-                        continue;
-                    };
-                    let target = self_type
-                        .path
-                        .segments
-                        .last()
-                        .map(|segment| segment.ident.unraw().to_string());
-                    let Some(name) = target else {
-                        continue;
-                    };
-                    let Some(enum_info) = self.enums.get_mut(&name) else {
-                        continue;
-                    };
-                    for impl_item in &item_impl.items {
-                        let ImplItem::Const(const_item) = impl_item else {
-                            continue;
-                        };
-                        if const_item.ident.unraw() == "VALUES" {
-                            enum_info.values_const = Some(string_array(&const_item.expr));
-                        }
-                    }
-                }
                 _ => {}
+            }
+        }
+        // Second pass: impl blocks may lexically precede their enum declaration.
+        for item in &file.items {
+            let Item::Impl(item_impl) = item else {
+                continue;
+            };
+            if item_impl.trait_.is_some() {
+                continue;
+            }
+            let Type::Path(self_type) = item_impl.self_ty.as_ref() else {
+                continue;
+            };
+            let target = self_type
+                .path
+                .segments
+                .last()
+                .map(|segment| segment.ident.unraw().to_string());
+            let Some(name) = target else {
+                continue;
+            };
+            let Some(enum_info) = self.enums.get_mut(&name) else {
+                continue;
+            };
+            for impl_item in &item_impl.items {
+                let ImplItem::Const(const_item) = impl_item else {
+                    continue;
+                };
+                if const_item.ident.unraw() == "VALUES" {
+                    enum_info.values_const = Some(string_array(&const_item.expr));
+                }
             }
         }
         Ok(())
@@ -568,7 +575,47 @@ mod tests {
             }
         "#;
         let inventory = RustInventory::parse("", models, "").unwrap();
-        assert!(!inventory.structs.contains_key("Widget") || !inventory.enums.contains_key("Widget"));
+        assert!(inventory.structs.contains_key("Widget"));
+        assert!(inventory.enums.values().all(|e| e.values_const.is_none()));
+    }
+
+    #[test]
+    fn inventories_values_const_when_impl_precedes_enum() {
+        let models = r#"
+            impl Color {
+                pub const VALUES: &'static [&'static str] = &["red", "blue"];
+            }
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+        "#;
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        assert_eq!(
+            inventory.enums["Color"].values_const,
+            Some(BTreeSet::from(["red".to_string(), "blue".to_string()]))
+        );
+    }
+
+    #[test]
+    fn values_const_in_trait_impl_is_ignored() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(other)]
+                Unknown,
+            }
+            impl Palette for Color {
+                const VALUES: &'static [&'static str] = &["stale"];
+            }
+        "#;
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        assert!(inventory.enums["Color"].values_const.is_none());
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -100,6 +100,7 @@ pub(crate) struct StructInfo {
 pub(crate) struct EnumInfo {
     pub(crate) values: BTreeSet<String>,
     pub(crate) is_value_enum: bool,
+    pub(crate) values_const: Option<BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -240,6 +241,7 @@ impl RustInventory {
                         EnumInfo {
                             values,
                             is_value_enum,
+                            values_const: None,
                         },
                     );
                 }
@@ -247,6 +249,30 @@ impl RustInventory {
                     let name = item_type.ident.unraw().to_string();
                     self.model_types.insert(name.clone());
                     self.aliases.insert(name, TypeNode::from_syn(&item_type.ty));
+                }
+                Item::Impl(item_impl) => {
+                    let Type::Path(self_type) = item_impl.self_ty.as_ref() else {
+                        continue;
+                    };
+                    let target = self_type
+                        .path
+                        .segments
+                        .last()
+                        .map(|segment| segment.ident.unraw().to_string());
+                    let Some(name) = target else {
+                        continue;
+                    };
+                    let Some(enum_info) = self.enums.get_mut(&name) else {
+                        continue;
+                    };
+                    for impl_item in &item_impl.items {
+                        let ImplItem::Const(const_item) = impl_item else {
+                            continue;
+                        };
+                        if const_item.ident.unraw() == "VALUES" {
+                            enum_info.values_const = Some(string_array(&const_item.expr));
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -500,6 +526,49 @@ mod tests {
             inventory.enums["State"].values,
             BTreeSet::from(["Ready".to_string()])
         );
+    }
+
+    #[test]
+    fn inventories_values_const_from_impl_block() {
+        let models = r#"
+            pub enum Color {
+                #[serde(rename = "red")]
+                Red,
+                #[serde(rename = "blue")]
+                Blue,
+                #[serde(untagged)]
+                Unknown(String),
+            }
+            impl Color {
+                pub const VALUES: &'static [&'static str] = &["red", "blue"];
+            }
+        "#;
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        assert_eq!(
+            inventory.enums["Color"].values_const,
+            Some(BTreeSet::from(["red".to_string(), "blue".to_string()]))
+        );
+    }
+
+    #[test]
+    fn values_const_absent_when_not_declared() {
+        let models = r#"
+            pub enum State { Ready, #[serde(other)] Unknown }
+        "#;
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        assert!(inventory.enums["State"].values_const.is_none());
+    }
+
+    #[test]
+    fn values_const_ignored_for_non_enum_impl() {
+        let models = r#"
+            pub struct Widget { pub name: String }
+            impl Widget {
+                pub const VALUES: &'static [&'static str] = &["a"];
+            }
+        "#;
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        assert!(!inventory.structs.contains_key("Widget") || !inventory.enums.contains_key("Widget"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -18,51 +18,6 @@ use clickhouse_cloud_api::models::{
 use std::io::{IsTerminal, Write};
 use tabled::{Table, Tabled, settings::Style};
 
-/// Known provider values for client-side validation (from OpenAPI spec).
-const KNOWN_PROVIDERS: &[&str] = &["aws", "gcp", "azure"];
-
-/// Known region values for client-side validation (from OpenAPI spec).
-const KNOWN_REGIONS: &[&str] = &[
-    "ap-northeast-1",
-    "ap-northeast-2",
-    "ap-south-1",
-    "ap-southeast-1",
-    "ap-southeast-2",
-    "eu-central-1",
-    "eu-west-1",
-    "eu-west-2",
-    "il-central-1",
-    "us-east-1",
-    "us-east-2",
-    "us-west-2",
-    "us-east1",
-    "us-central1",
-    "europe-west4",
-    "asia-southeast1",
-    "asia-northeast1",
-    "eastus",
-    "eastus2",
-    "westus3",
-    "germanywestcentral",
-    "centralus",
-];
-
-/// Known release channel values for client-side validation (from OpenAPI spec).
-const KNOWN_RELEASE_CHANNELS: &[&str] = &["slow", "default", "fast"];
-
-/// Known compliance type values for client-side validation (from OpenAPI spec).
-const KNOWN_COMPLIANCE_TYPES: &[&str] = &["hipaa", "pci"];
-
-/// Known service profile values for client-side validation (from OpenAPI spec).
-const KNOWN_PROFILES: &[&str] = &[
-    "v1-default",
-    "v1-highmem-xs",
-    "v1-highmem-s",
-    "v1-highmem-m",
-    "v1-highmem-l",
-    "v1-highmem-xl",
-];
-
 /// Resolve org ID from explicit arg or auto-detect
 pub(super) async fn resolve_org_id(
     client: &CloudClient,
@@ -644,12 +599,12 @@ fn build_create_service_request(
         provider: parse_serde_enum::<ServicePostRequestProvider>(
             &opts.provider,
             "provider",
-            KNOWN_PROVIDERS,
+            ServicePostRequestProvider::VALUES,
         )?,
         region: parse_serde_enum::<ServicePostRequestRegion>(
             &opts.region,
             "region",
-            KNOWN_REGIONS,
+            ServicePostRequestRegion::VALUES,
         )?,
         ip_access_list,
         min_replica_memory_gb: opts.min_replica_memory_gb.map(f64::from),
@@ -667,7 +622,7 @@ fn build_create_service_request(
             Some(value) => Some(parse_serde_enum::<ServicePostRequestReleasechannel>(
                 value,
                 "release_channel",
-                KNOWN_RELEASE_CHANNELS,
+                ServicePostRequestReleasechannel::VALUES,
             )?),
             None => None,
         },
@@ -681,7 +636,7 @@ fn build_create_service_request(
             Some(value) => Some(parse_serde_enum::<ServicePostRequestCompliancetype>(
                 value,
                 "compliance_type",
-                KNOWN_COMPLIANCE_TYPES,
+                ServicePostRequestCompliancetype::VALUES,
             )?),
             None => None,
         },
@@ -689,7 +644,7 @@ fn build_create_service_request(
             Some(value) => Some(parse_serde_enum::<ServicePostRequestProfile>(
                 value,
                 "profile",
-                KNOWN_PROFILES,
+                ServicePostRequestProfile::VALUES,
             )?),
             None => None,
         },
@@ -735,7 +690,7 @@ fn build_update_service_request(
                 parse_serde_enum::<ServicePatchRequestReleasechannel>(
                     value,
                     "release_channel",
-                    KNOWN_RELEASE_CHANNELS,
+                    ServicePatchRequestReleasechannel::VALUES,
                 )
             })
             .transpose()?,

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -701,10 +701,10 @@ fn build_create_service_request(
         endpoints: parse_service_endpoint_changes(&opts.enable_endpoints, &opts.disable_endpoints)?,
         enable_core_dumps: opts.enable_core_dumps,
         // Fields not exposed in CLI
+        autoscaling_mode: None,
         byoc_id: None,
         min_replicas: None,
         max_replicas: None,
-        replica_memory_gb: None,
         // Deprecated fields — only exist (and stay None) under the
         // `deprecated-fields` feature; gated out of the struct otherwise.
         #[cfg(feature = "deprecated-fields")]
@@ -1659,6 +1659,7 @@ pub async fn clickpipe_create_mysql(
         } else {
             None
         },
+        server_id: None,
         settings: ClickPipeMySQLPipeSettings {
             replication_mode: parse_enum(&args.replication_mode)?,
             replication_mechanism: Some(parse_enum(&args.replication_mechanism)?),
@@ -1961,10 +1962,10 @@ pub async fn service_scale(
         max_replica_memory_gb: opts.max_replica_memory_gb.map(f64::from),
         min_replicas: None,
         max_replicas: None,
-        replica_memory_gb: None,
         num_replicas: opts.num_replicas.map(f64::from),
         idle_scaling: opts.idle_scaling,
         idle_timeout_minutes: opts.idle_timeout_minutes.map(f64::from),
+        ..Default::default()
     };
 
     let svc = client

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -13,10 +13,6 @@ use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
 use tabled::{Table, Tabled, settings::Style};
 
-const KNOWN_PG_PROVIDERS: &[&str] = &["aws"];
-const KNOWN_PG_VERSIONS: &[&str] = &["18", "17"];
-const KNOWN_PG_HA_TYPES: &[&str] = &["none", "async", "sync"];
-
 #[derive(Subcommand)]
 pub enum PostgresCommands {
     /// List Postgres services in the organization
@@ -50,10 +46,10 @@ pub enum PostgresCommands {
         #[arg(long, default_value = "aws")]
         provider: String,
         /// Postgres major version
-        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(KNOWN_PG_VERSIONS))]
+        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgVersion::VALUES))]
         pg_version: Option<String>,
         /// High-availability type
-        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(KNOWN_PG_HA_TYPES))]
+        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgHaType::VALUES))]
         ha_type: Option<String>,
         /// Resource tag (repeatable), e.g. --tag env=prod
         #[arg(long)]
@@ -73,7 +69,7 @@ pub enum PostgresCommands {
         postgres_id: String,
         #[arg(long)]
         size: Option<String>,
-        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(KNOWN_PG_HA_TYPES))]
+        #[arg(long, value_parser = clap::builder::PossibleValuesParser::new(PgHaType::VALUES))]
         ha_type: Option<String>,
         /// Add a tag (repeatable), e.g. --add-tag env=prod
         #[arg(long)]
@@ -554,15 +550,15 @@ pub async fn postgres_create(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, opts.org_id).await?;
 
-    let provider: PgProvider = parse_serde_enum(opts.provider, "provider", KNOWN_PG_PROVIDERS)?;
+    let provider: PgProvider = parse_serde_enum(opts.provider, "provider", PgProvider::VALUES)?;
     let size = parse_pg_size(opts.size)?;
     let pg_version: Option<PgVersion> = opts
         .pg_version
-        .map(|v| parse_serde_enum(v, "pg-version", KNOWN_PG_VERSIONS))
+        .map(|v| parse_serde_enum(v, "pg-version", PgVersion::VALUES))
         .transpose()?;
     let ha_type: Option<PgHaType> = opts
         .ha_type
-        .map(|v| parse_serde_enum(v, "ha-type", KNOWN_PG_HA_TYPES))
+        .map(|v| parse_serde_enum(v, "ha-type", PgHaType::VALUES))
         .transpose()?;
     let tags = parse_tags(opts.tags)?;
     let pg_config = opts
@@ -621,7 +617,7 @@ pub async fn postgres_update(
     let size = opts.size.map(parse_pg_size).transpose()?;
     let ha_type = opts
         .ha_type
-        .map(|v| parse_serde_enum::<PgHaType>(v, "ha-type", KNOWN_PG_HA_TYPES))
+        .map(|v| parse_serde_enum::<PgHaType>(v, "ha-type", PgHaType::VALUES))
         .transpose()?;
 
     // Merge tag add/remove against current tags if any tag changes requested.

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -93,7 +93,7 @@ def run_analyzer(spec: dict) -> dict:
         report = json.loads(result.stdout)
     except json.JSONDecodeError as error:
         raise RuntimeError("OpenAPI analyzer emitted invalid JSON") from error
-    if report.get("schema_version") != 1:
+    if report.get("schema_version") != 2:
         raise RuntimeError(
             f"Unsupported DriftReport schema version: {report.get('schema_version')!r}"
         )
@@ -193,6 +193,7 @@ def build_issue_body(report: dict, live_spec: dict) -> str:
         f"| Extra struct fields | {counts['extra_struct_field']} |",
         f"| Missing enum values | {counts['missing_enum_value']} |",
         f"| Extra enum values | {counts['extra_enum_value']} |",
+        f"| Enum VALUES const mismatches | {counts['enum_values_mismatch']} |",
         f"| Field optionality mismatches | {counts['field_optionality_mismatch']} |",
         f"| Beta status changes | {total('newly_beta_operation', 'graduated_beta_operation')} |",
         f"| Deprecated-field changes | {total('newly_deprecated_field', 'undeprecated_field', 'missing_deprecated_marker', 'stray_deprecated_marker')} |",
@@ -238,6 +239,7 @@ def build_issue_body(report: dict, live_spec: dict) -> str:
         ("extra_struct_field", "Extra Struct Fields"),
         ("missing_enum_value", "Missing Enum Values"),
         ("extra_enum_value", "Extra Enum Values"),
+        ("enum_values_mismatch", "Enum VALUES Const Mismatches"),
         ("field_optionality_mismatch", "Field Optionality Mismatches"),
         ("newly_beta_operation", "Newly Beta Operations"),
         ("graduated_beta_operation", "Graduated Beta Operations"),

--- a/scripts/tests/test_check_openapi_drift.py
+++ b/scripts/tests/test_check_openapi_drift.py
@@ -16,7 +16,7 @@ SPEC.loader.exec_module(drift)
 class DriftScriptTests(unittest.TestCase):
     def test_groups_findings_and_renders_spec_snippets(self):
         report = {
-            "schema_version": 1,
+            "schema_version": 2,
             "findings": [
                 {
                     "kind": "missing_client_method",
@@ -30,7 +30,16 @@ class DriftScriptTests(unittest.TestCase):
                         "path": "/widgets",
                         "summary": "List widgets",
                     },
-                }
+                },
+                {
+                    "kind": "enum_values_mismatch",
+                    "message": "Color::VALUES does not match enum wire values: missing \"green\"",
+                    "rust_item": "models.rs::Color::VALUES",
+                    "details": {
+                        "enum": "Color",
+                        "missing": "green",
+                    },
+                },
             ],
             "unsupported_enum_constraints": [
                 {
@@ -57,6 +66,7 @@ class DriftScriptTests(unittest.TestCase):
         self.assertIn("## Missing Client Methods", body)
         self.assertIn('"operationId": "listWidgets"', body)
         self.assertIn("## Acknowledged Unsupported Enum Constraints", body)
+        self.assertIn("## Enum VALUES Const Mismatches", body)
 
     @mock.patch.object(drift.subprocess, "run")
     def test_analyzer_subprocess_failure_is_fatal(self, run):
@@ -68,7 +78,7 @@ class DriftScriptTests(unittest.TestCase):
     def test_analyzer_report_schema_is_validated(self, run):
         run.return_value = SimpleNamespace(
             returncode=0,
-            stdout=json.dumps({"schema_version": 2}),
+            stdout=json.dumps({"schema_version": 3}),
             stderr="",
         )
         with self.assertRaisesRegex(RuntimeError, "schema version"):


### PR DESCRIPTION
## Summary

Remediates all 36 actionable OpenAPI drift findings from #298. Library-only change; no new CLI surface.

### API library (`clickhouse-cloud-api`)

- **New client method**: `click_pipe_schema_discovery` (POST `/v1/organizations/{orgId}/services/{serviceId}/clickpipes/schemaDiscovery`, Beta)
- **4 new model types**: `ClickPipeSchemaDiscoveryField`, `ClickPipeSchemaDiscoveryRequest`, `ClickPipeSchemaDiscoveryResponse`, `ClickPipeSchemaDiscoverySource`
- **New shared enum**: `AutoscalingMode` (Vertical/Horizontal) used by 7 structs
- **10 new struct fields**:
  - `autoscalingMode` on `Service`, `ServicePostRequest`, `ServiceReplicaScalingPatchRequest`, `ServiceScalingPatchResponse`, `ScalingScheduleBaseConfig`, `ScalingScheduleEntry`, `ScalingScheduleEntryRequest`
  - `serverId` on `ClickPipeMySQLSource`, `ClickPipeMutateMySQLSource`, `ClickPipePatchMySQLSource`
- **5 removed extra fields**: `replicaMemoryGb` from 4 structs, `numReplicas` + `replicaMemoryGb` from `ScalingScheduleEntry`
- **9 new enum values**: `ca-central-1` added to 8 region enums; `stopped` added to `PgStateProperty`
- Regenerated `BETA_OPERATIONS` (42→43, adds `click_pipe_schema_discovery`)
- Replaced vendored OpenAPI snapshot with live spec (63→64 ops, 306→310 schemas)

### Analyzer (`clickhouse-openapi-analyzer`)

- Added optionality exemption `("ServicePostRequest", "autoscalingMode")` — server defaults to vertical when omitted
- Removed stale optionality exemption `("ServicePostRequest", "replicaMemoryGb")` — field no longer exists

### CLI (`clickhousectl`)

Compile fixes only (no new commands/flags):
- Added `autoscaling_mode`/`server_id` to struct constructions in `commands.rs`
- Removed `replica_memory_gb` from struct constructions in `commands.rs`

### Tests

- 10 new model tests: `AutoscalingMode` round-trip + catch-all, `PgStateProperty::Stopped`, `ServiceRegion`/`ByocConfigRegionid` ca-central-1, schema discovery response/request/field serde, MySQL `server_id`
- 1 new wiremock client test: `click_pipe_schema_discovery_kafka`
- Updated existing tests for removed/renamed fields

Closes #298.

## Verification

- [x] `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer` — all pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 3/3 pass
- [x] `python3 scripts/check-openapi-drift.py --dry-run` — **Actionable drift: 0**