### PR TITLE
Format workspace with cargo fmt and enforce it in CI

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Bulk formatting commits, skipped by git blame.
+# Enable locally with: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# (GitHub's blame view picks this file up automatically.)
+
+# Format entire workspace with cargo fmt
+d78a6d2aa40a70d9e1093f09ae987ca1b26e3e41

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,28 @@
+name: Format
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**.rs"
+      - ".github/workflows/fmt.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,8 @@ Test coverage is non-negotiable.
 
 CI enforces clippy, ensure you fix all warnings.
 
+CI enforces rustfmt (`cargo fmt --all --check`); run `cargo fmt` before committing. Bulk formatting commits are listed in `.git-blame-ignore-revs`.
+
 Use cargo build, cargo test, cargo clippy, locally.
 
 ### clickhouse-cloud-api library

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -52,10 +52,7 @@ fn derive_query_host(base_url: &str) -> Option<String> {
     let parsed = url::Url::parse(base_url).ok()?;
     let rest = parsed.host_str()?.strip_prefix("api.")?;
     let rest = rest.strip_prefix("control-plane.").unwrap_or(rest);
-    let port = parsed
-        .port()
-        .map(|p| format!(":{p}"))
-        .unwrap_or_default();
+    let port = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
     Some(format!("{}://queries.{}{}", parsed.scheme(), rest, port))
 }
 
@@ -83,10 +80,7 @@ impl Client {
     }
 
     /// Create a new client with Bearer token authentication and a custom base URL.
-    pub fn with_bearer_token(
-        base_url: impl Into<String>,
-        token: impl Into<String>,
-    ) -> Self {
+    pub fn with_bearer_token(base_url: impl Into<String>, token: impl Into<String>) -> Self {
         Self {
             http: reqwest::Client::new(),
             base_url: base_url.into().trim_end_matches('/').to_string(),
@@ -358,9 +352,7 @@ impl Client {
     }
 
     /// Get list of available organizations
-    pub async fn organization_get_list(
-        &self,
-    ) -> Result<ApiResponse<Vec<Organization>>, Error> {
+    pub async fn organization_get_list(&self) -> Result<ApiResponse<Vec<Organization>>, Error> {
         let path = "/v1/organizations".to_string();
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
@@ -507,7 +499,9 @@ impl Client {
         organization_id: &str,
         byoc_infrastructure_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/byocInfrastructure/{byoc_infrastructure_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/byocInfrastructure/{byoc_infrastructure_id}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -531,7 +525,9 @@ impl Client {
         byoc_infrastructure_id: &str,
         body: &ByocInfrastructurePatchRequest,
     ) -> Result<ApiResponse<ByocConfig>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/byocInfrastructure/{byoc_infrastructure_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/byocInfrastructure/{byoc_infrastructure_id}"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1091,7 +1087,8 @@ impl Client {
         organization_id: &str,
         postgres_id: &str,
     ) -> Result<String, Error> {
-        let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/caCertificates");
+        let path =
+            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/caCertificates");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1213,7 +1210,8 @@ impl Client {
         postgres_id: &str,
         body: &PostgresServiceReadReplicaRequest,
     ) -> Result<ApiResponse<PostgresService>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/readReplica");
+        let path =
+            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/readReplica");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1237,8 +1235,7 @@ impl Client {
         organization_id: &str,
         postgres_id: &str,
     ) -> Result<String, Error> {
-        let path =
-            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/prometheus");
+        let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/prometheus");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1284,7 +1281,8 @@ impl Client {
         postgres_id: &str,
         body: &PostgresServiceRestoreRequest,
     ) -> Result<ApiResponse<PostgresService>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/restoredService");
+        let path =
+            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/restoredService");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1337,8 +1335,7 @@ impl Client {
         to_date: &str,
         bucket_size_seconds: Option<i64>,
     ) -> Result<ApiResponse<PostgresMetrics>, Error> {
-        let path =
-            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/metrics");
+        let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/metrics");
         let mut req = self.request(reqwest::Method::GET, &path);
         req = req.query(&[("from_date", from_date), ("to_date", to_date)]);
         if let Some(v) = bucket_size_seconds {
@@ -1376,9 +1373,8 @@ impl Client {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<ApiResponse<Vec<PostgresSlowQueryPattern>>, Error> {
-        let path = format!(
-            "/v1/organizations/{organization_id}/postgres/{postgres_id}/slowQueryPatterns"
-        );
+        let path =
+            format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/slowQueryPatterns");
         let mut req = self.request(reqwest::Method::GET, &path);
         req = req.query(&[("from_date", from_date), ("to_date", to_date)]);
         if let Some(v) = db_name {
@@ -1644,7 +1640,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<BackupBucket>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1668,7 +1665,8 @@ impl Client {
         service_id: &str,
         body: &BackupBucketPostRequest,
     ) -> Result<ApiResponse<BackupBucket>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1693,7 +1691,8 @@ impl Client {
         service_id: &str,
         body: &BackupBucketPatchRequest,
     ) -> Result<ApiResponse<BackupBucket>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1717,7 +1716,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/backupBucket");
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1740,7 +1740,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<BackupConfiguration>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupConfiguration");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/backupConfiguration"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1764,7 +1766,9 @@ impl Client {
         service_id: &str,
         body: &BackupConfigurationPatchRequest,
     ) -> Result<ApiResponse<BackupConfiguration>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backupConfiguration");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/backupConfiguration"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1812,7 +1816,9 @@ impl Client {
         service_id: &str,
         backup_id: &str,
     ) -> Result<ApiResponse<Backup>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/backups/{backup_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/backups/{backup_id}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1884,7 +1890,9 @@ impl Client {
         service_id: &str,
         click_pipe_id: &str,
     ) -> Result<ApiResponse<ClickPipe>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1909,7 +1917,9 @@ impl Client {
         click_pipe_id: &str,
         body: &ClickPipePatchRequest,
     ) -> Result<ApiResponse<ClickPipe>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1934,7 +1944,9 @@ impl Client {
         service_id: &str,
         click_pipe_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -1959,7 +1971,9 @@ impl Client {
         click_pipe_id: &str,
         body: &ClickPipeScalingPatchRequest,
     ) -> Result<ApiResponse<ClickPipe>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/scaling");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/scaling"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -1984,7 +1998,9 @@ impl Client {
         service_id: &str,
         click_pipe_id: &str,
     ) -> Result<ApiResponse<ClickPipeSettings>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2009,7 +2025,9 @@ impl Client {
         click_pipe_id: &str,
         body: &ClickPipeSettingsPutRequest,
     ) -> Result<ApiResponse<ClickPipeSettings>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings"
+        );
         let mut req = self.request(reqwest::Method::PUT, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2035,7 +2053,9 @@ impl Client {
         click_pipe_id: &str,
         body: &ClickPipeStatePatchRequest,
     ) -> Result<ApiResponse<ClickPipe>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/state");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/state"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2059,7 +2079,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<ClickPipesCdcScaling>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesCdcScaling");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesCdcScaling"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2083,7 +2105,9 @@ impl Client {
         service_id: &str,
         body: &ClickPipesCdcScalingPatchRequest,
     ) -> Result<ApiResponse<ClickPipesCdcScaling>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesCdcScaling");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesCdcScaling"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2107,7 +2131,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<Vec<ReversePrivateEndpoint>>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2131,7 +2157,9 @@ impl Client {
         service_id: &str,
         body: &CreateReversePrivateEndpoint,
     ) -> Result<ApiResponse<ReversePrivateEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints"
+        );
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2156,7 +2184,9 @@ impl Client {
         service_id: &str,
         reverse_private_endpoint_id: &str,
     ) -> Result<ApiResponse<ReversePrivateEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2180,7 +2210,9 @@ impl Client {
         service_id: &str,
         reverse_private_endpoint_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2205,7 +2237,9 @@ impl Client {
         reverse_private_endpoint_id: &str,
         body: &UpdateReversePrivateEndpoint,
     ) -> Result<ApiResponse<ReversePrivateEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipesReversePrivateEndpoints/{reverse_private_endpoint_id}"
+        );
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2230,7 +2264,9 @@ impl Client {
         service_id: &str,
         body: &ClickPipeSchemaDiscoveryRequest,
     ) -> Result<ApiResponse<ClickPipeSchemaDiscoveryResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickpipes/schemaDiscovery");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/schemaDiscovery"
+        );
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2254,7 +2290,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<Vec<ClickStackAlertResponse>>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2278,7 +2315,8 @@ impl Client {
         service_id: &str,
         body: &ClickStackCreateAlertRequest,
     ) -> Result<ApiResponse<ClickStackAlertResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2303,7 +2341,9 @@ impl Client {
         service_id: &str,
         click_stack_alert_id: &str,
     ) -> Result<ApiResponse<ClickStackAlertResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2328,7 +2368,9 @@ impl Client {
         click_stack_alert_id: &str,
         body: &ClickStackUpdateAlertRequest,
     ) -> Result<ApiResponse<ClickStackAlertResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}"
+        );
         let mut req = self.request(reqwest::Method::PUT, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2353,7 +2395,9 @@ impl Client {
         service_id: &str,
         click_stack_alert_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/alerts/{click_stack_alert_id}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2376,7 +2420,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<Vec<ClickStackDashboardResponse>>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2400,7 +2446,9 @@ impl Client {
         service_id: &str,
         body: &ClickStackCreateDashboardRequest,
     ) -> Result<ApiResponse<ClickStackDashboardResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards"
+        );
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2425,7 +2473,9 @@ impl Client {
         service_id: &str,
         click_stack_dashboard_id: &str,
     ) -> Result<ApiResponse<ClickStackDashboardResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2450,7 +2500,9 @@ impl Client {
         click_stack_dashboard_id: &str,
         body: &ClickStackUpdateDashboardRequest,
     ) -> Result<ApiResponse<ClickStackDashboardResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}"
+        );
         let mut req = self.request(reqwest::Method::PUT, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2475,7 +2527,9 @@ impl Client {
         service_id: &str,
         click_stack_dashboard_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/dashboards/{click_stack_dashboard_id}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2498,7 +2552,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<Vec<ClickStackSource>>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2521,7 +2576,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<Vec<ClickStackWebhook>>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/webhooks");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickstack/webhooks"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2570,7 +2627,8 @@ impl Client {
         service_id: &str,
         body: &ServicPrivateEndpointePostRequest,
     ) -> Result<ApiResponse<InstancePrivateEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/privateEndpoint");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/privateEndpoint");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2594,7 +2652,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<PrivateEndpointConfig>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/privateEndpointConfig");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/privateEndpointConfig"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2645,7 +2705,8 @@ impl Client {
         service_id: &str,
         body: &ServiceReplicaScalingPatchRequest,
     ) -> Result<ApiResponse<ServiceScalingPatchResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/replicaScaling");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/replicaScaling");
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2696,7 +2757,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<ScalingSchedule>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2720,7 +2782,8 @@ impl Client {
         service_id: &str,
         body: &ScalingSchedulePostRequest,
     ) -> Result<ApiResponse<ScalingSchedule>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2744,7 +2807,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/scalingSchedule");
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2767,7 +2831,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<UpgradeWindow>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2791,7 +2856,8 @@ impl Client {
         service_id: &str,
         body: &UpgradeWindowPutRequest,
     ) -> Result<ApiResponse<UpgradeWindow>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
         let mut req = self.request(reqwest::Method::PUT, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2815,7 +2881,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/upgradeWindow");
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2838,7 +2905,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<ServiceQueryAPIEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2861,7 +2930,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2885,7 +2956,9 @@ impl Client {
         service_id: &str,
         body: &InstanceServiceQueryApiEndpointsPostRequest,
     ) -> Result<ApiResponse<ServiceQueryAPIEndpoint>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/serviceQueryEndpoint"
+        );
         let mut req = self.request(reqwest::Method::POST, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -2964,7 +3037,8 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<ServiceClickhouseSettingsList>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -2988,7 +3062,8 @@ impl Client {
         service_id: &str,
         body: &ServiceClickhouseSettingsPatchRequest,
     ) -> Result<ApiResponse<ServiceClickhouseSettingsPatchResponse>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings");
+        let path =
+            format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings");
         let mut req = self.request(reqwest::Method::PATCH, &path);
         req = req.json(body);
         let resp = req.send().await?;
@@ -3012,7 +3087,9 @@ impl Client {
         organization_id: &str,
         service_id: &str,
     ) -> Result<ApiResponse<ServiceClickhouseSettingsSchema>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/schema");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/schema"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -3036,7 +3113,9 @@ impl Client {
         service_id: &str,
         setting_name: &str,
     ) -> Result<ApiResponse<ServiceClickhouseSetting>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/{setting_name}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/{setting_name}"
+        );
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -3060,7 +3139,9 @@ impl Client {
         service_id: &str,
         setting_name: &str,
     ) -> Result<ApiResponse<serde_json::Value>, Error> {
-        let path = format!("/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/{setting_name}");
+        let path = format!(
+            "/v1/organizations/{organization_id}/services/{service_id}/clickhouseSettings/{setting_name}"
+        );
         let req = self.request(reqwest::Method::DELETE, &path);
         let resp = req.send().await?;
         let status = resp.status();
@@ -3076,7 +3157,6 @@ impl Client {
         }
         Ok(serde_json::from_str(&body_text)?)
     }
-
 }
 
 #[cfg(test)]

--- a/crates/clickhouse-cloud-api/src/lib.rs
+++ b/crates/clickhouse-cloud-api/src/lib.rs
@@ -25,5 +25,5 @@ pub mod serde_helpers;
 
 pub use client::Client;
 pub use error::Error;
-pub use meta::{is_beta_operation, is_deprecated_field, BETA_OPERATIONS, DEPRECATED_FIELDS};
+pub use meta::{BETA_OPERATIONS, DEPRECATED_FIELDS, is_beta_operation, is_deprecated_field};
 pub use models::*;

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -590,8 +590,12 @@ impl std::fmt::Display for ActivityType {
             Self::Transfer_service_out => write!(f, "transfer_service_out"),
             Self::Save_payment_method => write!(f, "save_payment_method"),
             Self::Marketplace_subscription => write!(f, "marketplace_subscription"),
-            Self::Migrate_marketplace_billing_details_in => write!(f, "migrate_marketplace_billing_details_in"),
-            Self::Migrate_marketplace_billing_details_out => write!(f, "migrate_marketplace_billing_details_out"),
+            Self::Migrate_marketplace_billing_details_in => {
+                write!(f, "migrate_marketplace_billing_details_in")
+            }
+            Self::Migrate_marketplace_billing_details_out => {
+                write!(f, "migrate_marketplace_billing_details_out")
+            }
             Self::Organization_update_tier => write!(f, "organization_update_tier"),
             Self::Organization_invite_create => write!(f, "organization_invite_create"),
             Self::Organization_invite_delete => write!(f, "organization_invite_delete"),
@@ -600,7 +604,9 @@ impl std::fmt::Display for ActivityType {
             Self::Organization_member_leave => write!(f, "organization_member_leave"),
             Self::Organization_member_delete => write!(f, "organization_member_delete"),
             Self::Organization_member_update_role => write!(f, "organization_member_update_role"),
-            Self::Organization_member_update_mfa_method => write!(f, "organization_member_update_mfa_method"),
+            Self::Organization_member_update_mfa_method => {
+                write!(f, "organization_member_update_mfa_method")
+            }
             Self::User_login => write!(f, "user_login"),
             Self::User_login_failed => write!(f, "user_login_failed"),
             Self::User_logout => write!(f, "user_logout"),
@@ -617,12 +623,22 @@ impl std::fmt::Display for ActivityType {
             Self::Service_delete => write!(f, "service_delete"),
             Self::Service_update_name => write!(f, "service_update_name"),
             Self::Service_update_ip_access_list => write!(f, "service_update_ip_access_list"),
-            Self::Service_update_autoscaling_memory => write!(f, "service_update_autoscaling_memory"),
-            Self::Service_update_autoscaling_idling => write!(f, "service_update_autoscaling_idling"),
+            Self::Service_update_autoscaling_memory => {
+                write!(f, "service_update_autoscaling_memory")
+            }
+            Self::Service_update_autoscaling_idling => {
+                write!(f, "service_update_autoscaling_idling")
+            }
             Self::Service_update_password => write!(f, "service_update_password"),
-            Self::Service_update_autoscaling_replicas => write!(f, "service_update_autoscaling_replicas"),
-            Self::Service_update_max_allowable_replicas => write!(f, "service_update_max_allowable_replicas"),
-            Self::Service_update_backup_configuration => write!(f, "service_update_backup_configuration"),
+            Self::Service_update_autoscaling_replicas => {
+                write!(f, "service_update_autoscaling_replicas")
+            }
+            Self::Service_update_max_allowable_replicas => {
+                write!(f, "service_update_max_allowable_replicas")
+            }
+            Self::Service_update_backup_configuration => {
+                write!(f, "service_update_backup_configuration")
+            }
             Self::Service_restore_backup => write!(f, "service_restore_backup"),
             Self::Service_update_release_channel => write!(f, "service_update_release_channel"),
             Self::Service_update_gpt_usage_consent => write!(f, "service_update_gpt_usage_consent"),
@@ -6261,12 +6277,24 @@ impl std::fmt::Display for ServiceTier {
             Self::Dedicated_high_mem => write!(f, "dedicated_high_mem"),
             Self::Dedicated_high_cpu => write!(f, "dedicated_high_cpu"),
             Self::Dedicated_standard => write!(f, "dedicated_standard"),
-            Self::Dedicated_standard_n2d_standard_4 => write!(f, "dedicated_standard_n2d_standard_4"),
-            Self::Dedicated_standard_n2d_standard_8 => write!(f, "dedicated_standard_n2d_standard_8"),
-            Self::Dedicated_standard_n2d_standard_32 => write!(f, "dedicated_standard_n2d_standard_32"),
-            Self::Dedicated_standard_n2d_standard_128 => write!(f, "dedicated_standard_n2d_standard_128"),
-            Self::Dedicated_standard_n2d_standard_32_16SSD => write!(f, "dedicated_standard_n2d_standard_32_16SSD"),
-            Self::Dedicated_standard_n2d_standard_64_24SSD => write!(f, "dedicated_standard_n2d_standard_64_24SSD"),
+            Self::Dedicated_standard_n2d_standard_4 => {
+                write!(f, "dedicated_standard_n2d_standard_4")
+            }
+            Self::Dedicated_standard_n2d_standard_8 => {
+                write!(f, "dedicated_standard_n2d_standard_8")
+            }
+            Self::Dedicated_standard_n2d_standard_32 => {
+                write!(f, "dedicated_standard_n2d_standard_32")
+            }
+            Self::Dedicated_standard_n2d_standard_128 => {
+                write!(f, "dedicated_standard_n2d_standard_128")
+            }
+            Self::Dedicated_standard_n2d_standard_32_16SSD => {
+                write!(f, "dedicated_standard_n2d_standard_32_16SSD")
+            }
+            Self::Dedicated_standard_n2d_standard_64_24SSD => {
+                write!(f, "dedicated_standard_n2d_standard_64_24SSD")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -6644,12 +6672,24 @@ impl std::fmt::Display for ServicePostRequestTier {
             Self::Dedicated_high_mem => write!(f, "dedicated_high_mem"),
             Self::Dedicated_high_cpu => write!(f, "dedicated_high_cpu"),
             Self::Dedicated_standard => write!(f, "dedicated_standard"),
-            Self::Dedicated_standard_n2d_standard_4 => write!(f, "dedicated_standard_n2d_standard_4"),
-            Self::Dedicated_standard_n2d_standard_8 => write!(f, "dedicated_standard_n2d_standard_8"),
-            Self::Dedicated_standard_n2d_standard_32 => write!(f, "dedicated_standard_n2d_standard_32"),
-            Self::Dedicated_standard_n2d_standard_128 => write!(f, "dedicated_standard_n2d_standard_128"),
-            Self::Dedicated_standard_n2d_standard_32_16SSD => write!(f, "dedicated_standard_n2d_standard_32_16SSD"),
-            Self::Dedicated_standard_n2d_standard_64_24SSD => write!(f, "dedicated_standard_n2d_standard_64_24SSD"),
+            Self::Dedicated_standard_n2d_standard_4 => {
+                write!(f, "dedicated_standard_n2d_standard_4")
+            }
+            Self::Dedicated_standard_n2d_standard_8 => {
+                write!(f, "dedicated_standard_n2d_standard_8")
+            }
+            Self::Dedicated_standard_n2d_standard_32 => {
+                write!(f, "dedicated_standard_n2d_standard_32")
+            }
+            Self::Dedicated_standard_n2d_standard_128 => {
+                write!(f, "dedicated_standard_n2d_standard_128")
+            }
+            Self::Dedicated_standard_n2d_standard_32_16SSD => {
+                write!(f, "dedicated_standard_n2d_standard_32_16SSD")
+            }
+            Self::Dedicated_standard_n2d_standard_64_24SSD => {
+                write!(f, "dedicated_standard_n2d_standard_64_24SSD")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -6952,12 +6992,24 @@ impl std::fmt::Display for ServiceScalingPatchResponseTier {
             Self::Dedicated_high_mem => write!(f, "dedicated_high_mem"),
             Self::Dedicated_high_cpu => write!(f, "dedicated_high_cpu"),
             Self::Dedicated_standard => write!(f, "dedicated_standard"),
-            Self::Dedicated_standard_n2d_standard_4 => write!(f, "dedicated_standard_n2d_standard_4"),
-            Self::Dedicated_standard_n2d_standard_8 => write!(f, "dedicated_standard_n2d_standard_8"),
-            Self::Dedicated_standard_n2d_standard_32 => write!(f, "dedicated_standard_n2d_standard_32"),
-            Self::Dedicated_standard_n2d_standard_128 => write!(f, "dedicated_standard_n2d_standard_128"),
-            Self::Dedicated_standard_n2d_standard_32_16SSD => write!(f, "dedicated_standard_n2d_standard_32_16SSD"),
-            Self::Dedicated_standard_n2d_standard_64_24SSD => write!(f, "dedicated_standard_n2d_standard_64_24SSD"),
+            Self::Dedicated_standard_n2d_standard_4 => {
+                write!(f, "dedicated_standard_n2d_standard_4")
+            }
+            Self::Dedicated_standard_n2d_standard_8 => {
+                write!(f, "dedicated_standard_n2d_standard_8")
+            }
+            Self::Dedicated_standard_n2d_standard_32 => {
+                write!(f, "dedicated_standard_n2d_standard_32")
+            }
+            Self::Dedicated_standard_n2d_standard_128 => {
+                write!(f, "dedicated_standard_n2d_standard_128")
+            }
+            Self::Dedicated_standard_n2d_standard_32_16SSD => {
+                write!(f, "dedicated_standard_n2d_standard_32_16SSD")
+            }
+            Self::Dedicated_standard_n2d_standard_64_24SSD => {
+                write!(f, "dedicated_standard_n2d_standard_64_24SSD")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7183,7 +7235,9 @@ impl std::fmt::Display for BackupBucketPatchRequest {
         match self {
             Self::AwsBackupBucketPatchRequestV1(_) => write!(f, "AwsBackupBucketPatchRequestV1"),
             Self::GcpBackupBucketPatchRequestV1(_) => write!(f, "GcpBackupBucketPatchRequestV1"),
-            Self::AzureBackupBucketPatchRequestV1(_) => write!(f, "AzureBackupBucketPatchRequestV1"),
+            Self::AzureBackupBucketPatchRequestV1(_) => {
+                write!(f, "AzureBackupBucketPatchRequestV1")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7312,7 +7366,9 @@ pub enum ClickStackBarChartConfig {
 impl std::fmt::Display for ClickStackBarChartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackBarBuilderChartConfig(_) => write!(f, "ClickStackBarBuilderChartConfig"),
+            Self::ClickStackBarBuilderChartConfig(_) => {
+                write!(f, "ClickStackBarBuilderChartConfig")
+            }
             Self::ClickStackBarRawSqlChartConfig(_) => write!(f, "ClickStackBarRawSqlChartConfig"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
@@ -7358,8 +7414,12 @@ pub enum ClickStackLineChartConfig {
 impl std::fmt::Display for ClickStackLineChartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackLineBuilderChartConfig(_) => write!(f, "ClickStackLineBuilderChartConfig"),
-            Self::ClickStackLineRawSqlChartConfig(_) => write!(f, "ClickStackLineRawSqlChartConfig"),
+            Self::ClickStackLineBuilderChartConfig(_) => {
+                write!(f, "ClickStackLineBuilderChartConfig")
+            }
+            Self::ClickStackLineRawSqlChartConfig(_) => {
+                write!(f, "ClickStackLineRawSqlChartConfig")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7378,8 +7438,12 @@ pub enum ClickStackNumberChartConfig {
 impl std::fmt::Display for ClickStackNumberChartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackNumberBuilderChartConfig(_) => write!(f, "ClickStackNumberBuilderChartConfig"),
-            Self::ClickStackNumberRawSqlChartConfig(_) => write!(f, "ClickStackNumberRawSqlChartConfig"),
+            Self::ClickStackNumberBuilderChartConfig(_) => {
+                write!(f, "ClickStackNumberBuilderChartConfig")
+            }
+            Self::ClickStackNumberRawSqlChartConfig(_) => {
+                write!(f, "ClickStackNumberRawSqlChartConfig")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7430,8 +7494,12 @@ impl Default for ClickStackOnClickTarget {
 impl std::fmt::Display for ClickStackOnClickTarget {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackOnClickTargetIdVariant(_) => write!(f, "ClickStackOnClickTargetIdVariant"),
-            Self::ClickStackOnClickTargetTemplateVariant(_) => write!(f, "ClickStackOnClickTargetTemplateVariant"),
+            Self::ClickStackOnClickTargetIdVariant(_) => {
+                write!(f, "ClickStackOnClickTargetIdVariant")
+            }
+            Self::ClickStackOnClickTargetTemplateVariant(_) => {
+                write!(f, "ClickStackOnClickTargetTemplateVariant")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7450,7 +7518,9 @@ pub enum ClickStackPieChartConfig {
 impl std::fmt::Display for ClickStackPieChartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackPieBuilderChartConfig(_) => write!(f, "ClickStackPieBuilderChartConfig"),
+            Self::ClickStackPieBuilderChartConfig(_) => {
+                write!(f, "ClickStackPieBuilderChartConfig")
+            }
             Self::ClickStackPieRawSqlChartConfig(_) => write!(f, "ClickStackPieRawSqlChartConfig"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
@@ -7494,8 +7564,12 @@ pub enum ClickStackTableChartConfig {
 impl std::fmt::Display for ClickStackTableChartConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::ClickStackTableBuilderChartConfig(_) => write!(f, "ClickStackTableBuilderChartConfig"),
-            Self::ClickStackTableRawSqlChartConfig(_) => write!(f, "ClickStackTableRawSqlChartConfig"),
+            Self::ClickStackTableBuilderChartConfig(_) => {
+                write!(f, "ClickStackTableBuilderChartConfig")
+            }
+            Self::ClickStackTableRawSqlChartConfig(_) => {
+                write!(f, "ClickStackTableRawSqlChartConfig")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -7655,11 +7729,19 @@ pub struct ApiKeyHashData {
 /// `ApiKeyPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKeyPatchRequest {
-    #[serde(rename = "assignedRoleIds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "assignedRoleIds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub assigned_role_ids: Option<Vec<uuid::Uuid>>,
     #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none", default)]
     pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "ipAccessList",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ip_access_list: Option<Vec<IpAccessListEntry>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
@@ -7736,7 +7818,11 @@ pub struct AwsBackupBucketPatchRequestV1 {
     pub bucket_provider: AwsBackupBucketPatchRequestV1Bucketprovider,
     #[serde(rename = "iamRoleArn", default)]
     pub iam_role_arn: String,
-    #[serde(rename = "iamRoleSessionName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "iamRoleSessionName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub iam_role_session_name: Option<String>,
 }
 
@@ -7854,11 +7940,23 @@ pub struct BackupConfiguration {
 /// `BackupConfigurationPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct BackupConfigurationPatchRequest {
-    #[serde(rename = "backupPeriodInHours", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "backupPeriodInHours",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub backup_period_in_hours: Option<f64>,
-    #[serde(rename = "backupRetentionPeriodInHours", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "backupRetentionPeriodInHours",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub backup_retention_period_in_hours: Option<f64>,
-    #[serde(rename = "backupStartTime", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "backupStartTime",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub backup_start_time: Option<String>,
 }
 
@@ -7901,7 +7999,11 @@ pub struct ByocConfig {
 /// `ByocInfrastructurePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ByocInfrastructurePatchRequest {
-    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub display_name: Option<String>,
 }
 
@@ -8024,9 +8126,17 @@ pub struct ClickPipeDestinationTableDefinition {
     // API rejects empty strings / empty arrays for these keys. Spec has no
     // `required` array so the description-heuristic treats them as required;
     // skip at serialize time when unset instead of modeling as Option<T>.
-    #[serde(rename = "partitionBy", skip_serializing_if = "String::is_empty", default)]
+    #[serde(
+        rename = "partitionBy",
+        skip_serializing_if = "String::is_empty",
+        default
+    )]
     pub partition_by: String,
-    #[serde(rename = "primaryKey", skip_serializing_if = "String::is_empty", default)]
+    #[serde(
+        rename = "primaryKey",
+        skip_serializing_if = "String::is_empty",
+        default
+    )]
     pub primary_key: String,
     #[serde(rename = "sortingKey", skip_serializing_if = "Vec::is_empty", default)]
     pub sorting_key: Vec<String>,
@@ -8043,7 +8153,11 @@ pub struct ClickPipeDestinationTableEngine {
     pub column_ids: Vec<String>,
     #[serde(default)]
     pub r#type: ClickPipeDestinationTableEngineType,
-    #[serde(rename = "versionColumnId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "versionColumnId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub version_column_id: Option<String>,
 }
 
@@ -8070,7 +8184,11 @@ pub struct ClickPipeKafkaOffset {
 pub struct ClickPipeKafkaSchemaRegistry {
     #[serde(default)]
     pub authentication: ClickPipeKafkaSchemaRegistryAuthentication,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(default)]
     pub url: String,
@@ -8092,11 +8210,23 @@ pub struct ClickPipeKafkaSource {
     pub authentication: ClickPipeKafkaSourceAuthentication,
     #[serde(default)]
     pub brokers: String,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
-    #[serde(rename = "consumerGroup", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "consumerGroup",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub consumer_group: Option<String>,
-    #[serde(rename = "exactlyOnce", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "exactlyOnce",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub exactly_once: Option<bool>,
     #[serde(default)]
     pub format: ClickPipeKafkaSourceFormat,
@@ -8104,9 +8234,17 @@ pub struct ClickPipeKafkaSource {
     pub iam_role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offset: Option<ClickPipeKafkaOffset>,
-    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
+    #[serde(
+        rename = "reversePrivateEndpointIds",
+        default,
+        deserialize_with = "crate::serde_helpers::null_to_empty"
+    )]
     pub reverse_private_endpoint_ids: Vec<String>,
-    #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "schemaRegistry",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schema_registry: Option<ClickPipeKafkaSchemaRegistry>,
     #[serde(default)]
     pub topics: String,
@@ -8131,26 +8269,54 @@ pub struct ClickPipeKinesisSource {
     pub stream_name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<i64>,
-    #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useEnhancedFanOut",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_enhanced_fan_out: Option<bool>,
 }
 
 /// `ClickPipeMongoDBPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMongoDBPipeSettings {
-    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "deleteOnMerge",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub delete_on_merge: Option<bool>,
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
     #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeMongoDBPipeSettingsReplicationmode,
-    #[serde(rename = "snapshotNumRowsPerPartition", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_num_rows_per_partition: Option<i64>,
-    #[serde(rename = "snapshotNumberOfParallelTables", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
-    #[serde(rename = "useJsonNativeFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useJsonNativeFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_json_native_format: Option<bool>,
 }
 
@@ -8161,7 +8327,11 @@ pub struct ClickPipeMongoDBPipeTableMapping {
     pub source_collection: String,
     #[serde(rename = "sourceDatabaseName")]
     pub source_database_name: String,
-    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableEngine",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_engine: Option<ClickPipeMongoDBPipeTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: String,
@@ -8170,17 +8340,33 @@ pub struct ClickPipeMongoDBPipeTableMapping {
 /// `ClickPipeMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMongoDBSource {
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     #[serde(rename = "readPreference")]
     pub read_preference: ClickPipeMongoDBSourceReadpreference,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settings: Option<ClickPipeMongoDBPipeSettings>,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableMappings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_mappings: Option<Vec<ClickPipeMongoDBPipeTableMapping>>,
     #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
     pub tls_host: Option<String>,
@@ -8212,13 +8398,21 @@ pub struct ClickPipeMutateDestination {
     pub columns: Vec<ClickPipeDestinationColumn>,
     #[serde(default)]
     pub database: String,
-    #[serde(rename = "managedTable", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "managedTable",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub managed_table: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub roles: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub table: Option<String>,
-    #[serde(rename = "tableDefinition", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableDefinition",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_definition: Option<ClickPipeDestinationTableDefinition>,
 }
 
@@ -8227,7 +8421,11 @@ pub struct ClickPipeMutateDestination {
 pub struct ClickPipeMutateKafkaSchemaRegistry {
     #[serde(default)]
     pub authentication: ClickPipeMutateKafkaSchemaRegistryAuthentication,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(default)]
     pub credentials: ClickPipeKafkaSchemaRegistryCredentials,
@@ -8238,16 +8436,28 @@ pub struct ClickPipeMutateKafkaSchemaRegistry {
 /// `ClickPipeMutateMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutateMongoDBSource {
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub credentials: Option<PLAIN>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     #[serde(rename = "readPreference")]
     pub read_preference: ClickPipeMutateMongoDBSourceReadpreference,
     pub settings: ClickPipeMongoDBPipeSettings,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeMongoDBPipeTableMapping>,
@@ -8261,11 +8471,19 @@ pub struct ClickPipeMutateMongoDBSource {
 pub struct ClickPipeMutateMySQLSource {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipeMutateMySQLSourceAuthentication>,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub credentials: Option<PLAIN>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     pub host: String,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
@@ -8274,7 +8492,11 @@ pub struct ClickPipeMutateMySQLSource {
     #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
     pub server_id: Option<i64>,
     pub settings: ClickPipeMySQLPipeSettings,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeMySQLPipeTableMapping>,
@@ -8292,7 +8514,11 @@ pub struct ClickPipeMutatePostgresSource {
     // caCertificate is `undefinedOr(isValidPEMCertificate)` server-side — sending
     // `""` (the bare-String default) fails PEM validation. Modeled as
     // `Option<String>` so callers can omit it.
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(default)]
     pub credentials: PLAIN,
@@ -8326,46 +8552,102 @@ pub struct ClickPipeMutatePostgresSource {
 /// `ClickPipeMySQLPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLPipeSettings {
-    #[serde(rename = "allowNullableColumns", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "allowNullableColumns",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub allow_nullable_columns: Option<bool>,
-    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "deleteOnMerge",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub delete_on_merge: Option<bool>,
-    #[serde(rename = "initialLoadParallelism", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub initial_load_parallelism: Option<i64>,
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
-    #[serde(rename = "replicationMechanism", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicationMechanism",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replication_mechanism: Option<ClickPipeMySQLPipeSettingsReplicationmechanism>,
     #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeMySQLPipeSettingsReplicationmode,
-    #[serde(rename = "snapshotNumRowsPerPartition", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_num_rows_per_partition: Option<i64>,
-    #[serde(rename = "snapshotNumberOfParallelTables", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
-    #[serde(rename = "useCompression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useCompression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_compression: Option<bool>,
 }
 
 /// `ClickPipeMySQLPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLPipeTableMapping {
-    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "excludedColumns",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub excluded_columns: Option<Vec<String>>,
-    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "partitionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub partition_key: Option<String>,
-    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sortingKeys",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sorting_keys: Option<Vec<String>>,
     #[serde(rename = "sourceSchemaName")]
     pub source_schema_name: String,
     #[serde(rename = "sourceTable")]
     pub source_table: String,
-    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableEngine",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_engine: Option<ClickPipeMySQLPipeTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: String,
-    #[serde(rename = "useCustomSortingKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useCustomSortingKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_custom_sorting_key: Option<bool>,
 }
 
@@ -8374,9 +8656,17 @@ pub struct ClickPipeMySQLPipeTableMapping {
 pub struct ClickPipeMySQLSource {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipeMySQLSourceAuthentication>,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     pub host: String,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
@@ -8385,7 +8675,11 @@ pub struct ClickPipeMySQLSource {
     #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
     pub server_id: Option<i64>,
     pub settings: ClickPipeMySQLPipeSettings,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeMySQLPipeTableMapping>,
@@ -8400,11 +8694,19 @@ pub struct ClickPipeMySQLSource {
 pub struct ClickPipeObjectStorageSource {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipeObjectStorageSourceAuthentication>,
-    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "azureContainerName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub azure_container_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub compression: Option<ClickPipeObjectStorageSourceCompression>,
-    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "connectionString",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub connection_string: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub delimiter: Option<String>,
@@ -8412,15 +8714,27 @@ pub struct ClickPipeObjectStorageSource {
     pub format: ClickPipeObjectStorageSourceFormat,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
-    #[serde(rename = "isContinuous", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "isContinuous",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub is_continuous: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub path: Option<String>,
     #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none", default)]
     pub queue_url: Option<String>,
-    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipInitialLoad",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_initial_load: Option<bool>,
-    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "startAfter",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub start_after: Option<String>,
     #[serde(default)]
     pub r#type: ClickPipeObjectStorageSourceType,
@@ -8440,13 +8754,21 @@ pub struct ClickPipePatchDestination {
 pub struct ClickPipePatchKafkaSource {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipePatchKafkaSourceAuthentication>,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(default)]
     pub credentials: serde_json::Value,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
-    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
+    #[serde(
+        rename = "reversePrivateEndpointIds",
+        default,
+        deserialize_with = "crate::serde_helpers::null_to_empty"
+    )]
     pub reverse_private_endpoint_ids: Vec<String>,
 }
 
@@ -8468,7 +8790,11 @@ pub struct ClickPipePatchMongoDBPipeRemoveTableMapping {
     pub source_collection: Option<String>,
     #[serde(rename = "sourceDatabaseName")]
     pub source_database_name: Option<String>,
-    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableEngine",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_engine: Option<ClickPipePatchMongoDBPipeRemoveTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: Option<String>,
@@ -8477,30 +8803,62 @@ pub struct ClickPipePatchMongoDBPipeRemoveTableMapping {
 /// `ClickPipePatchMongoDBPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMongoDBPipeSettings {
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
 }
 
 /// `ClickPipePatchMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMongoDBSource {
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub credentials: Option<PLAIN>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
-    #[serde(rename = "readPreference", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "readPreference",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub read_preference: Option<ClickPipePatchMongoDBSourceReadpreference>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settings: Option<ClickPipePatchMongoDBPipeSettings>,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappingsToAdd", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableMappingsToAdd",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_mappings_to_add: Option<Vec<ClickPipeMongoDBPipeTableMapping>>,
-    #[serde(rename = "tableMappingsToRemove", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableMappingsToRemove",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_mappings_to_remove: Option<Vec<ClickPipePatchMongoDBPipeRemoveTableMapping>>,
     #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
     pub tls_host: Option<String>,
@@ -8510,13 +8868,21 @@ pub struct ClickPipePatchMongoDBSource {
 /// `ClickPipePatchMySQLPipeRemoveTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLPipeRemoveTableMapping {
-    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "partitionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub partition_key: Option<String>,
     #[serde(rename = "sourceSchemaName")]
     pub source_schema_name: Option<String>,
     #[serde(rename = "sourceTable")]
     pub source_table: Option<String>,
-    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableEngine",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_engine: Option<ClickPipePatchMySQLPipeRemoveTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: Option<String>,
@@ -8525,11 +8891,23 @@ pub struct ClickPipePatchMySQLPipeRemoveTableMapping {
 /// `ClickPipePatchMySQLPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLPipeSettings {
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
-    #[serde(rename = "useCompression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useCompression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_compression: Option<bool>,
 }
 
@@ -8538,11 +8916,19 @@ pub struct ClickPipePatchMySQLPipeSettings {
 pub struct ClickPipePatchMySQLSource {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipePatchMySQLSourceAuthentication>,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub credentials: Option<PLAIN>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     pub host: Option<String>,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
@@ -8552,11 +8938,23 @@ pub struct ClickPipePatchMySQLSource {
     pub server_id: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub settings: Option<ClickPipePatchMySQLPipeSettings>,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappingsToAdd", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableMappingsToAdd",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_mappings_to_add: Option<Vec<ClickPipeMySQLPipeTableMapping>>,
-    #[serde(rename = "tableMappingsToRemove", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableMappingsToRemove",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_mappings_to_remove: Option<Vec<ClickPipePatchMySQLPipeRemoveTableMapping>>,
     #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
     pub tls_host: Option<String>,
@@ -8569,56 +8967,112 @@ pub struct ClickPipePatchObjectStorageSource {
     pub access_key: Option<MskIamUser>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipePatchObjectStorageSourceAuthentication>,
-    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "azureContainerName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub azure_container_name: Option<String>,
-    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "connectionString",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub connection_string: Option<String>,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub path: Option<String>,
-    #[serde(rename = "serviceAccountKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "serviceAccountKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub service_account_key: Option<String>,
-    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipInitialLoad",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_initial_load: Option<bool>,
-    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "startAfter",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub start_after: Option<String>,
 }
 
 /// `ClickPipePatchPostgresPipeRemoveTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresPipeRemoveTableMapping {
-    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "partitionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub partition_key: Option<String>,
-    #[serde(rename = "sourceSchemaName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sourceSchemaName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub source_schema_name: Option<String>,
-    #[serde(rename = "sourceTable", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sourceTable",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub source_table: Option<String>,
-    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "tableEngine",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub table_engine: Option<ClickPipePatchPostgresPipeRemoveTableMappingTableengine>,
-    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "targetTable",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub target_table: Option<String>,
 }
 
 /// `ClickPipePatchPostgresPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresPipeSettings {
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
 }
 
 /// `ClickPipePatchPostgresSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresSource {
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
     #[serde(default)]
     pub credentials: PLAIN,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub database: Option<String>,
-    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "disableTls",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub disable_tls: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub host: Option<String>,
@@ -8626,7 +9080,11 @@ pub struct ClickPipePatchPostgresSource {
     pub port: Option<i64>,
     #[serde(default)]
     pub settings: ClickPipePatchPostgresPipeSettings,
-    #[serde(rename = "skipCertVerification", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappingsToAdd", default)]
     pub table_mappings_to_add: Vec<ClickPipePostgresPipeTableMapping>,
@@ -8639,7 +9097,11 @@ pub struct ClickPipePatchPostgresSource {
 /// `ClickPipePatchPubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPubSubSource {
-    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "ackDeadline",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ack_deadline: Option<i64>,
     pub authentication: Option<ClickPipePatchPubSubSourceAuthentication>,
     #[serde(rename = "serviceAccountKey")]
@@ -8651,7 +9113,11 @@ pub struct ClickPipePatchPubSubSource {
 pub struct ClickPipePatchRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub destination: Option<ClickPipePatchDestination>,
-    #[serde(rename = "fieldMappings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "fieldMappings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub field_mappings: Option<Vec<ClickPipeFieldMapping>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
@@ -8672,7 +9138,11 @@ pub struct ClickPipePatchSource {
     pub mongodb: Option<ClickPipePatchMongoDBSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mysql: Option<ClickPipePatchMySQLSource>,
-    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "objectStorage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub object_storage: Option<ClickPipePatchObjectStorageSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub postgres: Option<ClickPipePatchPostgresSource>,
@@ -8689,13 +9159,25 @@ pub struct ClickPipePostKafkaSource {
     pub authentication: ClickPipePostKafkaSourceAuthentication,
     #[serde(default)]
     pub brokers: String,
-    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "caCertificate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ca_certificate: Option<String>,
-    #[serde(rename = "consumerGroup", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "consumerGroup",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub consumer_group: Option<String>,
     #[serde(default)]
     pub credentials: serde_json::Value,
-    #[serde(rename = "exactlyOnce", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "exactlyOnce",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub exactly_once: Option<bool>,
     #[serde(default)]
     pub format: ClickPipePostKafkaSourceFormat,
@@ -8703,9 +9185,17 @@ pub struct ClickPipePostKafkaSource {
     pub iam_role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub offset: Option<ClickPipeKafkaOffset>,
-    #[serde(rename = "reversePrivateEndpointIds", default, deserialize_with = "crate::serde_helpers::null_to_empty")]
+    #[serde(
+        rename = "reversePrivateEndpointIds",
+        default,
+        deserialize_with = "crate::serde_helpers::null_to_empty"
+    )]
     pub reverse_private_endpoint_ids: Vec<String>,
-    #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "schemaRegistry",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schema_registry: Option<ClickPipeMutateKafkaSchemaRegistry>,
     #[serde(default)]
     pub topics: String,
@@ -8732,7 +9222,11 @@ pub struct ClickPipePostKinesisSource {
     pub stream_name: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub timestamp: Option<i64>,
-    #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "useEnhancedFanOut",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub use_enhanced_fan_out: Option<bool>,
 }
 
@@ -8777,11 +9271,19 @@ pub struct ClickPipePostObjectStorageSource {
     pub access_key: Option<MskIamUser>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub authentication: Option<ClickPipePostObjectStorageSourceAuthentication>,
-    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "azureContainerName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub azure_container_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub compression: Option<ClickPipePostObjectStorageSourceCompression>,
-    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "connectionString",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub connection_string: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub delimiter: Option<String>,
@@ -8789,17 +9291,33 @@ pub struct ClickPipePostObjectStorageSource {
     pub format: ClickPipePostObjectStorageSourceFormat,
     #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
     pub iam_role: Option<String>,
-    #[serde(rename = "isContinuous", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "isContinuous",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub is_continuous: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub path: Option<String>,
     #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none", default)]
     pub queue_url: Option<String>,
-    #[serde(rename = "serviceAccountKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "serviceAccountKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub service_account_key: Option<String>,
-    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "skipInitialLoad",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub skip_initial_load: Option<bool>,
-    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "startAfter",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub start_after: Option<String>,
     #[serde(default)]
     pub r#type: ClickPipePostObjectStorageSourceType,
@@ -8810,17 +9328,29 @@ pub struct ClickPipePostObjectStorageSource {
 /// `ClickPipePostPubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostPubSubSource {
-    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "ackDeadline",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ack_deadline: Option<i64>,
     pub authentication: ClickPipePostPubSubSourceAuthentication,
-    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "enableOrdering",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub enable_ordering: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub filter: Option<String>,
     pub format: ClickPipePostPubSubSourceFormat,
     #[serde(rename = "projectId")]
     pub project_id: String,
-    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "seekTimestamp",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(rename = "seekType")]
     pub seek_type: ClickPipePostPubSubSourceSeektype,
@@ -8836,7 +9366,11 @@ pub struct ClickPipePostRequest {
     pub destination: ClickPipeMutateDestination,
     // Empty arrays rejected by some API paths and never useful on create —
     // skip when empty. Non-Option to match the spec description heuristic.
-    #[serde(rename = "fieldMappings", skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(
+        rename = "fieldMappings",
+        skip_serializing_if = "Vec::is_empty",
+        default
+    )]
     pub field_mappings: Vec<ClickPipeFieldMapping>,
     #[serde(default)]
     pub name: String,
@@ -8865,7 +9399,11 @@ pub struct ClickPipePostSource {
     pub mongodb: Option<ClickPipeMutateMongoDBSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mysql: Option<ClickPipeMutateMySQLSource>,
-    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "objectStorage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub object_storage: Option<ClickPipePostObjectStorageSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub postgres: Option<ClickPipeMutatePostgresSource>,
@@ -8884,21 +9422,49 @@ pub struct ClickPipePostgresPipeSettings {
     pub delete_on_merge: bool,
     #[serde(rename = "enableFailoverSlots", default)]
     pub enable_failover_slots: bool,
-    #[serde(rename = "initialLoadParallelism", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub initial_load_parallelism: Option<i64>,
-    #[serde(rename = "publicationName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "publicationName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub publication_name: Option<String>,
-    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pullBatchSize",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pull_batch_size: Option<i64>,
     #[serde(rename = "replicationMode", default)]
     pub replication_mode: ClickPipePostgresPipeSettingsReplicationmode,
-    #[serde(rename = "replicationSlotName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicationSlotName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replication_slot_name: Option<String>,
-    #[serde(rename = "snapshotNumRowsPerPartition", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_num_rows_per_partition: Option<i64>,
-    #[serde(rename = "snapshotNumberOfParallelTables", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
-    #[serde(rename = "syncIntervalSeconds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sync_interval_seconds: Option<i64>,
 }
 
@@ -8955,17 +9521,29 @@ pub struct ClickPipePostgresSource {
 /// `ClickPipePubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePubSubSource {
-    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "ackDeadline",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ack_deadline: Option<i64>,
     pub authentication: ClickPipePubSubSourceAuthentication,
-    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "enableOrdering",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub enable_ordering: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub filter: Option<String>,
     pub format: ClickPipePubSubSourceFormat,
     #[serde(rename = "projectId")]
     pub project_id: String,
-    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "seekTimestamp",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(rename = "seekType")]
     pub seek_type: ClickPipePubSubSourceSeektype,
@@ -8992,9 +9570,17 @@ pub struct ClickPipeScalingPatchRequest {
     #[cfg(feature = "deprecated-fields")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub concurrency: Option<i64>,
-    #[serde(rename = "replicaCpuMillicores", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicaCpuMillicores",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replica_cpu_millicores: Option<i64>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replica_memory_gb: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub replicas: Option<i64>,
@@ -9071,7 +9657,11 @@ pub struct ClickPipeSource {
     pub mongodb: Option<ClickPipeMongoDBSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub mysql: Option<ClickPipeMySQLSource>,
-    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "objectStorage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub object_storage: Option<ClickPipeObjectStorageSource>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub postgres: Option<ClickPipePostgresSource>,
@@ -9098,9 +9688,17 @@ pub struct ClickPipesCdcScaling {
 /// `ClickPipesCdcScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipesCdcScalingPatchRequest {
-    #[serde(rename = "replicaCpuMillicores", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicaCpuMillicores",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replica_cpu_millicores: Option<i64>,
-    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "replicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub replica_memory_gb: Option<f64>,
 }
 
@@ -9111,7 +9709,11 @@ pub struct ClickStackAggregatedColumn {
     pub agg_fn: String,
     #[serde(rename = "mvColumn")]
     pub mv_column: String,
-    #[serde(rename = "sourceColumn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sourceColumn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub source_column: Option<String>,
 }
 
@@ -9128,12 +9730,20 @@ pub struct ClickStackAlertChannelEmail {
 pub struct ClickStackAlertChannelWebhook {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub severity: Option<ClickStackAlertChannelWebhookSeverity>,
-    #[serde(rename = "slackChannelId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "slackChannelId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub slack_channel_id: Option<String>,
     pub r#type: ClickStackAlertChannelWebhookType,
     #[serde(rename = "webhookId")]
     pub webhook_id: String,
-    #[serde(rename = "webhookService", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "webhookService",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub webhook_service: Option<String>,
 }
 
@@ -9155,7 +9765,11 @@ pub struct ClickStackAlertResponse {
     pub channel: ClickStackAlertChannel,
     #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none", default)]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "dashboardId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub dashboard_id: Option<String>,
     #[serde(rename = "executionErrors", default)]
     pub execution_errors: Vec<ClickStackAlertExecutionError>,
@@ -9171,11 +9785,23 @@ pub struct ClickStackAlertResponse {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub note: Option<String>,
-    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedSearchId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_search_id: Option<String>,
-    #[serde(rename = "scheduleOffsetMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleOffsetMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleStartAt",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub silenced: Option<ClickStackAlertSilenced>,
@@ -9187,7 +9813,11 @@ pub struct ClickStackAlertResponse {
     pub team_id: String,
     #[serde(default)]
     pub threshold: f64,
-    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "thresholdMax",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub threshold_max: Option<f64>,
     #[serde(rename = "thresholdType", default)]
     pub threshold_type: ClickStackAlertResponseThresholdtype,
@@ -9211,7 +9841,11 @@ pub struct ClickStackAlertSilenced {
 /// `ClickStackBarBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBarBuilderChartConfig {
-    #[serde(rename = "alignDateRangeToGranularity", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub align_date_range_to_granularity: Option<bool>,
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
     pub as_ratio: Option<bool>,
@@ -9221,7 +9855,11 @@ pub struct ClickStackBarBuilderChartConfig {
     pub fill_nulls: Option<bool>,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackSelectItem>,
     #[serde(rename = "sourceId")]
@@ -9231,7 +9869,11 @@ pub struct ClickStackBarBuilderChartConfig {
 /// `ClickStackBarRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBarRawSqlChartConfig {
-    #[serde(rename = "alignDateRangeToGranularity", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub align_date_range_to_granularity: Option<bool>,
     #[serde(rename = "configType")]
     pub config_type: ClickStackBarRawSqlChartConfigConfigtype,
@@ -9241,7 +9883,11 @@ pub struct ClickStackBarRawSqlChartConfig {
     pub display_type: ClickStackBarRawSqlChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
@@ -9254,7 +9900,11 @@ pub struct ClickStackBarRawSqlChartConfig {
 pub struct ClickStackCreateAlertRequest {
     #[serde(default)]
     pub channel: ClickStackAlertChannel,
-    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "dashboardId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub dashboard_id: Option<String>,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
@@ -9266,17 +9916,33 @@ pub struct ClickStackCreateAlertRequest {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub note: Option<String>,
-    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedSearchId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_search_id: Option<String>,
-    #[serde(rename = "scheduleOffsetMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleOffsetMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleStartAt",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     pub source: ClickStackCreateAlertRequestSource,
     #[serde(default)]
     pub threshold: f64,
-    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "thresholdMax",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub threshold_max: Option<f64>,
     #[serde(rename = "thresholdType", default)]
     pub threshold_type: ClickStackCreateAlertRequestThresholdtype,
@@ -9292,11 +9958,23 @@ pub struct ClickStackCreateDashboardRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub filters: Option<Vec<ClickStackFilterInput>>,
     pub name: String,
-    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedFilterValues",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
-    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQuery",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query: Option<String>,
-    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQueryLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query_language: Option<ClickStackCreateDashboardRequestSavedquerylanguage>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -9335,11 +10013,23 @@ pub struct ClickStackDashboardResponse {
     pub id: String,
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedFilterValues",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
-    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQuery",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query: Option<String>,
-    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQueryLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query_language: Option<ClickStackDashboardResponseSavedquerylanguage>,
     #[serde(default)]
     pub tags: Vec<String>,
@@ -9355,12 +10045,20 @@ pub struct ClickStackFilter {
     pub name: String,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(rename = "sourceMetricType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sourceMetricType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub source_metric_type: Option<ClickStackFilterSourcemetrictype>,
     pub r#type: ClickStackFilterType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub r#where: Option<String>,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackFilterWherelanguage>,
 }
 
@@ -9371,12 +10069,20 @@ pub struct ClickStackFilterInput {
     pub name: String,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(rename = "sourceMetricType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sourceMetricType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub source_metric_type: Option<ClickStackFilterInputSourcemetrictype>,
     pub r#type: ClickStackFilterInputType,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub r#where: Option<String>,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackFilterInputWherelanguage>,
 }
 
@@ -9410,23 +10116,39 @@ pub struct ClickStackGenericWebhook {
 pub struct ClickStackHeatmapChartConfig {
     #[serde(rename = "displayType")]
     pub display_type: ClickStackHeatmapChartConfigDisplaytype,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackHeatmapSelectItem>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
     #[serde(rename = "where", skip_serializing_if = "Option::is_none", default)]
     pub r#where: Option<String>,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackHeatmapChartConfigWherelanguage>,
 }
 
 /// `ClickStackHeatmapSelectItem` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackHeatmapSelectItem {
-    #[serde(rename = "countExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "countExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub count_expression: Option<String>,
-    #[serde(rename = "heatmapScaleType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "heatmapScaleType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub heatmap_scale_type: Option<ClickStackHeatmapSelectItemHeatmapscaletype>,
     #[serde(rename = "valueExpression")]
     pub value_expression: String,
@@ -9437,7 +10159,11 @@ pub struct ClickStackHeatmapSelectItem {
 pub struct ClickStackHighlightedAttributeExpression {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub alias: Option<String>,
-    #[serde(rename = "luceneExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "luceneExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub lucene_expression: Option<String>,
     #[serde(rename = "sqlExpression")]
     pub sql_expression: String,
@@ -9462,11 +10188,19 @@ pub struct ClickStackIncidentIOWebhook {
 /// `ClickStackLineBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLineBuilderChartConfig {
-    #[serde(rename = "alignDateRangeToGranularity", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub align_date_range_to_granularity: Option<bool>,
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
     pub as_ratio: Option<bool>,
-    #[serde(rename = "compareToPreviousPeriod", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "compareToPreviousPeriod",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub compare_to_previous_period: Option<bool>,
     #[serde(rename = "displayType")]
     pub display_type: ClickStackLineBuilderChartConfigDisplaytype,
@@ -9474,7 +10208,11 @@ pub struct ClickStackLineBuilderChartConfig {
     pub fill_nulls: Option<bool>,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackSelectItem>,
     #[serde(rename = "sourceId")]
@@ -9484,9 +10222,17 @@ pub struct ClickStackLineBuilderChartConfig {
 /// `ClickStackLineRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLineRawSqlChartConfig {
-    #[serde(rename = "alignDateRangeToGranularity", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub align_date_range_to_granularity: Option<bool>,
-    #[serde(rename = "compareToPreviousPeriod", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "compareToPreviousPeriod",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub compare_to_previous_period: Option<bool>,
     #[serde(rename = "configType")]
     pub config_type: ClickStackLineRawSqlChartConfigConfigtype,
@@ -9496,7 +10242,11 @@ pub struct ClickStackLineRawSqlChartConfig {
     pub display_type: ClickStackLineRawSqlChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
@@ -9507,48 +10257,118 @@ pub struct ClickStackLineRawSqlChartConfig {
 /// `ClickStackLogSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLogSource {
-    #[serde(rename = "bodyExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "bodyExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub body_expression: Option<String>,
     pub connection: String,
     #[serde(rename = "defaultTableSelectExpression")]
     pub default_table_select_expression: String,
-    #[serde(rename = "displayedTimestampValueExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayedTimestampValueExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub displayed_timestamp_value_expression: Option<String>,
-    #[serde(rename = "eventAttributesExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "eventAttributesExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub event_attributes_expression: Option<String>,
-    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "filterSettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub filter_settings: Option<ClickStackSourceFilterSettings>,
     pub from: ClickStackSourceFrom,
-    #[serde(rename = "highlightedRowAttributeExpressions", skip_serializing_if = "Option::is_none", default)]
-    pub highlighted_row_attribute_expressions: Option<Vec<ClickStackHighlightedAttributeExpression>>,
-    #[serde(rename = "highlightedTraceAttributeExpressions", skip_serializing_if = "Option::is_none", default)]
-    pub highlighted_trace_attribute_expressions: Option<Vec<ClickStackHighlightedAttributeExpression>>,
+    #[serde(
+        rename = "highlightedRowAttributeExpressions",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub highlighted_row_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpression>>,
+    #[serde(
+        rename = "highlightedTraceAttributeExpressions",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub highlighted_trace_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpression>>,
     pub id: String,
-    #[serde(rename = "implicitColumnExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "implicitColumnExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub implicit_column_expression: Option<String>,
     pub kind: ClickStackLogSourceKind,
-    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "materializedViews",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub materialized_views: Option<Vec<ClickStackMaterializedView>>,
-    #[serde(rename = "metadataMaterializedViews", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metadataMaterializedViews",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metadata_materialized_views: Option<ClickStackLogSourceMetadataMaterializedViews>,
-    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_source_id: Option<String>,
     pub name: String,
-    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "querySettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
-    #[serde(rename = "resourceAttributesExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "resourceAttributesExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub resource_attributes_expression: Option<String>,
-    #[serde(rename = "serviceNameExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "serviceNameExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub service_name_expression: Option<String>,
-    #[serde(rename = "severityTextExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "severityTextExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub severity_text_expression: Option<String>,
-    #[serde(rename = "spanIdExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "spanIdExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub span_id_expression: Option<String>,
     #[serde(rename = "timestampValueExpression")]
     pub timestamp_value_expression: String,
-    #[serde(rename = "traceIdExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "traceIdExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub trace_id_expression: Option<String>,
-    #[serde(rename = "traceSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "traceSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub trace_source_id: Option<String>,
 }
 
@@ -9605,12 +10425,20 @@ pub struct ClickStackMetricSource {
     pub from: ClickStackMetricSourceFrom,
     pub id: String,
     pub kind: ClickStackMetricSourceKind,
-    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "logSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub log_source_id: Option<String>,
     #[serde(rename = "metricTables")]
     pub metric_tables: ClickStackMetricTables,
     pub name: String,
-    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "querySettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
     #[serde(rename = "resourceAttributesExpression")]
     pub resource_attributes_expression: String,
@@ -9647,7 +10475,11 @@ pub struct ClickStackMetricTables {
 pub struct ClickStackNumberBuilderChartConfig {
     #[serde(rename = "displayType")]
     pub display_type: ClickStackNumberBuilderChartConfigDisplaytype,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackSelectItem>,
     #[serde(rename = "sourceId")]
@@ -9665,11 +10497,23 @@ pub struct ClickStackNumberChartSeries {
     pub field: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub level: Option<f64>,
-    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricDataType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_data_type: Option<ClickStackNumberChartSeriesMetricdatatype>,
-    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_name: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
@@ -9711,7 +10555,11 @@ pub struct ClickStackNumberRawSqlChartConfig {
     pub connection_id: String,
     #[serde(rename = "displayType")]
     pub display_type: ClickStackNumberRawSqlChartConfigDisplaytype,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
@@ -9726,9 +10574,17 @@ pub struct ClickStackOnClickDashboard {
     pub filters: Option<Vec<ClickStackOnClickFilterTemplate>>,
     pub target: ClickStackOnClickTarget,
     pub r#type: ClickStackOnClickDashboardType,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackOnClickDashboardWherelanguage>,
-    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereTemplate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_template: Option<String>,
 }
 
@@ -9747,9 +10603,17 @@ pub struct ClickStackOnClickSearch {
     pub filters: Option<Vec<ClickStackOnClickFilterTemplate>>,
     pub target: ClickStackOnClickTarget,
     pub r#type: ClickStackOnClickSearchType,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackOnClickSearchWherelanguage>,
-    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereTemplate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_template: Option<String>,
 }
 
@@ -9790,7 +10654,11 @@ pub struct ClickStackPieBuilderChartConfig {
     pub display_type: ClickStackPieBuilderChartConfigDisplaytype,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackSelectItem>,
     #[serde(rename = "sourceId")]
@@ -9806,7 +10674,11 @@ pub struct ClickStackPieRawSqlChartConfig {
     pub connection_id: String,
     #[serde(rename = "displayType")]
     pub display_type: ClickStackPieRawSqlChartConfigDisplaytype,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
@@ -9864,19 +10736,43 @@ pub struct ClickStackSelectItem {
     pub alias: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub level: Option<ClickStackSelectItemLevel>,
-    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_name: Option<String>,
-    #[serde(rename = "metricType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_type: Option<ClickStackSelectItemMetrictype>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "periodAggFn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "periodAggFn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub period_agg_fn: Option<ClickStackSelectItemPeriodaggfn>,
-    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "valueExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub value_expression: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub r#where: Option<String>,
-    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "whereLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub where_language: Option<ClickStackSelectItemWherelanguage>,
 }
 
@@ -9888,9 +10784,17 @@ pub struct ClickStackSessionSource {
     pub id: String,
     pub kind: ClickStackSessionSourceKind,
     pub name: String,
-    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "querySettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
-    #[serde(rename = "timestampValueExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub timestamp_value_expression: Option<String>,
     #[serde(rename = "traceSourceId")]
     pub trace_source_id: String,
@@ -9956,11 +10860,19 @@ pub struct ClickStackTableBuilderChartConfig {
     pub display_type: ClickStackTableBuilderChartConfigDisplaytype,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
-    #[serde(rename = "groupByColumnsOnLeft", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "groupByColumnsOnLeft",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub group_by_columns_on_left: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub having: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "onClick", skip_serializing_if = "Option::is_none", default)]
     pub on_click: Option<ClickStackOnClick>,
@@ -9984,11 +10896,23 @@ pub struct ClickStackTableChartSeries {
     pub group_by: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub level: Option<f64>,
-    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricDataType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_data_type: Option<ClickStackTableChartSeriesMetricdatatype>,
-    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_name: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sortOrder", skip_serializing_if = "Option::is_none", default)]
     pub sort_order: Option<ClickStackTableChartSeriesSortorder>,
@@ -10009,7 +10933,11 @@ pub struct ClickStackTableRawSqlChartConfig {
     pub connection_id: String,
     #[serde(rename = "displayType")]
     pub display_type: ClickStackTableRawSqlChartConfigDisplaytype,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "onClick", skip_serializing_if = "Option::is_none", default)]
     pub on_click: Option<ClickStackOnClick>,
@@ -10027,7 +10955,11 @@ pub struct ClickStackTileInput {
     pub as_ratio: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub config: Option<ClickStackTileConfig>,
-    #[serde(rename = "containerId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "containerId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub container_id: Option<String>,
     pub h: i64,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -10048,7 +10980,11 @@ pub struct ClickStackTileInput {
 pub struct ClickStackTileOutput {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub config: Option<ClickStackTileConfig>,
-    #[serde(rename = "containerId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "containerId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub container_id: Option<String>,
     pub h: i64,
     pub id: String,
@@ -10067,7 +11003,11 @@ pub struct ClickStackTimeChartSeries {
     pub agg_fn: ClickStackTimeChartSeriesAggfn,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub alias: Option<String>,
-    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub display_type: Option<ClickStackTimeChartSeriesDisplaytype>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub field: Option<String>,
@@ -10075,11 +11015,23 @@ pub struct ClickStackTimeChartSeries {
     pub group_by: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub level: Option<f64>,
-    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricDataType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_data_type: Option<ClickStackTimeChartSeriesMetricdatatype>,
-    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_name: Option<String>,
-    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numberFormat",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
@@ -10093,45 +11045,107 @@ pub struct ClickStackTimeChartSeries {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTraceSource {
     pub connection: String,
-    #[serde(rename = "defaultTableSelectExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "defaultTableSelectExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub default_table_select_expression: Option<String>,
     #[serde(rename = "durationExpression")]
     pub duration_expression: String,
     #[serde(rename = "durationPrecision")]
     pub duration_precision: i64,
-    #[serde(rename = "eventAttributesExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "eventAttributesExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub event_attributes_expression: Option<String>,
-    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "filterSettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub filter_settings: Option<ClickStackSourceFilterSettings>,
     pub from: ClickStackSourceFrom,
-    #[serde(rename = "highlightedRowAttributeExpressions", skip_serializing_if = "Option::is_none", default)]
-    pub highlighted_row_attribute_expressions: Option<Vec<ClickStackHighlightedAttributeExpression>>,
-    #[serde(rename = "highlightedTraceAttributeExpressions", skip_serializing_if = "Option::is_none", default)]
-    pub highlighted_trace_attribute_expressions: Option<Vec<ClickStackHighlightedAttributeExpression>>,
+    #[serde(
+        rename = "highlightedRowAttributeExpressions",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub highlighted_row_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpression>>,
+    #[serde(
+        rename = "highlightedTraceAttributeExpressions",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub highlighted_trace_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpression>>,
     pub id: String,
-    #[serde(rename = "implicitColumnExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "implicitColumnExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub implicit_column_expression: Option<String>,
     pub kind: ClickStackTraceSourceKind,
-    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "logSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub log_source_id: Option<String>,
-    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "materializedViews",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub materialized_views: Option<Vec<ClickStackMaterializedView>>,
-    #[serde(rename = "metadataMaterializedViews", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metadataMaterializedViews",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metadata_materialized_views: Option<ClickStackTraceSourceMetadataMaterializedViews>,
-    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "metricSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub metric_source_id: Option<String>,
     pub name: String,
     #[serde(rename = "parentSpanIdExpression")]
     pub parent_span_id_expression: String,
-    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "querySettings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
-    #[serde(rename = "resourceAttributesExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "resourceAttributesExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub resource_attributes_expression: Option<String>,
-    #[serde(rename = "serviceNameExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "serviceNameExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub service_name_expression: Option<String>,
-    #[serde(rename = "sessionSourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "sessionSourceId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub session_source_id: Option<String>,
-    #[serde(rename = "spanEventsValueExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "spanEventsValueExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub span_events_value_expression: Option<String>,
     #[serde(rename = "spanIdExpression")]
     pub span_id_expression: String,
@@ -10139,9 +11153,17 @@ pub struct ClickStackTraceSource {
     pub span_kind_expression: String,
     #[serde(rename = "spanNameExpression")]
     pub span_name_expression: String,
-    #[serde(rename = "statusCodeExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "statusCodeExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub status_code_expression: Option<String>,
-    #[serde(rename = "statusMessageExpression", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "statusMessageExpression",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub status_message_expression: Option<String>,
     #[serde(rename = "timestampValueExpression")]
     pub timestamp_value_expression: String,
@@ -10165,7 +11187,11 @@ pub struct ClickStackTraceSourceMetadataMaterializedViews {
 pub struct ClickStackUpdateAlertRequest {
     #[serde(default)]
     pub channel: ClickStackAlertChannel,
-    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "dashboardId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub dashboard_id: Option<String>,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
@@ -10177,17 +11203,33 @@ pub struct ClickStackUpdateAlertRequest {
     pub name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub note: Option<String>,
-    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedSearchId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_search_id: Option<String>,
-    #[serde(rename = "scheduleOffsetMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleOffsetMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "scheduleStartAt",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     pub source: ClickStackUpdateAlertRequestSource,
     #[serde(default)]
     pub threshold: f64,
-    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "thresholdMax",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub threshold_max: Option<f64>,
     #[serde(rename = "thresholdType", default)]
     pub threshold_type: ClickStackUpdateAlertRequestThresholdtype,
@@ -10203,11 +11245,23 @@ pub struct ClickStackUpdateDashboardRequest {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub filters: Option<Vec<ClickStackFilter>>,
     pub name: String,
-    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedFilterValues",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
-    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQuery",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query: Option<String>,
-    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "savedQueryLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub saved_query_language: Option<ClickStackUpdateDashboardRequestSavedquerylanguage>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<String>>,
@@ -10217,23 +11271,51 @@ pub struct ClickStackUpdateDashboardRequest {
 /// `CreateReversePrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CreateReversePrivateEndpoint {
-    #[serde(rename = "customPrivateDnsMappings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "customPrivateDnsMappings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
     #[serde(default)]
     pub description: String,
-    #[serde(rename = "gcpServiceAttachment", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "gcpServiceAttachment",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub gcp_service_attachment: Option<String>,
-    #[serde(rename = "mskAuthentication", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "mskAuthentication",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub msk_authentication: Option<CreateReversePrivateEndpointMskauthentication>,
-    #[serde(rename = "mskClusterArn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "mskClusterArn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub msk_cluster_arn: Option<String>,
     #[serde(default)]
     pub r#type: CreateReversePrivateEndpointType,
-    #[serde(rename = "vpcEndpointServiceName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcEndpointServiceName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_endpoint_service_name: Option<String>,
-    #[serde(rename = "vpcResourceConfigurationId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcResourceConfigurationId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_resource_configuration_id: Option<String>,
-    #[serde(rename = "vpcResourceShareArn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcResourceShareArn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_resource_share_arn: Option<String>,
 }
 
@@ -10261,7 +11343,11 @@ pub struct CurrentScaling {
 /// `CustomPrivateDnsMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CustomPrivateDnsMapping {
-    #[serde(rename = "privateDnsName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "privateDnsName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub private_dns_name: Option<String>,
 }
 
@@ -10441,7 +11527,11 @@ pub struct Member {
 /// `MemberPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct MemberPatchRequest {
-    #[serde(rename = "assignedRoleIds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "assignedRoleIds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub assigned_role_ids: Option<Vec<String>>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -10506,11 +11596,19 @@ pub struct OrganizationPatchPrivateEndpoint {
 /// `OrganizationPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationPatchRequest {
-    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "enableCoreDumps",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub enable_core_dumps: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
-    #[serde(rename = "privateEndpoints", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "privateEndpoints",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub private_endpoints: Option<OrganizationPrivateEndpointsPatch>,
 }
 
@@ -10636,11 +11734,19 @@ pub struct PostgresServicePostRequest {
     #[serde(rename = "haType", skip_serializing_if = "Option::is_none", default)]
     pub ha_type: Option<PgHaType>,
     pub name: PgNameProperty,
-    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pgBouncerConfig",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
     #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
     pub pg_config: Option<PgConfig>,
-    #[serde(rename = "postgresVersion", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "postgresVersion",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub postgres_version: Option<PgVersion>,
     pub provider: PgProvider,
     pub region: PgRegion,
@@ -10653,7 +11759,11 @@ pub struct PostgresServicePostRequest {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceReadReplicaRequest {
     pub name: PgNameProperty,
-    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pgBouncerConfig",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
     #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
     pub pg_config: Option<PgConfig>,
@@ -10665,7 +11775,11 @@ pub struct PostgresServiceReadReplicaRequest {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceRestoreRequest {
     pub name: PgNameProperty,
-    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "pgBouncerConfig",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
     #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
     pub pg_config: Option<PgConfig>,
@@ -10748,9 +11862,17 @@ pub struct PostgresQueryExecution {
     pub duration_us: i64,
     #[serde(rename = "errElevel", skip_serializing_if = "Option::is_none", default)]
     pub err_elevel: Option<i64>,
-    #[serde(rename = "errMessage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "errMessage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub err_message: Option<String>,
-    #[serde(rename = "errSqlstate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "errSqlstate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub err_sqlstate: Option<String>,
     #[serde(rename = "jitDeformTimeUs", default)]
     pub jit_deform_time_us: i64,
@@ -10954,7 +12076,11 @@ pub struct ResourceTagsV1 {
 /// `ReversePrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ReversePrivateEndpoint {
-    #[serde(rename = "customPrivateDnsMappings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "customPrivateDnsMappings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
     #[serde(default)]
     pub description: String,
@@ -10962,13 +12088,25 @@ pub struct ReversePrivateEndpoint {
     pub dns_names: Vec<String>,
     #[serde(rename = "endpointId", default)]
     pub endpoint_id: String,
-    #[serde(rename = "gcpServiceAttachment", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "gcpServiceAttachment",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub gcp_service_attachment: Option<String>,
     #[serde(default)]
     pub id: uuid::Uuid,
-    #[serde(rename = "mskAuthentication", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "mskAuthentication",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub msk_authentication: Option<ReversePrivateEndpointMskauthentication>,
-    #[serde(rename = "mskClusterArn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "mskClusterArn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub msk_cluster_arn: Option<String>,
     #[serde(rename = "privateDnsNames", default)]
     pub private_dns_names: Vec<String>,
@@ -10978,11 +12116,23 @@ pub struct ReversePrivateEndpoint {
     pub status: ReversePrivateEndpointStatus,
     #[serde(default)]
     pub r#type: ReversePrivateEndpointType,
-    #[serde(rename = "vpcEndpointServiceName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcEndpointServiceName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_endpoint_service_name: Option<String>,
-    #[serde(rename = "vpcResourceConfigurationId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcResourceConfigurationId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_resource_configuration_id: Option<String>,
-    #[serde(rename = "vpcResourceShareArn", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "vpcResourceShareArn",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub vpc_resource_share_arn: Option<String>,
 }
 
@@ -11008,7 +12158,11 @@ pub struct RoleUpdateRequest {
 /// `ScalingSchedule` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingSchedule {
-    #[serde(rename = "activeEntryId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "activeEntryId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub active_entry_id: Option<uuid::Uuid>,
     #[serde(rename = "baseConfig", default)]
     pub base_config: ScalingScheduleBaseConfig,
@@ -11044,19 +12198,43 @@ pub struct ScalingScheduleEntry {
     pub end_hour_utc: i64,
     #[serde(default)]
     pub id: uuid::Uuid,
-    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleScaling",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_scaling: Option<bool>,
-    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_timeout_minutes: Option<i64>,
     #[serde(rename = "isActiveNow", default)]
     pub is_active_now: bool,
-    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replicas: Option<i64>,
-    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replicas: Option<i64>,
     #[serde(default)]
     pub name: String,
@@ -11069,25 +12247,57 @@ pub struct ScalingScheduleEntry {
 /// `ScalingScheduleEntryRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleEntryRequest {
-    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "autoscalingMode",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub autoscaling_mode: Option<AutoscalingMode>,
     #[serde(rename = "endHourUtc", default)]
     pub end_hour_utc: i64,
-    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleScaling",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_scaling: Option<bool>,
-    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_timeout_minutes: Option<i64>,
-    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replicas: Option<i64>,
-    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replicas: Option<i64>,
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub num_replicas: Option<i64>,
     #[serde(rename = "startHourUtc", default)]
     pub start_hour_utc: i64,
@@ -11133,7 +12343,11 @@ pub struct ScimEnterpriseUser {
 pub struct ScimGroup {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     pub id: uuid::Uuid,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -11183,7 +12397,11 @@ pub struct ScimGroupMeta {
 pub struct ScimGroupPostRequest {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub members: Option<Vec<ScimGroupMember>>,
@@ -11195,7 +12413,11 @@ pub struct ScimGroupPostRequest {
 pub struct ScimGroupPutRequest {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub id: Option<String>,
@@ -11244,12 +12466,20 @@ pub struct ScimUser {
     pub active: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub groups: Option<Vec<ScimUserGroup>>,
@@ -11262,13 +12492,25 @@ pub struct ScimUser {
     pub name: ScimUserName,
     #[serde(rename = "nickName", skip_serializing_if = "Option::is_none", default)]
     pub nick_name: Option<String>,
-    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "phoneNumbers",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "preferredLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub preferred_language: Option<String>,
-    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "profileUrl",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub profile_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub roles: Option<Vec<ScimUserRole>>,
@@ -11281,7 +12523,11 @@ pub struct ScimUser {
     pub user_name: String,
     #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
     pub user_type: Option<String>,
-    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "x509Certificates",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
@@ -11409,12 +12655,20 @@ pub struct ScimUserPostRequest {
     pub active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub groups: Option<Vec<ScimUserGroup>>,
@@ -11428,13 +12682,25 @@ pub struct ScimUserPostRequest {
     pub nick_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub password: Option<String>,
-    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "phoneNumbers",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "preferredLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub preferred_language: Option<String>,
-    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "profileUrl",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub profile_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub roles: Option<Vec<ScimUserRole>>,
@@ -11443,13 +12709,21 @@ pub struct ScimUserPostRequest {
     pub timezone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
-    #[serde(rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub urn_ietf_params_scim_schemas_extension_enterprise_2_0_user: Option<ScimEnterpriseUser>,
     #[serde(rename = "userName")]
     pub user_name: String,
     #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
     pub user_type: Option<String>,
-    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "x509Certificates",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
@@ -11460,12 +12734,20 @@ pub struct ScimUserPutRequest {
     pub active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "displayName",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "externalId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub external_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub groups: Option<Vec<ScimUserGroup>>,
@@ -11483,13 +12765,25 @@ pub struct ScimUserPutRequest {
     pub nick_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub password: Option<String>,
-    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "phoneNumbers",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "preferredLanguage",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub preferred_language: Option<String>,
-    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "profileUrl",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub profile_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub roles: Option<Vec<ScimUserRole>>,
@@ -11498,13 +12792,21 @@ pub struct ScimUserPutRequest {
     pub timezone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub title: Option<String>,
-    #[serde(rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub urn_ietf_params_scim_schemas_extension_enterprise_2_0_user: Option<ScimEnterpriseUser>,
     #[serde(rename = "userName")]
     pub user_name: String,
     #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
     pub user_type: Option<String>,
-    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "x509Certificates",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
@@ -11597,7 +12899,11 @@ pub struct ScimSchema {
 /// `ScimSchemaAttribute` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimSchemaAttribute {
-    #[serde(rename = "canonicalValues", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "canonicalValues",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub canonical_values: Option<Vec<String>>,
     #[serde(rename = "caseExact", skip_serializing_if = "Option::is_none", default)]
     pub case_exact: Option<bool>,
@@ -11606,11 +12912,19 @@ pub struct ScimSchemaAttribute {
     pub multi_valued: bool,
     pub mutability: String,
     pub name: String,
-    #[serde(rename = "referenceTypes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "referenceTypes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub reference_types: Option<Vec<String>>,
     pub required: bool,
     pub returned: String,
-    #[serde(rename = "subAttributes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "subAttributes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub sub_attributes: Option<Vec<ScimSchemaAttribute>>,
     #[serde(rename = "type")]
     pub r#type: String,
@@ -11655,7 +12969,11 @@ pub struct ScimServiceProviderConfig {
     pub bulk: ScimServiceProviderConfigBulk,
     #[serde(rename = "changePassword")]
     pub change_password: ScimBooleanFeature,
-    #[serde(rename = "documentationUri", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "documentationUri",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub documentation_uri: Option<String>,
     pub etag: ScimBooleanFeature,
     pub filter: ScimServiceProviderConfigFilter,
@@ -11727,9 +13045,17 @@ pub struct Service {
     pub data_warehouse_id: String,
     #[serde(rename = "enableCoreDumps", default)]
     pub enable_core_dumps: bool,
-    #[serde(rename = "encryptionAssumedRoleIdentifier", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionAssumedRoleIdentifier",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_key: Option<String>,
     #[serde(rename = "encryptionRoleId", default)]
     pub encryption_role_id: String,
@@ -11893,9 +13219,17 @@ pub struct ServiceEndpointChange {
 /// `ServicePasswordPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePasswordPatchRequest {
-    #[serde(rename = "newDoubleSha1Hash", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "newDoubleSha1Hash",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub new_double_sha1_hash: Option<String>,
-    #[serde(rename = "newPasswordHash", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "newPasswordHash",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub new_password_hash: Option<String>,
 }
 
@@ -11909,77 +13243,173 @@ pub struct ServicePasswordPatchResponse {
 /// `ServicePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePatchRequest {
-    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "enableCoreDumps",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub enable_core_dumps: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub endpoints: Option<Vec<ServiceEndpointChange>>,
-    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "ipAccessList",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub ip_access_list: Option<IpAccessListPatch>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub name: Option<String>,
-    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "privateEndpointIds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub private_endpoint_ids: Option<InstancePrivateEndpointsPatch>,
-    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "releaseChannel",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub release_channel: Option<ServicePatchRequestReleasechannel>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<InstanceTagsPatch>,
-    #[serde(rename = "transparentDataEncryptionKeyId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "transparentDataEncryptionKeyId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub transparent_data_encryption_key_id: Option<String>,
 }
 
 /// `ServicePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePostRequest {
-    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "autoscalingMode",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub autoscaling_mode: Option<AutoscalingMode>,
     #[serde(rename = "backupId", skip_serializing_if = "Option::is_none", default)]
     pub backup_id: Option<uuid::Uuid>,
     #[serde(rename = "byocId", skip_serializing_if = "Option::is_none", default)]
     pub byoc_id: Option<String>,
-    #[serde(rename = "complianceType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "complianceType",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub compliance_type: Option<ServicePostRequestCompliancetype>,
-    #[serde(rename = "dataWarehouseId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "dataWarehouseId",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub data_warehouse_id: Option<String>,
-    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "enableCoreDumps",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub enable_core_dumps: Option<bool>,
-    #[serde(rename = "encryptionAssumedRoleIdentifier", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionAssumedRoleIdentifier",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub endpoints: Option<Vec<ServiceEndpointChange>>,
-    #[serde(rename = "hasTransparentDataEncryption", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "hasTransparentDataEncryption",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub has_transparent_data_encryption: Option<bool>,
-    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleScaling",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_scaling: Option<bool>,
-    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_timeout_minutes: Option<f64>,
     #[serde(rename = "ipAccessList", default)]
     pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(rename = "isReadonly", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "isReadonly",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub is_readonly: Option<bool>,
-    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxTotalMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_total_memory_gb: Option<f64>,
-    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minTotalMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_total_memory_gb: Option<f64>,
     #[serde(default)]
     pub name: String,
-    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub num_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "privateEndpointIds",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub private_endpoint_ids: Option<Vec<String>>,
-    #[serde(rename = "privatePreviewTermsChecked", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "privatePreviewTermsChecked",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub private_preview_terms_checked: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub profile: Option<ServicePostRequestProfile>,
@@ -11987,7 +13417,11 @@ pub struct ServicePostRequest {
     pub provider: ServicePostRequestProvider,
     #[serde(default)]
     pub region: ServicePostRequestRegion,
-    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "releaseChannel",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub release_channel: Option<ServicePostRequestReleasechannel>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub tags: Option<Vec<ResourceTagsV1>>,
@@ -12021,38 +13455,90 @@ pub struct ServiceQueryAPIEndpoint {
 /// `ServiceReplicaScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceReplicaScalingPatchRequest {
-    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "autoscalingMode",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub autoscaling_mode: Option<AutoscalingMode>,
-    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleScaling",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_scaling: Option<bool>,
-    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_timeout_minutes: Option<f64>,
-    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_replicas: Option<f64>,
-    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_replicas: Option<f64>,
-    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub num_replicas: Option<f64>,
 }
 
 /// `ServiceScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceScalingPatchRequest {
-    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleScaling",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_scaling: Option<bool>,
-    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "idleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub idle_timeout_minutes: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "maxTotalMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub max_total_memory_gb: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "minTotalMemoryGb",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub min_total_memory_gb: Option<f64>,
-    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "numReplicas",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub num_replicas: Option<f64>,
 }
 
@@ -12077,9 +13563,17 @@ pub struct ServiceScalingPatchResponse {
     pub data_warehouse_id: String,
     #[serde(rename = "enableCoreDumps", default)]
     pub enable_core_dumps: bool,
-    #[serde(rename = "encryptionAssumedRoleIdentifier", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionAssumedRoleIdentifier",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "encryptionKey",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub encryption_key: Option<String>,
     #[serde(rename = "encryptionRoleId", default)]
     pub encryption_role_id: String,
@@ -12174,7 +13668,11 @@ pub struct UpgradeWindowPutRequest {
 /// `UpdateReversePrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UpdateReversePrivateEndpoint {
-    #[serde(rename = "customPrivateDnsMappings", skip_serializing_if = "Option::is_none", default)]
+    #[serde(
+        rename = "customPrivateDnsMappings",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
 }
 
@@ -12237,8 +13735,7 @@ pub struct UsageCostRecord {
 
 /// `pgBouncerConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
-pub struct PgBouncerConfig {
-}
+pub struct PgBouncerConfig {}
 
 /// `pgConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
@@ -12339,13 +13836,11 @@ pub struct ApiResponse<T> {
     pub error: Option<String>,
 }
 
-
 impl Default for BackupBucket {
     fn default() -> Self {
         Self::AwsBackupBucket(AwsBackupBucket::default())
     }
 }
-
 
 impl Default for BackupBucketPatchRequest {
     fn default() -> Self {
@@ -12353,13 +13848,11 @@ impl Default for BackupBucketPatchRequest {
     }
 }
 
-
 impl Default for BackupBucketPostRequest {
     fn default() -> Self {
         Self::AwsBackupBucketPostRequestV1(AwsBackupBucketPostRequestV1::default())
     }
 }
-
 
 impl Default for BackupBucketProperties {
     fn default() -> Self {
@@ -12367,13 +13860,11 @@ impl Default for BackupBucketProperties {
     }
 }
 
-
 impl Default for ClickStackAlertChannel {
     fn default() -> Self {
         Self::ClickStackAlertChannelEmail(ClickStackAlertChannelEmail::default())
     }
 }
-
 
 impl Default for ClickStackBarChartConfig {
     fn default() -> Self {
@@ -12381,13 +13872,11 @@ impl Default for ClickStackBarChartConfig {
     }
 }
 
-
 impl Default for ClickStackDashboardChartSeries {
     fn default() -> Self {
         Self::ClickStackTimeChartSeries(ClickStackTimeChartSeries::default())
     }
 }
-
 
 impl Default for ClickStackLineChartConfig {
     fn default() -> Self {
@@ -12395,13 +13884,11 @@ impl Default for ClickStackLineChartConfig {
     }
 }
 
-
 impl Default for ClickStackNumberChartConfig {
     fn default() -> Self {
         Self::ClickStackNumberBuilderChartConfig(ClickStackNumberBuilderChartConfig::default())
     }
 }
-
 
 impl Default for ClickStackPieChartConfig {
     fn default() -> Self {
@@ -12409,13 +13896,11 @@ impl Default for ClickStackPieChartConfig {
     }
 }
 
-
 impl Default for ClickStackSource {
     fn default() -> Self {
         Self::ClickStackLogSource(ClickStackLogSource::default())
     }
 }
-
 
 impl Default for ClickStackTableChartConfig {
     fn default() -> Self {
@@ -12423,13 +13908,11 @@ impl Default for ClickStackTableChartConfig {
     }
 }
 
-
 impl Default for ClickStackTileConfig {
     fn default() -> Self {
         Self::ClickStackLineChartConfig(ClickStackLineChartConfig::default())
     }
 }
-
 
 impl Default for ClickStackWebhook {
     fn default() -> Self {

--- a/crates/clickhouse-cloud-api/tests/clickpipes/driver.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/driver.rs
@@ -65,8 +65,8 @@ impl E2eHarness {
             .filter(|s| !s.is_empty())
         {
             Some(service_id) => {
-                let password = std::env::var("CLICKHOUSE_CLOUD_TEST_SERVICE_PASSWORD")
-                    .map_err(|_| {
+                let password =
+                    std::env::var("CLICKHOUSE_CLOUD_TEST_SERVICE_PASSWORD").map_err(|_| {
                         "CLICKHOUSE_CLOUD_TEST_SERVICE_ID set but \
                          CLICKHOUSE_CLOUD_TEST_SERVICE_PASSWORD missing"
                     })?;

--- a/crates/clickhouse-cloud-api/tests/clickpipes/e2e_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/e2e_test.rs
@@ -26,16 +26,15 @@ async fn cloud_clickpipe_e2e_all_sources() -> TestResult<()> {
     let mut harness = E2eHarness::provision("cloud_clickpipe_e2e_all_sources").await?;
 
     eprintln!("\n== Running stages in parallel ==");
-    let (s3_out, kafka_scram_out, kafka_mtls_out, kinesis_out, mysql_out, mongo_out, postgres_out) =
-        tokio::join!(
-            run_s3_stage(harness.make_stage_ctx()),
-            run_kafka_scram_tls_stage(harness.make_stage_ctx()),
-            run_kafka_mtls_stage(harness.make_stage_ctx()),
-            run_kinesis_stage(harness.make_stage_ctx()),
-            run_mysql_stage(harness.make_stage_ctx()),
-            run_mongo_stage(harness.make_stage_ctx()),
-            run_postgres_stage(harness.make_stage_ctx()),
-        );
+    let (s3_out, kafka_scram_out, kafka_mtls_out, kinesis_out, mysql_out, mongo_out, postgres_out) = tokio::join!(
+        run_s3_stage(harness.make_stage_ctx()),
+        run_kafka_scram_tls_stage(harness.make_stage_ctx()),
+        run_kafka_mtls_stage(harness.make_stage_ctx()),
+        run_kinesis_stage(harness.make_stage_ctx()),
+        run_mysql_stage(harness.make_stage_ctx()),
+        run_mongo_stage(harness.make_stage_ctx()),
+        run_postgres_stage(harness.make_stage_ctx()),
+    );
 
     let mut failures = Vec::new();
     for (name, outcome) in [

--- a/crates/clickhouse-cloud-api/tests/clickpipes/kafka_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/kafka_test.rs
@@ -24,10 +24,7 @@ async fn cloud_clickpipe_kafka() -> TestResult<()> {
     );
 
     let mut failures = Vec::new();
-    for (name, outcome) in [
-        ("kafka-scram-tls", scram_out),
-        ("kafka-mtls", mtls_out),
-    ] {
+    for (name, outcome) in [("kafka-scram-tls", scram_out), ("kafka-mtls", mtls_out)] {
         harness.collect(name, outcome, &mut failures);
     }
 

--- a/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
@@ -206,7 +206,10 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
         );
         let (pg_ready, ch_ready) = tokio::try_join!(pg_ready_fut, ch_ready_fut)?;
 
-        assert!(!pg_ready.connection_string.is_empty(), "empty pg connection string");
+        assert!(
+            !pg_ready.connection_string.is_empty(),
+            "empty pg connection string"
+        );
         assert!(!pg_ready.hostname.is_empty(), "empty pg hostname");
         let ch_endpoint = ch_ready
             .endpoints
@@ -318,10 +321,11 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                     let pipe = resp.result.ok_or("clickpipe get returned no result")?;
                     match pipe.state {
                         ClickPipeState::Running => Ok(Some(pipe)),
-                        ClickPipeState::Failed | ClickPipeState::InternalError => {
-                            Err(format!("clickpipe entered terminal failure state {}", pipe.state)
-                                .into())
-                        }
+                        ClickPipeState::Failed | ClickPipeState::InternalError => Err(format!(
+                            "clickpipe entered terminal failure state {}",
+                            pipe.state
+                        )
+                        .into()),
                         _ => Ok(None),
                     }
                 }
@@ -333,7 +337,12 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
 
         log_phase("Verify seed rows in ClickHouse");
 
-        let ch_query = ClickHouseQuery::new(&ch_endpoint.host, ch_endpoint.port as u16, &ch_username, &clickhouse_password);
+        let ch_query = ClickHouseQuery::new(
+            &ch_endpoint.host,
+            ch_endpoint.port as u16,
+            &ch_username,
+            &clickhouse_password,
+        );
 
         poll_until(
             "seed row count in ClickHouse",
@@ -357,7 +366,11 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                 "SELECT name FROM default.{TARGET_TABLE} WHERE id = 1 LIMIT 1"
             ))
             .await?;
-        assert_eq!(alice_name.as_deref(), Some("alice"), "row id=1 spot-check failed");
+        assert_eq!(
+            alice_name.as_deref(),
+            Some("alice"),
+            "row id=1 spot-check failed"
+        );
 
         // ── Insert more rows and verify ongoing CDC ─────────────────
 
@@ -573,4 +586,3 @@ impl ClickHouseQuery {
         }
     }
 }
-

--- a/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
@@ -99,7 +99,10 @@ async fn assert_create_shape_accepted(
     request: ClickPipePostRequest,
 ) -> TestResult<()> {
     let mut cleanup = CleanupRegistry::default();
-    eprintln!("create request body: {}", serde_json::to_string_pretty(&request)?);
+    eprintln!(
+        "create request body: {}",
+        serde_json::to_string_pretty(&request)?
+    );
 
     let outcome: TestResult<()> = match ctx
         .client
@@ -113,13 +116,17 @@ async fn assert_create_shape_accepted(
             }
             Ok(())
         }
-        Err(Error::Api { status: 400, message }) if is_runtime_error(&message) => {
+        Err(Error::Api {
+            status: 400,
+            message,
+        }) if is_runtime_error(&message) => {
             eprintln!("  shape accepted; runtime validation failed as expected: {message}");
             Ok(())
         }
-        Err(Error::Api { status: 400, message }) => {
-            Err(format!("shape rejected (HTTP 400): {message}").into())
-        }
+        Err(Error::Api {
+            status: 400,
+            message,
+        }) => Err(format!("shape rejected (HTTP 400): {message}").into()),
         Err(other) => Err(format!("create failed with non-shape error: {other}").into()),
     };
 
@@ -222,9 +229,7 @@ async fn cloud_clickpipe_create_kafka_msk_iam_smoke() -> TestResult<()> {
                 topics: "smoke-topic".to_string(),
                 authentication: ClickPipePostKafkaSourceAuthentication::IAM_ROLE,
                 credentials: serde_json::Value::Null,
-                iam_role: Some(
-                    "arn:aws:iam::000000000000:role/smoke-fake-role".to_string(),
-                ),
+                iam_role: Some("arn:aws:iam::000000000000:role/smoke-fake-role".to_string()),
                 offset: Some(ClickPipeKafkaOffset {
                     strategy: ClickPipeKafkaOffsetStrategy::From_beginning,
                     timestamp: None,
@@ -276,11 +281,8 @@ async fn cloud_clickpipe_create_s3_iam_user_smoke() -> TestResult<()> {
             object_storage: Some(ClickPipePostObjectStorageSource {
                 r#type: ClickPipePostObjectStorageSourceType::default(),
                 format: ClickPipePostObjectStorageSourceFormat::JSONEachRow,
-                url: "https://smoke-fake-bucket.s3.us-east-1.amazonaws.com/data/*.json"
-                    .to_string(),
-                authentication: Some(
-                    ClickPipePostObjectStorageSourceAuthentication::IAM_USER,
-                ),
+                url: "https://smoke-fake-bucket.s3.us-east-1.amazonaws.com/data/*.json".to_string(),
+                authentication: Some(ClickPipePostObjectStorageSourceAuthentication::IAM_USER),
                 access_key: Some(MskIamUser {
                     access_key_id: "AKIAFAKEKEYFORSMOKE".to_string(),
                     secret_key: "fake/secret/for/smoke/test/0000000000000000".to_string(),
@@ -305,14 +307,9 @@ async fn cloud_clickpipe_create_s3_iam_role_smoke() -> TestResult<()> {
             object_storage: Some(ClickPipePostObjectStorageSource {
                 r#type: ClickPipePostObjectStorageSourceType::default(),
                 format: ClickPipePostObjectStorageSourceFormat::JSONEachRow,
-                url: "https://smoke-fake-bucket.s3.us-east-1.amazonaws.com/data/*.json"
-                    .to_string(),
-                authentication: Some(
-                    ClickPipePostObjectStorageSourceAuthentication::IAM_ROLE,
-                ),
-                iam_role: Some(
-                    "arn:aws:iam::000000000000:role/smoke-fake-role".to_string(),
-                ),
+                url: "https://smoke-fake-bucket.s3.us-east-1.amazonaws.com/data/*.json".to_string(),
+                authentication: Some(ClickPipePostObjectStorageSourceAuthentication::IAM_ROLE),
+                iam_role: Some("arn:aws:iam::000000000000:role/smoke-fake-role".to_string()),
                 ..Default::default()
             }),
             ..Default::default()
@@ -353,8 +350,7 @@ async fn cloud_clickpipe_create_bigquery_snapshot_smoke() -> TestResult<()> {
                 },
                 snapshot_staging_path: "gs://smoke-fake-bucket/staging".to_string(),
                 settings: ClickPipeBigQueryPipeSettings {
-                    replication_mode:
-                        ClickPipeBigQueryPipeSettingsReplicationmode::Snapshot,
+                    replication_mode: ClickPipeBigQueryPipeSettingsReplicationmode::Snapshot,
                     ..Default::default()
                 },
                 table_mappings: vec![ClickPipeBigQueryPipeTableMapping {
@@ -421,11 +417,9 @@ async fn cloud_clickpipe_create_mongodb_cdc_smoke() -> TestResult<()> {
                     password: "smoke-pass".to_string(),
                 }),
                 uri: "mongodb://mongo.invalid:27017".to_string(),
-                read_preference:
-                    ClickPipeMutateMongoDBSourceReadpreference::Primary,
+                read_preference: ClickPipeMutateMongoDBSourceReadpreference::Primary,
                 settings: ClickPipeMongoDBPipeSettings {
-                    replication_mode:
-                        ClickPipeMongoDBPipeSettingsReplicationmode::Cdc,
+                    replication_mode: ClickPipeMongoDBPipeSettingsReplicationmode::Cdc,
                     ..Default::default()
                 },
                 table_mappings: vec![ClickPipeMongoDBPipeTableMapping {

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/kafka.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/kafka.rs
@@ -7,8 +7,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -20,10 +20,8 @@ use super::{
 const KAFKA_SCRAM_TLS_TARGET_TABLE: &str = "redpanda_scram_tls_users";
 const KAFKA_MTLS_TARGET_TABLE: &str = "redpanda_mtls_users";
 const KAFKA_SEED_ROW_COUNT: i64 = 3;
-const REDPANDA_SCRAM_TLS_USER_DATA: &str =
-    include_str!("redpanda_user_data_scram_tls.sh.template");
-const REDPANDA_MTLS_USER_DATA: &str =
-    include_str!("redpanda_user_data_mtls.sh.template");
+const REDPANDA_SCRAM_TLS_USER_DATA: &str = include_str!("redpanda_user_data_scram_tls.sh.template");
+const REDPANDA_MTLS_USER_DATA: &str = include_str!("redpanda_user_data_mtls.sh.template");
 
 const REDPANDA_INSTANCE_TYPE: &str = "t3.medium";
 const REDPANDA_BOOT_TIMEOUT_SECS: u64 = 600;
@@ -41,7 +39,9 @@ async fn launch_redpanda(
     user_data_with_ip: impl FnOnce(&str, &RedpandaCerts) -> String,
     client_cn: &str,
 ) -> TestResult<(String, RedpandaCerts)> {
-    log_phase(&format!("Kafka stage ({variant_tag}): allocate EIP + generate certs"));
+    log_phase(&format!(
+        "Kafka stage ({variant_tag}): allocate EIP + generate certs"
+    ));
 
     let (eip_address, allocation_id) = allocate_elastic_ip(ec2).await?;
     aws_cleanup.register_ec2_elastic_ip(allocation_id.clone());
@@ -94,7 +94,11 @@ pub async fn run_kafka_scram_tls_stage(sctx: StageCtx<'_>) -> StageOutcome {
         mut aws_cleanup,
     } = sctx;
     let result = run_scram_tls_inner(client, ctx, ch, ec2, &mut cleanup, &mut aws_cleanup).await;
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 async fn run_scram_tls_inner(
@@ -133,18 +137,25 @@ async fn run_scram_tls_inner(
             .replace("__CA_PEM_B64__", &b64(&certs.ca_pem))
     };
 
-    let (broker_ip, certs) =
-        launch_redpanda(ec2, ctx, aws_cleanup, "scram-tls", render_ud, "scram-tls-unused").await?;
-
-    log_phase("Kafka stage (scram-tls): wait for Redpanda to be reachable");
-    wait_for_tcp_port(&broker_ip, 9092, Duration::from_secs(REDPANDA_BOOT_TIMEOUT_SECS)).await?;
-    wait_for_redpanda_scram_user(
-        &broker_ip,
-        9644,
-        &clickpipe_user,
-        Duration::from_secs(180),
+    let (broker_ip, certs) = launch_redpanda(
+        ec2,
+        ctx,
+        aws_cleanup,
+        "scram-tls",
+        render_ud,
+        "scram-tls-unused",
     )
     .await?;
+
+    log_phase("Kafka stage (scram-tls): wait for Redpanda to be reachable");
+    wait_for_tcp_port(
+        &broker_ip,
+        9092,
+        Duration::from_secs(REDPANDA_BOOT_TIMEOUT_SECS),
+    )
+    .await?;
+    wait_for_redpanda_scram_user(&broker_ip, 9644, &clickpipe_user, Duration::from_secs(180))
+        .await?;
     // Tiny buffer after user appears: topic creation + ACL grants happen
     // right after, and ClickPipes can't consume without those.
     tokio::time::sleep(Duration::from_secs(15)).await;
@@ -221,7 +232,11 @@ pub async fn run_kafka_mtls_stage(sctx: StageCtx<'_>) -> StageOutcome {
         mut aws_cleanup,
     } = sctx;
     let result = run_mtls_inner(client, ctx, ch, ec2, &mut cleanup, &mut aws_cleanup).await;
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 async fn run_mtls_inner(
@@ -260,7 +275,12 @@ async fn run_mtls_inner(
         launch_redpanda(ec2, ctx, aws_cleanup, "mtls", render_ud, &client_cn).await?;
 
     log_phase("Kafka stage (mtls): wait for Redpanda to be reachable");
-    wait_for_tcp_port(&broker_ip, 9092, Duration::from_secs(REDPANDA_BOOT_TIMEOUT_SECS)).await?;
+    wait_for_tcp_port(
+        &broker_ip,
+        9092,
+        Duration::from_secs(REDPANDA_BOOT_TIMEOUT_SECS),
+    )
+    .await?;
     tokio::time::sleep(Duration::from_secs(60)).await;
 
     log_phase("Kafka stage (mtls): create ClickPipe");

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/kinesis.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/kinesis.rs
@@ -8,8 +8,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -21,9 +21,18 @@ use super::{
 const KINESIS_TARGET_TABLE: &str = "kinesis_users";
 const KINESIS_SEED_ROW_COUNT: i64 = 3;
 const KINESIS_SEED_RECORDS: &[(&str, &str)] = &[
-    ("1", "{\"id\": 1, \"name\": \"Ada Lovelace\", \"email\": \"ada@example.com\"}"),
-    ("2", "{\"id\": 2, \"name\": \"Grace Hopper\", \"email\": \"grace@example.com\"}"),
-    ("3", "{\"id\": 3, \"name\": \"Margaret Hamilton\", \"email\": \"margaret@example.com\"}"),
+    (
+        "1",
+        "{\"id\": 1, \"name\": \"Ada Lovelace\", \"email\": \"ada@example.com\"}",
+    ),
+    (
+        "2",
+        "{\"id\": 2, \"name\": \"Grace Hopper\", \"email\": \"grace@example.com\"}",
+    ),
+    (
+        "3",
+        "{\"id\": 3, \"name\": \"Margaret Hamilton\", \"email\": \"margaret@example.com\"}",
+    ),
 ];
 
 const DEFAULT_CLICKPIPE_READY_TIMEOUT_SECS: u64 = 600;
@@ -58,7 +67,11 @@ pub async fn run_kinesis_stage(sctx: StageCtx<'_>) -> StageOutcome {
     )
     .await;
 
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -141,14 +154,8 @@ async fn run_inner(
     })
     .to_string();
 
-    let role_arn = create_clickpipes_iam_role(
-        iam,
-        &role_name,
-        &ch.iam_role,
-        &read_policy,
-        &aws_tags,
-    )
-    .await?;
+    let role_arn =
+        create_clickpipes_iam_role(iam, &role_name, &ch.iam_role, &read_policy, &aws_tags).await?;
     aws_cleanup.register_iam_role(role_name.clone());
     eprintln!("  created iam role {role_name}");
 

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
@@ -12,8 +12,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -179,17 +179,22 @@ pub async fn verify_seed_rows(
     ingest_timeout: Duration,
     poll_interval: Duration,
 ) -> TestResult<()> {
-    poll_until("seeded row count in ClickHouse", ingest_timeout, poll_interval, || {
-        let query = ch.query.clone();
-        let table = table.to_string();
-        async move {
-            match query.count_rows(&table).await {
-                Ok(count) if count >= expected_count => Ok(Some(count)),
-                Ok(_) => Ok(None),
-                Err(e) => Err(e),
+    poll_until(
+        "seeded row count in ClickHouse",
+        ingest_timeout,
+        poll_interval,
+        || {
+            let query = ch.query.clone();
+            let table = table.to_string();
+            async move {
+                match query.count_rows(&table).await {
+                    Ok(count) if count >= expected_count => Ok(Some(count)),
+                    Ok(_) => Ok(None),
+                    Err(e) => Err(e),
+                }
             }
-        }
-    })
+        },
+    )
     .await?;
     let actual = ch
         .query
@@ -230,7 +235,9 @@ pub fn random_token(len: usize) -> String {
     let charset: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     let mut out = String::with_capacity(len);
     for _ in 0..len {
-        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         out.push(charset[(state >> 33) as usize % charset.len()] as char);
     }
     out
@@ -239,7 +246,7 @@ pub fn random_token(len: usize) -> String {
 /// Base64-encode a string for embedding in user_data templates without
 /// escaping issues (multi-line PEMs etc.).
 pub fn b64(s: &str) -> String {
-    use base64::engine::general_purpose::STANDARD;
     use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD;
     STANDARD.encode(s.as_bytes())
 }

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/mongo.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/mongo.rs
@@ -11,8 +11,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -54,7 +54,10 @@ async fn launch_mongo(
     let subnet_id = first_subnet_in_vpc(ec2, &vpc_id).await?;
     let ami_id = latest_ubuntu_noble_amd64_ami(ec2).await?;
 
-    let sg_name = format!("clickhousectl-e2e-mongo-{}", sanitize_for_topic(&ctx.run_id));
+    let sg_name = format!(
+        "clickhousectl-e2e-mongo-{}",
+        sanitize_for_topic(&ctx.run_id)
+    );
     let sg_id = create_open_security_group(ec2, &vpc_id, &sg_name, &[27017]).await?;
     aws_cleanup.register_ec2_security_group(sg_id.clone());
     eprintln!("  created security group {sg_id}");
@@ -68,7 +71,10 @@ async fn launch_mongo(
         &sg_id,
         MONGO_INSTANCE_TYPE,
         &user_data,
-        &format!("clickhousectl-e2e-mongo-{}", sanitize_for_topic(&ctx.run_id)),
+        &format!(
+            "clickhousectl-e2e-mongo-{}",
+            sanitize_for_topic(&ctx.run_id)
+        ),
     )
     .await?;
     aws_cleanup.register_ec2_instance(instance_id.clone());
@@ -95,7 +101,11 @@ pub async fn run_mongo_stage(sctx: StageCtx<'_>) -> StageOutcome {
         mut aws_cleanup,
     } = sctx;
     let result = run_inner(client, ctx, ch, ec2, &mut cleanup, &mut aws_cleanup).await;
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 async fn run_inner(

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/mysql.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/mysql.rs
@@ -7,8 +7,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -82,7 +82,10 @@ async fn launch_mysql(
     let subnet_id = first_subnet_in_vpc(ec2, &vpc_id).await?;
     let ami_id = latest_ubuntu_noble_amd64_ami(ec2).await?;
 
-    let sg_name = format!("clickhousectl-e2e-mysql-{}", sanitize_for_topic(&ctx.run_id));
+    let sg_name = format!(
+        "clickhousectl-e2e-mysql-{}",
+        sanitize_for_topic(&ctx.run_id)
+    );
     let sg_id = create_open_security_group(ec2, &vpc_id, &sg_name, &[3306]).await?;
     aws_cleanup.register_ec2_security_group(sg_id.clone());
     eprintln!("  created security group {sg_id}");
@@ -96,7 +99,10 @@ async fn launch_mysql(
         &sg_id,
         MYSQL_INSTANCE_TYPE,
         &user_data,
-        &format!("clickhousectl-e2e-mysql-{}", sanitize_for_topic(&ctx.run_id)),
+        &format!(
+            "clickhousectl-e2e-mysql-{}",
+            sanitize_for_topic(&ctx.run_id)
+        ),
     )
     .await?;
     aws_cleanup.register_ec2_instance(instance_id.clone());
@@ -123,7 +129,11 @@ pub async fn run_mysql_stage(sctx: StageCtx<'_>) -> StageOutcome {
         mut aws_cleanup,
     } = sctx;
     let result = run_inner(client, ctx, ch, ec2, &mut cleanup, &mut aws_cleanup).await;
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 async fn run_inner(

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/postgres.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/postgres.rs
@@ -13,8 +13,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -92,7 +92,12 @@ const POSTGRES_VARIANTS: &[PostgresVariant] = &[
         // right rows (rather than passing on aliased data).
         mappings: &[
             ("pg_users", "postgres_multi_a_users", 1, "Ada Lovelace"),
-            ("pg_users_more", "postgres_multi_b_users", 101, "Joan Clarke"),
+            (
+                "pg_users_more",
+                "postgres_multi_b_users",
+                101,
+                "Joan Clarke",
+            ),
         ],
         replication_mode: ClickPipePostgresPipeSettingsReplicationmode::Cdc,
         publication_name: None,
@@ -347,11 +352,7 @@ async fn run_inner(
             .map(|(name, err)| format!("    - {name}: {err}"))
             .collect::<Vec<_>>()
             .join("\n");
-        return Err(format!(
-            "{} variant failure(s):\n{summary}",
-            variant_failures.len()
-        )
-        .into());
+        return Err(format!("{} variant failure(s):\n{summary}", variant_failures.len()).into());
     }
 
     Ok(())

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/s3.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/s3.rs
@@ -4,8 +4,8 @@
 
 use std::time::Duration;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 
 use crate::support::*;
 
@@ -42,9 +42,23 @@ pub async fn run_s3_stage(sctx: StageCtx<'_>) -> StageOutcome {
         mut aws_cleanup,
     } = sctx;
 
-    let result = run_inner(client, ctx, ch, s3, iam, aws_region, &mut cleanup, &mut aws_cleanup).await;
+    let result = run_inner(
+        client,
+        ctx,
+        ch,
+        s3,
+        iam,
+        aws_region,
+        &mut cleanup,
+        &mut aws_cleanup,
+    )
+    .await;
 
-    StageOutcome { result, cleanup, aws_cleanup }
+    StageOutcome {
+        result,
+        cleanup,
+        aws_cleanup,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -78,7 +92,10 @@ async fn run_inner(
     ];
 
     create_private_bucket(s3, aws_region, &bucket, &aws_tags).await?;
-    aws_cleanup.register_s3_bucket(aws_sdk_s3::config::Region::new(aws_region.to_string()), bucket.clone());
+    aws_cleanup.register_s3_bucket(
+        aws_sdk_s3::config::Region::new(aws_region.to_string()),
+        bucket.clone(),
+    );
     eprintln!("  created bucket {bucket}");
 
     put_object_bytes(
@@ -110,14 +127,8 @@ async fn run_inner(
     })
     .to_string();
 
-    let role_arn = create_clickpipes_iam_role(
-        iam,
-        &role_name,
-        &ch.iam_role,
-        &read_policy,
-        &aws_tags,
-    )
-    .await?;
+    let role_arn =
+        create_clickpipes_iam_role(iam, &role_name, &ch.iam_role, &read_policy, &aws_tags).await?;
     aws_cleanup.register_iam_role(role_name.clone());
     eprintln!("  created iam role {role_name}");
 

--- a/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
@@ -13,7 +13,6 @@ pub use crate::common::support::*;
 
 use std::time::Duration;
 
-
 // ── AWS Cleanup Registry ─────────────────────────────────────────────
 //
 // Tracks AWS-side resources (S3 buckets, IAM roles) created by E2E tests
@@ -62,14 +61,16 @@ impl AwsCleanupRegistry {
         region: impl Into<String>,
         stream_name: impl Into<String>,
     ) {
-        self.kinesis_streams.push((region.into(), stream_name.into()));
+        self.kinesis_streams
+            .push((region.into(), stream_name.into()));
     }
 
     pub fn merge_from(&mut self, mut other: AwsCleanupRegistry) {
         self.s3_buckets.append(&mut other.s3_buckets);
         self.iam_roles.append(&mut other.iam_roles);
         self.ec2_instances.append(&mut other.ec2_instances);
-        self.ec2_security_groups.append(&mut other.ec2_security_groups);
+        self.ec2_security_groups
+            .append(&mut other.ec2_security_groups);
         self.ec2_elastic_ips.append(&mut other.ec2_elastic_ips);
         self.kinesis_streams.append(&mut other.kinesis_streams);
     }
@@ -108,7 +109,12 @@ impl AwsCleanupRegistry {
         }
 
         while let Some(sg_id) = self.ec2_security_groups.pop() {
-            if let Err(error) = ec2_client.delete_security_group().group_id(&sg_id).send().await {
+            if let Err(error) = ec2_client
+                .delete_security_group()
+                .group_id(&sg_id)
+                .send()
+                .await
+            {
                 let msg = error.to_string();
                 if !msg.contains("InvalidGroup.NotFound") {
                     failures.push(format!("ec2 sg {sg_id}: {msg}"));
@@ -152,10 +158,7 @@ impl AwsCleanupRegistry {
     }
 }
 
-async fn empty_and_delete_bucket(
-    s3: &aws_sdk_s3::Client,
-    bucket: &str,
-) -> TestResult<()> {
+async fn empty_and_delete_bucket(s3: &aws_sdk_s3::Client, bucket: &str) -> TestResult<()> {
     eprintln!("  cleanup: emptying s3 bucket");
 
     let mut continuation: Option<String> = None;
@@ -210,10 +213,7 @@ async fn empty_and_delete_bucket(
     }
 }
 
-async fn delete_iam_role(
-    iam: &aws_sdk_iam::Client,
-    role_name: &str,
-) -> TestResult<()> {
+async fn delete_iam_role(iam: &aws_sdk_iam::Client, role_name: &str) -> TestResult<()> {
     eprintln!("  cleanup: detaching inline policies on iam role");
 
     // Inline policies first.
@@ -232,7 +232,12 @@ async fn delete_iam_role(
     }
 
     // Managed policy attachments — none expected for our tests, but be defensive.
-    if let Ok(resp) = iam.list_attached_role_policies().role_name(role_name).send().await {
+    if let Ok(resp) = iam
+        .list_attached_role_policies()
+        .role_name(role_name)
+        .send()
+        .await
+    {
         for p in resp.attached_policies() {
             if let Some(arn) = p.policy_arn() {
                 let _ = iam
@@ -264,12 +269,14 @@ pub async fn create_private_bucket(
     tags: &[(String, String)],
 ) -> TestResult<()> {
     use aws_sdk_s3::types::{
-        BucketCannedAcl, BucketLocationConstraint, CreateBucketConfiguration,
-        ObjectOwnership, OwnershipControls, OwnershipControlsRule, PublicAccessBlockConfiguration,
-        Tag, Tagging,
+        BucketCannedAcl, BucketLocationConstraint, CreateBucketConfiguration, ObjectOwnership,
+        OwnershipControls, OwnershipControlsRule, PublicAccessBlockConfiguration, Tag, Tagging,
     };
 
-    let mut req = s3.create_bucket().bucket(bucket).acl(BucketCannedAcl::Private);
+    let mut req = s3
+        .create_bucket()
+        .bucket(bucket)
+        .acl(BucketCannedAcl::Private);
     // us-east-1 must NOT have a LocationConstraint; every other region must.
     if region != "us-east-1" {
         let cfg = CreateBucketConfiguration::builder()
@@ -366,9 +373,7 @@ pub fn generate_redpanda_certs_with_dns_sans(
     client_cn: &str,
     extra_dns_sans: &[&str],
 ) -> TestResult<RedpandaCerts> {
-    use rcgen::{
-        BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, SanType,
-    };
+    use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, Issuer, KeyPair, SanType};
 
     let parsed_ip: std::net::IpAddr = broker_ip
         .parse()
@@ -398,9 +403,7 @@ pub fn generate_redpanda_certs_with_dns_sans(
         let ia5 = (*dns)
             .try_into()
             .map_err(|e| format!("invalid DNS SAN {dns}: {e}"))?;
-        server_params
-            .subject_alt_names
-            .push(SanType::DnsName(ia5));
+        server_params.subject_alt_names.push(SanType::DnsName(ia5));
     }
     server_params
         .distinguished_name
@@ -444,10 +447,7 @@ pub async fn default_vpc_id(ec2: &aws_sdk_ec2::Client) -> TestResult<String> {
         .ok_or_else(|| "no default VPC found in region".into())
 }
 
-pub async fn first_subnet_in_vpc(
-    ec2: &aws_sdk_ec2::Client,
-    vpc_id: &str,
-) -> TestResult<String> {
+pub async fn first_subnet_in_vpc(ec2: &aws_sdk_ec2::Client, vpc_id: &str) -> TestResult<String> {
     use aws_sdk_ec2::types::Filter;
 
     let resp = ec2
@@ -462,9 +462,7 @@ pub async fn first_subnet_in_vpc(
 }
 
 /// Find the most recent Canonical-published Ubuntu 24.04 LTS amd64 AMI.
-pub async fn latest_ubuntu_noble_amd64_ami(
-    ec2: &aws_sdk_ec2::Client,
-) -> TestResult<String> {
+pub async fn latest_ubuntu_noble_amd64_ami(ec2: &aws_sdk_ec2::Client) -> TestResult<String> {
     use aws_sdk_ec2::types::Filter;
 
     let resp = ec2
@@ -525,7 +523,10 @@ pub async fn create_open_security_group(
         .tag_specifications(tag_spec)
         .send()
         .await?;
-    let sg_id = sg.group_id().ok_or("CreateSecurityGroup returned no id")?.to_string();
+    let sg_id = sg
+        .group_id()
+        .ok_or("CreateSecurityGroup returned no id")?
+        .to_string();
 
     let permissions: Vec<IpPermission> = ingress_ports
         .iter()
@@ -562,11 +563,11 @@ pub async fn launch_ec2_instance(
     name_tag: &str,
 ) -> TestResult<(String, String)> {
     use aws_sdk_ec2::types::{
-        BlockDeviceMapping, EbsBlockDevice, InstanceNetworkInterfaceSpecification,
-        InstanceType, ResourceType, Tag, TagSpecification, VolumeType,
+        BlockDeviceMapping, EbsBlockDevice, InstanceNetworkInterfaceSpecification, InstanceType,
+        ResourceType, Tag, TagSpecification, VolumeType,
     };
-    use base64::engine::general_purpose::STANDARD;
     use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD;
 
     let ud_b64 = STANDARD.encode(user_data.as_bytes());
 
@@ -690,9 +691,7 @@ pub async fn launch_ec2_instance(
 /// Allocate an Elastic IP. Returns `(public_ip, allocation_id)`. Caller is
 /// responsible for `register_ec2_elastic_ip(allocation_id)` and for calling
 /// `associate_elastic_ip` once an instance exists.
-pub async fn allocate_elastic_ip(
-    ec2: &aws_sdk_ec2::Client,
-) -> TestResult<(String, String)> {
+pub async fn allocate_elastic_ip(ec2: &aws_sdk_ec2::Client) -> TestResult<(String, String)> {
     use aws_sdk_ec2::types::{DomainType, ResourceType, Tag, TagSpecification};
 
     // Tag at creation so the IAM policy gating these tests can scope
@@ -714,7 +713,10 @@ pub async fn allocate_elastic_ip(
         .tag_specifications(tag_spec)
         .send()
         .await?;
-    let ip = resp.public_ip().ok_or("AllocateAddress returned no public_ip")?.to_string();
+    let ip = resp
+        .public_ip()
+        .ok_or("AllocateAddress returned no public_ip")?
+        .to_string();
     let alloc = resp
         .allocation_id()
         .ok_or("AllocateAddress returned no allocation_id")?
@@ -807,9 +809,7 @@ pub async fn wait_for_stable_tcp_port(
                 .await
                 {
                     Ok(Ok(_)) => {
-                        let n = consecutive
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-                            + 1;
+                        let n = consecutive.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                         if n >= required_consecutive {
                             Ok(Some(()))
                         } else {
@@ -853,10 +853,7 @@ pub async fn wait_for_tcp_port(host: &str, port: u16, timeout: Duration) -> Test
     .await
 }
 
-async fn terminate_and_wait(
-    ec2: &aws_sdk_ec2::Client,
-    instance_ids: &[String],
-) -> TestResult<()> {
+async fn terminate_and_wait(ec2: &aws_sdk_ec2::Client, instance_ids: &[String]) -> TestResult<()> {
     if instance_ids.is_empty() {
         return Ok(());
     }
@@ -881,17 +878,21 @@ async fn terminate_and_wait(
                     .set_instance_ids(Some(ids))
                     .send()
                     .await?;
-                let all_terminated = resp
-                    .reservations()
-                    .iter()
-                    .flat_map(|r| r.instances())
-                    .all(|i| {
-                        i.state()
-                            .and_then(|s| s.name())
-                            .map(|n| n.as_str() == "terminated")
-                            .unwrap_or(false)
-                    });
-                if all_terminated { Ok(Some(())) } else { Ok(None) }
+                let all_terminated =
+                    resp.reservations()
+                        .iter()
+                        .flat_map(|r| r.instances())
+                        .all(|i| {
+                            i.state()
+                                .and_then(|s| s.name())
+                                .map(|n| n.as_str() == "terminated")
+                                .unwrap_or(false)
+                        });
+                if all_terminated {
+                    Ok(Some(()))
+                } else {
+                    Ok(None)
+                }
             }
         },
     )

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use clickhouse_cloud_api::{models::*, Client};
+use clickhouse_cloud_api::{Client, models::*};
 use wiremock::matchers::{basic_auth, bearer_token, body_partial_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -90,7 +90,9 @@ async fn update_organization() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1"))
-        .and(body_partial_json(serde_json::json!({"name": "Renamed Org"})))
+        .and(body_partial_json(
+            serde_json::json!({"name": "Renamed Org"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
             "name": "Renamed Org"
@@ -257,7 +259,9 @@ async fn create_byoc_infrastructure() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/byocInfrastructure"))
-        .and(body_partial_json(serde_json::json!({"accountId": "123456789012", "displayName": "My BYOC"})))
+        .and(body_partial_json(
+            serde_json::json!({"accountId": "123456789012", "displayName": "My BYOC"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "byoc-1",
             "cloudProvider": "aws",
@@ -285,7 +289,9 @@ async fn update_byoc_infrastructure() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/byocInfrastructure/byoc-1"))
-        .and(body_partial_json(serde_json::json!({"displayName": "Renamed BYOC"})))
+        .and(body_partial_json(
+            serde_json::json!({"displayName": "Renamed BYOC"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "byoc-1",
             "displayName": "Renamed BYOC"
@@ -353,7 +359,9 @@ async fn create_invitation() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/invitations"))
-        .and(body_partial_json(serde_json::json!({"email": "newuser@example.com"})))
+        .and(body_partial_json(
+            serde_json::json!({"email": "newuser@example.com"}),
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "status": 200,
             "result": {
@@ -500,7 +508,9 @@ async fn update_api_key() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/keys/key-1"))
-        .and(body_partial_json(serde_json::json!({"name": "Renamed Key"})))
+        .and(body_partial_json(
+            serde_json::json!({"name": "Renamed Key"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "name": "Renamed Key",
@@ -677,7 +687,9 @@ async fn create_service() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-123/services"))
-        .and(body_partial_json(serde_json::json!({"name": "new-service", "provider": "aws", "region": "us-east-1"})))
+        .and(body_partial_json(
+            serde_json::json!({"name": "new-service", "provider": "aws", "region": "us-east-1"}),
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "status": 200,
             "result": {
@@ -751,7 +763,9 @@ async fn update_service() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/services/svc-1"))
-        .and(body_partial_json(serde_json::json!({"name": "renamed-svc"})))
+        .and(body_partial_json(
+            serde_json::json!({"name": "renamed-svc"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "11111111-2222-3333-4444-555555555555",
             "name": "renamed-svc",
@@ -913,8 +927,12 @@ async fn create_private_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/privateEndpoint"))
-        .and(body_partial_json(serde_json::json!({"id": "vpce-abc", "description": "My PE"})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/privateEndpoint",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"id": "vpce-abc", "description": "My PE"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "pe-1",
             "description": "My PE"
@@ -939,7 +957,9 @@ async fn get_private_endpoint_config_for_service() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/privateEndpointConfig"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/privateEndpointConfig",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "endpointServiceId": "vpce-svc-abc",
             "privateDnsHostname": "svc-1.private.clickhouse.cloud"
@@ -966,8 +986,7 @@ async fn get_service_prometheus_metrics() {
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/services/svc-1/prometheus"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("# HELP svc_metric\nsvc_metric 100\n"),
+            ResponseTemplate::new(200).set_body_string("# HELP svc_metric\nsvc_metric 100\n"),
         )
         .mount(&s)
         .await;
@@ -986,10 +1005,7 @@ async fn get_service_prometheus_with_filter() {
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/services/svc-1/prometheus"))
         .and(query_param("filtered_metrics", "cpu,memory"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("cpu 42\nmemory 1024\n"),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string("cpu 42\nmemory 1024\n"))
         .mount(&s)
         .await;
 
@@ -1005,7 +1021,9 @@ async fn get_query_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "qe-1",
             "allowedOrigins": "*",
@@ -1028,8 +1046,12 @@ async fn upsert_query_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint"))
-        .and(body_partial_json(serde_json::json!({"allowedOrigins": "https://example.com", "roles": ["reader"]})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"allowedOrigins": "https://example.com", "roles": ["reader"]}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "qe-1",
             "allowedOrigins": "https://example.com",
@@ -1048,10 +1070,7 @@ async fn upsert_query_endpoint() {
         .await
         .unwrap();
     let qe = resp.result.unwrap();
-    assert_eq!(
-        qe.allowed_origins,
-        "https://example.com"
-    );
+    assert_eq!(qe.allowed_origins, "https://example.com");
 }
 
 #[tokio::test]
@@ -1059,7 +1078,9 @@ async fn delete_query_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/serviceQueryEndpoint",
+        ))
         .respond_with(ok_empty())
         .mount(&s)
         .await;
@@ -1133,7 +1154,9 @@ async fn get_backup_configuration() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/backupConfiguration"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/backupConfiguration",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "backupPeriodInHours": 24,
             "backupRetentionPeriodInHours": 168,
@@ -1142,10 +1165,7 @@ async fn get_backup_configuration() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .backup_configuration_get("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.backup_configuration_get("org-1", "svc-1").await.unwrap();
     let config = resp.result.unwrap();
     assert_eq!(config.backup_period_in_hours, 24.0);
     assert_eq!(config.backup_start_time, "02:00");
@@ -1214,7 +1234,9 @@ async fn create_backup_bucket() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/services/svc-1/backupBucket"))
-        .and(body_partial_json(serde_json::json!({"bucketPath": "s3://new-bucket"})))
+        .and(body_partial_json(
+            serde_json::json!({"bucketPath": "s3://new-bucket"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "bucketPath": "s3://new-bucket",
             "bucketProvider": "aws_s3",
@@ -1223,12 +1245,11 @@ async fn create_backup_bucket() {
         .mount(&s)
         .await;
 
-    let body = BackupBucketPostRequest::AwsBackupBucketPostRequestV1(
-        AwsBackupBucketPostRequestV1 {
+    let body =
+        BackupBucketPostRequest::AwsBackupBucketPostRequestV1(AwsBackupBucketPostRequestV1 {
             bucket_path: "s3://new-bucket".to_string(),
             ..Default::default()
-        },
-    );
+        });
     let resp = c
         .backup_bucket_create("org-1", "svc-1", &body)
         .await
@@ -1242,7 +1263,9 @@ async fn update_backup_bucket() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/services/svc-1/backupBucket"))
-        .and(body_partial_json(serde_json::json!({"bucketPath": "s3://updated-bucket"})))
+        .and(body_partial_json(
+            serde_json::json!({"bucketPath": "s3://updated-bucket"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "bucketPath": "s3://updated-bucket",
             "bucketProvider": "aws_s3",
@@ -1251,12 +1274,11 @@ async fn update_backup_bucket() {
         .mount(&s)
         .await;
 
-    let body = BackupBucketPatchRequest::AwsBackupBucketPatchRequestV1(
-        AwsBackupBucketPatchRequestV1 {
+    let body =
+        BackupBucketPatchRequest::AwsBackupBucketPatchRequestV1(AwsBackupBucketPatchRequestV1 {
             bucket_path: "s3://updated-bucket".to_string(),
             ..Default::default()
-        },
-    );
+        });
     let resp = c
         .backup_bucket_update("org-1", "svc-1", &body)
         .await
@@ -1359,7 +1381,11 @@ async fn list_click_pipes_with_null_array_fields() {
     let pipes = resp.result.unwrap();
     assert_eq!(pipes.len(), 1);
     assert_eq!(pipes[0].name, "kafka-pipe");
-    let kafka = pipes[0].source.kafka.as_ref().expect("kafka source present");
+    let kafka = pipes[0]
+        .source
+        .kafka
+        .as_ref()
+        .expect("kafka source present");
     assert!(kafka.reverse_private_endpoint_ids.is_empty());
 }
 
@@ -1382,10 +1408,7 @@ async fn create_click_pipe() {
         name: "new-pipe".to_string(),
         ..Default::default()
     };
-    let resp = c
-        .click_pipe_create("org-1", "svc-1", &body)
-        .await
-        .unwrap();
+    let resp = c.click_pipe_create("org-1", "svc-1", &body).await.unwrap();
     let pipe = resp.result.unwrap();
     assert_eq!(pipe.name, "new-pipe");
 }
@@ -1395,7 +1418,9 @@ async fn get_click_pipe() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "name": "my-pipe",
@@ -1404,10 +1429,7 @@ async fn get_click_pipe() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .click_pipe_get("org-1", "svc-1", "pipe-1")
-        .await
-        .unwrap();
+    let resp = c.click_pipe_get("org-1", "svc-1", "pipe-1").await.unwrap();
     let pipe = resp.result.unwrap();
     assert_eq!(pipe.name, "my-pipe");
 }
@@ -1417,8 +1439,12 @@ async fn update_click_pipe() {
     let (s, c) = setup().await;
 
     Mock::given(method("PATCH"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1"))
-        .and(body_partial_json(serde_json::json!({"name": "renamed-pipe"})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"name": "renamed-pipe"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "name": "renamed-pipe",
@@ -1444,7 +1470,9 @@ async fn delete_click_pipe() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1",
+        ))
         .respond_with(ok_empty())
         .mount(&s)
         .await;
@@ -1461,7 +1489,9 @@ async fn update_click_pipe_state() {
     let (s, c) = setup().await;
 
     Mock::given(method("PATCH"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/state"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/state",
+        ))
         .and(body_partial_json(serde_json::json!({"command": "stop"})))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -1487,7 +1517,9 @@ async fn update_click_pipe_scaling() {
     let (s, c) = setup().await;
 
     Mock::given(method("PATCH"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/scaling"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/scaling",
+        ))
         .and(body_partial_json(serde_json::json!({})))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -1512,7 +1544,9 @@ async fn get_click_pipe_settings() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/settings"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/settings",
+        ))
         .respond_with(ok_json(serde_json::json!({})))
         .mount(&s)
         .await;
@@ -1529,7 +1563,9 @@ async fn update_click_pipe_settings() {
     let (s, c) = setup().await;
 
     Mock::given(method("PUT"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/settings"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/pipe-1/settings",
+        ))
         .and(body_partial_json(serde_json::json!({})))
         .respond_with(ok_json(serde_json::json!({})))
         .mount(&s)
@@ -1554,7 +1590,9 @@ async fn click_pipe_schema_discovery_kafka() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipes/schemaDiscovery"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipes/schemaDiscovery",
+        ))
         .and(body_partial_json(serde_json::json!({
             "source": {"kafka": {"brokers": "broker1:9092"}}
         })))
@@ -1596,7 +1634,9 @@ async fn get_cdc_scaling() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "replicaCpuMillicores": 2000,
             "replicaMemoryGb": 8.0
@@ -1618,8 +1658,12 @@ async fn update_cdc_scaling() {
     let (s, c) = setup().await;
 
     Mock::given(method("PATCH"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling"))
-        .and(body_partial_json(serde_json::json!({"replicaCpuMillicores": 4000, "replicaMemoryGb": 16.0})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesCdcScaling",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"replicaCpuMillicores": 4000, "replicaMemoryGb": 16.0}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "replicaCpuMillicores": 4000,
             "replicaMemoryGb": 16.0
@@ -1648,7 +1692,9 @@ async fn list_reverse_private_endpoints() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints",
+        ))
         .respond_with(ok_json(serde_json::json!([
             {
                 "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
@@ -1673,8 +1719,12 @@ async fn create_reverse_private_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints"))
-        .and(body_partial_json(serde_json::json!({"description": "New RPE"})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"description": "New RPE"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "description": "New RPE",
@@ -1700,7 +1750,9 @@ async fn get_reverse_private_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints/rpe-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints/rpe-1",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
             "description": "My RPE",
@@ -1722,7 +1774,9 @@ async fn delete_reverse_private_endpoint() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints/rpe-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickpipesReversePrivateEndpoints/rpe-1",
+        ))
         .respond_with(ok_empty())
         .mount(&s)
         .await;
@@ -1743,7 +1797,9 @@ async fn list_alerts() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/alerts"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/alerts",
+        ))
         .respond_with(ok_json(serde_json::json!([
             {
                 "id": "alert-1",
@@ -1753,10 +1809,7 @@ async fn list_alerts() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .click_stack_list_alerts("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.click_stack_list_alerts("org-1", "svc-1").await.unwrap();
     let alerts = resp.result.unwrap();
     assert_eq!(alerts.len(), 1);
 }
@@ -1766,7 +1819,9 @@ async fn create_alert() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/alerts"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/alerts",
+        ))
         .and(body_partial_json(serde_json::json!({"name": "New Alert"})))
         .respond_with(ok_json(serde_json::json!({
             "id": "alert-1",
@@ -1791,7 +1846,9 @@ async fn get_alert() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "alert-1",
             "name": "My Alert"
@@ -1811,8 +1868,12 @@ async fn update_alert() {
     let (s, c) = setup().await;
 
     Mock::given(method("PUT"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1"))
-        .and(body_partial_json(serde_json::json!({"name": "Updated Alert"})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"name": "Updated Alert"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "alert-1",
             "name": "Updated Alert"
@@ -1836,7 +1897,9 @@ async fn delete_alert() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/alerts/alert-1",
+        ))
         .respond_with(ok_empty())
         .mount(&s)
         .await;
@@ -1857,7 +1920,9 @@ async fn list_dashboards() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/dashboards"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards",
+        ))
         .respond_with(ok_json(serde_json::json!([
             {
                 "id": "dash-1",
@@ -1880,8 +1945,12 @@ async fn create_dashboard() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/dashboards"))
-        .and(body_partial_json(serde_json::json!({"name": "New Dashboard", "tiles": []})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"name": "New Dashboard", "tiles": []}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "dash-new",
             "name": "New Dashboard"
@@ -1906,7 +1975,9 @@ async fn get_dashboard() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "dash-1",
             "name": "My Dashboard"
@@ -1926,8 +1997,12 @@ async fn update_dashboard() {
     let (s, c) = setup().await;
 
     Mock::given(method("PUT"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1"))
-        .and(body_partial_json(serde_json::json!({"name": "Updated Dashboard", "tiles": []})))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"name": "Updated Dashboard", "tiles": []}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "dash-1",
             "name": "Updated Dashboard"
@@ -1952,7 +2027,9 @@ async fn delete_dashboard() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/dashboards/dash-1",
+        ))
         .respond_with(ok_empty())
         .mount(&s)
         .await;
@@ -1973,15 +2050,14 @@ async fn list_sources() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/sources"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/sources",
+        ))
         .respond_with(ok_json(serde_json::json!([])))
         .mount(&s)
         .await;
 
-    let resp = c
-        .click_stack_list_sources("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.click_stack_list_sources("org-1", "svc-1").await.unwrap();
     let sources = resp.result.unwrap();
     assert_eq!(sources.len(), 0);
 }
@@ -1991,15 +2067,14 @@ async fn list_webhooks() {
     let (s, c) = setup().await;
 
     Mock::given(method("GET"))
-        .and(path("/v1/organizations/org-1/services/svc-1/clickstack/webhooks"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/clickstack/webhooks",
+        ))
         .respond_with(ok_json(serde_json::json!([])))
         .mount(&s)
         .await;
 
-    let resp = c
-        .click_stack_list_webhooks("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.click_stack_list_webhooks("org-1", "svc-1").await.unwrap();
     let webhooks = resp.result.unwrap();
     assert_eq!(webhooks.len(), 0);
 }
@@ -2033,10 +2108,7 @@ async fn create_postgres_service() {
         size: PgSize::C6gd_large,
         ..Default::default()
     };
-    let resp = c
-        .postgres_service_create("org-1", &body)
-        .await
-        .unwrap();
+    let resp = c.postgres_service_create("org-1", &body).await.unwrap();
     let pg = resp.result.unwrap();
     assert_eq!(pg.name, "pg-svc");
     assert_eq!(pg.password, "generated-pw");
@@ -2082,10 +2154,7 @@ async fn get_postgres_service() {
     let resp = c.postgres_service_get("org-1", "pg-1").await.unwrap();
     let pg = resp.result.unwrap();
     assert_eq!(pg.name, "pg-1");
-    assert_eq!(
-        pg.connection_string,
-        "postgres://user@host/db"
-    );
+    assert_eq!(pg.connection_string, "postgres://user@host/db");
 }
 
 #[tokio::test]
@@ -2160,7 +2229,9 @@ async fn set_postgres_password() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/password"))
-        .and(body_partial_json(serde_json::json!({"password": "new-pg-password"})))
+        .and(body_partial_json(
+            serde_json::json!({"password": "new-pg-password"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "password": "new-pg-password"
         })))
@@ -2185,16 +2256,14 @@ async fn get_postgres_certs() {
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/caCertificates"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----\n"),
+            ResponseTemplate::new(200).set_body_string(
+                "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----\n",
+            ),
         )
         .mount(&s)
         .await;
 
-    let resp = c
-        .postgres_service_certs_get("org-1", "pg-1")
-        .await
-        .unwrap();
+    let resp = c.postgres_service_certs_get("org-1", "pg-1").await.unwrap();
     assert!(resp.contains("BEGIN CERTIFICATE"));
 }
 
@@ -2218,7 +2287,10 @@ async fn get_postgres_config() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.pg_config.max_connections, Some(serde_json::json!(100)));
+    assert_eq!(
+        config.pg_config.max_connections,
+        Some(serde_json::json!(100))
+    );
 }
 
 #[tokio::test]
@@ -2251,7 +2323,10 @@ async fn replace_postgres_config() {
         .unwrap();
     let result = resp.result.unwrap();
     assert_eq!(result.message, Some("Configuration updated".to_string()));
-    assert_eq!(result.pg_config.max_connections, Some(serde_json::json!(200)));
+    assert_eq!(
+        result.pg_config.max_connections,
+        Some(serde_json::json!(200))
+    );
 }
 
 #[tokio::test]
@@ -2283,7 +2358,10 @@ async fn patch_postgres_config() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.pg_config.max_connections, Some(serde_json::json!(150)));
+    assert_eq!(
+        result.pg_config.max_connections,
+        Some(serde_json::json!(150))
+    );
 }
 
 #[tokio::test]
@@ -2292,7 +2370,9 @@ async fn create_postgres_read_replica() {
 
     Mock::given(method("POST"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/readReplica"))
-        .and(body_partial_json(serde_json::json!({"name": "pg-1-replica"})))
+        .and(body_partial_json(
+            serde_json::json!({"name": "pg-1-replica"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "bbbbbbbb-cccc-dddd-eeee-ffffffffffff",
             "name": "pg-1-replica",
@@ -2318,8 +2398,12 @@ async fn restore_postgres_service() {
     let (s, c) = setup().await;
 
     Mock::given(method("POST"))
-        .and(path("/v1/organizations/org-1/postgres/pg-1/restoredService"))
-        .and(body_partial_json(serde_json::json!({"name": "pg-1-restored"})))
+        .and(path(
+            "/v1/organizations/org-1/postgres/pg-1/restoredService",
+        ))
+        .and(body_partial_json(
+            serde_json::json!({"name": "pg-1-restored"}),
+        ))
         .respond_with(ok_json(serde_json::json!({
             "id": "cccccccc-dddd-eeee-ffff-000000000000",
             "name": "pg-1-restored",
@@ -2403,8 +2487,7 @@ async fn with_http_client_basic_auth() {
         .await;
 
     let http = reqwest::Client::new();
-    let client =
-        Client::with_http_client(http, mock_server.uri(), "custom-key", "custom-secret");
+    let client = Client::with_http_client(http, mock_server.uri(), "custom-key", "custom-secret");
     let resp = client.organization_get_list().await.unwrap();
     assert_eq!(resp.result.unwrap().len(), 0);
 }
@@ -2505,10 +2588,7 @@ async fn api_error_404_not_found() {
         .mount(&s)
         .await;
 
-    let err = c
-        .instance_get("org-1", "nonexistent")
-        .await
-        .unwrap_err();
+    let err = c.instance_get("org-1", "nonexistent").await.unwrap_err();
     match err {
         clickhouse_cloud_api::Error::Api { status, message } => {
             assert_eq!(status, 404);
@@ -2547,9 +2627,7 @@ async fn api_error_non_json_body() {
 
     Mock::given(method("GET"))
         .and(path("/v1/organizations"))
-        .respond_with(
-            ResponseTemplate::new(502).set_body_string("Bad Gateway"),
-        )
+        .respond_with(ResponseTemplate::new(502).set_body_string("Bad Gateway"))
         .mount(&s)
         .await;
 
@@ -2570,12 +2648,10 @@ async fn api_error_on_prometheus_endpoint() {
 
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/prometheus"))
-        .respond_with(
-            ResponseTemplate::new(403).set_body_json(serde_json::json!({
-                "status": 403,
-                "error": "Metrics access denied"
-            })),
-        )
+        .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+            "status": 403,
+            "error": "Metrics access denied"
+        })))
         .mount(&s)
         .await;
 
@@ -2644,9 +2720,7 @@ async fn truncated_json_success_response() {
 
     Mock::given(method("GET"))
         .and(path("/v1/organizations"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_string(r#"{"status": 200, "result":"#),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"status": 200, "result":"#))
         .mount(&s)
         .await;
 
@@ -2839,10 +2913,7 @@ async fn organization_prometheus_with_filtered_metrics() {
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/prometheus"))
         .and(query_param("filtered_metrics", "cpu,memory"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("cpu 42\nmemory 1024\n"),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string("cpu 42\nmemory 1024\n"))
         .mount(&s)
         .await;
 
@@ -2859,17 +2930,11 @@ async fn organization_prometheus_without_filter() {
 
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/prometheus"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("# HELP metric\nmetric 1\n"),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string("# HELP metric\nmetric 1\n"))
         .mount(&s)
         .await;
 
-    let resp = c
-        .organization_prometheus_get("org-1", None)
-        .await
-        .unwrap();
+    let resp = c.organization_prometheus_get("org-1", None).await.unwrap();
     assert!(resp.contains("metric"));
 }
 
@@ -2879,10 +2944,7 @@ async fn postgres_instance_prometheus_get_returns_metrics() {
 
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/postgres/pg-1/prometheus"))
-        .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("# HELP pg_metric\npg_metric 7\n"),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_string("# HELP pg_metric\npg_metric 7\n"))
         .mount(&s)
         .await;
 
@@ -2900,16 +2962,12 @@ async fn postgres_org_prometheus_get_returns_metrics() {
     Mock::given(method("GET"))
         .and(path("/v1/organizations/org-1/postgres/prometheus"))
         .respond_with(
-            ResponseTemplate::new(200)
-                .set_body_string("# HELP pg_org_metric\npg_org_metric 3\n"),
+            ResponseTemplate::new(200).set_body_string("# HELP pg_org_metric\npg_org_metric 3\n"),
         )
         .mount(&s)
         .await;
 
-    let resp = c
-        .postgres_org_prometheus_get("org-1")
-        .await
-        .unwrap();
+    let resp = c.postgres_org_prometheus_get("org-1").await.unwrap();
     assert!(resp.contains("pg_org_metric"));
 }
 
@@ -2918,7 +2976,9 @@ async fn scaling_schedule_delete_succeeds() {
     let (s, c) = setup().await;
 
     Mock::given(method("DELETE"))
-        .and(path("/v1/organizations/org-1/services/svc-1/scalingSchedule"))
+        .and(path(
+            "/v1/organizations/org-1/services/svc-1/scalingSchedule",
+        ))
         .respond_with(ok_json(serde_json::json!({
             "status": 200,
             "requestId": "00000000-0000-0000-0000-000000000000"
@@ -2926,10 +2986,7 @@ async fn scaling_schedule_delete_succeeds() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .scaling_schedule_delete("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.scaling_schedule_delete("org-1", "svc-1").await.unwrap();
     assert_eq!(resp.status, Some(200.0));
 }
 
@@ -2951,10 +3008,7 @@ async fn upgrade_window_get_returns_window() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .upgrade_window_get("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.upgrade_window_get("org-1", "svc-1").await.unwrap();
     let window = resp.result.unwrap();
     assert_eq!(window.weekday, 2);
     assert_eq!(window.start_hour_utc, 6);
@@ -3002,10 +3056,7 @@ async fn upgrade_window_delete_succeeds() {
         .mount(&s)
         .await;
 
-    let resp = c
-        .upgrade_window_delete("org-1", "svc-1")
-        .await
-        .unwrap();
+    let resp = c.upgrade_window_delete("org-1", "svc-1").await.unwrap();
     assert_eq!(resp.status, Some(200.0));
 }
 

--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -8,8 +8,8 @@
 // Each test binary uses a different subset — silence dead_code for the rest.
 #![allow(dead_code)]
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 use std::env;
 use std::fmt;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -300,7 +300,10 @@ impl TestContext {
 pub fn create_client() -> TestResult<Client> {
     let key = required_env("CLICKHOUSE_CLOUD_API_KEY")?;
     let secret = required_env("CLICKHOUSE_CLOUD_API_SECRET")?;
-    match env::var("CLICKHOUSE_CLOUD_API_BASE_URL").ok().filter(|s| !s.is_empty()) {
+    match env::var("CLICKHOUSE_CLOUD_API_BASE_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
         Some(base_url) => Ok(Client::with_base_url(base_url, key, secret)),
         None => Ok(Client::new(key, secret)),
     }
@@ -505,7 +508,8 @@ impl CleanupRegistry {
         service_id: impl Into<String>,
         clickpipe_id: impl Into<String>,
     ) {
-        self.clickpipes.push((service_id.into(), clickpipe_id.into()));
+        self.clickpipes
+            .push((service_id.into(), clickpipe_id.into()));
     }
 
     /// Register a `default.<table>` destination table so teardown drops it.
@@ -521,7 +525,8 @@ impl CleanupRegistry {
     pub fn merge_from(&mut self, mut other: CleanupRegistry) {
         self.service_ids.append(&mut other.service_ids);
         self.postgres_ids.append(&mut other.postgres_ids);
-        self.postgres_replica_ids.append(&mut other.postgres_replica_ids);
+        self.postgres_replica_ids
+            .append(&mut other.postgres_replica_ids);
         self.clickpipes.append(&mut other.clickpipes);
         self.tables.append(&mut other.tables);
         self.api_key_ids.append(&mut other.api_key_ids);
@@ -543,8 +548,7 @@ impl CleanupRegistry {
     }
 
     pub fn unregister_api_key(&mut self, key_id: &str) {
-        self.api_key_ids
-            .retain(|registered| registered != key_id);
+        self.api_key_ids.retain(|registered| registered != key_id);
     }
 
     pub fn register_query_endpoint(&mut self, service_id: impl Into<String>) {
@@ -579,11 +583,12 @@ impl CleanupRegistry {
         setting_name: impl Into<String>,
         original_value: impl Into<String>,
     ) {
-        self.clickhouse_setting_restores.push(ClickhouseSettingRestore {
-            service_id: service_id.into(),
-            setting_name: setting_name.into(),
-            original_value: original_value.into(),
-        });
+        self.clickhouse_setting_restores
+            .push(ClickhouseSettingRestore {
+                service_id: service_id.into(),
+                setting_name: setting_name.into(),
+                original_value: original_value.into(),
+            });
     }
 
     pub fn unregister_clickhouse_setting_restore(&mut self, service_id: &str, setting_name: &str) {
@@ -672,9 +677,7 @@ impl CleanupRegistry {
         // the wrong role, every subsequent run starts with bad state. A
         // 404 means the user is no longer in the org and we have nothing
         // to do.
-        while let Some((user_id, original_assigned_role_ids)) =
-            self.member_role_restores.pop()
-        {
+        while let Some((user_id, original_assigned_role_ids)) = self.member_role_restores.pop() {
             let body = MemberPatchRequest {
                 assigned_role_ids: Some(original_assigned_role_ids.clone()),
                 #[cfg(feature = "deprecated-fields")]
@@ -752,7 +755,10 @@ impl CleanupRegistry {
         // The service itself may still be around; that's fine — we're just
         // removing the binding so the API key can be deleted cleanly next.
         while let Some(service_id) = self.query_endpoint_service_ids.pop() {
-            match client.instance_query_endpoint_delete(org_id, &service_id).await {
+            match client
+                .instance_query_endpoint_delete(org_id, &service_id)
+                .await
+            {
                 Ok(_) => {}
                 Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {}
                 Err(e) => failures.push(format!("query endpoint on {service_id}: {e}")),
@@ -823,9 +829,11 @@ impl CleanupRegistry {
             self.tables.clear();
         }
 
-
         while let Some(service_id) = self.service_ids.pop() {
-            if let Err(error) = ensure_service_gone(client, org_id, &service_id, delete_timeout, poll_interval).await {
+            if let Err(error) =
+                ensure_service_gone(client, org_id, &service_id, delete_timeout, poll_interval)
+                    .await
+            {
                 failures.push(format!("{service_id}: {error}"));
             }
         }
@@ -843,7 +851,10 @@ impl CleanupRegistry {
         }
 
         while let Some(postgres_id) = self.postgres_ids.pop() {
-            if let Err(error) = ensure_postgres_gone(client, org_id, &postgres_id, delete_timeout, poll_interval).await {
+            if let Err(error) =
+                ensure_postgres_gone(client, org_id, &postgres_id, delete_timeout, poll_interval)
+                    .await
+            {
                 failures.push(format!("postgres {postgres_id}: {error}"));
             }
         }
@@ -947,24 +958,32 @@ async fn ensure_service_gone(
                         )
                         .await;
                     // Wait for stop
-                    let _ = poll_until("service stop for cleanup", delete_timeout, poll_interval, || {
-                        let client = client.clone();
-                        let org_id = org_id.to_string();
-                        let service_id = service_id.to_string();
-                        async move {
-                            let resp = client.instance_get(&org_id, &service_id).await?;
-                            let state = resp
-                                .result
-                                .as_ref()
-                                .map(|s| s.state.to_string())
-                                .unwrap_or_default();
-                            if matches!(state.as_str(), "stopped" | "idle" | "degraded" | "failed") {
-                                Ok(Some(()))
-                            } else {
-                                Ok(None)
+                    let _ = poll_until(
+                        "service stop for cleanup",
+                        delete_timeout,
+                        poll_interval,
+                        || {
+                            let client = client.clone();
+                            let org_id = org_id.to_string();
+                            let service_id = service_id.to_string();
+                            async move {
+                                let resp = client.instance_get(&org_id, &service_id).await?;
+                                let state = resp
+                                    .result
+                                    .as_ref()
+                                    .map(|s| s.state.to_string())
+                                    .unwrap_or_default();
+                                if matches!(
+                                    state.as_str(),
+                                    "stopped" | "idle" | "degraded" | "failed"
+                                ) {
+                                    Ok(Some(()))
+                                } else {
+                                    Ok(None)
+                                }
                             }
-                        }
-                    })
+                        },
+                    )
                     .await;
                 }
             }
@@ -1008,13 +1027,19 @@ async fn ensure_clickpipe_gone(
 ) -> TestResult<()> {
     eprintln!("  cleanup: ensuring clickpipe is gone");
 
-    match client.click_pipe_get(org_id, service_id, clickpipe_id).await {
+    match client
+        .click_pipe_get(org_id, service_id, clickpipe_id)
+        .await
+    {
         Ok(_) => {}
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => return Ok(()),
         Err(_) => {}
     }
 
-    match client.click_pipe_delete(org_id, service_id, clickpipe_id).await {
+    match client
+        .click_pipe_delete(org_id, service_id, clickpipe_id)
+        .await
+    {
         Ok(_) => {}
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => return Ok(()),
         Err(e) => return Err(e.into()),
@@ -1026,7 +1051,10 @@ async fn ensure_clickpipe_gone(
         let service_id = service_id.to_string();
         let clickpipe_id = clickpipe_id.to_string();
         async move {
-            match client.click_pipe_get(&org_id, &service_id, &clickpipe_id).await {
+            match client
+                .click_pipe_get(&org_id, &service_id, &clickpipe_id)
+                .await
+            {
                 Ok(_) => Ok(None),
                 Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Ok(Some(())),
                 Err(e) => Err(e.into()),
@@ -1345,7 +1373,8 @@ pub async fn provision_clickhouse(
 
     if svc.iam_role.is_empty() {
         return Err(
-            "provisioned service has no iamRole populated — cannot establish ClickPipes trust".into(),
+            "provisioned service has no iamRole populated — cannot establish ClickPipes trust"
+                .into(),
         );
     }
 
@@ -1404,7 +1433,10 @@ pub async fn attach_clickhouse(
             .iter()
             .find(|e| matches!(e.protocol, ServiceEndpointProtocol::Https))
             .ok_or("service has no https endpoint to wake")?;
-        let username = https.username.clone().unwrap_or_else(|| "default".to_string());
+        let username = https
+            .username
+            .clone()
+            .unwrap_or_else(|| "default".to_string());
         let wake_query = ClickHouseQuery::new(&https.host, https.port as u16, &username, password);
         let _ = wake_query.run_query("SELECT 1 FORMAT TabSeparated").await?;
 
@@ -1429,10 +1461,9 @@ pub async fn attach_clickhouse(
         )
         .await?;
     } else if state != "running" {
-        return Err(format!(
-            "service {service_id} is in state {state}, expected running or idle"
-        )
-        .into());
+        return Err(
+            format!("service {service_id} is in state {state}, expected running or idle").into(),
+        );
     }
     if svc.iam_role.is_empty() {
         return Err(

--- a/crates/clickhouse-cloud-api/tests/integration_org_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_org_test.rs
@@ -1233,7 +1233,13 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
     .await;
 
     let cleanup_result = cleanup
-        .cleanup(&client, &ctx.org_id, ctx.delete_timeout, ctx.poll_interval, None)
+        .cleanup(
+            &client,
+            &ctx.org_id,
+            ctx.delete_timeout,
+            ctx.poll_interval,
+            None,
+        )
         .await;
 
     match (test_result, cleanup_result) {

--- a/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
@@ -867,7 +867,13 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
     .await;
 
     let cleanup_result = cleanup
-        .cleanup(&client, &ctx.org_id, ctx.delete_timeout, ctx.poll_interval, None)
+        .cleanup(
+            &client,
+            &ctx.org_id,
+            ctx.delete_timeout,
+            ctx.poll_interval,
+            None,
+        )
         .await;
 
     match (test_result, cleanup_result) {
@@ -918,7 +924,10 @@ fn filters_match_tags(filters: &[String], tags: &[ResourceTagsV1]) -> bool {
 /// unrelated validation 400s that should fail the test, not retry.
 fn is_no_backups_yet_error(error: &clickhouse_cloud_api::Error) -> bool {
     match error {
-        clickhouse_cloud_api::Error::Api { status: 400, message } => {
+        clickhouse_cloud_api::Error::Api {
+            status: 400,
+            message,
+        } => {
             let lower = message.to_ascii_lowercase();
             lower.contains("no backups") || lower.contains("not ready for read replicas")
         }
@@ -984,7 +993,11 @@ async fn run_pg_config_probe(org_id: &str, postgres_id: &str) -> TestResult<()> 
                 .map_err(|e| format!("{method} {label}: {e}"))?;
             let status = resp.status().as_u16();
             let text = resp.text().await.unwrap_or_default();
-            let snippet: String = text.chars().take(180).collect::<String>().replace('\n', " ");
+            let snippet: String = text
+                .chars()
+                .take(180)
+                .collect::<String>()
+                .replace('\n', " ");
             rows.push((method.to_string(), label.to_string(), status, snippet));
         }
     }

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use clickhouse_cloud_api::models::*;
 use clickhouse_cloud_api::Client;
+use clickhouse_cloud_api::models::*;
 use common::support::*;
 
 #[tokio::test]
@@ -2484,7 +2484,13 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
     .await;
 
     let cleanup_result = cleanup
-        .cleanup(&client, &ctx.org_id, ctx.delete_timeout, ctx.poll_interval, None)
+        .cleanup(
+            &client,
+            &ctx.org_id,
+            ctx.delete_timeout,
+            ctx.poll_interval,
+            None,
+        )
         .await;
 
     match (test_result, cleanup_result) {
@@ -2611,9 +2617,10 @@ fn synthetic_private_endpoint_id(ctx: &TestContext) -> String {
         // pick a 19-digit value seeded by the run id hash so different runs
         // collide neither with each other nor with real PSC endpoints.
         "gcp" => {
-            let hash: u64 = ctx.run_id.bytes().fold(0u64, |acc, b| {
-                acc.wrapping_mul(31).wrapping_add(b as u64)
-            });
+            let hash: u64 = ctx
+                .run_id
+                .bytes()
+                .fold(0u64, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u64));
             format!("{:019}", hash % 10u64.pow(19))
         }
         // Azure private endpoint resource ids are GUIDs. Synthesize one

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -382,8 +382,7 @@ fn service_state_enum_roundtrip() {
         ("idle", ServiceState::Idle),
     ];
     for (json_val, expected) in states {
-        let parsed: ServiceState =
-            serde_json::from_str(&format!(r#""{json_val}""#)).unwrap();
+        let parsed: ServiceState = serde_json::from_str(&format!(r#""{json_val}""#)).unwrap();
         assert_eq!(parsed, expected);
 
         let serialized = serde_json::to_string(&expected).unwrap();
@@ -410,8 +409,7 @@ fn clickpipe_state_all_variants() {
         "Resync",
     ];
     for s in states {
-        let parsed: ClickPipeState =
-            serde_json::from_str(&format!(r#""{s}""#)).unwrap();
+        let parsed: ClickPipeState = serde_json::from_str(&format!(r#""{s}""#)).unwrap();
         let serialized = serde_json::to_string(&parsed).unwrap();
         assert_eq!(serialized, format!(r#""{s}""#));
     }
@@ -455,7 +453,10 @@ fn unknown_enum_variant_deserializes() {
     // An unknown service state from the API should deserialize into Unknown(String)
     let json = r#"{"state": "brand-new-state"}"#;
     let svc: Service = serde_json::from_str(json).unwrap();
-    assert_eq!(svc.state, ServiceState::Unknown("brand-new-state".to_string()));
+    assert_eq!(
+        svc.state,
+        ServiceState::Unknown("brand-new-state".to_string())
+    );
 }
 
 #[test]
@@ -477,7 +478,10 @@ fn known_enum_variant_still_deserializes() {
 #[test]
 fn unknown_enum_display() {
     assert_eq!(ServiceState::Running.to_string(), "running");
-    assert_eq!(ServiceState::Unknown("brand-new".to_string()).to_string(), "brand-new");
+    assert_eq!(
+        ServiceState::Unknown("brand-new".to_string()).to_string(),
+        "brand-new"
+    );
 }
 
 // ===========================================================================
@@ -762,19 +766,18 @@ fn deprecated_request_fields_absent_by_default() {
     let member = MemberPatchRequest {
         assigned_role_ids: Some(vec!["admin".to_string()]),
     };
-    assert!(serde_json::to_value(&member)
-        .unwrap()
-        .get("role")
-        .is_none());
+    assert!(serde_json::to_value(&member).unwrap().get("role").is_none());
 
     let invitation = InvitationPostRequest {
         email: "alice@example.com".to_string(),
         assigned_role_ids: vec!["admin".to_string()],
     };
-    assert!(serde_json::to_value(&invitation)
-        .unwrap()
-        .get("role")
-        .is_none());
+    assert!(
+        serde_json::to_value(&invitation)
+            .unwrap()
+            .get("role")
+            .is_none()
+    );
 
     let scaling = ServiceScalingPatchRequest {
         num_replicas: Some(3.0),
@@ -930,7 +933,10 @@ fn deserialize_scaling_schedule_entry_fixed_scaling_fields() {
 fn serialize_postgres_instance_config_default_envelope() {
     // Default envelope serializes to the minimal accepted body shape.
     let json = serde_json::to_value(PostgresInstanceConfig::default()).unwrap();
-    assert_eq!(json, serde_json::json!({ "pgConfig": {}, "pgBouncerConfig": {} }));
+    assert_eq!(
+        json,
+        serde_json::json!({ "pgConfig": {}, "pgBouncerConfig": {} })
+    );
 }
 
 // ===========================================================================
@@ -1121,7 +1127,8 @@ fn clickpipe_minimal_response() {
 
 #[test]
 fn postgres_service_minimal_response() {
-    let pg: PostgresService = serde_json::from_str(r#"{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}"#).unwrap();
+    let pg: PostgresService =
+        serde_json::from_str(r#"{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}"#).unwrap();
     assert_eq!(pg.name, "");
     assert_eq!(pg.state, PgStateProperty::default());
 }
@@ -1269,7 +1276,10 @@ fn deserialize_postgres_instance_config() {
         "pgBouncerConfig": {}
     }"#;
     let config: PostgresInstanceConfig = serde_json::from_str(json).unwrap();
-    assert_eq!(config.pg_config.max_connections, Some(serde_json::json!(200)));
+    assert_eq!(
+        config.pg_config.max_connections,
+        Some(serde_json::json!(200))
+    );
 }
 
 #[test]
@@ -1290,15 +1300,30 @@ fn deserialize_postgres_instance_config_string_wrapped_numbers() {
         "pgBouncerConfig": {}
     }"#;
     let config: PostgresInstanceConfig = serde_json::from_str(json).unwrap();
-    assert_eq!(config.pg_config.max_connections, Some(serde_json::json!("100")));
-    assert_eq!(config.pg_config.random_page_cost, Some(serde_json::json!("1.1")));
-    assert_eq!(config.pg_config.max_worker_processes, Some(serde_json::json!(8)));
-    assert_eq!(config.pg_config.autovacuum_naptime, Some(serde_json::json!("5s")));
+    assert_eq!(
+        config.pg_config.max_connections,
+        Some(serde_json::json!("100"))
+    );
+    assert_eq!(
+        config.pg_config.random_page_cost,
+        Some(serde_json::json!("1.1"))
+    );
+    assert_eq!(
+        config.pg_config.max_worker_processes,
+        Some(serde_json::json!(8))
+    );
+    assert_eq!(
+        config.pg_config.autovacuum_naptime,
+        Some(serde_json::json!("5s"))
+    );
     assert_eq!(
         config.pg_config.autovacuum_vacuum_scale_factor,
         Some(serde_json::json!("0.2"))
     );
-    assert_eq!(config.pg_config.autovacuum_max_workers, Some(serde_json::json!(3)));
+    assert_eq!(
+        config.pg_config.autovacuum_max_workers,
+        Some(serde_json::json!(3))
+    );
 }
 
 #[test]
@@ -1310,7 +1335,10 @@ fn deserialize_reverse_private_endpoint() {
     }"#;
     let rpe: ReversePrivateEndpoint = serde_json::from_str(json).unwrap();
     assert_eq!(rpe.description, "MSK endpoint");
-    assert_eq!(rpe.status, ReversePrivateEndpointStatus::Other("available".to_string()));
+    assert_eq!(
+        rpe.status,
+        ReversePrivateEndpointStatus::Other("available".to_string())
+    );
 }
 
 #[test]
@@ -1409,7 +1437,10 @@ fn deserialize_clickpipe_pubsub_source() {
     let src: ClickPipePubSubSource = serde_json::from_str(json).unwrap();
     assert_eq!(src.topic, "projects/p/topics/t");
     assert_eq!(src.project_id, "my-project");
-    assert_eq!(src.authentication, ClickPipePubSubSourceAuthentication::ServiceAccount);
+    assert_eq!(
+        src.authentication,
+        ClickPipePubSubSourceAuthentication::ServiceAccount
+    );
     assert_eq!(src.format, ClickPipePubSubSourceFormat::JSONEachRow);
     assert_eq!(src.seek_type, ClickPipePubSubSourceSeektype::Latest);
     assert_eq!(src.ack_deadline, Some(60));
@@ -1431,7 +1462,10 @@ fn deserialize_clickpipe_post_pubsub_source_required_fields() {
     let src: ClickPipePostPubSubSource = serde_json::from_str(json).unwrap();
     assert_eq!(src.topic, "projects/p/topics/t");
     assert_eq!(src.seek_type, ClickPipePostPubSubSourceSeektype::Earliest);
-    assert_eq!(src.service_account_key.service_account_file, "/path/to/key.json");
+    assert_eq!(
+        src.service_account_key.service_account_file,
+        "/path/to/key.json"
+    );
 }
 
 #[test]
@@ -1506,7 +1540,10 @@ fn deserialize_clickstack_tile_config_heatmap_variant() {
     match cfg {
         ClickStackTileConfig::ClickStackHeatmapChartConfig(h) => {
             assert_eq!(h.source_id, "src-1");
-            assert_eq!(h.display_type, ClickStackHeatmapChartConfigDisplaytype::Heatmap);
+            assert_eq!(
+                h.display_type,
+                ClickStackHeatmapChartConfigDisplaytype::Heatmap
+            );
             assert_eq!(h.select.len(), 1);
             assert_eq!(h.select[0].value_expression, "latency_ms");
         }

--- a/crates/clickhouse-cloud-api/tests/run_query_test.rs
+++ b/crates/clickhouse-cloud-api/tests/run_query_test.rs
@@ -49,7 +49,12 @@ async fn run_query_sends_basic_auth_with_query_key() {
 
     // Basic auth must use the per-service Query API key, not the client's
     // primary (org-level) credentials.
-    let auth = request.headers.get("authorization").unwrap().to_str().unwrap();
+    let auth = request
+        .headers
+        .get("authorization")
+        .unwrap()
+        .to_str()
+        .unwrap();
     let expected = format!(
         "Basic {}",
         base64::engine::general_purpose::STANDARD.encode("query-key:query-secret")
@@ -94,7 +99,12 @@ async fn run_query_bearer_sends_bearer_token() {
     assert_eq!(requests.len(), 1);
     let request = &requests[0];
 
-    let auth = request.headers.get("authorization").unwrap().to_str().unwrap();
+    let auth = request
+        .headers
+        .get("authorization")
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert_eq!(auth, "Bearer oauth-token");
 
     // `auth-provider: custom` marks a custom Query API key; it must not be

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -473,7 +473,10 @@ fn compare_enum_values_consts(rust: &RustInventory, report: &mut DriftReport) {
         let rust_item = format!("models.rs::{name}::VALUES");
         let finding = Finding::new(
             FindingKind::EnumValuesMismatch,
-            format!("{name}::VALUES does not match enum wire values: {}", parts.join("; ")),
+            format!(
+                "{name}::VALUES does not match enum wire values: {}",
+                parts.join("; ")
+            ),
         )
         .at_rust(&rust_item)
         .detail("enum", name);

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -124,7 +124,10 @@ pub fn load_tokens() -> Option<TokenStore> {
 /// Path-injected core of [`load_tokens`]. Reads the global token file first;
 /// if absent/unreadable, attempts a one-time migration from `legacy_path`
 /// (write the global copy, best-effort delete the legacy file).
-fn load_tokens_from(global_path: &std::path::Path, legacy_path: &std::path::Path) -> Option<TokenStore> {
+fn load_tokens_from(
+    global_path: &std::path::Path,
+    legacy_path: &std::path::Path,
+) -> Option<TokenStore> {
     if let Ok(data) = std::fs::read_to_string(global_path)
         && let Ok(tokens) = serde_json::from_str::<TokenStore>(&data)
     {
@@ -197,8 +200,7 @@ pub async fn device_auth_login(api_url: &str) -> Result<TokenStore, Box<dyn std:
         )
     })?;
 
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     // Step 1: Request device code
     let form_body = format!(
@@ -314,8 +316,7 @@ pub async fn refresh_access_token(
     let config = auth_config_for_url(&tokens.api_url)
         .ok_or_else(|| format!("Cannot refresh: unknown API host in '{}'", tokens.api_url))?;
 
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     let form_body = format!(
         "grant_type={}&client_id={}&refresh_token={}",
@@ -521,11 +522,19 @@ mod tests {
 
         let mut global_tokens = sample_tokens();
         global_tokens.access_token = "global-wins".into();
-        std::fs::write(&global, serde_json::to_string_pretty(&global_tokens).unwrap()).unwrap();
+        std::fs::write(
+            &global,
+            serde_json::to_string_pretty(&global_tokens).unwrap(),
+        )
+        .unwrap();
 
         let mut legacy_tokens = sample_tokens();
         legacy_tokens.access_token = "legacy-ignored".into();
-        std::fs::write(&legacy, serde_json::to_string_pretty(&legacy_tokens).unwrap()).unwrap();
+        std::fs::write(
+            &legacy,
+            serde_json::to_string_pretty(&legacy_tokens).unwrap(),
+        )
+        .unwrap();
 
         let loaded = load_tokens_from(&global, &legacy).expect("global file should load");
         assert_eq!(loaded.access_token, "global-wins");

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -15,8 +15,9 @@ const OBJECT_STORAGE_FORMATS: &[&str] = &[
     "Parquet",
     "Avro",
 ];
-const OBJECT_STORAGE_COMPRESSIONS: &[&str] =
-    &["none", "gzip", "gz", "brotli", "br", "xz", "LZMA", "zstd", "auto"];
+const OBJECT_STORAGE_COMPRESSIONS: &[&str] = &[
+    "none", "gzip", "gz", "brotli", "br", "xz", "LZMA", "zstd", "auto",
+];
 const OBJECT_STORAGE_TYPES: &[&str] = &[
     "s3",
     "gcs",
@@ -2560,10 +2561,7 @@ mod tests {
             panic!("expected schema-discover");
         };
         assert_eq!(service_id, "svc-1");
-        assert!(matches!(
-            command,
-            ClickPipeSchemaDiscoverCommands::Kafka(_)
-        ));
+        assert!(matches!(command, ClickPipeSchemaDiscoverCommands::Kafka(_)));
     }
 
     #[test]
@@ -2975,8 +2973,14 @@ mod tests {
 
         // Service reads
         assert_write(&["clickhousectl", "cloud", "service", "list"], false);
-        assert_write(&["clickhousectl", "cloud", "service", "get", "svc-1"], false);
-        assert_write(&["clickhousectl", "cloud", "service", "prometheus", "svc-1"], false);
+        assert_write(
+            &["clickhousectl", "cloud", "service", "get", "svc-1"],
+            false,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "service", "prometheus", "svc-1"],
+            false,
+        );
 
         // Backup reads
         assert_write(
@@ -3051,10 +3055,25 @@ mod tests {
 
         // Postgres reads
         assert_write(&["clickhousectl", "cloud", "postgres", "list"], false);
-        assert_write(&["clickhousectl", "cloud", "postgres", "get", "pg-1"], false);
-        assert_write(&["clickhousectl", "cloud", "postgres", "certs", "get", "pg-1"], false);
-        assert_write(&["clickhousectl", "cloud", "postgres", "config", "get", "pg-1"], false);
-
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "get", "pg-1"],
+            false,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "certs", "get", "pg-1"],
+            false,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "config",
+                "get",
+                "pg-1",
+            ],
+            false,
+        );
     }
 
     #[test]
@@ -3267,16 +3286,112 @@ mod tests {
         );
 
         // Postgres writes
-        assert_write(&["clickhousectl", "cloud", "postgres", "create", "--name", "pg", "--region", "us-east-1", "--size", "m7i.2xlarge"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "update", "pg-1", "--size", "c6gd.large"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "delete", "pg-1"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "config", "replace", "pg-1", "--file", "/tmp/c.json"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "config", "patch", "pg-1", "--set", "max_connections=500"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "reset-password", "pg-1", "--generate"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "read-replica", "create", "pg-1", "--name", "r1"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "restore", "pg-1", "--name", "r", "--restore-target", "2026-04-16T12:00:00Z"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "restart", "pg-1"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "promote", "pg-1"], true);
-        assert_write(&["clickhousectl", "cloud", "postgres", "switchover", "pg-1"], true);
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "create",
+                "--name",
+                "pg",
+                "--region",
+                "us-east-1",
+                "--size",
+                "m7i.2xlarge",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "update",
+                "pg-1",
+                "--size",
+                "c6gd.large",
+            ],
+            true,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "delete", "pg-1"],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "config",
+                "replace",
+                "pg-1",
+                "--file",
+                "/tmp/c.json",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "config",
+                "patch",
+                "pg-1",
+                "--set",
+                "max_connections=500",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "reset-password",
+                "pg-1",
+                "--generate",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "read-replica",
+                "create",
+                "pg-1",
+                "--name",
+                "r1",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "postgres",
+                "restore",
+                "pg-1",
+                "--name",
+                "r",
+                "--restore-target",
+                "2026-04-16T12:00:00Z",
+            ],
+            true,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "restart", "pg-1"],
+            true,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "promote", "pg-1"],
+            true,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "postgres", "switchover", "pg-1"],
+            true,
+        );
     }
 }

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -158,12 +158,12 @@ fn resolve_auth_with_sources(
     };
 
     if api_key.is_some() || api_secret.is_some() {
-        let key = api_key
-            .map(String::from)
-            .ok_or_else(|| CloudError::auth("API key required when --api-key or --api-secret is set"))?;
-        let secret = api_secret
-            .map(String::from)
-            .ok_or_else(|| CloudError::auth("API secret required when --api-key or --api-secret is set"))?;
+        let key = api_key.map(String::from).ok_or_else(|| {
+            CloudError::auth("API key required when --api-key or --api-secret is set")
+        })?;
+        let secret = api_secret.map(String::from).ok_or_else(|| {
+            CloudError::auth("API secret required when --api-key or --api-secret is set")
+        })?;
         return Ok(ResolvedAuth {
             creds: ResolvedCreds::Basic { key, secret },
             source: AuthSource::CliFlags,
@@ -292,7 +292,8 @@ impl AuthSource {
                 crate::cloud::credentials::credentials_path().display()
             ),
             AuthSource::EnvVars => {
-                let base = "environment variables (CLICKHOUSE_CLOUD_API_KEY, CLICKHOUSE_CLOUD_API_SECRET)";
+                let base =
+                    "environment variables (CLICKHOUSE_CLOUD_API_KEY, CLICKHOUSE_CLOUD_API_SECRET)";
                 match dotenv_env_provenance() {
                     Some(path) => format!("{base} (loaded from {})", path.display()),
                     None => base.to_string(),
@@ -1231,7 +1232,11 @@ mod tests {
                 .describe()
                 .contains("CLICKHOUSE_CLOUD_API_KEY")
         );
-        assert!(AuthSource::CredentialsFile.describe().contains("credentials"));
+        assert!(
+            AuthSource::CredentialsFile
+                .describe()
+                .contains("credentials")
+        );
         assert!(AuthSource::OAuthTokens.describe().contains("OAuth"));
     }
 
@@ -1312,10 +1317,15 @@ mod tests {
     }
 
     fn env_map(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
-    fn lookup_from(map: &std::collections::HashMap<String, String>) -> impl Fn(&str) -> Option<String> + '_ {
+    fn lookup_from(
+        map: &std::collections::HashMap<String, String>,
+    ) -> impl Fn(&str) -> Option<String> + '_ {
         move |k: &str| map.get(k).cloned()
     }
 
@@ -1352,9 +1362,16 @@ mod tests {
             ("CLICKHOUSE_CLOUD_API_SECRET", "shell_s"),
         ]);
         let lookup = lookup_from(&env);
-        let resolved =
-            resolve_auth_with_sources(None, None, None, &dotenv, &lookup, &some_credentials, &no_tokens)
-                .unwrap();
+        let resolved = resolve_auth_with_sources(
+            None,
+            None,
+            None,
+            &dotenv,
+            &lookup,
+            &some_credentials,
+            &no_tokens,
+        )
+        .unwrap();
         assert_eq!(resolved.source, AuthSource::CredentialsFile);
         match resolved.creds {
             ResolvedCreds::Basic { key, secret } => {
@@ -1373,8 +1390,16 @@ mod tests {
         ]);
         let env = env_map(&[]);
         let lookup = lookup_from(&env);
-        let resolved =
-            resolve_auth_with_sources(None, None, None, &dotenv, &lookup, &no_credentials, &no_tokens).unwrap();
+        let resolved = resolve_auth_with_sources(
+            None,
+            None,
+            None,
+            &dotenv,
+            &lookup,
+            &no_credentials,
+            &no_tokens,
+        )
+        .unwrap();
         assert_eq!(resolved.source, AuthSource::EnvVars);
         match resolved.creds {
             ResolvedCreds::Basic { key, secret } => {
@@ -1404,8 +1429,16 @@ mod tests {
             ("CLICKHOUSE_CLOUD_API_SECRET", "shell_s"),
         ]);
         let lookup = lookup_from(&env);
-        let resolved =
-            resolve_auth_with_sources(None, None, None, &dotenv, &lookup, &no_credentials, &no_tokens).unwrap();
+        let resolved = resolve_auth_with_sources(
+            None,
+            None,
+            None,
+            &dotenv,
+            &lookup,
+            &no_credentials,
+            &no_tokens,
+        )
+        .unwrap();
         match resolved.creds {
             ResolvedCreds::Basic { key, secret } => {
                 assert_eq!(key, "shell_k");
@@ -1423,8 +1456,16 @@ mod tests {
         let dotenv = dotenv_with(&[("CLICKHOUSE_CLOUD_API_SECRET", "dot_s")]);
         let env = env_map(&[("CLICKHOUSE_CLOUD_API_KEY", "shell_k")]);
         let lookup = lookup_from(&env);
-        let resolved =
-            resolve_auth_with_sources(None, None, None, &dotenv, &lookup, &no_credentials, &no_tokens).unwrap();
+        let resolved = resolve_auth_with_sources(
+            None,
+            None,
+            None,
+            &dotenv,
+            &lookup,
+            &no_credentials,
+            &no_tokens,
+        )
+        .unwrap();
         match resolved.creds {
             ResolvedCreds::Basic { key, secret } => {
                 assert_eq!(key, "shell_k");
@@ -1457,7 +1498,16 @@ mod tests {
             ("CLICKHOUSE_CLOUD_API_SECRET", ""),
         ]);
         let lookup = lookup_from(&env);
-        let resolved = resolve_auth_with_sources(None, None, None, &dotenv, &lookup, &no_credentials, &no_tokens).unwrap();
+        let resolved = resolve_auth_with_sources(
+            None,
+            None,
+            None,
+            &dotenv,
+            &lookup,
+            &no_credentials,
+            &no_tokens,
+        )
+        .unwrap();
         match resolved.creds {
             ResolvedCreds::Basic { key, secret } => {
                 assert_eq!(key, "dot_k");

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -3,17 +3,17 @@ use crate::cloud::credentials;
 use crate::cloud::output::print_human;
 use clickhouse_cloud_api::models::{
     ApiKeyPatchRequest, ApiKeyPatchRequestState, ApiKeyPostRequest, ApiKeyPostRequestState,
-    BackupConfigurationPatchRequest, InstancePrivateEndpointsPatch,
+    AutoscalingMode, BackupConfigurationPatchRequest, InstancePrivateEndpointsPatch,
     InstanceServiceQueryApiEndpointsPostRequest, InstanceTagsPatch, IpAccessListEntry,
     IpAccessListPatch, OrganizationPatchPrivateEndpoint,
     OrganizationPatchPrivateEndpointCloudprovider, OrganizationPatchPrivateEndpointRegion,
-    OrganizationPatchRequest, OrganizationPrivateEndpointsPatch, ResourceTagsV1, Service,
-    ServiceEndpointChange, ServiceEndpointChangeProtocol,
-    ServicePasswordPatchRequest, ServicePatchRequest, ServicePatchRequestReleasechannel,
-    ServicePostRequest, ServicePostRequestCompliancetype, ServicePostRequestProfile,
-    ServicePostRequestProvider, ServicePostRequestRegion, ServicePostRequestReleasechannel,
-    ServiceReplicaScalingPatchRequest,
-    ServiceStatePatchRequestCommand, ServicPrivateEndpointePostRequest, AutoscalingMode,
+    OrganizationPatchRequest, OrganizationPrivateEndpointsPatch, ResourceTagsV1,
+    ServicPrivateEndpointePostRequest, Service, ServiceEndpointChange,
+    ServiceEndpointChangeProtocol, ServicePasswordPatchRequest, ServicePatchRequest,
+    ServicePatchRequestReleasechannel, ServicePostRequest, ServicePostRequestCompliancetype,
+    ServicePostRequestProfile, ServicePostRequestProvider, ServicePostRequestRegion,
+    ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest,
+    ServiceStatePatchRequestCommand,
 };
 use std::io::{IsTerminal, Write};
 use tabled::{Table, Tabled, settings::Style};
@@ -1053,7 +1053,11 @@ pub async fn clickpipe_create_s3(
         azure_container_name: args.azure_container_name.clone(),
         path: args.path.clone(),
         service_account_key,
-        skip_initial_load: if args.skip_initial_load { Some(true) } else { None },
+        skip_initial_load: if args.skip_initial_load {
+            Some(true)
+        } else {
+            None
+        },
         start_after: args.start_after.clone(),
     };
 
@@ -1110,9 +1114,7 @@ fn build_kafka_credentials(
             }
         }
         Auth::MUTUAL_TLS => match mtls_contents {
-            Some((cert, key)) => {
-                Ok(serde_json::json!({ "certificate": cert, "privateKey": key }))
-            }
+            Some((cert, key)) => Ok(serde_json::json!({ "certificate": cert, "privateKey": key })),
             None => Err("MUTUAL_TLS requires --client-certificate and --client-key".into()),
         },
         Auth::Unknown(_) => Ok(serde_json::Value::Null),
@@ -1228,13 +1230,16 @@ fn build_kinesis_source(
         authentication: parse_enum(&args.auth)?,
         iam_role: args.iam_role.clone(),
         access_key,
-        use_enhanced_fan_out: if args.enhanced_fan_out { Some(true) } else { None },
+        use_enhanced_fan_out: if args.enhanced_fan_out {
+            Some(true)
+        } else {
+            None
+        },
         iterator_type: parse_enum(&args.iterator_type)?,
         timestamp: args
             .iterator_timestamp
             .map(|t| {
-                i64::try_from(t)
-                    .map_err(|_| format!("--iterator-timestamp {t} is out of range"))
+                i64::try_from(t).map_err(|_| format!("--iterator-timestamp {t} is out of range"))
             })
             .transpose()?,
     })
@@ -2212,8 +2217,8 @@ pub async fn service_query(
     let sql = read_query_sql(opts.query.as_deref(), opts.queries_file.as_deref())?;
 
     let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
-    let service = resolve_service(client, &org_id, opts.name.as_deref(), opts.id.as_deref())
-        .await?;
+    let service =
+        resolve_service(client, &org_id, opts.name.as_deref(), opts.id.as_deref()).await?;
     let service_id = service.id.to_string();
 
     let format = opts.format.unwrap_or_else(default_query_format);
@@ -2226,9 +2231,13 @@ pub async fn service_query(
         // `--no-auto-enable` is a no-op here since nothing is ever
         // provisioned.
         let run = |wake: bool| {
-            client
-                .api()
-                .run_query_bearer(&service_id, &sql, opts.database.as_deref(), &format, wake)
+            client.api().run_query_bearer(
+                &service_id,
+                &sql,
+                opts.database.as_deref(),
+                &format,
+                wake,
+            )
         };
         let result = match run(false).await {
             Err(clickhouse_cloud_api::Error::ServiceIdle) => {
@@ -2352,9 +2361,7 @@ fn read_query_sql(
     }
 
     if std::io::stdin().is_terminal() {
-        return Err(
-            "no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.".into(),
-        );
+        return Err("no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.".into());
     }
 
     let mut content = String::new();
@@ -3465,8 +3472,7 @@ mod tests {
     fn resolve_horizontal_autoscaling_explicit_vertical_with_no_replicas() {
         // Explicit --autoscaling-mode vertical with no replica pair → mode set,
         // replicas absent (lets the server apply vertical defaults).
-        let resolved =
-            resolve_horizontal_autoscaling(Some("vertical"), None, None).unwrap();
+        let resolved = resolve_horizontal_autoscaling(Some("vertical"), None, None).unwrap();
         assert_eq!(resolved.autoscaling_mode, Some(AutoscalingMode::Vertical));
         assert!(resolved.min_replicas.is_none());
         assert!(resolved.max_replicas.is_none());
@@ -3837,7 +3843,8 @@ mod tests {
         use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
         let args = kafka_args();
         let contents = Some(("CERT_PEM".into(), "KEY_PEM".into()));
-        let creds = super::build_kafka_credentials(&Auth::MUTUAL_TLS, &args.source, contents).unwrap();
+        let creds =
+            super::build_kafka_credentials(&Auth::MUTUAL_TLS, &args.source, contents).unwrap();
         assert_eq!(creds["certificate"], "CERT_PEM");
         assert_eq!(creds["privateKey"], "KEY_PEM");
     }

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -68,9 +68,7 @@ pub fn set_service_query_key(
     key: ServiceQueryKey,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut creds = load_credentials().unwrap_or_default();
-    creds
-        .service_query_keys
-        .insert(service_id.to_string(), key);
+    creds.service_query_keys.insert(service_id.to_string(), key);
     save_credentials(&creds)
 }
 

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -160,10 +160,7 @@ mod tests {
     #[test]
     fn renders_flat_object() {
         let v = json!({"name": "svc", "port": 9000, "secure": true});
-        assert_eq!(
-            render_to_string(&v),
-            "name: svc\nport: 9000\nsecure: true"
-        );
+        assert_eq!(render_to_string(&v), "name: svc\nport: 9000\nsecure: true");
     }
 
     #[test]
@@ -248,7 +245,10 @@ mod tests {
         let rendered = render_to_string(&serde_json::to_value(&svc).unwrap());
         assert!(rendered.contains("name: analytics"));
         assert!(rendered.contains("numReplicas: 3"));
-        assert!(!rendered.contains("tier"), "deprecated tier leaked: {rendered}");
+        assert!(
+            !rendered.contains("tier"),
+            "deprecated tier leaked: {rendered}"
+        );
         assert!(!rendered.contains("minTotalMemoryGb"));
         assert!(!rendered.contains("maxTotalMemoryGb"));
     }

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,5 +1,5 @@
-use crate::cloud::client::CloudClient;
 use crate::cloud::cli::parse_datetime;
+use crate::cloud::client::CloudClient;
 use crate::cloud::commands::{parse_serde_enum, parse_tags, resolve_org_id};
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
@@ -250,7 +250,9 @@ fn unwrap_api<T>(resp: ApiResponse<T>) -> Result<T, Box<dyn std::error::Error>> 
         .ok_or_else(|| "API response was missing a result body".into())
 }
 
-fn parse_pg_size(value: &str) -> Result<clickhouse_cloud_api::models::PgSize, Box<dyn std::error::Error>> {
+fn parse_pg_size(
+    value: &str,
+) -> Result<clickhouse_cloud_api::models::PgSize, Box<dyn std::error::Error>> {
     serde_json::from_value(serde_json::Value::String(value.to_string()))
         .map_err(|e| format!("invalid size '{}': {}", value, e).into())
 }
@@ -1005,9 +1007,14 @@ mod tests {
     #[test]
     fn parses_postgres_list_with_filters() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "list",
-            "--filter", "state=running",
-            "--filter", "region=us-east-1",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "list",
+            "--filter",
+            "state=running",
+            "--filter",
+            "region=us-east-1",
         ]);
         let PostgresCommands::List { filter, .. } = cmd else {
             panic!("expected list");
@@ -1027,13 +1034,25 @@ mod tests {
     #[test]
     fn parses_postgres_create_minimal() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "create",
-            "--name", "pg1",
-            "--region", "us-east-1",
-            "--size", "m7i.2xlarge",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
         ]);
         let PostgresCommands::Create {
-            name, region, size, provider, pg_version, ha_type, ..
+            name,
+            region,
+            size,
+            provider,
+            pg_version,
+            ha_type,
+            ..
         } = cmd
         else {
             panic!("expected create");
@@ -1049,16 +1068,32 @@ mod tests {
     #[test]
     fn parses_postgres_create_with_all_flags() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "create",
-            "--name", "pg1",
-            "--region", "us-east-1",
-            "--size", "m7i.2xlarge",
-            "--pg-version", "17",
-            "--ha-type", "sync",
-            "--tag", "env=prod",
-            "--tag", "owner=data",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
+            "--pg-version",
+            "17",
+            "--ha-type",
+            "sync",
+            "--tag",
+            "env=prod",
+            "--tag",
+            "owner=data",
         ]);
-        let PostgresCommands::Create { pg_version, ha_type, tag, .. } = cmd else {
+        let PostgresCommands::Create {
+            pg_version,
+            ha_type,
+            tag,
+            ..
+        } = cmd
+        else {
             panic!("expected create");
         };
         assert_eq!(pg_version.as_deref(), Some("17"));
@@ -1069,52 +1104,86 @@ mod tests {
     #[test]
     fn rejects_postgres_create_missing_required() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "create",
-            "--name", "pg1",
-            "--region", "us-east-1",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
             // missing --size
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("--size"));
     }
 
     #[test]
     fn rejects_postgres_create_invalid_pg_version() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "create",
-            "--name", "pg1",
-            "--region", "us-east-1",
-            "--size", "m7i.2xlarge",
-            "--pg-version", "15",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
+            "--pg-version",
+            "15",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("invalid value"));
     }
 
     #[test]
     fn rejects_postgres_create_pg_version_16() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "create",
-            "--name", "pg1",
-            "--region", "us-east-1",
-            "--size", "m7i.2xlarge",
-            "--pg-version", "16",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "create",
+            "--name",
+            "pg1",
+            "--region",
+            "us-east-1",
+            "--size",
+            "m7i.2xlarge",
+            "--pg-version",
+            "16",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("invalid value"));
     }
 
     #[test]
     fn parses_postgres_update_tag_diff_flags() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "update", "pg-1",
-            "--size", "c6gd.large",
-            "--add-tag", "env=prod",
-            "--add-tag", "team=data",
-            "--remove-tag", "old",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "update",
+            "pg-1",
+            "--size",
+            "c6gd.large",
+            "--add-tag",
+            "env=prod",
+            "--add-tag",
+            "team=data",
+            "--remove-tag",
+            "old",
         ]);
         let PostgresCommands::Update {
-            postgres_id, size, add_tag, remove_tag, ..
+            postgres_id,
+            size,
+            add_tag,
+            remove_tag,
+            ..
         } = cmd
         else {
             panic!("expected update");
@@ -1128,7 +1197,10 @@ mod tests {
     #[test]
     fn parses_postgres_update_no_fields() {
         let cmd = parse_postgres(&["clickhousectl", "cloud", "postgres", "update", "pg-1"]);
-        let PostgresCommands::Update { postgres_id, size, .. } = cmd else {
+        let PostgresCommands::Update {
+            postgres_id, size, ..
+        } = cmd
+        else {
             panic!("expected update");
         };
         assert_eq!(postgres_id, "pg-1");
@@ -1153,8 +1225,14 @@ mod tests {
         assert!(output.is_none());
 
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "certs", "get", "pg-1",
-            "--output", "/tmp/ca.pem",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "certs",
+            "get",
+            "pg-1",
+            "--output",
+            "/tmp/ca.pem",
         ]);
         let PostgresCommands::Certs(CertsCommands::Get { output, .. }) = cmd else {
             panic!("expected certs get");
@@ -1164,7 +1242,14 @@ mod tests {
 
     #[test]
     fn parses_postgres_config_get() {
-        let cmd = parse_postgres(&["clickhousectl", "cloud", "postgres", "config", "get", "pg-1"]);
+        let cmd = parse_postgres(&[
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "get",
+            "pg-1",
+        ]);
         assert!(matches!(
             cmd,
             PostgresCommands::Config(ConfigCommands::Get { .. })
@@ -1174,8 +1259,14 @@ mod tests {
     #[test]
     fn parses_postgres_config_replace_requires_file() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "config", "replace", "pg-1",
-            "--file", "/tmp/cfg.json",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "replace",
+            "pg-1",
+            "--file",
+            "/tmp/cfg.json",
         ]);
         let PostgresCommands::Config(ConfigCommands::Replace { file, .. }) = cmd else {
             panic!("expected replace");
@@ -1183,18 +1274,31 @@ mod tests {
         assert_eq!(file, PathBuf::from("/tmp/cfg.json"));
 
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "config", "replace", "pg-1",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "replace",
+            "pg-1",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("--file"));
     }
 
     #[test]
     fn parses_postgres_config_patch_with_set_entries() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "config", "patch", "pg-1",
-            "--set", "max_connections=500",
-            "--set", "random_page_cost=1.1",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "patch",
+            "pg-1",
+            "--set",
+            "max_connections=500",
+            "--set",
+            "random_page_cost=1.1",
         ]);
         let PostgresCommands::Config(ConfigCommands::Patch { sets, file, .. }) = cmd else {
             panic!("expected patch");
@@ -1206,8 +1310,14 @@ mod tests {
     #[test]
     fn parses_postgres_config_patch_with_file() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "config", "patch", "pg-1",
-            "--file", "/tmp/p.json",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "patch",
+            "pg-1",
+            "--file",
+            "/tmp/p.json",
         ]);
         let PostgresCommands::Config(ConfigCommands::Patch { sets, file, .. }) = cmd else {
             panic!("expected patch");
@@ -1219,31 +1329,54 @@ mod tests {
     #[test]
     fn rejects_postgres_config_patch_set_and_file_together() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "config", "patch", "pg-1",
-            "--set", "max_connections=500",
-            "--file", "/tmp/p.json",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "config",
+            "patch",
+            "pg-1",
+            "--set",
+            "max_connections=500",
+            "--file",
+            "/tmp/p.json",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("cannot be used"));
     }
 
     #[test]
     fn parses_postgres_reset_password_with_password_and_generate() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "reset-password", "pg-1",
-            "--password", "Hunter2345678",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "reset-password",
+            "pg-1",
+            "--password",
+            "Hunter2345678",
         ]);
-        let PostgresCommands::ResetPassword { password, generate, .. } = cmd else {
+        let PostgresCommands::ResetPassword {
+            password, generate, ..
+        } = cmd
+        else {
             panic!("expected reset-password");
         };
         assert_eq!(password.as_deref(), Some("Hunter2345678"));
         assert!(!generate);
 
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "reset-password", "pg-1",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "reset-password",
+            "pg-1",
             "--generate",
         ]);
-        let PostgresCommands::ResetPassword { password, generate, .. } = cmd else {
+        let PostgresCommands::ResetPassword {
+            password, generate, ..
+        } = cmd
+        else {
             panic!("expected reset-password");
         };
         assert!(password.is_none());
@@ -1253,22 +1386,39 @@ mod tests {
     #[test]
     fn rejects_postgres_reset_password_both() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "reset-password", "pg-1",
-            "--password", "abc",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "reset-password",
+            "pg-1",
+            "--password",
+            "abc",
             "--generate",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("cannot be used"));
     }
 
     #[test]
     fn parses_postgres_restore_valid_rfc3339() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "restore", "pg-1",
-            "--name", "restored",
-            "--restore-target", "2026-04-16T12:00:00Z",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "restore",
+            "pg-1",
+            "--name",
+            "restored",
+            "--restore-target",
+            "2026-04-16T12:00:00Z",
         ]);
-        let PostgresCommands::Restore { name, restore_target, .. } = cmd else {
+        let PostgresCommands::Restore {
+            name,
+            restore_target,
+            ..
+        } = cmd
+        else {
             panic!("expected restore");
         };
         assert_eq!(name, "restored");
@@ -1278,22 +1428,42 @@ mod tests {
     #[test]
     fn rejects_postgres_restore_invalid_datetime() {
         let err = Cli::try_parse_from([
-            "clickhousectl", "cloud", "postgres", "restore", "pg-1",
-            "--name", "restored",
-            "--restore-target", "yesterday",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "restore",
+            "pg-1",
+            "--name",
+            "restored",
+            "--restore-target",
+            "yesterday",
         ])
-        .err().expect("expected parse error");
+        .err()
+        .expect("expected parse error");
         assert!(err.to_string().contains("invalid datetime"));
     }
 
     #[test]
     fn parses_postgres_read_replica_create() {
         let cmd = parse_postgres(&[
-            "clickhousectl", "cloud", "postgres", "read-replica", "create", "pg-1",
-            "--name", "replica1",
-            "--tag", "role=read",
+            "clickhousectl",
+            "cloud",
+            "postgres",
+            "read-replica",
+            "create",
+            "pg-1",
+            "--name",
+            "replica1",
+            "--tag",
+            "role=read",
         ]);
-        let PostgresCommands::ReadReplica(ReadReplicaCommands::Create { postgres_id, name, tag, .. }) = cmd else {
+        let PostgresCommands::ReadReplica(ReadReplicaCommands::Create {
+            postgres_id,
+            name,
+            tag,
+            ..
+        }) = cmd
+        else {
             panic!("expected read-replica create");
         };
         assert_eq!(postgres_id, "pg-1");

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -10,8 +10,8 @@ use crate::cloud::client::CloudClient;
 use crate::cloud::credentials::{self, ServiceQueryKey};
 use chrono::Utc;
 use clickhouse_cloud_api::models::{
-    ApiKeyPostRequest, ApiKeyPostRequestState,
-    InstanceServiceQueryApiEndpointsPostRequest, IpAccessListEntry,
+    ApiKeyPostRequest, ApiKeyPostRequestState, InstanceServiceQueryApiEndpointsPostRequest,
+    IpAccessListEntry,
 };
 
 /// The role attached to the query endpoint binding. Grants the key read +

--- a/crates/clickhousectl/src/dotenv.rs
+++ b/crates/clickhousectl/src/dotenv.rs
@@ -114,7 +114,10 @@ mod tests {
         write_env(dir.path(), "CLICKHOUSE_CLOUD_API_KEY=k\n");
         let loaded = load_from(dir.path());
         assert_eq!(loaded.get("CLICKHOUSE_CLOUD_API_KEY"), Some("k"));
-        assert_eq!(loaded.source_path(), Some(dir.path().join(".env").as_path()));
+        assert_eq!(
+            loaded.source_path(),
+            Some(dir.path().join(".env").as_path())
+        );
     }
 
     #[test]
@@ -142,10 +145,7 @@ mod tests {
     #[test]
     fn filters_non_clickhouse_keys() {
         let dir = tempfile::tempdir().unwrap();
-        write_env(
-            dir.path(),
-            "OPENAI_KEY=foo\nCLICKHOUSE_CLOUD_API_KEY=bar\n",
-        );
+        write_env(dir.path(), "OPENAI_KEY=foo\nCLICKHOUSE_CLOUD_API_KEY=bar\n");
         let loaded = load_from(dir.path());
         assert_eq!(loaded.get("CLICKHOUSE_CLOUD_API_KEY"), Some("bar"));
         assert!(loaded.get("OPENAI_KEY").is_none());

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -25,7 +25,9 @@ pub enum Error {
     #[error("Version {0} is already installed")]
     VersionAlreadyInstalled(String),
 
-    #[error("Version {version} is in use by running server(s): {servers}. Stop them first, or pass --force.")]
+    #[error(
+        "Version {version} is in use by running server(s): {servers}. Stop them first, or pass --force."
+    )]
     VersionInUse { version: String, servers: String },
 
     #[error("Unsupported platform: {os}/{arch}")]
@@ -73,7 +75,9 @@ pub enum Error {
     #[error("{0}")]
     ConfigNotFound(String),
 
-    #[error("Invalid config name '{0}': must be a file in the configs dir, not a path (no '/', '\\', or '..')")]
+    #[error(
+        "Invalid config name '{0}': must be a file in the configs dir, not a path (no '/', '\\', or '..')"
+    )]
     InvalidConfigName(String),
 
     #[error("Docker is not available: {0}")]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -506,7 +506,9 @@ mod tests {
     #[test]
     fn server_start_config_file_defaults_to_none() {
         let LocalCommands::Server {
-            command: ServerCommands::Start { config_file, args, .. },
+            command: ServerCommands::Start {
+                config_file, args, ..
+            },
         } = local_command(&["server", "start"])
         else {
             panic!("expected server start");

--- a/crates/clickhousectl/src/local/config.rs
+++ b/crates/clickhousectl/src/local/config.rs
@@ -249,10 +249,7 @@ mod tests {
         std::fs::create_dir(&configs).unwrap();
 
         let err = resolve_config_in(&configs, "../outside").unwrap_err();
-        assert!(
-            matches!(err, Error::InvalidConfigName(_)),
-            "got: {err:?}"
-        );
+        assert!(matches!(err, Error::InvalidConfigName(_)), "got: {err:?}");
     }
 
     #[test]
@@ -264,10 +261,7 @@ mod tests {
         std::fs::create_dir(&configs).unwrap();
 
         let err = resolve_config_in(&configs, "../outside.xml").unwrap_err();
-        assert!(
-            matches!(err, Error::InvalidConfigName(_)),
-            "got: {err:?}"
-        );
+        assert!(matches!(err, Error::InvalidConfigName(_)), "got: {err:?}");
     }
 
     #[test]
@@ -277,20 +271,14 @@ mod tests {
         // Absolute path would make `dir.join` discard the configs dir entirely.
         let abs = tmp.path().join("dev.xml");
         let err = resolve_config_in(tmp.path(), abs.to_str().unwrap()).unwrap_err();
-        assert!(
-            matches!(err, Error::InvalidConfigName(_)),
-            "got: {err:?}"
-        );
+        assert!(matches!(err, Error::InvalidConfigName(_)), "got: {err:?}");
     }
 
     #[test]
     fn rejects_dotdot() {
         let tmp = tempfile::tempdir().unwrap();
         let err = resolve_config_in(tmp.path(), "..").unwrap_err();
-        assert!(
-            matches!(err, Error::InvalidConfigName(_)),
-            "got: {err:?}"
-        );
+        assert!(matches!(err, Error::InvalidConfigName(_)), "got: {err:?}");
     }
 
     #[test]
@@ -338,7 +326,12 @@ mod tests {
 
         apply_config_overlay(&data_dir, Some(&src)).unwrap();
 
-        assert!(data_dir.join("config.d").join("chctl-config.yaml").is_file());
+        assert!(
+            data_dir
+                .join("config.d")
+                .join("chctl-config.yaml")
+                .is_file()
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/discovery.rs
+++ b/crates/clickhousectl/src/local/discovery.rs
@@ -137,9 +137,10 @@ pub fn parse_server_cwd(cwd: &str) -> Option<(String, String)> {
 /// Parse a port value from command-line flags like `--http_port=8123`.
 pub fn parse_port_flag(cmdline: &str, flag: &str) -> Option<u16> {
     let prefix = format!("{}=", flag);
-    cmdline
-        .split_whitespace()
-        .find_map(|arg| arg.strip_prefix(&prefix).and_then(|v| v.parse::<u16>().ok()))
+    cmdline.split_whitespace().find_map(|arg| {
+        arg.strip_prefix(&prefix)
+            .and_then(|v| v.parse::<u16>().ok())
+    })
 }
 
 /// Extract the ClickHouse version from the binary path in the command line.
@@ -222,15 +223,13 @@ mod tests {
 
     #[test]
     fn parse_http_port() {
-        let cmdline =
-            "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8123 --tcp_port=9000";
+        let cmdline = "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8123 --tcp_port=9000";
         assert_eq!(parse_port_flag(cmdline, "--http_port"), Some(8123));
     }
 
     #[test]
     fn parse_tcp_port() {
-        let cmdline =
-            "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8124 --tcp_port=9001";
+        let cmdline = "/home/user/.clickhouse/versions/25.12.5.44/clickhouse server --http_port=8124 --tcp_port=9001";
         assert_eq!(parse_port_flag(cmdline, "--tcp_port"), Some(9001));
     }
 

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -52,7 +52,9 @@ pub async fn connect() -> Result<Docker> {
 pub async fn pull_image(docker: &Docker, tag: &str) -> Result<()> {
     use bollard::query_parameters::CreateImageOptionsBuilder;
     let from = format!("postgres:{}", tag);
-    let opts = CreateImageOptionsBuilder::default().from_image(&from).build();
+    let opts = CreateImageOptionsBuilder::default()
+        .from_image(&from)
+        .build();
     let mut stream = docker.create_image(Some(opts), None, None);
     while let Some(item) = stream.next().await {
         let info = item.map_err(|e| Error::DockerError(e.to_string()))?;
@@ -69,7 +71,9 @@ pub async fn image_exists(docker: &Docker, tag: &str) -> Result<bool> {
     let name = format!("postgres:{}", tag);
     match docker.inspect_image(&name).await {
         Ok(_) => Ok(true),
-        Err(BErr::DockerResponseServerError { status_code: 404, .. }) => Ok(false),
+        Err(BErr::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(false),
         Err(e) => Err(Error::DockerError(e.to_string())),
     }
 }
@@ -194,7 +198,9 @@ pub async fn ensure_name_free(
             let _ = stop_container(docker, &id).await;
             remove_container(docker, &id).await
         }
-        Err(BErr::DockerResponseServerError { status_code: 404, .. }) => Ok(()),
+        Err(BErr::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(()),
         Err(e) => Err(Error::DockerError(e.to_string())),
     }
 }
@@ -451,7 +457,7 @@ pub async fn exec_psql_in_container(
 
     #[cfg(unix)]
     let resize_task = {
-        use tokio::signal::unix::{signal, SignalKind};
+        use tokio::signal::unix::{SignalKind, signal};
         let docker_clone = docker.clone();
         let exec_id_clone = exec_id.clone();
         tokio::spawn(async move {
@@ -596,8 +602,9 @@ pub fn remove_host_dir_blocking(host_path: &std::path::Path) -> Result<()> {
         let docker = connect().await?;
 
         // Pull alpine on first use.
-        if let Err(BErr::DockerResponseServerError { status_code: 404, .. }) =
-            docker.inspect_image("alpine:latest").await
+        if let Err(BErr::DockerResponseServerError {
+            status_code: 404, ..
+        }) = docker.inspect_image("alpine:latest").await
         {
             let mut s = docker.create_image(
                 Some(
@@ -626,10 +633,7 @@ pub fn remove_host_dir_blocking(host_path: &std::path::Path) -> Result<()> {
             ..Default::default()
         };
         let created = docker
-            .create_container(
-                Some(CreateContainerOptionsBuilder::default().build()),
-                cfg,
-            )
+            .create_container(Some(CreateContainerOptionsBuilder::default().build()), cfg)
             .await
             .map_err(|e| Error::DockerError(e.to_string()))?;
         docker
@@ -682,8 +686,8 @@ pub fn start_existing_blocking(id: &str) -> Result<()> {
 /// timeout) and we return silently.
 pub fn recover_project_postgres_blocking(project_cwd: &str) {
     use crate::local::server::{
-        ensure_pg_data_dir, pg_instance_key, save_server_info,
-        server_meta_path_for_recovery, Engine, ServerInfo,
+        Engine, ServerInfo, ensure_pg_data_dir, pg_instance_key, save_server_info,
+        server_meta_path_for_recovery,
     };
     let cwd_owned = project_cwd.to_string();
     let _ = block_on(async move {

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -53,7 +53,8 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
 /// the tag. The CLI accepts both `@` (more shell-friendly, no need to quote)
 /// and `:` (matches Docker image syntax).
 fn parse_postgres_install_spec(spec: &str) -> Option<&str> {
-    spec.strip_prefix("postgres@").or_else(|| spec.strip_prefix("postgres:"))
+    spec.strip_prefix("postgres@")
+        .or_else(|| spec.strip_prefix("postgres:"))
 }
 
 async fn install_postgres(tag: &str, force: bool, json: bool) -> Result<()> {
@@ -160,8 +161,7 @@ async fn use_version(version_spec: &str, no_global: bool, json: bool) -> Result<
     let spec = version_manager::parse_version_spec(version_spec)?;
     let platform = version_manager::platform::Platform::detect()?;
 
-    let version =
-        version_manager::install::ensure_installed_local_first(&spec, &platform).await?;
+    let version = version_manager::install::ensure_installed_local_first(&spec, &platform).await?;
 
     version_manager::set_default_version(&version)?;
 
@@ -794,7 +794,11 @@ fn list_servers_local(json: bool) -> Result<()> {
                     match e.info {
                         Some(info) => {
                             let is_ch = info.engine == server::Engine::Clickhouse;
-                            let pid = if is_ch && running { Some(info.pid) } else { None };
+                            let pid = if is_ch && running {
+                                Some(info.pid)
+                            } else {
+                                None
+                            };
                             let http_port = if is_ch { Some(info.http_port) } else { None };
                             // For Postgres the disk key is `<name>-pg<major>`;
                             // show users the friendly name without the suffix.
@@ -892,10 +896,7 @@ fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<(
 
     let entry = matches[0];
     if !json {
-        println!(
-            "Stopping server '{}' in {}...",
-            entry.name, entry.project
-        );
+        println!("Stopping server '{}' in {}...", entry.name, entry.project);
     }
     server::kill_server_by_pid(entry.pid)?;
     let out = output::ServerStopOutput {
@@ -1024,7 +1025,10 @@ mod tests {
     #[test]
     fn parse_postgres_install_spec_recognizes_at_and_colon() {
         assert_eq!(parse_postgres_install_spec("postgres@17"), Some("17"));
-        assert_eq!(parse_postgres_install_spec("postgres:17-alpine"), Some("17-alpine"));
+        assert_eq!(
+            parse_postgres_install_spec("postgres:17-alpine"),
+            Some("17-alpine")
+        );
         assert_eq!(parse_postgres_install_spec("25.12"), None);
         assert_eq!(parse_postgres_install_spec("stable"), None);
     }
@@ -1064,7 +1068,8 @@ mod tests {
 
     #[test]
     fn update_dotenv_replaces_existing_vars() {
-        let existing = "CLICKHOUSE_HOST=oldhost\nDATABASE_URL=postgres://...\nCLICKHOUSE_PORT=1234\n";
+        let existing =
+            "CLICKHOUSE_HOST=oldhost\nDATABASE_URL=postgres://...\nCLICKHOUSE_PORT=1234\n";
         let vars = vec![
             ("CLICKHOUSE_HOST", "localhost".to_string()),
             ("CLICKHOUSE_PORT", "9000".to_string()),
@@ -1144,17 +1149,26 @@ mod tests {
 
     #[test]
     fn extract_dotenv_key_simple() {
-        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(
+            extract_dotenv_key("CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"),
+            Some("CLICKHOUSE_HOST")
+        );
     }
 
     #[test]
     fn extract_dotenv_key_with_export() {
-        assert_eq!(extract_dotenv_key("export CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(
+            extract_dotenv_key("export CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"),
+            Some("CLICKHOUSE_HOST")
+        );
     }
 
     #[test]
     fn extract_dotenv_key_with_spaces() {
-        assert_eq!(extract_dotenv_key("CLICKHOUSE_HOST = localhost", "CLICKHOUSE_"), Some("CLICKHOUSE_HOST"));
+        assert_eq!(
+            extract_dotenv_key("CLICKHOUSE_HOST = localhost", "CLICKHOUSE_"),
+            Some("CLICKHOUSE_HOST")
+        );
         assert_eq!(
             extract_dotenv_key("export CLICKHOUSE_HOST = localhost", "CLICKHOUSE_"),
             Some("CLICKHOUSE_HOST")
@@ -1163,13 +1177,19 @@ mod tests {
 
     #[test]
     fn extract_dotenv_key_non_clickhouse() {
-        assert_eq!(extract_dotenv_key("DATABASE_URL=postgres://...", "CLICKHOUSE_"), None);
+        assert_eq!(
+            extract_dotenv_key("DATABASE_URL=postgres://...", "CLICKHOUSE_"),
+            None
+        );
         assert_eq!(extract_dotenv_key("export FOO=bar", "CLICKHOUSE_"), None);
     }
 
     #[test]
     fn extract_dotenv_key_comment_and_blank() {
-        assert_eq!(extract_dotenv_key("# CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"), None);
+        assert_eq!(
+            extract_dotenv_key("# CLICKHOUSE_HOST=localhost", "CLICKHOUSE_"),
+            None
+        );
         assert_eq!(extract_dotenv_key("", "CLICKHOUSE_"), None);
     }
 
@@ -1180,7 +1200,10 @@ mod tests {
 
     #[test]
     fn format_dotenv_line_with_prefix() {
-        assert_eq!(format_dotenv_line("export ", "KEY", "value"), "export KEY=value");
+        assert_eq!(
+            format_dotenv_line("export ", "KEY", "value"),
+            "export KEY=value"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -336,7 +336,11 @@ impl fmt::Display for ServerListOutput {
                     ServerListRowWithEngine {
                         name: e.name.clone(),
                         engine: e.engine.clone(),
-                        status: if e.running { "running".into() } else { "stopped".into() },
+                        status: if e.running {
+                            "running".into()
+                        } else {
+                            "stopped".into()
+                        },
                         pid_or_container: id,
                         version: e.version.clone().unwrap_or_default(),
                         http_port: e.http_port.map(|p| p.to_string()).unwrap_or_default(),
@@ -422,11 +426,7 @@ pub struct PostgresStartOutput {
 impl fmt::Display for PostgresStartOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let short = self.container_id.chars().take(12).collect::<String>();
-        writeln!(
-            f,
-            "Postgres '{}' running (container: {})",
-            self.name, short
-        )?;
+        writeln!(f, "Postgres '{}' running (container: {})", self.name, short)?;
         writeln!(f, "  Image:    {}", self.image)?;
         writeln!(f, "  Port:     {}", self.port)?;
         writeln!(f, "  User:     {}", self.user)?;
@@ -587,10 +587,8 @@ mod tests {
                 },
             ],
         };
-        let json: serde_json::Value = serde_json::from_str(
-            &serde_json::to_string_pretty(&output).unwrap(),
-        )
-        .unwrap();
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
         assert_eq!(json["versions"][0]["version"], "25.12.5.44");
         assert_eq!(json["versions"][0]["default"], true);
@@ -601,9 +599,7 @@ mod tests {
 
     #[test]
     fn list_installed_json_empty() {
-        let output = ListInstalledOutput {
-            versions: vec![],
-        };
+        let output = ListInstalledOutput { versions: vec![] };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
         assert_eq!(json["versions"].as_array().unwrap().len(), 0);
@@ -828,9 +824,7 @@ mod tests {
 
     #[test]
     fn server_stop_all_json_empty() {
-        let output = ServerStopAllOutput {
-            servers: vec![],
-        };
+        let output = ServerStopAllOutput { servers: vec![] };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
@@ -910,9 +904,7 @@ mod tests {
 
     #[test]
     fn list_installed_display_empty() {
-        let output = ListInstalledOutput {
-            versions: vec![],
-        };
+        let output = ListInstalledOutput { versions: vec![] };
         let text = output.to_string();
         assert!(text.contains("No versions installed"));
         assert!(text.contains("Run: clickhousectl local install stable"));
@@ -943,9 +935,7 @@ mod tests {
 
     #[test]
     fn list_available_display_empty() {
-        let output = ListAvailableOutput {
-            versions: vec![],
-        };
+        let output = ListAvailableOutput { versions: vec![] };
         assert_eq!(output.to_string(), "No versions available");
     }
 
@@ -1090,8 +1080,8 @@ mod tests {
                 http_port: Some(8123),
                 tcp_port: Some(9000),
                 project: None,
-                    engine: "clickhouse".to_string(),
-                    container_id: None,
+                engine: "clickhouse".to_string(),
+                container_id: None,
             }],
             total_servers: 1,
             total_running_servers: 1,
@@ -1133,9 +1123,7 @@ mod tests {
 
     #[test]
     fn server_stop_all_display_empty() {
-        let output = ServerStopAllOutput {
-            servers: vec![],
-        };
+        let output = ServerStopAllOutput { servers: vec![] };
         assert_eq!(output.to_string(), "No running servers");
     }
 

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -64,9 +64,11 @@ pub async fn run(cmd: PostgresCommands, json: bool) -> Result<()> {
             queries_file,
             args,
         } => client(name, version, host, port, query, queries_file, args).await,
-        PostgresCommands::Dotenv { name, version, local } => {
-            dotenv(name.as_deref(), version.as_deref(), local, json)
-        }
+        PostgresCommands::Dotenv {
+            name,
+            version,
+            local,
+        } => dotenv(name.as_deref(), version.as_deref(), local, json),
     }
 }
 
@@ -106,10 +108,16 @@ async fn start(
         None => {
             let existing = server::find_pg_instances(&user_name);
             match existing.len() {
-                0 => (DEFAULT_PG_TAG.to_string(), pg_major_from_tag(DEFAULT_PG_TAG)),
+                0 => (
+                    DEFAULT_PG_TAG.to_string(),
+                    pg_major_from_tag(DEFAULT_PG_TAG),
+                ),
                 1 => {
                     let info = &existing[0];
-                    let stored_tag = info.version.strip_prefix("postgres:").unwrap_or(&info.version);
+                    let stored_tag = info
+                        .version
+                        .strip_prefix("postgres:")
+                        .unwrap_or(&info.version);
                     (stored_tag.to_string(), pg_major_from_tag(stored_tag))
                 }
                 _ => {
@@ -254,13 +262,12 @@ async fn start(
 /// Default user-facing name when `--name` is omitted: `"default"` if no
 /// postgres "default" is running, otherwise a random adjective-noun.
 fn default_pg_name() -> String {
-    let any_default_running = server::find_pg_instances("default")
-        .iter()
-        .any(|i| i
-            .container_id
+    let any_default_running = server::find_pg_instances("default").iter().any(|i| {
+        i.container_id
             .as_deref()
             .map(docker::is_container_running_blocking)
-            .unwrap_or(false));
+            .unwrap_or(false)
+    });
     if any_default_running {
         // Fall back to the existing random-name generator, which checks
         // metadata file uniqueness across engines.
@@ -273,10 +280,7 @@ fn default_pg_name() -> String {
 /// Resolve `--name <X> [--version <V>]` to a single Postgres instance on disk.
 /// If `version` is given, target the (X, major(V)) pair directly. Otherwise:
 /// 0 instances → ServerNotFound; 1 → use it; >1 → ask for `--version`.
-fn resolve_pg_target(
-    user_name: &str,
-    version: Option<&str>,
-) -> Result<server::ServerInfo> {
+fn resolve_pg_target(user_name: &str, version: Option<&str>) -> Result<server::ServerInfo> {
     if let Some(v) = version {
         validate_pg_tag(v)?;
         let major = pg_major_from_tag(v);
@@ -303,11 +307,7 @@ fn resolve_pg_target(
 /// Resume an existing stopped Postgres container. Reads credentials from the
 /// container's persisted env (the source of truth — PGDATA was initialized
 /// for them) and refreshes the metadata.
-async fn resume_existing(
-    docker: &bollard::Docker,
-    prior: ServerInfo,
-    json: bool,
-) -> Result<()> {
+async fn resume_existing(docker: &bollard::Docker, prior: ServerInfo, json: bool) -> Result<()> {
     let container_id = prior.container_id.clone().expect("checked by caller");
     let display_name = user_name_from_key(&prior.name).to_string();
 
@@ -384,7 +384,9 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
             return Ok(p);
         }
     }
-    Err(Error::Exec("could not find a free TCP port for Postgres".into()))
+    Err(Error::Exec(
+        "could not find a free TCP port for Postgres".into(),
+    ))
 }
 
 fn generate_password() -> String {
@@ -398,11 +400,7 @@ async fn stop(name: &str, version: Option<&str>, json: bool) -> Result<()> {
     server::recover_current_project_servers();
     let target = resolve_pg_target(name, version)?;
     if !json {
-        let display = format!(
-            "{} ({})",
-            user_name_from_key(&target.name),
-            target.version
-        );
+        let display = format!("{} ({})", user_name_from_key(&target.name), target.version);
         println!("Stopping Postgres {}...", display);
     }
     server::kill_server(&target.name)?;
@@ -504,7 +502,16 @@ async fn client(
         // Direct connect — no server lookup; require host psql.
         let h = host.unwrap_or_else(|| "127.0.0.1".to_string());
         let p = port.unwrap_or(DEFAULT_PG_PORT);
-        return exec_host_psql(&h, p, DEFAULT_USER, None, DEFAULT_DATABASE, query, queries_file, extra_args);
+        return exec_host_psql(
+            &h,
+            p,
+            DEFAULT_USER,
+            None,
+            DEFAULT_DATABASE,
+            query,
+            queries_file,
+            extra_args,
+        );
     }
 
     server::recover_current_project_servers();
@@ -536,10 +543,7 @@ async fn client(
     }
 
     let one_shot = query.is_some() || queries_file.is_some();
-    let mut psql_args: Vec<String> = vec![
-        "-U".into(), user,
-        "-d".into(), database,
-    ];
+    let mut psql_args: Vec<String> = vec!["-U".into(), user, "-d".into(), database];
     if let Some(q) = query {
         psql_args.push("-c".into());
         psql_args.push(q);
@@ -601,10 +605,14 @@ fn exec_host_psql(
 ) -> Result<()> {
     use std::os::unix::process::CommandExt;
     let mut cmd = Command::new("psql");
-    cmd.arg("-h").arg(host)
-        .arg("-p").arg(port.to_string())
-        .arg("-U").arg(user)
-        .arg("-d").arg(database);
+    cmd.arg("-h")
+        .arg(host)
+        .arg("-p")
+        .arg(port.to_string())
+        .arg("-U")
+        .arg(user)
+        .arg("-d")
+        .arg(database);
     if let Some(p) = password {
         cmd.env("PGPASSWORD", p);
     }
@@ -619,12 +627,7 @@ fn exec_host_psql(
     Err(Error::Exec(err.to_string()))
 }
 
-fn dotenv(
-    name: Option<&str>,
-    version: Option<&str>,
-    use_local: bool,
-    json: bool,
-) -> Result<()> {
+fn dotenv(name: Option<&str>, version: Option<&str>, use_local: bool, json: bool) -> Result<()> {
     server::recover_current_project_servers();
     let server_name = name.unwrap_or("default");
     let info = resolve_pg_target(server_name, version)?;
@@ -704,15 +707,39 @@ mod tests {
 
     #[test]
     fn validate_pg_tag_accepts_supported_majors() {
-        for tag in ["17", "18", "17-alpine", "17.0", "18-bookworm", "18.1-alpine3.20"] {
-            assert!(validate_pg_tag(tag).is_ok(), "expected `{}` to be accepted", tag);
+        for tag in [
+            "17",
+            "18",
+            "17-alpine",
+            "17.0",
+            "18-bookworm",
+            "18.1-alpine3.20",
+        ] {
+            assert!(
+                validate_pg_tag(tag).is_ok(),
+                "expected `{}` to be accepted",
+                tag
+            );
         }
     }
 
     #[test]
     fn validate_pg_tag_rejects_unsupported() {
-        for tag in ["latest", "15", "16", "16-alpine", "19", "14-alpine", "alpine", ""] {
-            assert!(validate_pg_tag(tag).is_err(), "expected `{}` to be rejected", tag);
+        for tag in [
+            "latest",
+            "15",
+            "16",
+            "16-alpine",
+            "19",
+            "14-alpine",
+            "alpine",
+            "",
+        ] {
+            assert!(
+                validate_pg_tag(tag).is_err(),
+                "expected `{}` to be rejected",
+                tag
+            );
         }
     }
 

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -123,7 +123,9 @@ pub fn servers_dir_join(child: &str) -> PathBuf {
 
 /// Data directory for a Postgres instance.
 pub fn pg_data_dir(name: &str, major: &str) -> PathBuf {
-    servers_dir().join(pg_instance_key(name, major)).join("data")
+    servers_dir()
+        .join(pg_instance_key(name, major))
+        .join("data")
 }
 
 /// Ensure project-local servers dir + .gitignore exist. Idempotent.
@@ -605,8 +607,14 @@ mod tests {
 
     #[test]
     fn engine_serializes_lowercase() {
-        assert_eq!(serde_json::to_string(&Engine::Clickhouse).unwrap(), "\"clickhouse\"");
-        assert_eq!(serde_json::to_string(&Engine::Postgres).unwrap(), "\"postgres\"");
+        assert_eq!(
+            serde_json::to_string(&Engine::Clickhouse).unwrap(),
+            "\"clickhouse\""
+        );
+        assert_eq!(
+            serde_json::to_string(&Engine::Postgres).unwrap(),
+            "\"postgres\""
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/symlink.rs
+++ b/crates/clickhousectl/src/local/symlink.rs
@@ -4,10 +4,20 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum SymlinkOutcome {
-    Created { path: PathBuf, target: PathBuf },
-    Updated { path: PathBuf, target: PathBuf },
-    Unchanged { path: PathBuf },
-    SkippedRegularFile { path: PathBuf },
+    Created {
+        path: PathBuf,
+        target: PathBuf,
+    },
+    Updated {
+        path: PathBuf,
+        target: PathBuf,
+    },
+    Unchanged {
+        path: PathBuf,
+    },
+    SkippedRegularFile {
+        path: PathBuf,
+    },
     #[allow(dead_code)] // only constructed on non-unix
     SkippedNonUnix,
 }
@@ -42,11 +52,7 @@ fn ensure_symlink_at(link: &Path, target: &Path, bin_dir: &Path) -> Result<Symli
     use std::os::unix::fs::symlink;
 
     if let Err(e) = std::fs::create_dir_all(bin_dir) {
-        eprintln!(
-            "warning: could not create {}: {}",
-            bin_dir.display(),
-            e
-        );
+        eprintln!("warning: could not create {}: {}", bin_dir.display(), e);
         return Ok(SymlinkOutcome::Unchanged {
             path: link.to_path_buf(),
         });
@@ -63,21 +69,13 @@ fn ensure_symlink_at(link: &Path, target: &Path, bin_dir: &Path) -> Result<Symli
                 });
             }
             if let Err(e) = std::fs::remove_file(link) {
-                eprintln!(
-                    "warning: could not update {}: {}",
-                    link.display(),
-                    e
-                );
+                eprintln!("warning: could not update {}: {}", link.display(), e);
                 return Ok(SymlinkOutcome::Unchanged {
                     path: link.to_path_buf(),
                 });
             }
             if let Err(e) = symlink(target, link) {
-                eprintln!(
-                    "warning: could not update {}: {}",
-                    link.display(),
-                    e
-                );
+                eprintln!("warning: could not update {}: {}", link.display(), e);
                 return Ok(SymlinkOutcome::Unchanged {
                     path: link.to_path_buf(),
                 });
@@ -100,11 +98,7 @@ fn ensure_symlink_at(link: &Path, target: &Path, bin_dir: &Path) -> Result<Symli
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             if let Err(e) = symlink(target, link) {
-                eprintln!(
-                    "warning: could not create {}: {}",
-                    link.display(),
-                    e
-                );
+                eprintln!("warning: could not create {}: {}", link.display(), e);
                 return Ok(SymlinkOutcome::Unchanged {
                     path: link.to_path_buf(),
                 });
@@ -116,11 +110,7 @@ fn ensure_symlink_at(link: &Path, target: &Path, bin_dir: &Path) -> Result<Symli
             })
         }
         Err(e) => {
-            eprintln!(
-                "warning: could not stat {}: {}",
-                link.display(),
-                e
-            );
+            eprintln!("warning: could not stat {}: {}", link.display(), e);
             Ok(SymlinkOutcome::Unchanged {
                 path: link.to_path_buf(),
             })

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -19,8 +19,8 @@ use cli::{
     ActivityCommands, AuthCommands, BackupCommands, BackupConfigCommands, Cli, ClickPipeCommands,
     ClickPipeCreateCommands, ClickPipeSettingsCommands, CloudArgs, CloudCommands, Commands,
     InvitationCommands, KeyCommands, MemberCommands, OrgCommands, PostgresCertsCommands,
-    PostgresCommands, PostgresConfigCommands, PostgresReadReplicaCommands,
-    PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands, SkillsArgs, UpdateArgs,
+    PostgresCommands, PostgresConfigCommands, PostgresReadReplicaCommands, PrivateEndpointCommands,
+    QueryEndpointCommands, ServiceCommands, SkillsArgs, UpdateArgs,
 };
 
 use cloud::CloudClient;
@@ -237,8 +237,8 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                         .map_err(|e| Error::Cloud(e.to_string()))?;
                     cloud::auth::save_tokens(&tokens).map_err(|e| Error::Cloud(e.to_string()))?;
                     println!("Logged in successfully.");
-                    let tokens_path = cloud::auth::tokens_path()
-                        .map_err(|e| Error::Cloud(e.to_string()))?;
+                    let tokens_path =
+                        cloud::auth::tokens_path().map_err(|e| Error::Cloud(e.to_string()))?;
                     println!("Tokens saved to {}", tokens_path.display());
                     Ok(())
                 }
@@ -301,7 +301,11 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                 // CLI --api-key/--api-secret aren't relevant to `auth status` itself.
                 let active = cloud::resolve_active_auth_source();
                 let mark = |src: cloud::AuthSource| -> String {
-                    if active == Some(src) { "yes".into() } else { "-".into() }
+                    if active == Some(src) {
+                        "yes".into()
+                    } else {
+                        "-".into()
+                    }
                 };
 
                 let mut rows = Vec::new();
@@ -1379,7 +1383,10 @@ mod tests {
             Some(false)
         );
         // The update command never surfaces the notice.
-        assert_eq!(command_json_flag(&parse(&["clickhousectl", "update"])), None);
+        assert_eq!(
+            command_json_flag(&parse(&["clickhousectl", "update"])),
+            None
+        );
         // Telemetry management commands are human-readable output.
         #[cfg(feature = "telemetry")]
         assert_eq!(

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -561,14 +561,32 @@ mod tests {
     fn payload_serializes_exactly_the_wire_fields() {
         let payload = build_payload(&invocation(), 0, &env_of(&[]));
         let value = serde_json::to_value(&payload).unwrap();
-        let keys: Vec<&str> = value.as_object().unwrap().keys().map(|k| k.as_str()).collect();
+        let keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(|k| k.as_str())
+            .collect();
         assert_eq!(
             keys,
-            ["command", "flags", "exit_code", "is_agent", "agent", "ci", "version", "os", "arch"]
+            [
+                "command",
+                "flags",
+                "exit_code",
+                "is_agent",
+                "agent",
+                "ci",
+                "version",
+                "os",
+                "arch"
+            ]
         );
         // The two agent fields are set from the same single detection and can
         // never disagree.
-        assert_eq!(value["is_agent"].as_bool().unwrap(), !value["agent"].is_null());
+        assert_eq!(
+            value["is_agent"].as_bool().unwrap(),
+            !value["agent"].is_null()
+        );
     }
 
     #[test]
@@ -620,7 +638,11 @@ mod tests {
         let mut cmd = Command::new("root").subcommand(
             Command::new("sub")
                 .arg(Arg::new("level").long("level").default_value("info"))
-                .arg(Arg::new("verbose").long("verbose").action(ArgAction::SetTrue))
+                .arg(
+                    Arg::new("verbose")
+                        .long("verbose")
+                        .action(ArgAction::SetTrue),
+                )
                 .arg(Arg::new("target")),
         );
         let matches = cmd

--- a/crates/clickhousectl/src/update.rs
+++ b/crates/clickhousectl/src/update.rs
@@ -58,10 +58,11 @@ fn is_newer(current: &str, latest: &str) -> bool {
 
 /// Fetch the latest release info from GitHub with configurable timeout.
 async fn fetch_latest_release(timeout: std::time::Duration) -> Result<GitHubRelease> {
-    let url = format!("https://api.github.com/repos/{}/releases/latest", GITHUB_REPO);
-    let client = crate::http::client_builder()
-        .timeout(timeout)
-        .build()?;
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/latest",
+        GITHUB_REPO
+    );
+    let client = crate::http::client_builder().timeout(timeout).build()?;
 
     let response = client
         .get(&url)
@@ -400,8 +401,7 @@ mod tests {
     #[test]
     fn extracts_clickhousectl_binary_from_release_archive() {
         let payload = b"\x7fELF fake binary contents".as_slice();
-        let archive =
-            build_release_archive("clickhousectl-aarch64-apple-darwin-v0.0.1", payload);
+        let archive = build_release_archive("clickhousectl-aarch64-apple-darwin-v0.0.1", payload);
 
         let extracted = extract_binary_from_archive(&archive).unwrap();
         assert_eq!(extracted, payload);

--- a/crates/clickhousectl/src/user_agent.rs
+++ b/crates/clickhousectl/src/user_agent.rs
@@ -41,7 +41,10 @@ mod tests {
     fn agent_invocation_appends_paren_comment() {
         assert_eq!(
             user_agent_from(Some("claude-code")),
-            format!("clickhousectl/{} (agent=claude-code)", env!("CARGO_PKG_VERSION"))
+            format!(
+                "clickhousectl/{} (agent=claude-code)",
+                env!("CARGO_PKG_VERSION")
+            )
         );
     }
 

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -17,8 +17,7 @@ pub async fn download_from_source(
 
 /// Downloads a file from a URL to the specified path, with progress bar
 pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     let response = client
         .get(url)

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -16,9 +16,7 @@ pub async fn install_local_first(
     platform: &Platform,
     force: bool,
 ) -> Result<String> {
-    if !force
-        && let Some(local) = try_resolve_local(spec)
-    {
+    if !force && let Some(local) = try_resolve_local(spec) {
         if matches!(spec, VersionSpec::Exact(_)) {
             return Err(Error::VersionAlreadyInstalled(local));
         }
@@ -66,8 +64,7 @@ pub async fn install_resolved(
     let mut master_head = None;
     if is_master {
         master_head = master::head_info(platform).await;
-        if !force
-            && let Some(version) = master::reuse_if_unchanged(platform, master_head.as_ref())
+        if !force && let Some(version) = master::reuse_if_unchanged(platform, master_head.as_ref())
         {
             eprintln!(
                 "latest is up to date (master build unchanged); using {}",
@@ -349,5 +346,4 @@ mod tests {
     fn test_parse_version_output_empty() {
         assert!(parse_version_output("").is_err());
     }
-
 }

--- a/crates/clickhousectl/src/version_manager/list.rs
+++ b/crates/clickhousectl/src/version_manager/list.rs
@@ -72,8 +72,7 @@ pub struct VersionEntry {
 /// Fetches available versions from GitHub releases
 pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     let url = "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     let response = client
         .get(url)

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -140,7 +140,10 @@ pub async fn head_info(platform: &Platform) -> Option<HeadInfo> {
     };
     let etag = header(reqwest::header::ETAG)?;
     let last_modified = header(reqwest::header::LAST_MODIFIED);
-    Some(HeadInfo { etag, last_modified })
+    Some(HeadInfo {
+        etag,
+        last_modified,
+    })
 }
 
 /// Pure reuse decision: reuse the recorded build only when we have a record,
@@ -255,7 +258,11 @@ mod tests {
         sidecar
             .builds
             .insert("macos-aarch64".to_string(), rec("\"x-1\"", "26.5.1.1"));
-        assert!(clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
+        assert!(clear_version_from(
+            &mut sidecar,
+            "macos-aarch64",
+            "26.5.1.1"
+        ));
         assert!(!sidecar.builds.contains_key("macos-aarch64"));
     }
 
@@ -267,7 +274,11 @@ mod tests {
         sidecar
             .builds
             .insert("macos-aarch64".to_string(), rec("\"x-1\"", "26.5.1.1"));
-        assert!(!clear_version_from(&mut sidecar, "macos-aarch64", "25.12.9.61"));
+        assert!(!clear_version_from(
+            &mut sidecar,
+            "macos-aarch64",
+            "25.12.9.61"
+        ));
         assert!(sidecar.builds.contains_key("macos-aarch64"));
     }
 
@@ -280,13 +291,21 @@ mod tests {
         sidecar
             .builds
             .insert("macos-aarch64".to_string(), rec("\"y-2\"", "26.5.1.1"));
-        assert!(clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
+        assert!(clear_version_from(
+            &mut sidecar,
+            "macos-aarch64",
+            "26.5.1.1"
+        ));
         assert!(sidecar.builds.contains_key("amd64"));
     }
 
     #[test]
     fn clear_version_no_record_is_noop() {
         let mut sidecar = Sidecar::default();
-        assert!(!clear_version_from(&mut sidecar, "macos-aarch64", "26.5.1.1"));
+        assert!(!clear_version_from(
+            &mut sidecar,
+            "macos-aarch64",
+            "26.5.1.1"
+        ));
     }
 }

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -1,5 +1,7 @@
 use crate::error::{Error, Result};
-use crate::version_manager::list::{Channel, VersionEntry, list_available_versions, list_installed_versions};
+use crate::version_manager::list::{
+    Channel, VersionEntry, list_available_versions, list_installed_versions,
+};
 use crate::version_manager::platform::{DownloadSource, Platform, builds_probe_url};
 use crate::version_manager::spec::VersionSpec;
 use serde::Deserialize;
@@ -187,8 +189,7 @@ async fn find_exact_channel(version: &str) -> Result<Channel> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
         version
     );
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     let response = client
         .get(&url)
@@ -247,9 +248,7 @@ fn fallback_source(version: &str, channel: Channel, platform: &Platform) -> Reso
 /// Probe builds.clickhouse.com with a HEAD request to check if a version exists
 async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
     let url = builds_probe_url(version_path, platform);
-    let client = match crate::http::client_builder()
-        .build()
-    {
+    let client = match crate::http::client_builder().build() {
         Ok(c) => c,
         Err(_) => return false,
     };
@@ -274,8 +273,7 @@ async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix
     );
-    let client = crate::http::client_builder()
-        .build()?;
+    let client = crate::http::client_builder().build()?;
 
     let response = client
         .get(&url)
@@ -305,9 +303,7 @@ fn parse_version_refs(refs: &[GitRef], prefix: &str) -> Result<VersionEntry> {
             let version = &tag[..dash_pos];
             let suffix = &tag[dash_pos + 1..];
             let is_higher = |current: &Option<VersionEntry>| match current {
-                Some(existing) => {
-                    compare_versions(version, &existing.version) == Ordering::Greater
-                }
+                Some(existing) => compare_versions(version, &existing.version) == Ordering::Greater,
                 None => true,
             };
             if let Some(channel) = Channel::from_tag_suffix(suffix) {
@@ -435,10 +431,7 @@ mod tests {
 
     #[test]
     fn test_parse_version_refs_no_matching_tags() {
-        let refs = vec![
-            make_ref("refs/heads/main"),
-            make_ref("something/else"),
-        ];
+        let refs = vec![make_ref("refs/heads/main"), make_ref("something/else")];
         assert!(parse_version_refs(&refs, "25.12").is_err());
     }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -408,10 +408,7 @@ async fn gcs_service_account_file_is_read_and_base64_encoded() {
 
     let gcs = &body["source"]["objectStorage"];
     assert_eq!(gcs["authentication"], "SERVICE_ACCOUNT");
-    let expected = base64::Engine::encode(
-        &base64::engine::general_purpose::STANDARD,
-        sa_contents,
-    );
+    let expected = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, sa_contents);
     assert_eq!(
         gcs["serviceAccountKey"].as_str(),
         Some(expected.as_str()),
@@ -590,7 +587,12 @@ async fn kafka_optional_fields_absent_when_flags_omitted() {
     let body = invoke_cli_capture_body(&mock, &kafka_args_minimal()).await;
 
     let kafka = &body["source"]["kafka"];
-    for field in ["consumerGroup", "iamRole", "schemaRegistry", "caCertificate"] {
+    for field in [
+        "consumerGroup",
+        "iamRole",
+        "schemaRegistry",
+        "caCertificate",
+    ] {
         assert!(
             kafka.get(field).is_none(),
             "{field} leaked into kafka source body: {kafka}",
@@ -1065,7 +1067,8 @@ async fn postgres_replication_mode_snapshot_serializes() {
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let body = invoke_cli_capture_body(&mock, &arg_refs).await;
     assert_eq!(
-        body["source"]["postgres"]["settings"]["replicationMode"], "snapshot",
+        body["source"]["postgres"]["settings"]["replicationMode"],
+        "snapshot",
     );
 }
 
@@ -1084,7 +1087,8 @@ async fn postgres_replication_mode_cdc_only_serializes() {
     let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let body = invoke_cli_capture_body(&mock, &arg_refs).await;
     assert_eq!(
-        body["source"]["postgres"]["settings"]["replicationMode"], "cdc_only",
+        body["source"]["postgres"]["settings"]["replicationMode"],
+        "cdc_only",
     );
 }
 
@@ -1218,7 +1222,9 @@ async fn dotenv_creds_produce_basic_auth_request() {
     let dir = tempfile::tempdir().unwrap();
     let mut env_file = std::fs::File::create(dir.path().join(".env")).unwrap();
     env_file
-        .write_all(b"CLICKHOUSE_CLOUD_API_KEY=dotenv-key\nCLICKHOUSE_CLOUD_API_SECRET=dotenv-secret\n")
+        .write_all(
+            b"CLICKHOUSE_CLOUD_API_KEY=dotenv-key\nCLICKHOUSE_CLOUD_API_SECRET=dotenv-secret\n",
+        )
         .unwrap();
     drop(env_file);
 
@@ -1576,7 +1582,9 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
     let query_host = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
-        .respond_with(ResponseTemplate::new(206).set_body_string(r#"{"data":"Service is stopped"}"#))
+        .respond_with(
+            ResponseTemplate::new(206).set_body_string(r#"{"data":"Service is stopped"}"#),
+        )
         .mount(&query_host)
         .await;
 
@@ -1649,7 +1657,9 @@ async fn shell_env_overrides_dotenv_creds_in_request() {
     let dir = tempfile::tempdir().unwrap();
     let mut env_file = std::fs::File::create(dir.path().join(".env")).unwrap();
     env_file
-        .write_all(b"CLICKHOUSE_CLOUD_API_KEY=dotenv-key\nCLICKHOUSE_CLOUD_API_SECRET=dotenv-secret\n")
+        .write_all(
+            b"CLICKHOUSE_CLOUD_API_KEY=dotenv-key\nCLICKHOUSE_CLOUD_API_SECRET=dotenv-secret\n",
+        )
         .unwrap();
     drop(env_file);
 

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -38,9 +38,7 @@ impl Sandbox {
         let mock = MockServer::start().await;
         Mock::given(method("POST"))
             .and(path("/v1/telemetry"))
-            .respond_with(
-                ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})),
-            )
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"ok": true})))
             .mount(&mock)
             .await;
         Sandbox {
@@ -210,7 +208,10 @@ async fn no_agent_correlation_headers_on_the_wire() {
         .env_remove("AGENT")
         .env("CLAUDECODE", "1")
         .env("CLAUDE_CODE_SESSION_ID", "sess-should-never-hit-the-wire")
-        .env("TRACEPARENT", "00-11111111111111111111111111111111-2222222222222222-01")
+        .env(
+            "TRACEPARENT",
+            "00-11111111111111111111111111111111-2222222222222222-01",
+        )
         .output()
         .unwrap();
     assert!(output.status.success());
@@ -454,7 +455,10 @@ async fn parent_never_waits_for_a_slow_endpoint() {
     let started = Instant::now();
     let output = sandbox
         .command(&["local", "list"])
-        .env("CHCTL_TELEMETRY_URL", format!("{}/v1/telemetry", mock.uri()))
+        .env(
+            "CHCTL_TELEMETRY_URL",
+            format!("{}/v1/telemetry", mock.uri()),
+        )
         .output()
         .unwrap();
     let elapsed = started.elapsed();
@@ -481,5 +485,8 @@ async fn marker_lives_in_dot_clickhouse_telemetry_json() {
         .unwrap()
         .map(|e| e.unwrap().file_name().into_string().unwrap())
         .collect();
-    assert!(entries.contains(&"telemetry.json".to_string()), "{entries:?}");
+    assert!(
+        entries.contains(&"telemetry.json".to_string()),
+        "{entries:?}"
+    );
 }


### PR DESCRIPTION
Closes #302

## What

- **Commit 1** is the pure mechanical reformat: `cargo fmt --all` across the workspace (54 files, no functional changes).
- **Commit 2** adds enforcement:
  - New `Format` workflow running `cargo fmt --all --check` on PRs touching `**.rs` (actions pinned to the same SHAs as the existing workflows).
  - `.git-blame-ignore-revs` listing the reformat commit so `git blame` (and GitHub's blame view) skips it.
  - AGENTS.md note that fmt is now CI-enforced.

## Why now

We'd been avoiding `cargo fmt` because it used to break `spec_coverage_test.rs`, which parsed `models.rs` as text. The analyzer now parses with `syn`, which doesn't care about formatting — verified by running the full suite after the reformat.

## Verification

- `cargo build --workspace`
- `cargo test --workspace` — all green, including the analyzer spec-coverage tests
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-features`
- `cargo fmt --all --check` passes

Review tip: commit 1 is noise by construction; review commit 2 by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)