### PR TITLE
Split request/response model types; tolerant responses via all-Option fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Work from the issue's typed findings. `spec_pointer` is an RFC 6901 location in 
 
 ##### Field optionality and the OpenAPI spec
 
+Checking is direction-aware: the analyzer classifies every spec schema by the position(s) it is used in — request position (reachable from a request body or operation parameter) and/or response position (reachable from an operation response). Requiredness applies in request position only; response-side optionality drift is invisible by design (every response field is `Option<T>` by policy), while field *presence* (missing/extra fields) and enum values are checked in both directions. A schema used in both directions resolves to Rust `{Name}` in request position and, once the split type exists, `{Name}Response` in response position (falling back to `{Name}` until then). Response-tree membership is exposed via `clickhouse_openapi_analyzer::response_tree()` for policy enforcement tests.
+
 Requiredness has repository-specific semantics implemented in `openapi.rs`: PATCH request schemas are all-optional; nullable fields are always `Option<T>`; ordinary schemas with `required[]` use it; schemas without it use the `"Optional"` description convention. A schema whose `required[]` is known to be partial uses the union of that array and the description heuristic and must be listed in `partial_required_schemas`. `scripts/resolve-field-requirements.py` is a code-generation aid, not a comparison implementation or policy source.
 
 ##### Analyzer configuration and exemptions
@@ -93,11 +95,11 @@ Requiredness has repository-specific semantics implemented in `openapi.rs`: PATC
 All analyzer policy lives in `crates/clickhouse-openapi-analyzer/src/config.rs`; edit `clickhouse_cloud_config()` or its backing constants. Introduce a named, documented constant when an empty policy list first gains entries. Keys use Rust type names but spec/wire field and enum values:
 
 - `non_openapi_client_methods`: intentional `Client` helpers with no operation, keyed by snake-case method name.
-- `optionality_exemptions`: fields deliberately kept optional despite the resolved spec, keyed by `(RustStructName, specFieldName)`.
+- `optionality_exemptions`: fields deliberately kept optional despite the resolved spec, keyed by `(RustStructName, specFieldName)`. Request-position-only: optionality findings are suppressed in response position, so a response-only entry can never hit and surfaces as stale.
 - `extra_field_exemptions`: deliberate code-only fields, keyed by `(RustStructName, specFieldName)`.
 - `deprecated_field_exemptions`: spec-deprecated fields deliberately excluded from the hiding mechanism, keyed by `(RustStructName, specFieldName)`.
 - `extra_enum_value_exemptions`: intentional Rust-only wire values, keyed by `(RustEnumName, wireValue)`.
-- `partial_required_schemas`: upstream schemas whose `required[]` is non-exhaustive, keyed by spec schema name. This changes requiredness resolution; it is not a shortcut for one optionality mismatch.
+- `partial_required_schemas`: upstream schemas whose `required[]` is non-exhaustive, keyed by spec schema name. This changes requiredness resolution — request-position-only semantics — and is not a shortcut for one optionality mismatch.
 - `acknowledged_unsupported_enum_pointers`: exact RFC 6901 pointers the analyzer inventories but cannot map to a concrete Rust value enum.
 
 Add an exemption only for intentional, verified runtime behavior, with a nearby comment stating why the spec cannot be followed. Never exempt missing API surface or ordinary model drift. Pair a new unsupported-enum acknowledgement with a tracking issue to make the Rust type checkable; do not acknowledge it merely to make CI green. Pair-keyed field/enum exemptions and unsupported acknowledgements produce actionable stale findings when no longer needed, so remove them during normal remediation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ For both local and cloud commands, define the clap variant in the appropriate `c
    }
    ```
    List views stay as `tabled` tables, and short action confirmations (e.g. "Service X starting") stay as plain `println!`.
+
+   Every field of a library response type is `Option` (see Request and response models), so never `unwrap()`/`expect()` one. Render absence with `crate::cloud::output::or_absent` (`-`) or `ABSENT` in `tabled` cells and plain output, and have `--filter`-style predicates treat an absent field as non-matching. `print_human` and `--json` serialize the model and need no per-field work.
 8. Add `Cli::try_parse_from` coverage in `src/cloud/cli.rs` for the new command's body-related flags, asserting parsed values.
 
 ### API library (`crates/clickhouse-cloud-api/`)
@@ -54,9 +56,48 @@ For both local and cloud commands, define the clap variant in the appropriate `c
 Typed Rust client library for the ClickHouse Cloud API. The library owns all OpenAPI interaction and all cloud integration testing.
 
 - `src/client.rs` — `Client` struct with one async method per OpenAPI operation.
-- `src/models.rs` — request/response types matching the spec (see Field optionality below).
+- `src/models.rs` — request/response types matching the spec (see Request and response models below). Model structs, enums and type aliases must live here; it is the only file the drift analyzer inventories.
+- `src/convert.rs` — explicit response→request conversions. The analyzer does not parse it, so nothing declared here counts as a model.
 
 The API library can be updated independently of the CLI. When OpenAPI drifts, prefer updating API library on its own, add to CLI separately.
+
+#### Request and response models
+
+A response must never fail to deserialize because the API dropped a field, sent it as `null`, or added one. Several teams evolve the Cloud API independently, so in a crate published to crates.io every strict response field is a latent outage. Tolerance lives in the **type system**, not in serde attributes:
+
+- **Request types are strict.** A field the spec requires is `T`; optional or nullable fields are `Option<T>` plus `#[serde(skip_serializing_if = "Option::is_none")]`. The compiler is what enforces "strict in what we send".
+- **Response types are all-`Option`.** Every field of every type reachable from a `Client` return type is `Option<T>` plus `skip_serializing_if`. A missing key *and* an explicit JSON `null` both land as `None`, natively — no attribute needed. Nothing is fabricated, so "the server sent `0`" and "the server dropped the field" stay distinguishable, and each caller resolves absence where it is used.
+- **`#[serde(default)]` is banned in `models.rs`.** On a required request field it invents `""`/`0`/`false` that a get → edit → write-back caller silently persists; on an `Option` field it is dead weight. Sweeping it across every model field was the superseded policy of issues 312 and 313 — do not reintroduce it.
+- **Unknown fields are ignored.** Never `deny_unknown_fields`.
+
+##### Naming and the split
+
+A schema used in one direction only keeps its Rust name: most schemas are one-directional, so most models are simply all-`Option` in place (response) or strict in place (request body, orphan schema). A schema used in **both** directions becomes two types — the request variant keeps the schema's name, the response variant is exactly `{Name}Response`, matching spec-derived names like `ApiKeyPostResponse`. The analyzer resolves the pair from that convention, so the suffix is load-bearing rather than cosmetic. Splitting propagates: a nested type reachable from both a strict and a tolerant parent splits too, and a field of a response type must point at the `*Response` variant of anything that has one. Also re-point the element type of any shared alias (`pub type PgTagsResponse = Vec<ResourceTagsV1Response>`).
+
+Object unions follow the variant structs they hold. When those split, duplicate the whole `discriminated_union!` invocation for a `{Name}Response` enum over the `*Response` structs and keep the discriminator and `none unless` guards identical; the macro emits only `Deserialize`, so the enum declaration, derives, `Display` and any `Default` stay literal source for the syn analyzer to inventory. Enums and unions are otherwise **unchanged** by the split: string enums keep their `Unknown(String)` catch-all, unions keep the lossless `Unknown(serde_json::Value)` fallback, and dispatch reads the raw JSON rather than struct fields, so all-`Option` variants cannot weaken it. The `discriminated_union!` rustdoc in `models.rs` owns the grammar.
+
+##### Serialization: absent means omitted
+
+Response types keep `derive(Serialize)` — `--json` and `print_human` serialize them directly. `skip_serializing_if` on every response field means an absent field is **omitted**, never emitted as `null`. That is a deliberate decision with a test pinning it: `--json` consumers see the key set the API actually sent.
+
+##### Write-back conversions
+
+Because the variants are distinct types, a caller that fetches a resource, edits it and writes it back must resolve absence explicitly — that is the point of the split, not an inconvenience of it. `src/convert.rs` owns those conversions: `TryFrom<{Name}Response> for {Name}` where a required request field can be absent, `From` where the conversion is total. A fallible one returns `MissingRequiredFields` (re-exported at the crate root; `.fields()` lists the missing **wire** names). Give each nested object its own conversion so a missing field is named at the level it is missing from, and reuse `MissingRequiredFields` rather than adding a second error type.
+
+##### The residual, honestly
+
+A key that is *present* with a changed type still fails. `Option<T>` absorbs absence and `null`, not a string where an array used to be — no more than `serde(default)` did. Enums absorb it through their catch-alls and `discriminated_union!` unions through the `Unknown(Value)` fallback, but a plain struct field does not. Spec conformance is the drift job's responsibility, not the runtime's.
+
+##### How the policy is enforced
+
+`crates/clickhouse-cloud-api/tests/spec_coverage_test.rs` pins all of it against the analyzer's `response_tree()`, which derives response reachability from `client.rs` return types so a newly wired operation is covered automatically:
+
+- `every_response_tree_field_is_option` — no non-`Option` field in the tree. Its exception list is empty; an entry needs the same bar as an analyzer exemption. A vacuity guard fails the test if the tree collapses.
+- `every_response_tree_option_field_omits_none_when_serialized` — `skip_serializing_if` on every response `Option` field.
+- `models_carry_no_serde_default` — via the analyzer's `model_fields_with_serde_default()`.
+- `scim_models_are_outside_the_response_tree` — the 40 `Scim*` schemas have no path in the spec and no `Client` method, so they are legitimately strict, and the test fails if one becomes response-reachable.
+
+Scope enforcement to the response tree, never to "every model type": operation-unreferenced and request-only schemas resolve in request position, so making them all-`Option` reports genuine `FieldOptionalityMismatch` drift.
 
 #### OpenAPI drift
 
@@ -75,18 +116,20 @@ Work from the issue's typed findings. `spec_pointer` is an RFC 6901 location in 
 2. Replace `crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json` with the same live document being remediated; do not hand-edit the spec. Snapshot operation/schema findings mean this file is stale.
 3. Fix the API library before considering CLI exposure. Follow the finding's pointer and Rust item:
    - Missing/extra operations: add or remove the corresponding `Client` method in `client.rs`; only intentional non-OpenAPI helpers belong in `non_openapi_client_methods`.
-   - Missing models, fields, or extra fields: update public structs/enums/type aliases and Serde names in `models.rs`. An undefined `$ref` (`missing_schema_definition`) is an upstream-spec defect, not a model to invent locally. `models.rs` uses explicit `#[serde(rename = "...")]` wire names exclusively; `rename_all` is rejected by the analyzer parser, because wire vocabulary (Postgres GUCs, SCIM URNs, region IDs, duration literals) cannot be derived from Rust identifiers by any casing rule, and explicit literals keep the code↔spec mapping verbatim and greppable.
-   - Optionality: use `T` for required non-nullable fields and `Option<T>` plus `skip_serializing_if` for optional/nullable fields. Retain `#[serde(default)]` on model fields.
+   - Missing models, fields, or extra fields: update public structs/enums/type aliases and Serde names in `models.rs`. An undefined `$ref` (`missing_schema_definition`) is an upstream-spec defect, not a model to invent locally. `models.rs` uses explicit `#[serde(rename = "...")]` wire names exclusively; `rename_all` is rejected by the analyzer parser, because wire vocabulary (Postgres GUCs, SCIM URNs, region IDs, duration literals) cannot be derived from Rust identifiers by any casing rule, and explicit literals keep the code↔spec mapping verbatim and greppable. A new schema needs one Rust type per position it is used in: `{Name}` if the finding is in request position, `{Name}Response` if in response position, both if the spec uses it in both — and the same field added to every variant. See Request and response models above.
+   - Optionality: express requiredness in the type, and pick the shape from the position. Request-position fields are `T` when the resolved spec requires them and `Option<T>` plus `skip_serializing_if` otherwise; every response-position field is `Option<T>` plus `skip_serializing_if`, whatever the spec says its requiredness is. Never add `#[serde(default)]`. A request field deliberately optional against the resolved spec needs an `optionality_exemptions` entry keyed on the **request** variant's name.
    - Missing/extra enum values: update the typed enum, its Serde wire value, and its `Display` implementation. Preserve data-carrying catch-all variants.
-   - Beta/deprecation findings: regenerate `BETA_OPERATIONS` with `python3 scripts/regenerate-beta-lists.py` and `DEPRECATED_FIELDS` with `python3 scripts/regenerate-deprecated-fields.py`; deprecated fields also need the matching `#[cfg(feature = "deprecated-fields")]` marker in `models.rs`.
+   - Beta/deprecation findings: regenerate `BETA_OPERATIONS` with `python3 scripts/regenerate-beta-lists.py` and `DEPRECATED_FIELDS` with `python3 scripts/regenerate-deprecated-fields.py`; deprecated fields also need the matching `#[cfg(feature = "deprecated-fields")]` marker in `models.rs`. The generator works from the spec, which knows nothing about split variants, so a deprecated field on a split schema needs the `{Name}Response` entry and its marker added by hand.
    - Stale exemption: remove or narrow the configuration entry. Do not change comparison logic to preserve a stale exception.
    - Unsupported enum constraint: prefer changing the Rust scalar to a concrete value enum. Acknowledgement is the fallback policy below, not a model-drift fix.
-4. Add focused library tests for changed models/methods. If the unsupported inventory changes, update `acknowledged_unsupported_enum_pointers`; the snapshot test derives its exact expected inventory from that configuration.
+4. Add focused library tests for changed models/methods. A new response type wants a missing-key → `None` and an explicit-`null` → `None` case; a new split pair wants the request variant's strictness and the `TryFrom` write-back asserted. If the unsupported inventory changes, update `acknowledged_unsupported_enum_pointers`; the snapshot test derives its exact expected inventory from that configuration.
 5. Verify with `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`, `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`, and `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`. If deprecated fields changed, also run `cargo check --workspace --all-features`. Re-run the dry run to check the live document.
 
 ##### Field optionality and the OpenAPI spec
 
-Checking is direction-aware: the analyzer classifies every spec schema by the position(s) it is used in — request position (reachable from a request body or operation parameter) and/or response position (reachable from an operation response). Requiredness applies in request position only; response-side optionality drift is invisible by design (every response field is `Option<T>` by policy), while field *presence* (missing/extra fields) and enum values are checked in both directions. A schema used in both directions resolves to Rust `{Name}` in request position and, once the split type exists, `{Name}Response` in response position (falling back to `{Name}` until then). Response-tree membership is exposed via `clickhouse_openapi_analyzer::response_tree()` for policy enforcement tests.
+Checking is direction-aware, matching the request/response model split above: the analyzer classifies every spec schema by the position(s) it is used in — request position (reachable from a request body or operation parameter) and/or response position (reachable from an operation response). Requiredness applies in request position only. Response-side optionality drift is therefore invisible by design and that is deliberate, not a gap: every response field is `Option<T>` by policy, so a requiredness comparison would fire on all of them and signal nothing. Field *presence* (missing/extra fields) and enum values — the drift that actually matters — are checked in both directions. A schema used in both directions resolves to Rust `{Name}` in request position and `{Name}Response` in response position, falling back to `{Name}` when no split type exists, so the naming convention is what makes the dual mapping mechanical instead of hand-maintained. Response-tree membership is exposed via `clickhouse_openapi_analyzer::response_tree()` for the policy enforcement tests.
+
+An operation-unreferenced (orphan) schema resolves in request position, so it stays strict.
 
 Requiredness has repository-specific semantics implemented in `openapi.rs`: PATCH request schemas are all-optional; nullable fields are always `Option<T>`; ordinary schemas with `required[]` use it; schemas without it use the `"Optional"` description convention. A schema whose `required[]` is known to be partial uses the union of that array and the description heuristic and must be listed in `partial_required_schemas`. `scripts/resolve-field-requirements.py` is a code-generation aid, not a comparison implementation or policy source.
 
@@ -114,7 +157,7 @@ Enums that the CLI validates against declare `pub const VALUES: &'static [&'stat
 
 ##### Deprecated field hiding
 
-Every spec-deprecated request or response field belongs in `meta.rs::DEPRECATED_FIELDS` and carries `#[cfg(feature = "deprecated-fields")]` on the `models.rs` field. It is therefore absent from the public model by default. Request fields that must be gated out but resolve as required are `Option<T>` with a documented optionality exemption. Update CLI code that directly accesses or constructs an affected model so both feature configurations compile.
+Every spec-deprecated request or response field belongs in `meta.rs::DEPRECATED_FIELDS` and carries `#[cfg(feature = "deprecated-fields")]` on the `models.rs` field. It is therefore absent from the public model by default. Request fields that must be gated out but resolve as required are `Option<T>` with a documented optionality exemption. Entries are keyed per Rust type, so a deprecated field on a split schema needs one entry and one marker for `{Name}` and one for `{Name}Response`. Update CLI code that directly accesses or constructs an affected model so both feature configurations compile.
 
 ##### Extending the analyzer
 

--- a/README.md
+++ b/README.md
@@ -800,6 +800,10 @@ clickhousectl cloud --json service get <service-id>
 
 `clickhousectl` auto-detects coding-agent contexts (Claude Code, Cursor, Codex, Gemini CLI, Goose, Devin, and any tool that sets the standard `AGENT` env var) and emits JSON to stdout automatically without setting `--json`.
 
+### Absent fields
+
+Cloud commands never invent values for data the API did not return. A field the API omits is shown as `-` in tables and human-readable output, and is left out of `--json` output entirely rather than emitted as `null` — so `--json` reflects exactly what the API sent.
+
 ### Exit codes
 
 Follow `gh` conventions:

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -2728,7 +2728,7 @@ impl Client {
         &self,
         organization_id: &str,
         service_id: &str,
-    ) -> Result<ApiResponse<Vec<ClickStackSource>>, Error> {
+    ) -> Result<ApiResponse<Vec<ClickStackSourceResponse>>, Error> {
         let path =
             format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources");
         let req = self.request(reqwest::Method::GET, &path);
@@ -2753,7 +2753,7 @@ impl Client {
         organization_id: &str,
         service_id: &str,
         body: &ClickStackSource,
-    ) -> Result<ApiResponse<ClickStackSource>, Error> {
+    ) -> Result<ApiResponse<ClickStackSourceResponse>, Error> {
         let path =
             format!("/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources");
         let mut req = self.request(reqwest::Method::POST, &path);
@@ -2779,7 +2779,7 @@ impl Client {
         organization_id: &str,
         service_id: &str,
         click_stack_source_id: &str,
-    ) -> Result<ApiResponse<ClickStackSource>, Error> {
+    ) -> Result<ApiResponse<ClickStackSourceResponse>, Error> {
         let path = format!(
             "/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources/{click_stack_source_id}"
         );
@@ -2806,7 +2806,7 @@ impl Client {
         service_id: &str,
         click_stack_source_id: &str,
         body: &ClickStackSource,
-    ) -> Result<ApiResponse<ClickStackSource>, Error> {
+    ) -> Result<ApiResponse<ClickStackSourceResponse>, Error> {
         let path = format!(
             "/v1/organizations/{organization_id}/services/{service_id}/clickstack/sources/{click_stack_source_id}"
         );

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -2042,7 +2042,7 @@ impl Client {
         organization_id: &str,
         service_id: &str,
         click_pipe_id: &str,
-    ) -> Result<ApiResponse<ClickPipeSettings>, Error> {
+    ) -> Result<ApiResponse<ClickPipeSettingsResponse>, Error> {
         let path = format!(
             "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings"
         );
@@ -2069,7 +2069,7 @@ impl Client {
         service_id: &str,
         click_pipe_id: &str,
         body: &ClickPipeSettingsPutRequest,
-    ) -> Result<ApiResponse<ClickPipeSettings>, Error> {
+    ) -> Result<ApiResponse<ClickPipeSettingsResponse>, Error> {
         let path = format!(
             "/v1/organizations/{organization_id}/services/{service_id}/clickpipes/{click_pipe_id}/settings"
         );

--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -1155,7 +1155,7 @@ impl Client {
         &self,
         organization_id: &str,
         postgres_id: &str,
-    ) -> Result<ApiResponse<PostgresInstanceConfig>, Error> {
+    ) -> Result<ApiResponse<PostgresInstanceConfigResponse>, Error> {
         let path = format!("/v1/organizations/{organization_id}/postgres/{postgres_id}/config");
         let req = self.request(reqwest::Method::GET, &path);
         let resp = req.send().await?;

--- a/crates/clickhouse-cloud-api/src/convert.rs
+++ b/crates/clickhouse-cloud-api/src/convert.rs
@@ -15,7 +15,8 @@ use std::fmt;
 
 use crate::models::{
     PgBouncerConfig, PgBouncerConfigResponse, PgConfig, PgConfigResponse, PostgresInstanceConfig,
-    PostgresInstanceConfigResponse,
+    PostgresInstanceConfigResponse, ResourceTagsV1, ResourceTagsV1Response, ScalingScheduleEntry,
+    ScalingScheduleEntryRequest, UpgradeWindow, UpgradeWindowPutRequest,
 };
 
 /// The response omitted fields that the matching request model requires.
@@ -117,6 +118,99 @@ impl TryFrom<PostgresInstanceConfigResponse> for PostgresInstanceConfig {
             (Some(pg_bouncer_config), Some(pg_config)) => Ok(Self {
                 pg_bouncer_config: pg_bouncer_config.into(),
                 pg_config: pg_config.into(),
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ResourceTagsV1Response> for ResourceTagsV1 {
+    type Error = MissingRequiredFields;
+
+    /// Turns a fetched tag into one that can be sent back.
+    ///
+    /// A tag is identified by its key, so a response tag without one cannot be
+    /// written back — dropping it silently would delete the tag on the next
+    /// write, and inventing an empty key would create a bogus one.
+    fn try_from(value: ResourceTagsV1Response) -> Result<Self, Self::Error> {
+        match value.key {
+            Some(key) => Ok(Self {
+                key,
+                value: value.value,
+            }),
+            None => Err(MissingRequiredFields::new(vec!["key"])),
+        }
+    }
+}
+
+impl TryFrom<ScalingScheduleEntry> for ScalingScheduleEntryRequest {
+    type Error = MissingRequiredFields;
+
+    /// Turns a fetched schedule entry into one that can be re-sent.
+    ///
+    /// An upsert replaces the whole schedule, so a caller that reads a schedule
+    /// and writes it back has to send every entry in full: the window bounds,
+    /// weekdays and name the API requires cannot be defaulted away.
+    fn try_from(value: ScalingScheduleEntry) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.end_hour_utc.is_none() {
+            missing.push("endHourUtc");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.start_hour_utc.is_none() {
+            missing.push("startHourUtc");
+        }
+        if value.weekdays.is_none() {
+            missing.push("weekdays");
+        }
+        match (
+            value.end_hour_utc,
+            value.name,
+            value.start_hour_utc,
+            value.weekdays,
+        ) {
+            (Some(end_hour_utc), Some(name), Some(start_hour_utc), Some(weekdays)) => Ok(Self {
+                autoscaling_mode: value.autoscaling_mode,
+                end_hour_utc,
+                idle_scaling: value.idle_scaling,
+                idle_timeout_minutes: value.idle_timeout_minutes,
+                max_replica_memory_gb: value.max_replica_memory_gb,
+                max_replicas: value.max_replicas,
+                min_replica_memory_gb: value.min_replica_memory_gb,
+                min_replicas: value.min_replicas,
+                name,
+                // Not part of the response shape; a horizontal entry carries a
+                // min/max band instead of a fixed replica count.
+                num_replicas: None,
+                start_hour_utc,
+                weekdays,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<UpgradeWindow> for UpgradeWindowPutRequest {
+    type Error = MissingRequiredFields;
+
+    /// Turns a fetched upgrade window into one that can be re-sent.
+    ///
+    /// `duration` is response-only (the API derives it), so only the window's
+    /// start hour and weekday cross over — and both are required.
+    fn try_from(value: UpgradeWindow) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.start_hour_utc.is_none() {
+            missing.push("startHourUtc");
+        }
+        if value.weekday.is_none() {
+            missing.push("weekday");
+        }
+        match (value.start_hour_utc, value.weekday) {
+            (Some(start_hour_utc), Some(weekday)) => Ok(Self {
+                start_hour_utc,
+                weekday,
             }),
             _ => Err(MissingRequiredFields::new(missing)),
         }

--- a/crates/clickhouse-cloud-api/src/convert.rs
+++ b/crates/clickhouse-cloud-api/src/convert.rs
@@ -10,10 +10,29 @@
 //! field and persisted it on the next write. A conversion that can lose that
 //! information is a [`TryFrom`] reporting the missing wire field names; a
 //! conversion that cannot is a [`From`].
+//!
+//! The ClickStack source tree converts as a group: [`TryFrom<ClickStackSourceResponse>`]
+//! for [`ClickStackSource`] is the entry point, and every nested object in that
+//! tree carries its own conversion so a missing field is named at the level it is
+//! missing from.
 
 use std::fmt;
 
 use crate::models::{
+    ClickStackAggregatedColumn, ClickStackAggregatedColumnResponse, ClickStackFilterSettingsColumn,
+    ClickStackFilterSettingsColumnResponse, ClickStackHighlightedAttributeExpression,
+    ClickStackHighlightedAttributeExpressionResponse, ClickStackLogSource,
+    ClickStackLogSourceMetadataMaterializedViews,
+    ClickStackLogSourceMetadataMaterializedViewsResponse, ClickStackLogSourceResponse,
+    ClickStackMaterializedView, ClickStackMaterializedViewResponse, ClickStackMetricSource,
+    ClickStackMetricSourceFrom, ClickStackMetricSourceFromResponse, ClickStackMetricSourceResponse,
+    ClickStackMetricTables, ClickStackMetricTablesResponse, ClickStackPromqlSource,
+    ClickStackPromqlSourceResponse, ClickStackQuerySetting, ClickStackQuerySettingResponse,
+    ClickStackSessionSource, ClickStackSessionSourceResponse, ClickStackSource,
+    ClickStackSourceFilterSettings, ClickStackSourceFilterSettingsResponse, ClickStackSourceFrom,
+    ClickStackSourceFromResponse, ClickStackSourceResponse, ClickStackTraceSource,
+    ClickStackTraceSourceMetadataMaterializedViews,
+    ClickStackTraceSourceMetadataMaterializedViewsResponse, ClickStackTraceSourceResponse,
     PgBouncerConfig, PgBouncerConfigResponse, PgConfig, PgConfigResponse, PostgresInstanceConfig,
     PostgresInstanceConfigResponse, ResourceTagsV1, ResourceTagsV1Response, ScalingScheduleEntry,
     ScalingScheduleEntryRequest, UpgradeWindow, UpgradeWindowPutRequest,
@@ -50,6 +69,794 @@ impl fmt::Display for MissingRequiredFields {
 }
 
 impl std::error::Error for MissingRequiredFields {}
+
+impl TryFrom<ClickStackAggregatedColumnResponse> for ClickStackAggregatedColumn {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackAggregatedColumnResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.agg_fn.is_none() {
+            missing.push("aggFn");
+        }
+        if value.mv_column.is_none() {
+            missing.push("mvColumn");
+        }
+        match (value.agg_fn, value.mv_column) {
+            (Some(agg_fn), Some(mv_column)) => Ok(Self {
+                agg_fn,
+                mv_column,
+                source_column: value.source_column,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackFilterSettingsColumnResponse> for ClickStackFilterSettingsColumn {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackFilterSettingsColumnResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.label.is_none() {
+            missing.push("label");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        match (value.label, value.name) {
+            (Some(label), Some(name)) => Ok(Self { label, name }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackHighlightedAttributeExpressionResponse>
+    for ClickStackHighlightedAttributeExpression
+{
+    type Error = MissingRequiredFields;
+
+    fn try_from(
+        value: ClickStackHighlightedAttributeExpressionResponse,
+    ) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.sql_expression.is_none() {
+            missing.push("sqlExpression");
+        }
+        match value.sql_expression {
+            Some(sql_expression) => Ok(Self {
+                alias: value.alias,
+                lucene_expression: value.lucene_expression,
+                sql_expression,
+            }),
+            None => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackLogSourceMetadataMaterializedViewsResponse>
+    for ClickStackLogSourceMetadataMaterializedViews
+{
+    type Error = MissingRequiredFields;
+
+    fn try_from(
+        value: ClickStackLogSourceMetadataMaterializedViewsResponse,
+    ) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.granularity.is_none() {
+            missing.push("granularity");
+        }
+        if value.key_rollup_table.is_none() {
+            missing.push("keyRollupTable");
+        }
+        if value.kv_rollup_table.is_none() {
+            missing.push("kvRollupTable");
+        }
+        match (
+            value.granularity,
+            value.key_rollup_table,
+            value.kv_rollup_table,
+        ) {
+            (Some(granularity), Some(key_rollup_table), Some(kv_rollup_table)) => Ok(Self {
+                granularity,
+                key_rollup_table,
+                kv_rollup_table,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackLogSourceResponse> for ClickStackLogSource {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackLogSourceResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.connection.is_none() {
+            missing.push("connection");
+        }
+        if value.default_table_select_expression.is_none() {
+            missing.push("defaultTableSelectExpression");
+        }
+        if value.from.is_none() {
+            missing.push("from");
+        }
+        if value.kind.is_none() {
+            missing.push("kind");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.timestamp_value_expression.is_none() {
+            missing.push("timestampValueExpression");
+        }
+        match (
+            value.connection,
+            value.default_table_select_expression,
+            value.from,
+            value.kind,
+            value.name,
+            value.timestamp_value_expression,
+        ) {
+            (
+                Some(connection),
+                Some(default_table_select_expression),
+                Some(from),
+                Some(kind),
+                Some(name),
+                Some(timestamp_value_expression),
+            ) => Ok(Self {
+                body_expression: value.body_expression,
+                connection,
+                default_table_select_expression,
+                disabled: value.disabled,
+                displayed_timestamp_value_expression: value.displayed_timestamp_value_expression,
+                event_attributes_expression: value.event_attributes_expression,
+                filter_settings: value.filter_settings.map(TryInto::try_into).transpose()?,
+                from: from.try_into()?,
+                highlighted_row_attribute_expressions: value
+                    .highlighted_row_attribute_expressions
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                highlighted_trace_attribute_expressions: value
+                    .highlighted_trace_attribute_expressions
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                id: value.id,
+                implicit_column_expression: value.implicit_column_expression,
+                kind,
+                known_columns_list_expression: value.known_columns_list_expression,
+                materialized_views: value
+                    .materialized_views
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                metadata_materialized_views: value
+                    .metadata_materialized_views
+                    .map(TryInto::try_into)
+                    .transpose()?,
+                metric_source_id: value.metric_source_id,
+                name,
+                query_settings: value
+                    .query_settings
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                resource_attributes_expression: value.resource_attributes_expression,
+                section: value.section,
+                service_name_expression: value.service_name_expression,
+                severity_text_expression: value.severity_text_expression,
+                span_id_expression: value.span_id_expression,
+                timestamp_value_expression,
+                trace_id_expression: value.trace_id_expression,
+                trace_source_id: value.trace_source_id,
+                use_text_index_for_implicit_column: value.use_text_index_for_implicit_column,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackMaterializedViewResponse> for ClickStackMaterializedView {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackMaterializedViewResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.aggregated_columns.is_none() {
+            missing.push("aggregatedColumns");
+        }
+        if value.database_name.is_none() {
+            missing.push("databaseName");
+        }
+        if value.dimension_columns.is_none() {
+            missing.push("dimensionColumns");
+        }
+        if value.min_granularity.is_none() {
+            missing.push("minGranularity");
+        }
+        if value.table_name.is_none() {
+            missing.push("tableName");
+        }
+        if value.timestamp_column.is_none() {
+            missing.push("timestampColumn");
+        }
+        match (
+            value.aggregated_columns,
+            value.database_name,
+            value.dimension_columns,
+            value.min_granularity,
+            value.table_name,
+            value.timestamp_column,
+        ) {
+            (
+                Some(aggregated_columns),
+                Some(database_name),
+                Some(dimension_columns),
+                Some(min_granularity),
+                Some(table_name),
+                Some(timestamp_column),
+            ) => Ok(Self {
+                aggregated_columns: aggregated_columns
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+                database_name,
+                dimension_columns,
+                min_date: value.min_date,
+                min_granularity,
+                table_name,
+                timestamp_column,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackMetricSourceFromResponse> for ClickStackMetricSourceFrom {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackMetricSourceFromResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.database_name.is_none() {
+            missing.push("databaseName");
+        }
+        match value.database_name {
+            Some(database_name) => Ok(Self {
+                database_name,
+                table_name: value.table_name,
+            }),
+            None => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackMetricSourceResponse> for ClickStackMetricSource {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackMetricSourceResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.connection.is_none() {
+            missing.push("connection");
+        }
+        if value.from.is_none() {
+            missing.push("from");
+        }
+        if value.kind.is_none() {
+            missing.push("kind");
+        }
+        if value.metric_tables.is_none() {
+            missing.push("metricTables");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.resource_attributes_expression.is_none() {
+            missing.push("resourceAttributesExpression");
+        }
+        if value.timestamp_value_expression.is_none() {
+            missing.push("timestampValueExpression");
+        }
+        match (
+            value.connection,
+            value.from,
+            value.kind,
+            value.metric_tables,
+            value.name,
+            value.resource_attributes_expression,
+            value.timestamp_value_expression,
+        ) {
+            (
+                Some(connection),
+                Some(from),
+                Some(kind),
+                Some(metric_tables),
+                Some(name),
+                Some(resource_attributes_expression),
+                Some(timestamp_value_expression),
+            ) => Ok(Self {
+                connection,
+                disabled: value.disabled,
+                from: from.try_into()?,
+                id: value.id,
+                kind,
+                log_source_id: value.log_source_id,
+                metric_tables: metric_tables.try_into()?,
+                name,
+                query_settings: value
+                    .query_settings
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                resource_attributes_expression,
+                section: value.section,
+                timestamp_value_expression,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackMetricTablesResponse> for ClickStackMetricTables {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackMetricTablesResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.exponential_histogram.is_none() {
+            missing.push("exponential histogram");
+        }
+        if value.gauge.is_none() {
+            missing.push("gauge");
+        }
+        if value.histogram.is_none() {
+            missing.push("histogram");
+        }
+        if value.sum.is_none() {
+            missing.push("sum");
+        }
+        if value.summary.is_none() {
+            missing.push("summary");
+        }
+        match (
+            value.exponential_histogram,
+            value.gauge,
+            value.histogram,
+            value.sum,
+            value.summary,
+        ) {
+            (
+                Some(exponential_histogram),
+                Some(gauge),
+                Some(histogram),
+                Some(sum),
+                Some(summary),
+            ) => Ok(Self {
+                exponential_histogram,
+                gauge,
+                histogram,
+                sum,
+                summary,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackPromqlSourceResponse> for ClickStackPromqlSource {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackPromqlSourceResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.connection.is_none() {
+            missing.push("connection");
+        }
+        if value.from.is_none() {
+            missing.push("from");
+        }
+        if value.kind.is_none() {
+            missing.push("kind");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.timestamp_value_expression.is_none() {
+            missing.push("timestampValueExpression");
+        }
+        match (
+            value.connection,
+            value.from,
+            value.kind,
+            value.name,
+            value.timestamp_value_expression,
+        ) {
+            (
+                Some(connection),
+                Some(from),
+                Some(kind),
+                Some(name),
+                Some(timestamp_value_expression),
+            ) => Ok(Self {
+                connection,
+                disabled: value.disabled,
+                from: from.try_into()?,
+                id: value.id,
+                kind,
+                name,
+                query_settings: value
+                    .query_settings
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                section: value.section,
+                timestamp_value_expression,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackQuerySettingResponse> for ClickStackQuerySetting {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackQuerySettingResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.setting.is_none() {
+            missing.push("setting");
+        }
+        if value.value.is_none() {
+            missing.push("value");
+        }
+        match (value.setting, value.value) {
+            (Some(setting), Some(value)) => Ok(Self { setting, value }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSessionSourceResponse> for ClickStackSessionSource {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackSessionSourceResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.connection.is_none() {
+            missing.push("connection");
+        }
+        if value.from.is_none() {
+            missing.push("from");
+        }
+        if value.kind.is_none() {
+            missing.push("kind");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.trace_source_id.is_none() {
+            missing.push("traceSourceId");
+        }
+        match (
+            value.connection,
+            value.from,
+            value.kind,
+            value.name,
+            value.trace_source_id,
+        ) {
+            (Some(connection), Some(from), Some(kind), Some(name), Some(trace_source_id)) => {
+                Ok(Self {
+                    connection,
+                    disabled: value.disabled,
+                    from: from.try_into()?,
+                    id: value.id,
+                    kind,
+                    name,
+                    query_settings: value
+                        .query_settings
+                        .map(|items| {
+                            items
+                                .into_iter()
+                                .map(TryInto::try_into)
+                                .collect::<Result<Vec<_>, _>>()
+                        })
+                        .transpose()?,
+                    section: value.section,
+                    timestamp_value_expression: value.timestamp_value_expression,
+                    trace_source_id,
+                })
+            }
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSourceFilterSettingsResponse> for ClickStackSourceFilterSettings {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackSourceFilterSettingsResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.columns.is_none() {
+            missing.push("columns");
+        }
+        if value.database_name.is_none() {
+            missing.push("databaseName");
+        }
+        if value.table_name.is_none() {
+            missing.push("tableName");
+        }
+        match (value.columns, value.database_name, value.table_name) {
+            (Some(columns), Some(database_name), Some(table_name)) => Ok(Self {
+                columns: columns
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+                database_name,
+                table_name,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSourceFromResponse> for ClickStackSourceFrom {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackSourceFromResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.database_name.is_none() {
+            missing.push("databaseName");
+        }
+        if value.table_name.is_none() {
+            missing.push("tableName");
+        }
+        match (value.database_name, value.table_name) {
+            (Some(database_name), Some(table_name)) => Ok(Self {
+                database_name,
+                table_name,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackSourceResponse> for ClickStackSource {
+    type Error = MissingRequiredFields;
+
+    /// Turns a fetched source into a create/update body.
+    ///
+    /// A write replaces the whole source, so every field the schema requires for
+    /// the source's `kind` has to be present in the response; a missing one is
+    /// named rather than invented. Nested objects report their own wire names,
+    /// unprefixed — `databaseName` for a source's `from`, say.
+    ///
+    /// An `Unknown` payload — a `kind` this crate does not model, or a body that
+    /// did not fit the variant its `kind` selected — converts losslessly: the
+    /// request union's own `Unknown` arm holds the raw JSON and serializes it
+    /// verbatim, so such a source can still be written back.
+    fn try_from(value: ClickStackSourceResponse) -> Result<Self, Self::Error> {
+        Ok(match value {
+            ClickStackSourceResponse::ClickStackLogSource(source) => {
+                Self::ClickStackLogSource(source.try_into()?)
+            }
+            ClickStackSourceResponse::ClickStackTraceSource(source) => {
+                Self::ClickStackTraceSource(source.try_into()?)
+            }
+            ClickStackSourceResponse::ClickStackMetricSource(source) => {
+                Self::ClickStackMetricSource(source.try_into()?)
+            }
+            ClickStackSourceResponse::ClickStackSessionSource(source) => {
+                Self::ClickStackSessionSource(source.try_into()?)
+            }
+            ClickStackSourceResponse::ClickStackPromqlSource(source) => {
+                Self::ClickStackPromqlSource(source.try_into()?)
+            }
+            ClickStackSourceResponse::Unknown(raw) => Self::Unknown(raw),
+        })
+    }
+}
+
+impl TryFrom<ClickStackTraceSourceMetadataMaterializedViewsResponse>
+    for ClickStackTraceSourceMetadataMaterializedViews
+{
+    type Error = MissingRequiredFields;
+
+    fn try_from(
+        value: ClickStackTraceSourceMetadataMaterializedViewsResponse,
+    ) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.granularity.is_none() {
+            missing.push("granularity");
+        }
+        if value.key_rollup_table.is_none() {
+            missing.push("keyRollupTable");
+        }
+        if value.kv_rollup_table.is_none() {
+            missing.push("kvRollupTable");
+        }
+        match (
+            value.granularity,
+            value.key_rollup_table,
+            value.kv_rollup_table,
+        ) {
+            (Some(granularity), Some(key_rollup_table), Some(kv_rollup_table)) => Ok(Self {
+                granularity,
+                key_rollup_table,
+                kv_rollup_table,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
+
+impl TryFrom<ClickStackTraceSourceResponse> for ClickStackTraceSource {
+    type Error = MissingRequiredFields;
+
+    fn try_from(value: ClickStackTraceSourceResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.connection.is_none() {
+            missing.push("connection");
+        }
+        if value.default_table_select_expression.is_none() {
+            missing.push("defaultTableSelectExpression");
+        }
+        if value.duration_expression.is_none() {
+            missing.push("durationExpression");
+        }
+        if value.duration_precision.is_none() {
+            missing.push("durationPrecision");
+        }
+        if value.from.is_none() {
+            missing.push("from");
+        }
+        if value.kind.is_none() {
+            missing.push("kind");
+        }
+        if value.name.is_none() {
+            missing.push("name");
+        }
+        if value.parent_span_id_expression.is_none() {
+            missing.push("parentSpanIdExpression");
+        }
+        if value.span_id_expression.is_none() {
+            missing.push("spanIdExpression");
+        }
+        if value.span_kind_expression.is_none() {
+            missing.push("spanKindExpression");
+        }
+        if value.span_name_expression.is_none() {
+            missing.push("spanNameExpression");
+        }
+        if value.timestamp_value_expression.is_none() {
+            missing.push("timestampValueExpression");
+        }
+        if value.trace_id_expression.is_none() {
+            missing.push("traceIdExpression");
+        }
+        match (
+            value.connection,
+            value.default_table_select_expression,
+            value.duration_expression,
+            value.duration_precision,
+            value.from,
+            value.kind,
+            value.name,
+            value.parent_span_id_expression,
+            value.span_id_expression,
+            value.span_kind_expression,
+            value.span_name_expression,
+            value.timestamp_value_expression,
+            value.trace_id_expression,
+        ) {
+            (
+                Some(connection),
+                Some(default_table_select_expression),
+                Some(duration_expression),
+                Some(duration_precision),
+                Some(from),
+                Some(kind),
+                Some(name),
+                Some(parent_span_id_expression),
+                Some(span_id_expression),
+                Some(span_kind_expression),
+                Some(span_name_expression),
+                Some(timestamp_value_expression),
+                Some(trace_id_expression),
+            ) => Ok(Self {
+                connection,
+                default_table_select_expression,
+                disabled: value.disabled,
+                duration_expression,
+                duration_precision,
+                event_attributes_expression: value.event_attributes_expression,
+                filter_settings: value.filter_settings.map(TryInto::try_into).transpose()?,
+                from: from.try_into()?,
+                highlighted_row_attribute_expressions: value
+                    .highlighted_row_attribute_expressions
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                highlighted_trace_attribute_expressions: value
+                    .highlighted_trace_attribute_expressions
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                id: value.id,
+                implicit_column_expression: value.implicit_column_expression,
+                kind,
+                known_columns_list_expression: value.known_columns_list_expression,
+                log_source_id: value.log_source_id,
+                materialized_views: value
+                    .materialized_views
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                metadata_materialized_views: value
+                    .metadata_materialized_views
+                    .map(TryInto::try_into)
+                    .transpose()?,
+                metric_source_id: value.metric_source_id,
+                name,
+                parent_span_id_expression,
+                query_settings: value
+                    .query_settings
+                    .map(|items| {
+                        items
+                            .into_iter()
+                            .map(TryInto::try_into)
+                            .collect::<Result<Vec<_>, _>>()
+                    })
+                    .transpose()?,
+                resource_attributes_expression: value.resource_attributes_expression,
+                section: value.section,
+                service_name_expression: value.service_name_expression,
+                session_source_id: value.session_source_id,
+                span_events_value_expression: value.span_events_value_expression,
+                span_id_expression,
+                span_kind_expression,
+                span_name_expression,
+                status_code_expression: value.status_code_expression,
+                status_message_expression: value.status_message_expression,
+                timestamp_value_expression,
+                trace_id_expression,
+                use_text_index_for_implicit_column: value.use_text_index_for_implicit_column,
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}
 
 impl From<PgBouncerConfigResponse> for PgBouncerConfig {
     fn from(_value: PgBouncerConfigResponse) -> Self {

--- a/crates/clickhouse-cloud-api/src/convert.rs
+++ b/crates/clickhouse-cloud-api/src/convert.rs
@@ -1,0 +1,124 @@
+//! Explicit conversions from response models back into request models.
+//!
+//! Response models are tolerant by construction: every field is `Option<T>`, so
+//! a field the API drops or sends as `null` deserializes to `None` instead of
+//! failing. Request models are strict: a field the API requires is `T`.
+//!
+//! A caller that fetches a resource, edits it, and writes it back therefore has
+//! to resolve absence explicitly, and that is the point of this module — the old
+//! `#[serde(default)]` policy silently fabricated `""`/`0`/`false` for a dropped
+//! field and persisted it on the next write. A conversion that can lose that
+//! information is a [`TryFrom`] reporting the missing wire field names; a
+//! conversion that cannot is a [`From`].
+
+use std::fmt;
+
+use crate::models::{
+    PgBouncerConfig, PgBouncerConfigResponse, PgConfig, PgConfigResponse, PostgresInstanceConfig,
+    PostgresInstanceConfigResponse,
+};
+
+/// The response omitted fields that the matching request model requires.
+///
+/// Field names are the wire (spec) names, so an error message points at the
+/// JSON the API returned rather than at Rust identifiers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingRequiredFields {
+    fields: Vec<&'static str>,
+}
+
+impl MissingRequiredFields {
+    pub(crate) fn new(fields: Vec<&'static str>) -> Self {
+        Self { fields }
+    }
+
+    /// The missing wire field names, in declaration order.
+    pub fn fields(&self) -> &[&'static str] {
+        &self.fields
+    }
+}
+
+impl fmt::Display for MissingRequiredFields {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "the API response is missing required field(s): {}",
+            self.fields.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for MissingRequiredFields {}
+
+impl From<PgBouncerConfigResponse> for PgBouncerConfig {
+    fn from(_value: PgBouncerConfigResponse) -> Self {
+        // The schema declares no properties, so the conversion is total.
+        Self {}
+    }
+}
+
+impl From<PgConfigResponse> for PgConfig {
+    fn from(value: PgConfigResponse) -> Self {
+        // Every `pgConfig` GUC is optional in both directions (omitting one
+        // selects the server default), so the conversion is total.
+        Self {
+            autovacuum_analyze_scale_factor: value.autovacuum_analyze_scale_factor,
+            autovacuum_max_workers: value.autovacuum_max_workers,
+            autovacuum_naptime: value.autovacuum_naptime,
+            autovacuum_vacuum_cost_delay: value.autovacuum_vacuum_cost_delay,
+            autovacuum_vacuum_cost_limit: value.autovacuum_vacuum_cost_limit,
+            autovacuum_vacuum_insert_scale_factor: value.autovacuum_vacuum_insert_scale_factor,
+            autovacuum_vacuum_scale_factor: value.autovacuum_vacuum_scale_factor,
+            autovacuum_work_mem: value.autovacuum_work_mem,
+            default_transaction_isolation: value.default_transaction_isolation,
+            effective_cache_size: value.effective_cache_size,
+            effective_io_concurrency: value.effective_io_concurrency,
+            idle_in_transaction_session_timeout: value.idle_in_transaction_session_timeout,
+            idle_session_timeout: value.idle_session_timeout,
+            lock_timeout: value.lock_timeout,
+            maintenance_work_mem: value.maintenance_work_mem,
+            max_connections: value.max_connections,
+            max_parallel_maintenance_workers: value.max_parallel_maintenance_workers,
+            max_parallel_workers: value.max_parallel_workers,
+            max_parallel_workers_per_gather: value.max_parallel_workers_per_gather,
+            max_slot_wal_keep_size: value.max_slot_wal_keep_size,
+            max_wal_size: value.max_wal_size,
+            max_worker_processes: value.max_worker_processes,
+            min_wal_size: value.min_wal_size,
+            random_page_cost: value.random_page_cost,
+            ssl_min_protocol_version: value.ssl_min_protocol_version,
+            statement_timeout: value.statement_timeout,
+            transaction_timeout: value.transaction_timeout,
+            wal_compression: value.wal_compression,
+            wal_keep_size: value.wal_keep_size,
+            wal_sender_timeout: value.wal_sender_timeout,
+            work_mem: value.work_mem,
+        }
+    }
+}
+
+impl TryFrom<PostgresInstanceConfigResponse> for PostgresInstanceConfig {
+    type Error = MissingRequiredFields;
+
+    /// Turns a fetched configuration into a POST/PATCH body.
+    ///
+    /// The API requires both `pgConfig` and `pgBouncerConfig` in a write body
+    /// (it rejects a body omitting either), so a response missing one cannot be
+    /// written back verbatim and the caller has to supply it.
+    fn try_from(value: PostgresInstanceConfigResponse) -> Result<Self, Self::Error> {
+        let mut missing = Vec::new();
+        if value.pg_bouncer_config.is_none() {
+            missing.push("pgBouncerConfig");
+        }
+        if value.pg_config.is_none() {
+            missing.push("pgConfig");
+        }
+        match (value.pg_bouncer_config, value.pg_config) {
+            (Some(pg_bouncer_config), Some(pg_config)) => Ok(Self {
+                pg_bouncer_config: pg_bouncer_config.into(),
+                pg_config: pg_config.into(),
+            }),
+            _ => Err(MissingRequiredFields::new(missing)),
+        }
+    }
+}

--- a/crates/clickhouse-cloud-api/src/lib.rs
+++ b/crates/clickhouse-cloud-api/src/lib.rs
@@ -17,6 +17,7 @@
 //! ```
 
 pub mod client;
+pub mod convert;
 pub mod error;
 pub mod meta;
 #[allow(non_camel_case_types)]
@@ -24,6 +25,7 @@ pub mod models;
 pub mod serde_helpers;
 
 pub use client::Client;
+pub use convert::MissingRequiredFields;
 pub use error::Error;
 pub use meta::{BETA_OPERATIONS, DEPRECATED_FIELDS, is_beta_operation, is_deprecated_field};
 pub use models::*;

--- a/crates/clickhouse-cloud-api/src/lib.rs
+++ b/crates/clickhouse-cloud-api/src/lib.rs
@@ -15,6 +15,65 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! ## Request and response models
+//!
+//! Requests are strict and responses are tolerant, and both are expressed in the
+//! type system rather than through serde attributes.
+//!
+//! A request model mirrors the spec: a required field is `T`, an optional or
+//! nullable field is `Option<T>`. **Every field of every response model is
+//! `Option<T>`**, so a field the API stops sending, or sends as `null`,
+//! deserializes to `None` instead of failing the whole response. Several teams
+//! evolve the Cloud API independently; a strict response field would make each of
+//! those changes a breaking one for you. Nothing is fabricated to fill a gap, so
+//! "the server sent `0`" and "the server dropped the field" stay distinguishable,
+//! and absence is resolved where the value is used.
+//!
+//! A schema the API uses in both directions is therefore two Rust types: the
+//! request variant keeps the schema's name and the response variant is
+//! `{Name}Response`, as in [`models::PostgresInstanceConfig`] and
+//! [`models::PostgresInstanceConfigResponse`]. Response models implement
+//! [`serde::Serialize`] with absent fields **omitted**, never written as `null`,
+//! so serializing one reproduces the key set the API sent.
+//!
+//! Editing a fetched resource and writing it back crosses that boundary
+//! deliberately. [`convert`] holds the conversions, and a fallible one names the
+//! wire fields it needs via [`MissingRequiredFields`]:
+//!
+//! ```rust,no_run
+//! use clickhouse_cloud_api::{Client, PostgresInstanceConfig};
+//!
+//! # async fn write_back() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = Client::new("your-key-id", "your-key-secret");
+//! let fetched = client
+//!     .postgres_instance_config_get("org-id", "postgres-id")
+//!     .await?
+//!     .result
+//!     .ok_or("the API returned no result")?;
+//!
+//! // Absence has to be resolved before the value can become a write body.
+//! let mut body = PostgresInstanceConfig::try_from(fetched)?;
+//! body.pg_config.autovacuum_max_workers = Some(4.into());
+//! client
+//!     .postgres_instance_config_post("org-id", "postgres-id", &body)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Enums and unions are tolerant in their own right, in both directions: a string
+//! enum keeps an `Unknown(String)` catch-all and an object union an
+//! `Unknown(serde_json::Value)` fallback holding the payload verbatim, so an
+//! unrecognized or reshaped variant round-trips rather than being rejected.
+//! Unknown object fields are ignored everywhere.
+//!
+//! One failure mode remains, honestly: a field that is *present* with a different
+//! type than the spec declares. `Option<T>` absorbs absence and `null`, not an
+//! object where a string used to be, so such a change still fails a plain struct
+//! field. Enums and unions absorb it through the catch-alls above. Detecting
+//! spec drift of that kind is the job of the repository's daily OpenAPI drift
+//! check, not of runtime deserialization.
 
 pub mod client;
 pub mod convert;

--- a/crates/clickhouse-cloud-api/src/meta.rs
+++ b/crates/clickhouse-cloud-api/src/meta.rs
@@ -121,6 +121,13 @@ pub fn is_beta_operation(name: &str) -> bool {
 /// python3 scripts/regenerate-deprecated-fields.py
 /// ```
 ///
+/// The script derives struct names from spec schema names alone, so a schema
+/// modeled as both a request and a response type needs the `{Name}Response`
+/// entry added by hand after regenerating (e.g. `ClickPipeScalingResponse`).
+/// The analyzer expects the pair once per Rust type the schema maps to, so a
+/// dropped response-variant entry fails the drift check rather than passing
+/// silently.
+///
 /// The shared OpenAPI analyzer reports drift if this list differs from the
 /// spec or if a field here lacks the `#[cfg(feature = "deprecated-fields")]`
 /// marker in `models.rs` (or vice versa).
@@ -130,6 +137,7 @@ pub const DEPRECATED_FIELDS: &[(&str, &str)] = &[
     ("ApiKeyPostRequest", "roles"),
     ("ClickPipeScaling", "concurrency"),
     ("ClickPipeScalingPatchRequest", "concurrency"),
+    ("ClickPipeScalingResponse", "concurrency"),
     ("ClickStackTileInput", "asRatio"),
     ("ClickStackTileInput", "series"),
     ("Invitation", "role"),

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -8551,237 +8551,227 @@ pub type PgStorageSize = i64;
 /// Type alias for `pgTags`.
 pub type PgTags = Vec<ResourceTagsV1>;
 
+/// Type alias for `pgTags` in response position, over
+/// [`ResourceTagsV1Response`].
+pub type PgTagsResponse = Vec<ResourceTagsV1Response>;
+
 /// `Activity` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Activity {
-    #[serde(rename = "actorDetails", default)]
-    pub actor_details: String,
-    #[serde(rename = "actorId", default)]
-    pub actor_id: String,
-    #[serde(rename = "actorIpAddress", default)]
-    pub actor_ip_address: String,
-    #[serde(rename = "actorType", default)]
-    pub actor_type: ActivityActortype,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub id: String,
-    #[serde(rename = "keyUpdateType", default)]
-    pub key_update_type: ActivityKeyupdatetype,
-    #[serde(rename = "organizationId", default)]
-    pub organization_id: String,
-    #[serde(rename = "serviceId", default)]
-    pub service_id: String,
-    #[serde(rename = "targetKeyId", default)]
-    pub target_key_id: String,
-    #[serde(default)]
-    pub r#type: ActivityType,
-    #[serde(rename = "userAgent", default)]
-    pub user_agent: String,
+    #[serde(rename = "actorDetails", skip_serializing_if = "Option::is_none")]
+    pub actor_details: Option<String>,
+    #[serde(rename = "actorId", skip_serializing_if = "Option::is_none")]
+    pub actor_id: Option<String>,
+    #[serde(rename = "actorIpAddress", skip_serializing_if = "Option::is_none")]
+    pub actor_ip_address: Option<String>,
+    #[serde(rename = "actorType", skip_serializing_if = "Option::is_none")]
+    pub actor_type: Option<ActivityActortype>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "keyUpdateType", skip_serializing_if = "Option::is_none")]
+    pub key_update_type: Option<ActivityKeyupdatetype>,
+    #[serde(rename = "organizationId", skip_serializing_if = "Option::is_none")]
+    pub organization_id: Option<String>,
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
+    #[serde(rename = "targetKeyId", skip_serializing_if = "Option::is_none")]
+    pub target_key_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ActivityType>,
+    #[serde(rename = "userAgent", skip_serializing_if = "Option::is_none")]
+    pub user_agent: Option<String>,
 }
 
 /// `ApiKey` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKey {
-    #[serde(rename = "assignedRoles", default)]
-    pub assigned_roles: Vec<AssignedRole>,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "assignedRoles", skip_serializing_if = "Option::is_none")]
+    pub assigned_roles: Option<Vec<AssignedRole>>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none")]
     pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(rename = "ipAccessList", default)]
-    pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(rename = "keySuffix", default)]
-    pub key_suffix: String,
-    #[serde(default)]
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
+    pub ip_access_list: Option<Vec<IpAccessListEntryResponse>>,
+    #[serde(rename = "keySuffix", skip_serializing_if = "Option::is_none")]
+    pub key_suffix: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
-    pub roles: Vec<String>,
-    #[serde(default)]
-    pub state: ApiKeyState,
-    #[serde(rename = "usedAt", default)]
-    pub used_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ApiKeyState>,
+    #[serde(rename = "usedAt", skip_serializing_if = "Option::is_none")]
+    pub used_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `ApiKeyHashData` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKeyHashData {
-    #[serde(rename = "keyIdHash", default)]
+    #[serde(rename = "keyIdHash")]
     pub key_id_hash: String,
-    #[serde(rename = "keyIdSuffix", default)]
+    #[serde(rename = "keyIdSuffix")]
     pub key_id_suffix: String,
-    #[serde(rename = "keySecretHash", default)]
+    #[serde(rename = "keySecretHash")]
     pub key_secret_hash: String,
 }
 
 /// `ApiKeyPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKeyPatchRequest {
-    #[serde(
-        rename = "assignedRoleIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "assignedRoleIds", skip_serializing_if = "Option::is_none")]
     pub assigned_role_ids: Option<Vec<uuid::Uuid>>,
-    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none")]
     pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(
-        rename = "ipAccessList",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
     pub ip_access_list: Option<Vec<IpAccessListEntry>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<ApiKeyPatchRequestState>,
 }
 
 /// `ApiKeyPostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKeyPostRequest {
-    #[serde(rename = "assignedRoleIds", default)]
+    #[serde(rename = "assignedRoleIds")]
     pub assigned_role_ids: Vec<uuid::Uuid>,
-    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none")]
     pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(rename = "hashData", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "hashData", skip_serializing_if = "Option::is_none")]
     pub hash_data: Option<ApiKeyHashData>,
-    #[serde(rename = "ipAccessList", default)]
+    #[serde(rename = "ipAccessList")]
     pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(default)]
     pub name: String,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<String>>,
-    #[serde(default)]
     pub state: ApiKeyPostRequestState,
 }
 
 /// `ApiKeyPostResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiKeyPostResponse {
-    #[serde(default)]
-    pub key: ApiKey,
-    #[serde(rename = "keyId", default)]
-    pub key_id: String,
-    #[serde(rename = "keySecret", default)]
-    pub key_secret: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<ApiKey>,
+    #[serde(rename = "keyId", skip_serializing_if = "Option::is_none")]
+    pub key_id: Option<String>,
+    #[serde(rename = "keySecret", skip_serializing_if = "Option::is_none")]
+    pub key_secret: Option<String>,
 }
 
 /// `AssignedRole` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AssignedRole {
-    #[serde(rename = "roleId", default)]
-    pub role_id: uuid::Uuid,
-    #[serde(rename = "roleName", default)]
-    pub role_name: String,
-    #[serde(rename = "roleType", default)]
-    pub role_type: AssignedRoleRoletype,
+    #[serde(rename = "roleId", skip_serializing_if = "Option::is_none")]
+    pub role_id: Option<uuid::Uuid>,
+    #[serde(rename = "roleName", skip_serializing_if = "Option::is_none")]
+    pub role_name: Option<String>,
+    #[serde(rename = "roleType", skip_serializing_if = "Option::is_none")]
+    pub role_type: Option<AssignedRoleRoletype>,
 }
 
 /// `AwsBackupBucket` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AwsBackupBucket {
-    #[serde(rename = "bucketPath", default)]
-    pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
-    pub bucket_provider: AwsBackupBucketBucketprovider,
-    #[serde(rename = "iamRoleArn", default)]
-    pub iam_role_arn: String,
-    #[serde(rename = "iamRoleSessionName", default)]
-    pub iam_role_session_name: String,
-    #[serde(default)]
-    pub id: uuid::Uuid,
+    #[serde(rename = "bucketPath", skip_serializing_if = "Option::is_none")]
+    pub bucket_path: Option<String>,
+    #[serde(rename = "bucketProvider", skip_serializing_if = "Option::is_none")]
+    pub bucket_provider: Option<AwsBackupBucketBucketprovider>,
+    #[serde(rename = "iamRoleArn", skip_serializing_if = "Option::is_none")]
+    pub iam_role_arn: Option<String>,
+    #[serde(rename = "iamRoleSessionName", skip_serializing_if = "Option::is_none")]
+    pub iam_role_session_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
 }
 
 /// `AwsBackupBucketPatchRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AwsBackupBucketPatchRequestV1 {
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AwsBackupBucketPatchRequestV1Bucketprovider,
-    #[serde(rename = "iamRoleArn", default)]
+    #[serde(rename = "iamRoleArn")]
     pub iam_role_arn: String,
-    #[serde(
-        rename = "iamRoleSessionName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "iamRoleSessionName", skip_serializing_if = "Option::is_none")]
     pub iam_role_session_name: Option<String>,
 }
 
 /// `AwsBackupBucketPostRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AwsBackupBucketPostRequestV1 {
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AwsBackupBucketPostRequestV1Bucketprovider,
-    #[serde(rename = "iamRoleArn", default)]
+    #[serde(rename = "iamRoleArn")]
     pub iam_role_arn: String,
-    #[serde(rename = "iamRoleSessionName", default)]
+    #[serde(rename = "iamRoleSessionName")]
     pub iam_role_session_name: String,
 }
 
 /// `AwsBackupBucketProperties` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AwsBackupBucketProperties {
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AwsBackupBucketPropertiesBucketprovider,
-    #[serde(rename = "iamRoleArn", default)]
+    #[serde(rename = "iamRoleArn")]
     pub iam_role_arn: String,
-    #[serde(rename = "iamRoleSessionName", default)]
+    #[serde(rename = "iamRoleSessionName")]
     pub iam_role_session_name: String,
 }
 
 /// `AzureBackupBucket` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AzureBackupBucket {
-    #[serde(rename = "bucketProvider", default)]
-    pub bucket_provider: AzureBackupBucketBucketprovider,
-    #[serde(rename = "containerName", default)]
-    pub container_name: String,
-    #[serde(default)]
-    pub id: uuid::Uuid,
+    #[serde(rename = "bucketProvider", skip_serializing_if = "Option::is_none")]
+    pub bucket_provider: Option<AzureBackupBucketBucketprovider>,
+    #[serde(rename = "containerName", skip_serializing_if = "Option::is_none")]
+    pub container_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
 }
 
 /// `AzureBackupBucketPatchRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AzureBackupBucketPatchRequestV1 {
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AzureBackupBucketPatchRequestV1Bucketprovider,
-    #[serde(rename = "connectionString", default)]
+    #[serde(rename = "connectionString")]
     pub connection_string: String,
-    #[serde(rename = "containerName", default)]
+    #[serde(rename = "containerName")]
     pub container_name: String,
 }
 
 /// `AzureBackupBucketPostRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AzureBackupBucketPostRequestV1 {
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AzureBackupBucketPostRequestV1Bucketprovider,
-    #[serde(rename = "connectionString", default)]
+    #[serde(rename = "connectionString")]
     pub connection_string: String,
-    #[serde(rename = "containerName", default)]
+    #[serde(rename = "containerName")]
     pub container_name: String,
 }
 
 /// `AzureBackupBucketProperties` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AzureBackupBucketProperties {
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: AzureBackupBucketPropertiesBucketprovider,
-    #[serde(rename = "containerName", default)]
+    #[serde(rename = "containerName")]
     pub container_name: String,
 }
 
@@ -8795,37 +8785,43 @@ pub struct AzureEventHub {
 /// `Backup` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Backup {
-    #[serde(rename = "backupName", default)]
-    pub backup_name: String,
-    #[serde(default)]
-    pub bucket: serde_json::Value,
-    #[serde(rename = "durationInSeconds", default)]
-    pub duration_in_seconds: f64,
-    #[serde(rename = "finishedAt", default)]
-    pub finished_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(rename = "serviceId", default)]
-    pub service_id: String,
-    #[serde(rename = "sizeInBytes", default)]
-    pub size_in_bytes: f64,
-    #[serde(rename = "startedAt", default)]
-    pub started_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub status: BackupStatus,
-    #[serde(default)]
-    pub r#type: BackupType,
+    #[serde(rename = "backupName", skip_serializing_if = "Option::is_none")]
+    pub backup_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bucket: Option<serde_json::Value>,
+    #[serde(rename = "durationInSeconds", skip_serializing_if = "Option::is_none")]
+    pub duration_in_seconds: Option<f64>,
+    #[serde(rename = "finishedAt", skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
+    #[serde(rename = "sizeInBytes", skip_serializing_if = "Option::is_none")]
+    pub size_in_bytes: Option<f64>,
+    #[serde(rename = "startedAt", skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<BackupStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<BackupType>,
 }
 
 /// `BackupConfiguration` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct BackupConfiguration {
-    #[serde(rename = "backupPeriodInHours", default)]
-    pub backup_period_in_hours: f64,
-    #[serde(rename = "backupRetentionPeriodInHours", default)]
-    pub backup_retention_period_in_hours: f64,
-    #[serde(rename = "backupStartTime", default)]
-    pub backup_start_time: String,
+    #[serde(
+        rename = "backupPeriodInHours",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub backup_period_in_hours: Option<f64>,
+    #[serde(
+        rename = "backupRetentionPeriodInHours",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub backup_retention_period_in_hours: Option<f64>,
+    #[serde(rename = "backupStartTime", skip_serializing_if = "Option::is_none")]
+    pub backup_start_time: Option<String>,
 }
 
 /// `BackupConfigurationPatchRequest` from the ClickHouse Cloud API.
@@ -8833,21 +8829,15 @@ pub struct BackupConfiguration {
 pub struct BackupConfigurationPatchRequest {
     #[serde(
         rename = "backupPeriodInHours",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub backup_period_in_hours: Option<f64>,
     #[serde(
         rename = "backupRetentionPeriodInHours",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub backup_retention_period_in_hours: Option<f64>,
-    #[serde(
-        rename = "backupStartTime",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "backupStartTime", skip_serializing_if = "Option::is_none")]
     pub backup_start_time: Option<String>,
 }
 
@@ -8868,43 +8858,39 @@ pub struct BasePostgresService {
 /// `ByocConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ByocConfig {
-    #[serde(rename = "accountName", default)]
-    pub account_name: String,
-    #[serde(rename = "cloudProvider", default)]
-    pub cloud_provider: ByocConfigCloudprovider,
-    #[serde(rename = "displayName", default)]
-    pub display_name: String,
-    #[serde(default)]
-    pub id: String,
-    #[serde(rename = "regionId", default)]
-    pub region_id: ByocConfigRegionid,
-    #[serde(default)]
-    pub state: ByocConfigState,
+    #[serde(rename = "accountName", skip_serializing_if = "Option::is_none")]
+    pub account_name: Option<String>,
+    #[serde(rename = "cloudProvider", skip_serializing_if = "Option::is_none")]
+    pub cloud_provider: Option<ByocConfigCloudprovider>,
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "regionId", skip_serializing_if = "Option::is_none")]
+    pub region_id: Option<ByocConfigRegionid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ByocConfigState>,
 }
 
 /// `ByocInfrastructurePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ByocInfrastructurePatchRequest {
-    #[serde(
-        rename = "displayName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
 
 /// `ByocInfrastructurePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ByocInfrastructurePostRequest {
-    #[serde(rename = "accountId", default)]
+    #[serde(rename = "accountId")]
     pub account_id: String,
-    #[serde(rename = "availabilityZoneSuffixes", default)]
+    #[serde(rename = "availabilityZoneSuffixes")]
     pub availability_zone_suffixes: Vec<String>,
-    #[serde(rename = "displayName", default)]
+    #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(rename = "regionId", default)]
+    #[serde(rename = "regionId")]
     pub region_id: ByocInfrastructurePostRequestRegionid,
-    #[serde(rename = "vpcCidrRange", default)]
+    #[serde(rename = "vpcCidrRange")]
     pub vpc_cidr_range: String,
 }
 
@@ -12676,22 +12662,43 @@ pub struct CreateReversePrivateEndpoint {
 /// `CurrentScaling` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CurrentScaling {
-    #[serde(rename = "activeEntryId", default)]
-    pub active_entry_id: uuid::Uuid,
-    #[serde(rename = "effectiveAutoscalingMode", default)]
-    pub effective_autoscaling_mode: CurrentScalingEffectiveautoscalingmode,
-    #[serde(rename = "effectiveIdleScaling", default)]
-    pub effective_idle_scaling: bool,
-    #[serde(rename = "effectiveIdleTimeoutMinutes", default)]
-    pub effective_idle_timeout_minutes: i64,
-    #[serde(rename = "effectiveMaxReplicaMemoryGb", default)]
-    pub effective_max_replica_memory_gb: f64,
-    #[serde(rename = "effectiveMaxReplicas", default)]
-    pub effective_max_replicas: i64,
-    #[serde(rename = "effectiveMinReplicaMemoryGb", default)]
-    pub effective_min_replica_memory_gb: f64,
-    #[serde(rename = "effectiveMinReplicas", default)]
-    pub effective_min_replicas: i64,
+    #[serde(rename = "activeEntryId", skip_serializing_if = "Option::is_none")]
+    pub active_entry_id: Option<uuid::Uuid>,
+    #[serde(
+        rename = "effectiveAutoscalingMode",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_autoscaling_mode: Option<CurrentScalingEffectiveautoscalingmode>,
+    #[serde(
+        rename = "effectiveIdleScaling",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_idle_scaling: Option<bool>,
+    #[serde(
+        rename = "effectiveIdleTimeoutMinutes",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_idle_timeout_minutes: Option<i64>,
+    #[serde(
+        rename = "effectiveMaxReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_max_replica_memory_gb: Option<f64>,
+    #[serde(
+        rename = "effectiveMaxReplicas",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_max_replicas: Option<i64>,
+    #[serde(
+        rename = "effectiveMinReplicaMemoryGb",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_min_replica_memory_gb: Option<f64>,
+    #[serde(
+        rename = "effectiveMinReplicas",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub effective_min_replicas: Option<i64>,
 }
 
 /// `CustomPrivateDnsMapping` from the ClickHouse Cloud API.
@@ -12708,140 +12715,144 @@ pub struct CustomPrivateDnsMapping {
 /// `GcpBackupBucket` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GcpBackupBucket {
-    #[serde(rename = "accessKeyId", default)]
-    pub access_key_id: String,
-    #[serde(rename = "bucketPath", default)]
-    pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
-    pub bucket_provider: GcpBackupBucketBucketprovider,
-    #[serde(default)]
-    pub id: uuid::Uuid,
+    #[serde(rename = "accessKeyId", skip_serializing_if = "Option::is_none")]
+    pub access_key_id: Option<String>,
+    #[serde(rename = "bucketPath", skip_serializing_if = "Option::is_none")]
+    pub bucket_path: Option<String>,
+    #[serde(rename = "bucketProvider", skip_serializing_if = "Option::is_none")]
+    pub bucket_provider: Option<GcpBackupBucketBucketprovider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
 }
 
 /// `GcpBackupBucketPatchRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GcpBackupBucketPatchRequestV1 {
-    #[serde(rename = "accessKeyId", default)]
+    #[serde(rename = "accessKeyId")]
     pub access_key_id: String,
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: GcpBackupBucketPatchRequestV1Bucketprovider,
-    #[serde(rename = "secretAccessKey", default)]
+    #[serde(rename = "secretAccessKey")]
     pub secret_access_key: String,
 }
 
 /// `GcpBackupBucketPostRequestV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GcpBackupBucketPostRequestV1 {
-    #[serde(rename = "accessKeyId", default)]
+    #[serde(rename = "accessKeyId")]
     pub access_key_id: String,
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: GcpBackupBucketPostRequestV1Bucketprovider,
-    #[serde(rename = "secretAccessKey", default)]
+    #[serde(rename = "secretAccessKey")]
     pub secret_access_key: String,
 }
 
 /// `GcpBackupBucketProperties` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct GcpBackupBucketProperties {
-    #[serde(rename = "accessKeyId", default)]
+    #[serde(rename = "accessKeyId")]
     pub access_key_id: String,
-    #[serde(rename = "bucketPath", default)]
+    #[serde(rename = "bucketPath")]
     pub bucket_path: String,
-    #[serde(rename = "bucketProvider", default)]
+    #[serde(rename = "bucketProvider")]
     pub bucket_provider: GcpBackupBucketPropertiesBucketprovider,
 }
 
 /// `InstancePrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct InstancePrivateEndpoint {
-    #[serde(rename = "cloudProvider", default)]
-    pub cloud_provider: InstancePrivateEndpointCloudprovider,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub region: InstancePrivateEndpointRegion,
+    #[serde(rename = "cloudProvider", skip_serializing_if = "Option::is_none")]
+    pub cloud_provider: Option<InstancePrivateEndpointCloudprovider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<InstancePrivateEndpointRegion>,
 }
 
 /// `InstancePrivateEndpointsPatch` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct InstancePrivateEndpointsPatch {
-    #[serde(default)]
     pub add: Vec<String>,
-    #[serde(default)]
     pub remove: Vec<String>,
 }
 
 /// `InstanceServiceQueryApiEndpointsPostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct InstanceServiceQueryApiEndpointsPostRequest {
-    #[serde(rename = "allowedOrigins", default)]
+    #[serde(rename = "allowedOrigins")]
     pub allowed_origins: String,
-    #[serde(rename = "openApiKeys", default)]
+    #[serde(rename = "openApiKeys")]
     pub open_api_keys: Vec<String>,
-    #[serde(default)]
     pub roles: Vec<String>,
 }
 
 /// `InstanceTagsPatch` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct InstanceTagsPatch {
-    #[serde(default)]
     pub add: Vec<ResourceTagsV1>,
-    #[serde(default)]
     pub remove: Vec<ResourceTagsV1>,
 }
 
 /// `Invitation` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Invitation {
-    #[serde(rename = "assignedRoles", default)]
-    pub assigned_roles: Vec<AssignedRole>,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub email: String,
-    #[serde(rename = "expireAt", default)]
-    pub expire_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub id: uuid::Uuid,
+    #[serde(rename = "assignedRoles", skip_serializing_if = "Option::is_none")]
+    pub assigned_roles: Option<Vec<AssignedRole>>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(rename = "expireAt", skip_serializing_if = "Option::is_none")]
+    pub expire_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
-    pub role: InvitationRole,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<InvitationRole>,
 }
 
 /// `InvitationPostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct InvitationPostRequest {
-    #[serde(rename = "assignedRoleIds", default)]
+    #[serde(rename = "assignedRoleIds")]
     pub assigned_role_ids: Vec<String>,
-    #[serde(default)]
     pub email: String,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<InvitationPostRequestRole>,
 }
 
 /// `IpAccessListEntry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct IpAccessListEntry {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default)]
     pub source: String,
+}
+
+/// `IpAccessListEntry` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`IpAccessListEntry`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct IpAccessListEntryResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// `IpAccessListPatch` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct IpAccessListPatch {
-    #[serde(default)]
     pub add: Vec<IpAccessListEntry>,
-    #[serde(default)]
     pub remove: Vec<IpAccessListEntry>,
 }
 
@@ -12863,32 +12874,28 @@ pub struct License {
 /// `Member` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Member {
-    #[serde(rename = "assignedRoles", default)]
-    pub assigned_roles: Vec<AssignedRole>,
-    #[serde(default)]
-    pub email: String,
-    #[serde(rename = "joinedAt", default)]
-    pub joined_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub name: String,
+    #[serde(rename = "assignedRoles", skip_serializing_if = "Option::is_none")]
+    pub assigned_roles: Option<Vec<AssignedRole>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(rename = "joinedAt", skip_serializing_if = "Option::is_none")]
+    pub joined_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
-    pub role: MemberRole,
-    #[serde(rename = "userId", default)]
-    pub user_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<MemberRole>,
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
 }
 
 /// `MemberPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct MemberPatchRequest {
-    #[serde(
-        rename = "assignedRoleIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "assignedRoleIds", skip_serializing_if = "Option::is_none")]
     pub assigned_role_ids: Option<Vec<String>>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<MemberPatchRequestRole>,
 }
 
@@ -12913,79 +12920,68 @@ pub struct MutualTLS {
 /// `Organization` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Organization {
-    #[serde(rename = "byocConfig", default)]
-    pub byoc_config: Vec<ByocConfig>,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(rename = "enableCoreDumps", default)]
-    pub enable_core_dumps: bool,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(default)]
-    pub name: String,
-    #[serde(rename = "privateEndpoints", default)]
-    pub private_endpoints: Vec<OrganizationPrivateEndpoint>,
+    #[serde(rename = "byocConfig", skip_serializing_if = "Option::is_none")]
+    pub byoc_config: Option<Vec<ByocConfig>>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
+    pub enable_core_dumps: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "privateEndpoints", skip_serializing_if = "Option::is_none")]
+    pub private_endpoints: Option<Vec<OrganizationPrivateEndpoint>>,
 }
 
 /// `OrganizationCloudRegionPrivateEndpointConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationCloudRegionPrivateEndpointConfig {
-    #[serde(rename = "endpointServiceId", default)]
-    pub endpoint_service_id: String,
+    #[serde(rename = "endpointServiceId", skip_serializing_if = "Option::is_none")]
+    pub endpoint_service_id: Option<String>,
 }
 
 /// `OrganizationPatchPrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationPatchPrivateEndpoint {
-    #[serde(rename = "cloudProvider", default)]
+    #[serde(rename = "cloudProvider")]
     pub cloud_provider: OrganizationPatchPrivateEndpointCloudprovider,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default)]
     pub id: String,
-    #[serde(default)]
     pub region: OrganizationPatchPrivateEndpointRegion,
 }
 
 /// `OrganizationPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationPatchRequest {
-    #[serde(
-        rename = "enableCoreDumps",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
     pub enable_core_dumps: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(
-        rename = "privateEndpoints",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "privateEndpoints", skip_serializing_if = "Option::is_none")]
     pub private_endpoints: Option<OrganizationPrivateEndpointsPatch>,
 }
 
 /// `OrganizationPrivateEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationPrivateEndpoint {
-    #[serde(rename = "cloudProvider", default)]
-    pub cloud_provider: OrganizationPrivateEndpointCloudprovider,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub region: OrganizationPrivateEndpointRegion,
+    #[serde(rename = "cloudProvider", skip_serializing_if = "Option::is_none")]
+    pub cloud_provider: Option<OrganizationPrivateEndpointCloudprovider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<OrganizationPrivateEndpointRegion>,
 }
 
 /// `OrganizationPrivateEndpointsPatch` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationPrivateEndpointsPatch {
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub add: Option<Vec<OrganizationPatchPrivateEndpoint>>,
-    #[serde(default)]
     pub remove: Vec<OrganizationPatchPrivateEndpoint>,
 }
 
@@ -13044,7 +13040,7 @@ pub struct PostgresService {
     #[serde(rename = "storageSize", skip_serializing_if = "Option::is_none")]
     pub storage_size: Option<PgStorageSize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<PgTags>,
+    pub tags: Option<PgTagsResponse>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
 }
@@ -13073,7 +13069,7 @@ pub struct PostgresServiceListItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<PgStateProperty>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<PgTags>,
+    pub tags: Option<PgTagsResponse>,
 }
 
 /// `PostgresServicePasswordResource` from the ClickHouse Cloud API.
@@ -13360,29 +13356,29 @@ pub struct PostgresSlowQueryPatternDetail {
 /// `PrivateEndpointConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PrivateEndpointConfig {
-    #[serde(rename = "endpointServiceId", default)]
-    pub endpoint_service_id: String,
-    #[serde(rename = "privateDnsHostname", default)]
-    pub private_dns_hostname: String,
+    #[serde(rename = "endpointServiceId", skip_serializing_if = "Option::is_none")]
+    pub endpoint_service_id: Option<String>,
+    #[serde(rename = "privateDnsHostname", skip_serializing_if = "Option::is_none")]
+    pub private_dns_hostname: Option<String>,
 }
 
 /// `RBACPolicy` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RBACPolicy {
-    #[serde(rename = "allowDeny", default)]
-    pub allow_deny: RBACPolicyAllowdeny,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub permissions: Vec<String>,
-    #[serde(default)]
-    pub resources: Vec<String>,
-    #[serde(rename = "roleId", default)]
-    pub role_id: String,
-    #[serde(default)]
-    pub tags: RBACPolicyTags,
-    #[serde(rename = "tenantId", default)]
-    pub tenant_id: String,
+    #[serde(rename = "allowDeny", skip_serializing_if = "Option::is_none")]
+    pub allow_deny: Option<RBACPolicyAllowdeny>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<Vec<String>>,
+    #[serde(rename = "roleId", skip_serializing_if = "Option::is_none")]
+    pub role_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<RBACPolicyTags>,
+    #[serde(rename = "tenantId", skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
 }
 
 /// `RBACPolicyCreateRequest` from the ClickHouse Cloud API.
@@ -13392,7 +13388,7 @@ pub struct RBACPolicyCreateRequest {
     pub allow_deny: RBACPolicyCreateRequestAllowdeny,
     pub permissions: Vec<String>,
     pub resources: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<RBACPolicyTags>,
 }
 
@@ -13408,31 +13404,46 @@ pub struct RBACPolicyTags {
 /// `RBACRole` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RBACRole {
-    #[serde(default)]
-    pub actors: Vec<String>,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub name: String,
-    #[serde(rename = "ownerId", default)]
-    pub owner_id: String,
-    #[serde(default)]
-    pub policies: Vec<RBACPolicy>,
-    #[serde(rename = "tenantId", default)]
-    pub tenant_id: String,
-    #[serde(default)]
-    pub r#type: RBACRoleType,
-    #[serde(rename = "updatedAt", default)]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actors: Option<Vec<String>>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "ownerId", skip_serializing_if = "Option::is_none")]
+    pub owner_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policies: Option<Vec<RBACPolicy>>,
+    #[serde(rename = "tenantId", skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<RBACRoleType>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `ResourceTagsV1` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ResourceTagsV1 {
     pub key: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
+/// `ResourceTagsV1` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ResourceTagsV1`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing. Writing a fetched tag back to the API goes through
+/// `TryFrom<ResourceTagsV1Response>` (see [`crate::convert`]), because a tag
+/// without a key cannot be sent.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ResourceTagsV1Response {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -13510,168 +13521,102 @@ pub struct RoleCreateRequest {
 /// `RoleUpdateRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RoleUpdateRequest {
-    #[serde(default)]
     pub actors: Vec<String>,
-    #[serde(default)]
     pub name: String,
-    #[serde(default)]
     pub policies: Vec<RBACPolicyCreateRequest>,
 }
 
 /// `ScalingSchedule` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingSchedule {
-    #[serde(
-        rename = "activeEntryId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "activeEntryId", skip_serializing_if = "Option::is_none")]
     pub active_entry_id: Option<uuid::Uuid>,
-    #[serde(rename = "baseConfig", default)]
-    pub base_config: ScalingScheduleBaseConfig,
-    #[serde(default)]
-    pub entries: Vec<ScalingScheduleEntry>,
+    #[serde(rename = "baseConfig", skip_serializing_if = "Option::is_none")]
+    pub base_config: Option<ScalingScheduleBaseConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entries: Option<Vec<ScalingScheduleEntry>>,
 }
 
 /// `ScalingScheduleBaseConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleBaseConfig {
-    #[serde(rename = "autoscalingMode", default)]
-    pub autoscaling_mode: AutoscalingMode,
-    #[serde(rename = "idleScaling", default)]
-    pub idle_scaling: bool,
-    #[serde(rename = "idleTimeoutMinutes", default)]
-    pub idle_timeout_minutes: i64,
-    #[serde(rename = "maxReplicaMemoryGb", default)]
-    pub max_replica_memory_gb: f64,
-    #[serde(rename = "maxReplicas", default)]
-    pub max_replicas: i64,
-    #[serde(rename = "minReplicaMemoryGb", default)]
-    pub min_replica_memory_gb: f64,
-    #[serde(rename = "minReplicas", default)]
-    pub min_replicas: i64,
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
+    pub autoscaling_mode: Option<AutoscalingMode>,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
+    pub idle_scaling: Option<bool>,
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_minutes: Option<i64>,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
+    pub max_replicas: Option<i64>,
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
+    pub min_replicas: Option<i64>,
 }
 
 /// `ScalingScheduleEntry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleEntry {
-    #[serde(rename = "autoscalingMode", default)]
-    pub autoscaling_mode: AutoscalingMode,
-    #[serde(rename = "endHourUtc", default)]
-    pub end_hour_utc: i64,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(
-        rename = "idleScaling",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
+    pub autoscaling_mode: Option<AutoscalingMode>,
+    #[serde(rename = "endHourUtc", skip_serializing_if = "Option::is_none")]
+    pub end_hour_utc: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
     pub idle_scaling: Option<bool>,
-    #[serde(
-        rename = "idleTimeoutMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
     pub idle_timeout_minutes: Option<i64>,
-    #[serde(rename = "isActiveNow", default)]
-    pub is_active_now: bool,
-    #[serde(
-        rename = "maxReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "isActiveNow", skip_serializing_if = "Option::is_none")]
+    pub is_active_now: Option<bool>,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "maxReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
     pub max_replicas: Option<i64>,
-    #[serde(
-        rename = "minReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "minReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
     pub min_replicas: Option<i64>,
-    #[serde(default)]
-    pub name: String,
-    #[serde(rename = "startHourUtc", default)]
-    pub start_hour_utc: i64,
-    #[serde(default)]
-    pub weekdays: Vec<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "startHourUtc", skip_serializing_if = "Option::is_none")]
+    pub start_hour_utc: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weekdays: Option<Vec<i64>>,
 }
 
 /// `ScalingScheduleEntryRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingScheduleEntryRequest {
-    #[serde(
-        rename = "autoscalingMode",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
     pub autoscaling_mode: Option<AutoscalingMode>,
-    #[serde(rename = "endHourUtc", default)]
+    #[serde(rename = "endHourUtc")]
     pub end_hour_utc: i64,
-    #[serde(
-        rename = "idleScaling",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
     pub idle_scaling: Option<bool>,
-    #[serde(
-        rename = "idleTimeoutMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
     pub idle_timeout_minutes: Option<i64>,
-    #[serde(
-        rename = "maxReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "maxReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
     pub max_replicas: Option<i64>,
-    #[serde(
-        rename = "minReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "minReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
     pub min_replicas: Option<i64>,
-    #[serde(default)]
     pub name: String,
-    #[serde(
-        rename = "numReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
     pub num_replicas: Option<i64>,
-    #[serde(rename = "startHourUtc", default)]
+    #[serde(rename = "startHourUtc")]
     pub start_hour_utc: i64,
-    #[serde(default)]
     pub weekdays: Vec<i64>,
 }
 
 /// `ScalingSchedulePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScalingSchedulePostRequest {
-    #[serde(default)]
     pub entries: Vec<ScalingScheduleEntryRequest>,
 }
 
@@ -14381,106 +14326,108 @@ pub struct ScimServiceProviderConfigPatch {
 /// `ServicPrivateEndpointePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicPrivateEndpointePostRequest {
-    #[serde(default)]
     pub description: String,
-    #[serde(default)]
     pub id: String,
 }
 
 /// `Service` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct Service {
-    #[serde(rename = "availablePrivateEndpointIds", default)]
-    pub available_private_endpoint_ids: Vec<String>,
-    #[serde(rename = "autoscalingMode", default)]
-    pub autoscaling_mode: AutoscalingMode,
-    #[serde(rename = "byocId", default)]
-    pub byoc_id: String,
-    #[serde(rename = "clickhouseVersion", default)]
-    pub clickhouse_version: String,
-    #[serde(rename = "complianceType", default)]
-    pub compliance_type: ServiceCompliancetype,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(rename = "currentScaling", default)]
-    pub current_scaling: CurrentScaling,
-    #[serde(rename = "dataWarehouseId", default)]
-    pub data_warehouse_id: String,
-    #[serde(rename = "enableCoreDumps", default)]
-    pub enable_core_dumps: bool,
+    #[serde(
+        rename = "availablePrivateEndpointIds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub available_private_endpoint_ids: Option<Vec<String>>,
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
+    pub autoscaling_mode: Option<AutoscalingMode>,
+    #[serde(rename = "byocId", skip_serializing_if = "Option::is_none")]
+    pub byoc_id: Option<String>,
+    #[serde(rename = "clickhouseVersion", skip_serializing_if = "Option::is_none")]
+    pub clickhouse_version: Option<String>,
+    #[serde(rename = "complianceType", skip_serializing_if = "Option::is_none")]
+    pub compliance_type: Option<ServiceCompliancetype>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "currentScaling", skip_serializing_if = "Option::is_none")]
+    pub current_scaling: Option<CurrentScaling>,
+    #[serde(rename = "dataWarehouseId", skip_serializing_if = "Option::is_none")]
+    pub data_warehouse_id: Option<String>,
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
+    pub enable_core_dumps: Option<bool>,
     #[serde(
         rename = "encryptionAssumedRoleIdentifier",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(
-        rename = "encryptionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none")]
     pub encryption_key: Option<String>,
-    #[serde(rename = "encryptionRoleId", default)]
-    pub encryption_role_id: String,
-    #[serde(default)]
-    pub endpoints: Vec<ServiceEndpoint>,
-    #[serde(rename = "hasTransparentDataEncryption", default)]
-    pub has_transparent_data_encryption: bool,
-    #[serde(rename = "iamRole", default)]
-    pub iam_role: String,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(rename = "idleScaling", default)]
-    pub idle_scaling: bool,
-    #[serde(rename = "idleTimeoutMinutes", default)]
-    pub idle_timeout_minutes: f64,
-    #[serde(rename = "ipAccessList", default)]
-    pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(rename = "isPrimary", default)]
-    pub is_primary: bool,
-    #[serde(rename = "isReadonly", default)]
-    pub is_readonly: bool,
-    #[serde(rename = "maxReplicaMemoryGb", default)]
-    pub max_replica_memory_gb: f64,
-    #[serde(rename = "maxReplicas", default)]
-    pub max_replicas: f64,
+    #[serde(rename = "encryptionRoleId", skip_serializing_if = "Option::is_none")]
+    pub encryption_role_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoints: Option<Vec<ServiceEndpoint>>,
+    #[serde(
+        rename = "hasTransparentDataEncryption",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub has_transparent_data_encryption: Option<bool>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
+    pub iam_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
+    pub idle_scaling: Option<bool>,
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_minutes: Option<f64>,
+    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
+    pub ip_access_list: Option<Vec<IpAccessListEntryResponse>>,
+    #[serde(rename = "isPrimary", skip_serializing_if = "Option::is_none")]
+    pub is_primary: Option<bool>,
+    #[serde(rename = "isReadonly", skip_serializing_if = "Option::is_none")]
+    pub is_readonly: Option<bool>,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
+    pub max_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "maxTotalMemoryGb", default)]
-    pub max_total_memory_gb: f64,
-    #[serde(rename = "minReplicaMemoryGb", default)]
-    pub min_replica_memory_gb: f64,
-    #[serde(rename = "minReplicas", default)]
-    pub min_replicas: f64,
+    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub max_total_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
+    pub min_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "minTotalMemoryGb", default)]
-    pub min_total_memory_gb: f64,
-    #[serde(default)]
-    pub name: String,
-    #[serde(rename = "numReplicas", default)]
-    pub num_replicas: f64,
-    #[serde(rename = "privateEndpointIds", default)]
-    pub private_endpoint_ids: Vec<String>,
-    #[serde(default)]
-    pub profile: ServiceProfile,
-    #[serde(default)]
-    pub provider: ServiceProvider,
-    #[serde(default)]
-    pub region: ServiceRegion,
-    #[serde(rename = "releaseChannel", default)]
-    pub release_channel: ServiceReleasechannel,
-    #[serde(rename = "replicaMemoryGb", default)]
-    pub replica_memory_gb: f64,
-    #[serde(rename = "scalingSchedule", default)]
-    pub scaling_schedule: ScalingSchedule,
-    #[serde(default)]
-    pub state: ServiceState,
-    #[serde(default)]
-    pub tags: Vec<ResourceTagsV1>,
+    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub min_total_memory_gb: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
+    pub num_replicas: Option<f64>,
+    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
+    pub private_endpoint_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<ServiceProfile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ServiceProvider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<ServiceRegion>,
+    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none")]
+    pub release_channel: Option<ServiceReleasechannel>,
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub replica_memory_gb: Option<f64>,
+    #[serde(rename = "scalingSchedule", skip_serializing_if = "Option::is_none")]
+    pub scaling_schedule: Option<ScalingSchedule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ServiceState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<ResourceTagsV1Response>>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
-    pub tier: ServiceTier,
-    #[serde(rename = "transparentDataEncryptionKeyId", default)]
-    pub transparent_data_encryption_key_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<ServiceTier>,
+    #[serde(
+        rename = "transparentDataEncryptionKeyId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transparent_data_encryption_key_id: Option<String>,
 }
 
 /// `ServiceAccount` from the ClickHouse Cloud API.
@@ -14493,153 +14440,126 @@ pub struct ServiceAccount {
 /// `ServiceClickhouseSetting` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSetting {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub value: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
 }
 
 /// `ServiceClickhouseSettingSchemaEntry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingSchemaEntry {
-    #[serde(rename = "deprecationNotice", default)]
-    pub deprecation_notice: String,
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub r#enum: Vec<i64>,
-    #[serde(default)]
-    pub example: String,
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub r#type: String,
-    #[serde(default)]
-    pub warning: String,
+    #[serde(rename = "deprecationNotice", skip_serializing_if = "Option::is_none")]
+    pub deprecation_notice: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#enum: Option<Vec<i64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning: Option<String>,
 }
 
 /// `ServiceClickhouseSettingWarning` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingWarning {
-    #[serde(default)]
-    pub message: String,
-    #[serde(default)]
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 /// `ServiceClickhouseSettingsList` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingsList {
-    #[serde(default)]
-    pub settings: Vec<ServiceClickhouseSetting>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Vec<ServiceClickhouseSetting>>,
 }
 
 /// `ServiceClickhouseSettingsPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingsPatchRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<String>,
 }
 
 /// `ServiceClickhouseSettingsPatchResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingsPatchResponse {
-    #[serde(default)]
-    pub settings: String,
-    #[serde(default)]
-    pub warnings: Vec<ServiceClickhouseSettingWarning>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warnings: Option<Vec<ServiceClickhouseSettingWarning>>,
 }
 
 /// `ServiceClickhouseSettingsSchema` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceClickhouseSettingsSchema {
-    #[serde(default)]
-    pub settings: Vec<ServiceClickhouseSettingSchemaEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Vec<ServiceClickhouseSettingSchemaEntry>>,
 }
 
 /// `ServiceEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceEndpoint {
-    #[serde(default)]
-    pub host: String,
-    #[serde(default)]
-    pub port: f64,
-    #[serde(default)]
-    pub protocol: ServiceEndpointProtocol,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<ServiceEndpointProtocol>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
 }
 
 /// `ServiceEndpointChange` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceEndpointChange {
-    #[serde(default)]
     pub enabled: bool,
-    #[serde(default)]
     pub protocol: ServiceEndpointChangeProtocol,
 }
 
 /// `ServicePasswordPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePasswordPatchRequest {
-    #[serde(
-        rename = "newDoubleSha1Hash",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "newDoubleSha1Hash", skip_serializing_if = "Option::is_none")]
     pub new_double_sha1_hash: Option<String>,
-    #[serde(
-        rename = "newPasswordHash",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "newPasswordHash", skip_serializing_if = "Option::is_none")]
     pub new_password_hash: Option<String>,
 }
 
 /// `ServicePasswordPatchResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePasswordPatchResponse {
-    #[serde(default)]
-    pub password: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }
 
 /// `ServicePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePatchRequest {
-    #[serde(
-        rename = "enableCoreDumps",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
     pub enable_core_dumps: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoints: Option<Vec<ServiceEndpointChange>>,
-    #[serde(
-        rename = "ipAccessList",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
     pub ip_access_list: Option<IpAccessListPatch>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(
-        rename = "privateEndpointIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<InstancePrivateEndpointsPatch>,
-    #[serde(
-        rename = "releaseChannel",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none")]
     pub release_channel: Option<ServicePatchRequestReleasechannel>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<InstanceTagsPatch>,
     #[serde(
         rename = "transparentDataEncryptionKeyId",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub transparent_data_encryption_key_id: Option<String>,
 }
@@ -14647,384 +14567,261 @@ pub struct ServicePatchRequest {
 /// `ServicePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePostRequest {
-    #[serde(
-        rename = "autoscalingMode",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
     pub autoscaling_mode: Option<AutoscalingMode>,
-    #[serde(rename = "backupId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "backupId", skip_serializing_if = "Option::is_none")]
     pub backup_id: Option<uuid::Uuid>,
-    #[serde(rename = "byocId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "byocId", skip_serializing_if = "Option::is_none")]
     pub byoc_id: Option<String>,
-    #[serde(
-        rename = "complianceType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "complianceType", skip_serializing_if = "Option::is_none")]
     pub compliance_type: Option<ServicePostRequestCompliancetype>,
-    #[serde(
-        rename = "dataWarehouseId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "dataWarehouseId", skip_serializing_if = "Option::is_none")]
     pub data_warehouse_id: Option<String>,
-    #[serde(
-        rename = "enableCoreDumps",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
     pub enable_core_dumps: Option<bool>,
     #[serde(
         rename = "encryptionAssumedRoleIdentifier",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(
-        rename = "encryptionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none")]
     pub encryption_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoints: Option<Vec<ServiceEndpointChange>>,
     #[serde(
         rename = "hasTransparentDataEncryption",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub has_transparent_data_encryption: Option<bool>,
-    #[serde(
-        rename = "idleScaling",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
     pub idle_scaling: Option<bool>,
-    #[serde(
-        rename = "idleTimeoutMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
     pub idle_timeout_minutes: Option<f64>,
-    #[serde(rename = "ipAccessList", default)]
+    #[serde(rename = "ipAccessList")]
     pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(
-        rename = "isReadonly",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "isReadonly", skip_serializing_if = "Option::is_none")]
     pub is_readonly: Option<bool>,
-    #[serde(
-        rename = "maxReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "maxReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
     pub max_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(
-        rename = "maxTotalMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_total_memory_gb: Option<f64>,
-    #[serde(
-        rename = "minReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "minReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
     pub min_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(
-        rename = "minTotalMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
-    #[serde(default)]
     pub name: String,
-    #[serde(
-        rename = "numReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
     pub num_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(
-        rename = "privateEndpointIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<Vec<String>>,
     #[serde(
         rename = "privatePreviewTermsChecked",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub private_preview_terms_checked: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profile: Option<ServicePostRequestProfile>,
-    #[serde(default)]
     pub provider: ServicePostRequestProvider,
-    #[serde(default)]
     pub region: ServicePostRequestRegion,
-    #[serde(
-        rename = "releaseChannel",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none")]
     pub release_channel: Option<ServicePostRequestReleasechannel>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<ResourceTagsV1>>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tier: Option<ServicePostRequestTier>,
 }
 
 /// `ServicePostResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServicePostResponse {
-    #[serde(default)]
-    pub password: String,
-    #[serde(default)]
-    pub service: Service,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<Service>,
 }
 
 /// `ServiceQueryAPIEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceQueryAPIEndpoint {
-    #[serde(rename = "allowedOrigins", default)]
-    pub allowed_origins: String,
-    #[serde(default)]
-    pub id: String,
-    #[serde(rename = "openApiKeys", default)]
-    pub open_api_keys: Vec<String>,
-    #[serde(default)]
-    pub roles: Vec<String>,
+    #[serde(rename = "allowedOrigins", skip_serializing_if = "Option::is_none")]
+    pub allowed_origins: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "openApiKeys", skip_serializing_if = "Option::is_none")]
+    pub open_api_keys: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub roles: Option<Vec<String>>,
 }
 
 /// `ServiceReplicaScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceReplicaScalingPatchRequest {
-    #[serde(
-        rename = "autoscalingMode",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
     pub autoscaling_mode: Option<AutoscalingMode>,
-    #[serde(
-        rename = "idleScaling",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
     pub idle_scaling: Option<bool>,
-    #[serde(
-        rename = "idleTimeoutMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
     pub idle_timeout_minutes: Option<f64>,
-    #[serde(
-        rename = "maxReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "maxReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
     pub max_replicas: Option<f64>,
-    #[serde(
-        rename = "minReplicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
-    #[serde(
-        rename = "minReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
     pub min_replicas: Option<f64>,
-    #[serde(
-        rename = "numReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
     pub num_replicas: Option<f64>,
 }
 
 /// `ServiceScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceScalingPatchRequest {
-    #[serde(
-        rename = "idleScaling",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
     pub idle_scaling: Option<bool>,
-    #[serde(
-        rename = "idleTimeoutMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
     pub idle_timeout_minutes: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(
-        rename = "maxTotalMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_total_memory_gb: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(
-        rename = "minTotalMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
-    #[serde(
-        rename = "numReplicas",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
     pub num_replicas: Option<f64>,
 }
 
 /// `ServiceScalingPatchResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceScalingPatchResponse {
-    #[serde(rename = "availablePrivateEndpointIds", default)]
-    pub available_private_endpoint_ids: Vec<String>,
-    #[serde(rename = "autoscalingMode", default)]
-    pub autoscaling_mode: AutoscalingMode,
-    #[serde(rename = "byocId", default)]
-    pub byoc_id: String,
-    #[serde(rename = "clickhouseVersion", default)]
-    pub clickhouse_version: String,
-    #[serde(rename = "complianceType", default)]
-    pub compliance_type: ServiceScalingPatchResponseCompliancetype,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(rename = "currentScaling", default)]
-    pub current_scaling: CurrentScaling,
-    #[serde(rename = "dataWarehouseId", default)]
-    pub data_warehouse_id: String,
-    #[serde(rename = "enableCoreDumps", default)]
-    pub enable_core_dumps: bool,
+    #[serde(
+        rename = "availablePrivateEndpointIds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub available_private_endpoint_ids: Option<Vec<String>>,
+    #[serde(rename = "autoscalingMode", skip_serializing_if = "Option::is_none")]
+    pub autoscaling_mode: Option<AutoscalingMode>,
+    #[serde(rename = "byocId", skip_serializing_if = "Option::is_none")]
+    pub byoc_id: Option<String>,
+    #[serde(rename = "clickhouseVersion", skip_serializing_if = "Option::is_none")]
+    pub clickhouse_version: Option<String>,
+    #[serde(rename = "complianceType", skip_serializing_if = "Option::is_none")]
+    pub compliance_type: Option<ServiceScalingPatchResponseCompliancetype>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "currentScaling", skip_serializing_if = "Option::is_none")]
+    pub current_scaling: Option<CurrentScaling>,
+    #[serde(rename = "dataWarehouseId", skip_serializing_if = "Option::is_none")]
+    pub data_warehouse_id: Option<String>,
+    #[serde(rename = "enableCoreDumps", skip_serializing_if = "Option::is_none")]
+    pub enable_core_dumps: Option<bool>,
     #[serde(
         rename = "encryptionAssumedRoleIdentifier",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub encryption_assumed_role_identifier: Option<String>,
-    #[serde(
-        rename = "encryptionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "encryptionKey", skip_serializing_if = "Option::is_none")]
     pub encryption_key: Option<String>,
-    #[serde(rename = "encryptionRoleId", default)]
-    pub encryption_role_id: String,
-    #[serde(default)]
-    pub endpoints: Vec<ServiceEndpoint>,
-    #[serde(rename = "hasTransparentDataEncryption", default)]
-    pub has_transparent_data_encryption: bool,
-    #[serde(rename = "iamRole", default)]
-    pub iam_role: String,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(rename = "idleScaling", default)]
-    pub idle_scaling: bool,
-    #[serde(rename = "idleTimeoutMinutes", default)]
-    pub idle_timeout_minutes: f64,
-    #[serde(rename = "ipAccessList", default)]
-    pub ip_access_list: Vec<IpAccessListEntry>,
-    #[serde(rename = "isPrimary", default)]
-    pub is_primary: bool,
-    #[serde(rename = "isReadonly", default)]
-    pub is_readonly: bool,
-    #[serde(rename = "maxReplicaMemoryGb", default)]
-    pub max_replica_memory_gb: f64,
-    #[serde(rename = "maxReplicas", default)]
-    pub max_replicas: f64,
+    #[serde(rename = "encryptionRoleId", skip_serializing_if = "Option::is_none")]
+    pub encryption_role_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoints: Option<Vec<ServiceEndpoint>>,
+    #[serde(
+        rename = "hasTransparentDataEncryption",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub has_transparent_data_encryption: Option<bool>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
+    pub iam_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "idleScaling", skip_serializing_if = "Option::is_none")]
+    pub idle_scaling: Option<bool>,
+    #[serde(rename = "idleTimeoutMinutes", skip_serializing_if = "Option::is_none")]
+    pub idle_timeout_minutes: Option<f64>,
+    #[serde(rename = "ipAccessList", skip_serializing_if = "Option::is_none")]
+    pub ip_access_list: Option<Vec<IpAccessListEntryResponse>>,
+    #[serde(rename = "isPrimary", skip_serializing_if = "Option::is_none")]
+    pub is_primary: Option<bool>,
+    #[serde(rename = "isReadonly", skip_serializing_if = "Option::is_none")]
+    pub is_readonly: Option<bool>,
+    #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub max_replica_memory_gb: Option<f64>,
+    #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
+    pub max_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "maxTotalMemoryGb", default)]
-    pub max_total_memory_gb: f64,
-    #[serde(rename = "minReplicaMemoryGb", default)]
-    pub min_replica_memory_gb: f64,
-    #[serde(rename = "minReplicas", default)]
-    pub min_replicas: f64,
+    #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub max_total_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub min_replica_memory_gb: Option<f64>,
+    #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
+    pub min_replicas: Option<f64>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "minTotalMemoryGb", default)]
-    pub min_total_memory_gb: f64,
-    #[serde(default)]
-    pub name: String,
-    #[serde(rename = "numReplicas", default)]
-    pub num_replicas: f64,
-    #[serde(rename = "privateEndpointIds", default)]
-    pub private_endpoint_ids: Vec<String>,
-    #[serde(default)]
-    pub profile: ServiceScalingPatchResponseProfile,
-    #[serde(default)]
-    pub provider: ServiceScalingPatchResponseProvider,
-    #[serde(default)]
-    pub region: ServiceScalingPatchResponseRegion,
-    #[serde(rename = "releaseChannel", default)]
-    pub release_channel: ServiceScalingPatchResponseReleasechannel,
-    #[serde(rename = "replicaMemoryGb", default)]
-    pub replica_memory_gb: f64,
-    #[serde(rename = "scalingSchedule", default)]
-    pub scaling_schedule: ScalingSchedule,
-    #[serde(default)]
-    pub state: ServiceScalingPatchResponseState,
-    #[serde(default)]
-    pub tags: Vec<ResourceTagsV1>,
+    #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub min_total_memory_gb: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
+    pub num_replicas: Option<f64>,
+    #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
+    pub private_endpoint_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<ServiceScalingPatchResponseProfile>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<ServiceScalingPatchResponseProvider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<ServiceScalingPatchResponseRegion>,
+    #[serde(rename = "releaseChannel", skip_serializing_if = "Option::is_none")]
+    pub release_channel: Option<ServiceScalingPatchResponseReleasechannel>,
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub replica_memory_gb: Option<f64>,
+    #[serde(rename = "scalingSchedule", skip_serializing_if = "Option::is_none")]
+    pub scaling_schedule: Option<ScalingSchedule>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ServiceScalingPatchResponseState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<ResourceTagsV1Response>>,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
-    pub tier: ServiceScalingPatchResponseTier,
-    #[serde(rename = "transparentDataEncryptionKeyId", default)]
-    pub transparent_data_encryption_key_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tier: Option<ServiceScalingPatchResponseTier>,
+    #[serde(
+        rename = "transparentDataEncryptionKeyId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transparent_data_encryption_key_id: Option<String>,
 }
 
 /// `ServiceStatePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceStatePatchRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<ServiceStatePatchRequestCommand>,
 }
 
 /// `UpgradeWindow` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UpgradeWindow {
-    #[serde(default)]
-    pub duration: i64,
-    #[serde(rename = "startHourUtc", default)]
-    pub start_hour_utc: i64,
-    #[serde(default)]
-    pub weekday: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<i64>,
+    #[serde(rename = "startHourUtc", skip_serializing_if = "Option::is_none")]
+    pub start_hour_utc: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub weekday: Option<i64>,
 }
 
 /// `UpgradeWindowPutRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UpgradeWindowPutRequest {
-    #[serde(rename = "startHourUtc", default)]
+    #[serde(rename = "startHourUtc")]
     pub start_hour_utc: i64,
-    #[serde(default)]
     pub weekday: i64,
 }
 
@@ -15042,58 +14839,73 @@ pub struct UpdateReversePrivateEndpoint {
 /// `UsageCost` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UsageCost {
-    #[serde(default)]
-    pub costs: Vec<UsageCostRecord>,
-    #[serde(rename = "grandTotalCHC", default)]
-    pub grand_total_chc: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub costs: Option<Vec<UsageCostRecord>>,
+    #[serde(rename = "grandTotalCHC", skip_serializing_if = "Option::is_none")]
+    pub grand_total_chc: Option<f64>,
 }
 
 /// `UsageCostMetrics` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UsageCostMetrics {
-    #[serde(rename = "backupCHC", default)]
-    pub backup_chc: f64,
-    #[serde(rename = "computeCHC", default)]
-    pub compute_chc: f64,
-    #[serde(rename = "dataTransferCHC", default)]
-    pub data_transfer_chc: f64,
-    #[serde(rename = "initialLoadCHC", default)]
-    pub initial_load_chc: f64,
-    #[serde(rename = "interRegionTier1DataTransferCHC", default)]
-    pub inter_region_tier1_data_transfer_chc: f64,
-    #[serde(rename = "interRegionTier2DataTransferCHC", default)]
-    pub inter_region_tier2_data_transfer_chc: f64,
-    #[serde(rename = "interRegionTier3DataTransferCHC", default)]
-    pub inter_region_tier3_data_transfer_chc: f64,
-    #[serde(rename = "interRegionTier4DataTransferCHC", default)]
-    pub inter_region_tier4_data_transfer_chc: f64,
-    #[serde(rename = "publicDataTransferCHC", default)]
-    pub public_data_transfer_chc: f64,
-    #[serde(rename = "storageCHC", default)]
-    pub storage_chc: f64,
+    #[serde(rename = "backupCHC", skip_serializing_if = "Option::is_none")]
+    pub backup_chc: Option<f64>,
+    #[serde(rename = "computeCHC", skip_serializing_if = "Option::is_none")]
+    pub compute_chc: Option<f64>,
+    #[serde(rename = "dataTransferCHC", skip_serializing_if = "Option::is_none")]
+    pub data_transfer_chc: Option<f64>,
+    #[serde(rename = "initialLoadCHC", skip_serializing_if = "Option::is_none")]
+    pub initial_load_chc: Option<f64>,
+    #[serde(
+        rename = "interRegionTier1DataTransferCHC",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inter_region_tier1_data_transfer_chc: Option<f64>,
+    #[serde(
+        rename = "interRegionTier2DataTransferCHC",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inter_region_tier2_data_transfer_chc: Option<f64>,
+    #[serde(
+        rename = "interRegionTier3DataTransferCHC",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inter_region_tier3_data_transfer_chc: Option<f64>,
+    #[serde(
+        rename = "interRegionTier4DataTransferCHC",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub inter_region_tier4_data_transfer_chc: Option<f64>,
+    #[serde(
+        rename = "publicDataTransferCHC",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub public_data_transfer_chc: Option<f64>,
+    #[serde(rename = "storageCHC", skip_serializing_if = "Option::is_none")]
+    pub storage_chc: Option<f64>,
 }
 
 /// `UsageCostRecord` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct UsageCostRecord {
-    #[serde(rename = "dataWarehouseId", default)]
-    pub data_warehouse_id: uuid::Uuid,
-    #[serde(default)]
-    pub date: String,
-    #[serde(rename = "entityId", default)]
-    pub entity_id: uuid::Uuid,
-    #[serde(rename = "entityName", default)]
-    pub entity_name: String,
-    #[serde(rename = "entityType", default)]
-    pub entity_type: UsageCostRecordEntitytype,
-    #[serde(default)]
-    pub locked: bool,
-    #[serde(default)]
-    pub metrics: UsageCostMetrics,
-    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "dataWarehouseId", skip_serializing_if = "Option::is_none")]
+    pub data_warehouse_id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    #[serde(rename = "entityId", skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<uuid::Uuid>,
+    #[serde(rename = "entityName", skip_serializing_if = "Option::is_none")]
+    pub entity_name: Option<String>,
+    #[serde(rename = "entityType", skip_serializing_if = "Option::is_none")]
+    pub entity_type: Option<UsageCostRecordEntitytype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<UsageCostMetrics>,
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none")]
     pub service_id: Option<uuid::Uuid>,
-    #[serde(rename = "totalCHC", default)]
-    pub total_chc: f64,
+    #[serde(rename = "totalCHC", skip_serializing_if = "Option::is_none")]
+    pub total_chc: Option<f64>,
 }
 
 /// `pgBouncerConfig` from the ClickHouse Cloud API.
@@ -15295,7 +15107,15 @@ pub struct ApiResponse<T> {
 
 impl Default for BackupBucket {
     fn default() -> Self {
-        Self::AwsBackupBucket(AwsBackupBucket::default())
+        // Every field of a response variant is `Option<T>`, so the derived
+        // `AwsBackupBucket::default()` leaves `bucketProvider` absent and
+        // serializes to `{}` — which deserializes back through the
+        // discriminator dispatch as `Unknown`, not as this variant. Naming the
+        // variant's own wire value keeps the default round-tripping.
+        Self::AwsBackupBucket(AwsBackupBucket {
+            bucket_provider: Some(AwsBackupBucketBucketprovider::default()),
+            ..AwsBackupBucket::default()
+        })
     }
 }
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -8854,19 +8854,14 @@ pub struct BackupConfigurationPatchRequest {
 /// `BasePostgresService` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct BasePostgresService {
-    #[serde(rename = "haType", default)]
+    #[serde(rename = "haType")]
     pub ha_type: PgHaType,
-    #[serde(default)]
     pub name: PgNameProperty,
-    #[serde(rename = "postgresVersion", default)]
+    #[serde(rename = "postgresVersion")]
     pub postgres_version: PgVersion,
-    #[serde(default)]
     pub provider: PgProvider,
-    #[serde(default)]
     pub region: PgRegion,
-    #[serde(default)]
     pub size: PgSize,
-    #[serde(default)]
     pub tags: PgTags,
 }
 
@@ -13020,111 +13015,103 @@ pub struct PLAIN {
 /// `PostgresService` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresService {
-    #[serde(rename = "connectionString", default)]
-    pub connection_string: String,
-    #[serde(rename = "createdAt", default)]
-    pub created_at: PgCreatedAtProperty,
-    #[serde(rename = "haType", default)]
-    pub ha_type: PgHaType,
-    #[serde(default)]
-    pub hostname: String,
-    #[serde(default)]
-    pub id: PgIdProperty,
-    #[serde(rename = "isPrimary", default)]
-    pub is_primary: PgIsPrimaryProperty,
-    #[serde(default)]
-    pub name: PgNameProperty,
-    #[serde(default)]
-    pub password: String,
-    #[serde(rename = "postgresVersion", default)]
-    pub postgres_version: PgVersion,
-    #[serde(default)]
-    pub provider: PgProvider,
-    #[serde(default)]
-    pub region: PgRegion,
-    #[serde(default)]
-    pub size: PgSize,
-    #[serde(default)]
-    pub state: PgStateProperty,
-    #[serde(rename = "storageSize", default)]
-    pub storage_size: PgStorageSize,
-    #[serde(default)]
-    pub tags: PgTags,
-    #[serde(default)]
-    pub username: String,
+    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none")]
+    pub connection_string: Option<String>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<PgCreatedAtProperty>,
+    #[serde(rename = "haType", skip_serializing_if = "Option::is_none")]
+    pub ha_type: Option<PgHaType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hostname: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<PgIdProperty>,
+    #[serde(rename = "isPrimary", skip_serializing_if = "Option::is_none")]
+    pub is_primary: Option<PgIsPrimaryProperty>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<PgNameProperty>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
+    #[serde(rename = "postgresVersion", skip_serializing_if = "Option::is_none")]
+    pub postgres_version: Option<PgVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<PgProvider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<PgRegion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<PgSize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<PgStateProperty>,
+    #[serde(rename = "storageSize", skip_serializing_if = "Option::is_none")]
+    pub storage_size: Option<PgStorageSize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<PgTags>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
 }
 
 /// `PostgresServiceListItem` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceListItem {
-    #[serde(rename = "createdAt", default)]
-    pub created_at: PgCreatedAtProperty,
-    #[serde(rename = "haType", default)]
-    pub ha_type: PgHaType,
-    #[serde(default)]
-    pub id: PgIdProperty,
-    #[serde(rename = "isPrimary", default)]
-    pub is_primary: PgIsPrimaryProperty,
-    #[serde(default)]
-    pub name: PgNameProperty,
-    #[serde(rename = "postgresVersion", default)]
-    pub postgres_version: PgVersion,
-    #[serde(default)]
-    pub provider: PgProvider,
-    #[serde(default)]
-    pub region: PgRegion,
-    #[serde(default)]
-    pub size: PgSize,
-    #[serde(default)]
-    pub state: PgStateProperty,
-    #[serde(default)]
-    pub tags: PgTags,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<PgCreatedAtProperty>,
+    #[serde(rename = "haType", skip_serializing_if = "Option::is_none")]
+    pub ha_type: Option<PgHaType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<PgIdProperty>,
+    #[serde(rename = "isPrimary", skip_serializing_if = "Option::is_none")]
+    pub is_primary: Option<PgIsPrimaryProperty>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<PgNameProperty>,
+    #[serde(rename = "postgresVersion", skip_serializing_if = "Option::is_none")]
+    pub postgres_version: Option<PgVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<PgProvider>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<PgRegion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<PgSize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<PgStateProperty>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<PgTags>,
 }
 
 /// `PostgresServicePasswordResource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServicePasswordResource {
-    #[serde(default)]
-    pub password: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }
 
 /// `PostgresServicePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServicePatchRequest {
-    #[serde(rename = "haType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "haType", skip_serializing_if = "Option::is_none")]
     pub ha_type: Option<PgHaType>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<PgNameProperty>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<PgSize>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<PgTags>,
 }
 
 /// `PostgresServicePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServicePostRequest {
-    #[serde(rename = "haType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "haType", skip_serializing_if = "Option::is_none")]
     pub ha_type: Option<PgHaType>,
     pub name: PgNameProperty,
-    #[serde(
-        rename = "pgBouncerConfig",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none")]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
-    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none")]
     pub pg_config: Option<PgConfig>,
-    #[serde(
-        rename = "postgresVersion",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "postgresVersion", skip_serializing_if = "Option::is_none")]
     pub postgres_version: Option<PgVersion>,
     pub provider: PgProvider,
     pub region: PgRegion,
     pub size: PgSize,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<PgTags>,
 }
 
@@ -13132,15 +13119,11 @@ pub struct PostgresServicePostRequest {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceReadReplicaRequest {
     pub name: PgNameProperty,
-    #[serde(
-        rename = "pgBouncerConfig",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none")]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
-    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none")]
     pub pg_config: Option<PgConfig>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<PgTags>,
 }
 
@@ -13148,223 +13131,230 @@ pub struct PostgresServiceReadReplicaRequest {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceRestoreRequest {
     pub name: PgNameProperty,
-    #[serde(
-        rename = "pgBouncerConfig",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none")]
     pub pg_bouncer_config: Option<PgBouncerConfig>,
-    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none")]
     pub pg_config: Option<PgConfig>,
     #[serde(rename = "restoreTarget")]
     pub restore_target: PgPitrRestoreTargetProperty,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<PgTags>,
 }
 
 /// `PostgresServiceSetPassword` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceSetPassword {
-    #[serde(default)]
     pub password: PgPassword,
 }
 
 /// `PostgresServiceSetState` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresServiceSetState {
-    #[serde(default)]
     pub command: PostgresServiceSetStateCommand,
 }
 
 /// `PostgresMetricDataPoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresMetricDataPoint {
-    #[serde(default)]
-    pub timestamp: i64,
-    #[serde(default)]
-    pub value: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
 }
 
 /// `PostgresMetricSeries` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresMetricSeries {
-    #[serde(rename = "dataPoints", default)]
-    pub data_points: Vec<PostgresMetricDataPoint>,
-    #[serde(default)]
-    pub label: String,
+    #[serde(rename = "dataPoints", skip_serializing_if = "Option::is_none")]
+    pub data_points: Option<Vec<PostgresMetricDataPoint>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
 }
 
 /// `PostgresMetric` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresMetric {
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub key: String,
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub series: Vec<PostgresMetricSeries>,
-    #[serde(default)]
-    pub unit: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub series: Option<Vec<PostgresMetricSeries>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
 }
 
 /// `PostgresMetrics` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresMetrics {
-    #[serde(default)]
-    pub metrics: Vec<PostgresMetric>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<Vec<PostgresMetric>>,
 }
 
 /// `PostgresQueryExecution` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresQueryExecution {
-    #[serde(default)]
-    pub app: String,
-    #[serde(rename = "cpuSysTimeUs", default)]
-    pub cpu_sys_time_us: i64,
-    #[serde(rename = "cpuUserTimeUs", default)]
-    pub cpu_user_time_us: i64,
-    #[serde(rename = "dbName", default)]
-    pub db_name: String,
-    #[serde(rename = "dbOperation", default)]
-    pub db_operation: String,
-    #[serde(rename = "dbUser", default)]
-    pub db_user: String,
-    #[serde(rename = "durationUs", default)]
-    pub duration_us: i64,
-    #[serde(rename = "errElevel", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
+    #[serde(rename = "cpuSysTimeUs", skip_serializing_if = "Option::is_none")]
+    pub cpu_sys_time_us: Option<i64>,
+    #[serde(rename = "cpuUserTimeUs", skip_serializing_if = "Option::is_none")]
+    pub cpu_user_time_us: Option<i64>,
+    #[serde(rename = "dbName", skip_serializing_if = "Option::is_none")]
+    pub db_name: Option<String>,
+    #[serde(rename = "dbOperation", skip_serializing_if = "Option::is_none")]
+    pub db_operation: Option<String>,
+    #[serde(rename = "dbUser", skip_serializing_if = "Option::is_none")]
+    pub db_user: Option<String>,
+    #[serde(rename = "durationUs", skip_serializing_if = "Option::is_none")]
+    pub duration_us: Option<i64>,
+    #[serde(rename = "errElevel", skip_serializing_if = "Option::is_none")]
     pub err_elevel: Option<i64>,
-    #[serde(
-        rename = "errMessage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "errMessage", skip_serializing_if = "Option::is_none")]
     pub err_message: Option<String>,
-    #[serde(
-        rename = "errSqlstate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "errSqlstate", skip_serializing_if = "Option::is_none")]
     pub err_sqlstate: Option<String>,
-    #[serde(rename = "jitDeformTimeUs", default)]
-    pub jit_deform_time_us: i64,
-    #[serde(rename = "jitEmissionTimeUs", default)]
-    pub jit_emission_time_us: i64,
-    #[serde(rename = "jitFunctions", default)]
-    pub jit_functions: i64,
-    #[serde(rename = "jitGenerationTimeUs", default)]
-    pub jit_generation_time_us: i64,
-    #[serde(rename = "jitInliningTimeUs", default)]
-    pub jit_inlining_time_us: i64,
-    #[serde(rename = "jitOptimizationTimeUs", default)]
-    pub jit_optimization_time_us: i64,
-    #[serde(rename = "localBlksDirtied", default)]
-    pub local_blks_dirtied: i64,
-    #[serde(rename = "localBlksHit", default)]
-    pub local_blks_hit: i64,
-    #[serde(rename = "localBlksRead", default)]
-    pub local_blks_read: i64,
-    #[serde(rename = "localBlksWritten", default)]
-    pub local_blks_written: i64,
-    #[serde(rename = "parallelWorkersLaunched", default)]
-    pub parallel_workers_launched: i64,
-    #[serde(rename = "parallelWorkersPlanned", default)]
-    pub parallel_workers_planned: i64,
-    #[serde(default)]
-    pub pid: String,
-    #[serde(rename = "queryId", default)]
-    pub query_id: String,
-    #[serde(rename = "queryText", default)]
-    pub query_text: String,
-    #[serde(default)]
-    pub rows: i64,
-    #[serde(rename = "serverRole", default)]
-    pub server_role: String,
-    #[serde(rename = "sharedBlkReadTimeUs", default)]
-    pub shared_blk_read_time_us: i64,
-    #[serde(rename = "sharedBlkWriteTimeUs", default)]
-    pub shared_blk_write_time_us: i64,
-    #[serde(rename = "sharedBlksDirtied", default)]
-    pub shared_blks_dirtied: i64,
-    #[serde(rename = "sharedBlksHit", default)]
-    pub shared_blks_hit: i64,
-    #[serde(rename = "sharedBlksRead", default)]
-    pub shared_blks_read: i64,
-    #[serde(rename = "sharedBlksWritten", default)]
-    pub shared_blks_written: i64,
-    #[serde(rename = "spanId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "jitDeformTimeUs", skip_serializing_if = "Option::is_none")]
+    pub jit_deform_time_us: Option<i64>,
+    #[serde(rename = "jitEmissionTimeUs", skip_serializing_if = "Option::is_none")]
+    pub jit_emission_time_us: Option<i64>,
+    #[serde(rename = "jitFunctions", skip_serializing_if = "Option::is_none")]
+    pub jit_functions: Option<i64>,
+    #[serde(
+        rename = "jitGenerationTimeUs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub jit_generation_time_us: Option<i64>,
+    #[serde(rename = "jitInliningTimeUs", skip_serializing_if = "Option::is_none")]
+    pub jit_inlining_time_us: Option<i64>,
+    #[serde(
+        rename = "jitOptimizationTimeUs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub jit_optimization_time_us: Option<i64>,
+    #[serde(rename = "localBlksDirtied", skip_serializing_if = "Option::is_none")]
+    pub local_blks_dirtied: Option<i64>,
+    #[serde(rename = "localBlksHit", skip_serializing_if = "Option::is_none")]
+    pub local_blks_hit: Option<i64>,
+    #[serde(rename = "localBlksRead", skip_serializing_if = "Option::is_none")]
+    pub local_blks_read: Option<i64>,
+    #[serde(rename = "localBlksWritten", skip_serializing_if = "Option::is_none")]
+    pub local_blks_written: Option<i64>,
+    #[serde(
+        rename = "parallelWorkersLaunched",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parallel_workers_launched: Option<i64>,
+    #[serde(
+        rename = "parallelWorkersPlanned",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parallel_workers_planned: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pid: Option<String>,
+    #[serde(rename = "queryId", skip_serializing_if = "Option::is_none")]
+    pub query_id: Option<String>,
+    #[serde(rename = "queryText", skip_serializing_if = "Option::is_none")]
+    pub query_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rows: Option<i64>,
+    #[serde(rename = "serverRole", skip_serializing_if = "Option::is_none")]
+    pub server_role: Option<String>,
+    #[serde(
+        rename = "sharedBlkReadTimeUs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub shared_blk_read_time_us: Option<i64>,
+    #[serde(
+        rename = "sharedBlkWriteTimeUs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub shared_blk_write_time_us: Option<i64>,
+    #[serde(rename = "sharedBlksDirtied", skip_serializing_if = "Option::is_none")]
+    pub shared_blks_dirtied: Option<i64>,
+    #[serde(rename = "sharedBlksHit", skip_serializing_if = "Option::is_none")]
+    pub shared_blks_hit: Option<i64>,
+    #[serde(rename = "sharedBlksRead", skip_serializing_if = "Option::is_none")]
+    pub shared_blks_read: Option<i64>,
+    #[serde(rename = "sharedBlksWritten", skip_serializing_if = "Option::is_none")]
+    pub shared_blks_written: Option<i64>,
+    #[serde(rename = "spanId", skip_serializing_if = "Option::is_none")]
     pub span_id: Option<String>,
-    #[serde(rename = "tempBlkReadTimeUs", default)]
-    pub temp_blk_read_time_us: i64,
-    #[serde(rename = "tempBlkWriteTimeUs", default)]
-    pub temp_blk_write_time_us: i64,
-    #[serde(rename = "tempBlksRead", default)]
-    pub temp_blks_read: i64,
-    #[serde(rename = "tempBlksWritten", default)]
-    pub temp_blks_written: i64,
-    #[serde(default)]
-    pub timestamp: String,
-    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tempBlkReadTimeUs", skip_serializing_if = "Option::is_none")]
+    pub temp_blk_read_time_us: Option<i64>,
+    #[serde(rename = "tempBlkWriteTimeUs", skip_serializing_if = "Option::is_none")]
+    pub temp_blk_write_time_us: Option<i64>,
+    #[serde(rename = "tempBlksRead", skip_serializing_if = "Option::is_none")]
+    pub temp_blks_read: Option<i64>,
+    #[serde(rename = "tempBlksWritten", skip_serializing_if = "Option::is_none")]
+    pub temp_blks_written: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+    #[serde(rename = "traceId", skip_serializing_if = "Option::is_none")]
     pub trace_id: Option<String>,
-    #[serde(rename = "walBytes", default)]
-    pub wal_bytes: i64,
-    #[serde(rename = "walFpi", default)]
-    pub wal_fpi: i64,
-    #[serde(rename = "walRecords", default)]
-    pub wal_records: i64,
+    #[serde(rename = "walBytes", skip_serializing_if = "Option::is_none")]
+    pub wal_bytes: Option<i64>,
+    #[serde(rename = "walFpi", skip_serializing_if = "Option::is_none")]
+    pub wal_fpi: Option<i64>,
+    #[serde(rename = "walRecords", skip_serializing_if = "Option::is_none")]
+    pub wal_records: Option<i64>,
 }
 
 /// `PostgresSlowQueryPattern` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresSlowQueryPattern {
-    #[serde(default)]
-    pub app: String,
-    #[serde(rename = "avgDurationUs", default)]
-    pub avg_duration_us: i64,
-    #[serde(rename = "callCount", default)]
-    pub call_count: i64,
-    #[serde(rename = "dbName", default)]
-    pub db_name: String,
-    #[serde(rename = "dbOperation", default)]
-    pub db_operation: String,
-    #[serde(rename = "dbUser", default)]
-    pub db_user: String,
-    #[serde(rename = "errorCount", default)]
-    pub error_count: i64,
-    #[serde(rename = "maxDurationUs", default)]
-    pub max_duration_us: i64,
-    #[serde(rename = "p50DurationUs", default)]
-    pub p50_duration_us: i64,
-    #[serde(rename = "p95DurationUs", default)]
-    pub p95_duration_us: i64,
-    #[serde(rename = "p99DurationUs", default)]
-    pub p99_duration_us: i64,
-    #[serde(rename = "queryId", default)]
-    pub query_id: String,
-    #[serde(rename = "queryText", default)]
-    pub query_text: String,
-    #[serde(rename = "totalCpuTimeUs", default)]
-    pub total_cpu_time_us: i64,
-    #[serde(rename = "totalDurationUs", default)]
-    pub total_duration_us: i64,
-    #[serde(rename = "totalRows", default)]
-    pub total_rows: i64,
-    #[serde(rename = "totalSharedBlksHit", default)]
-    pub total_shared_blks_hit: i64,
-    #[serde(rename = "totalSharedBlksRead", default)]
-    pub total_shared_blks_read: i64,
-    #[serde(rename = "totalWalBytes", default)]
-    pub total_wal_bytes: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app: Option<String>,
+    #[serde(rename = "avgDurationUs", skip_serializing_if = "Option::is_none")]
+    pub avg_duration_us: Option<i64>,
+    #[serde(rename = "callCount", skip_serializing_if = "Option::is_none")]
+    pub call_count: Option<i64>,
+    #[serde(rename = "dbName", skip_serializing_if = "Option::is_none")]
+    pub db_name: Option<String>,
+    #[serde(rename = "dbOperation", skip_serializing_if = "Option::is_none")]
+    pub db_operation: Option<String>,
+    #[serde(rename = "dbUser", skip_serializing_if = "Option::is_none")]
+    pub db_user: Option<String>,
+    #[serde(rename = "errorCount", skip_serializing_if = "Option::is_none")]
+    pub error_count: Option<i64>,
+    #[serde(rename = "maxDurationUs", skip_serializing_if = "Option::is_none")]
+    pub max_duration_us: Option<i64>,
+    #[serde(rename = "p50DurationUs", skip_serializing_if = "Option::is_none")]
+    pub p50_duration_us: Option<i64>,
+    #[serde(rename = "p95DurationUs", skip_serializing_if = "Option::is_none")]
+    pub p95_duration_us: Option<i64>,
+    #[serde(rename = "p99DurationUs", skip_serializing_if = "Option::is_none")]
+    pub p99_duration_us: Option<i64>,
+    #[serde(rename = "queryId", skip_serializing_if = "Option::is_none")]
+    pub query_id: Option<String>,
+    #[serde(rename = "queryText", skip_serializing_if = "Option::is_none")]
+    pub query_text: Option<String>,
+    #[serde(rename = "totalCpuTimeUs", skip_serializing_if = "Option::is_none")]
+    pub total_cpu_time_us: Option<i64>,
+    #[serde(rename = "totalDurationUs", skip_serializing_if = "Option::is_none")]
+    pub total_duration_us: Option<i64>,
+    #[serde(rename = "totalRows", skip_serializing_if = "Option::is_none")]
+    pub total_rows: Option<i64>,
+    #[serde(rename = "totalSharedBlksHit", skip_serializing_if = "Option::is_none")]
+    pub total_shared_blks_hit: Option<i64>,
+    #[serde(
+        rename = "totalSharedBlksRead",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_shared_blks_read: Option<i64>,
+    #[serde(rename = "totalWalBytes", skip_serializing_if = "Option::is_none")]
+    pub total_wal_bytes: Option<i64>,
 }
 
 /// `PostgresSlowQueryPatternDetail` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresSlowQueryPatternDetail {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate: Option<PostgresSlowQueryPattern>,
-    #[serde(rename = "recentExecutions", default)]
-    pub recent_executions: Vec<PostgresQueryExecution>,
+    #[serde(rename = "recentExecutions", skip_serializing_if = "Option::is_none")]
+    pub recent_executions: Option<Vec<PostgresQueryExecution>>,
 }
 
 /// `PrivateEndpointConfig` from the ClickHouse Cloud API.
@@ -15110,91 +15100,185 @@ pub struct UsageCostRecord {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PgBouncerConfig {}
 
+/// `pgBouncerConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`PgBouncerConfig`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing. The schema currently declares no properties.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PgBouncerConfigResponse {}
+
 /// `pgConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PgConfig {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_analyze_scale_factor: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_max_workers: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_naptime: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_vacuum_cost_delay: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_vacuum_cost_limit: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_vacuum_insert_scale_factor: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_vacuum_scale_factor: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub autovacuum_work_mem: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_transaction_isolation: Option<PgConfigDefaultTransactionIsolation>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effective_cache_size: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub effective_io_concurrency: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub idle_in_transaction_session_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub idle_session_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lock_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub maintenance_work_mem: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_connections: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_parallel_maintenance_workers: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_parallel_workers: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_parallel_workers_per_gather: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_slot_wal_keep_size: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_wal_size: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_worker_processes: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub min_wal_size: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub random_page_cost: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ssl_min_protocol_version: Option<PgConfigSslMinProtocolVersion>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub statement_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub transaction_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub wal_compression: Option<PgConfigWalCompression>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub wal_keep_size: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub wal_sender_timeout: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub work_mem: Option<serde_json::Value>,
+}
+
+/// `pgConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`PgConfig`]: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PgConfigResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_analyze_scale_factor: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_max_workers: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_naptime: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_vacuum_cost_delay: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_vacuum_cost_limit: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_vacuum_insert_scale_factor: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_vacuum_scale_factor: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub autovacuum_work_mem: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_transaction_isolation: Option<PgConfigDefaultTransactionIsolation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_cache_size: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_io_concurrency: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_in_transaction_session_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub idle_session_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lock_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maintenance_work_mem: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_parallel_maintenance_workers: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_parallel_workers: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_parallel_workers_per_gather: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_slot_wal_keep_size: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_wal_size: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_worker_processes: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_wal_size: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub random_page_cost: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssl_min_protocol_version: Option<PgConfigSslMinProtocolVersion>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub statement_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wal_compression: Option<PgConfigWalCompression>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wal_keep_size: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wal_sender_timeout: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub work_mem: Option<serde_json::Value>,
 }
 
 /// `postgresInstanceConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresInstanceConfig {
-    #[serde(rename = "pgBouncerConfig", default)]
+    #[serde(rename = "pgBouncerConfig")]
     pub pg_bouncer_config: PgBouncerConfig,
-    #[serde(rename = "pgConfig", default)]
+    #[serde(rename = "pgConfig")]
     pub pg_config: PgConfig,
+}
+
+/// `postgresInstanceConfig` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`PostgresInstanceConfig`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing. Writing a fetched configuration back to the API goes through
+/// `TryFrom<PostgresInstanceConfigResponse>` (see [`crate::convert`]), which
+/// forces every absent required field to be resolved explicitly.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct PostgresInstanceConfigResponse {
+    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none")]
+    pub pg_bouncer_config: Option<PgBouncerConfigResponse>,
+    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none")]
+    pub pg_config: Option<PgConfigResponse>,
 }
 
 /// `postgresInstanceUpdateConfigResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PostgresInstanceUpdateConfigResponse {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(rename = "pgBouncerConfig")]
-    pub pg_bouncer_config: PgBouncerConfig,
-    #[serde(rename = "pgConfig")]
-    pub pg_config: PgConfig,
+    #[serde(rename = "pgBouncerConfig", skip_serializing_if = "Option::is_none")]
+    pub pg_bouncer_config: Option<PgBouncerConfigResponse>,
+    #[serde(rename = "pgConfig", skip_serializing_if = "Option::is_none")]
+    pub pg_config: Option<PgConfigResponse>,
 }
 
 /// Standard API response wrapper.

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -8778,7 +8778,7 @@ pub struct AzureBackupBucketProperties {
 /// `AzureEventHub` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct AzureEventHub {
-    #[serde(rename = "connectionString", default)]
+    #[serde(rename = "connectionString")]
     pub connection_string: String,
 }
 
@@ -12613,48 +12613,33 @@ pub struct ClickStackWebhookInput {
 pub struct CreateReversePrivateEndpoint {
     #[serde(
         rename = "customPrivateDnsMappings",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
-    #[serde(default)]
     pub description: String,
     #[serde(
         rename = "gcpServiceAttachment",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub gcp_service_attachment: Option<String>,
-    #[serde(
-        rename = "mskAuthentication",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "mskAuthentication", skip_serializing_if = "Option::is_none")]
     pub msk_authentication: Option<CreateReversePrivateEndpointMskauthentication>,
-    #[serde(
-        rename = "mskClusterArn",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "mskClusterArn", skip_serializing_if = "Option::is_none")]
     pub msk_cluster_arn: Option<String>,
-    #[serde(default)]
     pub r#type: CreateReversePrivateEndpointType,
     #[serde(
         rename = "vpcEndpointServiceName",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_endpoint_service_name: Option<String>,
     #[serde(
         rename = "vpcResourceConfigurationId",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_resource_configuration_id: Option<String>,
     #[serde(
         rename = "vpcResourceShareArn",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_resource_share_arn: Option<String>,
 }
@@ -12704,11 +12689,19 @@ pub struct CurrentScaling {
 /// `CustomPrivateDnsMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CustomPrivateDnsMapping {
-    #[serde(
-        rename = "privateDnsName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "privateDnsName", skip_serializing_if = "Option::is_none")]
+    pub private_dns_name: Option<String>,
+}
+
+/// `CustomPrivateDnsMapping` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`CustomPrivateDnsMapping`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct CustomPrivateDnsMappingResponse {
+    #[serde(rename = "privateDnsName", skip_serializing_if = "Option::is_none")]
     pub private_dns_name: Option<String>,
 }
 
@@ -12859,15 +12852,11 @@ pub struct IpAccessListPatch {
 /// `License` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct License {
-    #[serde(rename = "environmentFingerprint", default)]
+    #[serde(rename = "environmentFingerprint")]
     pub environment_fingerprint: String,
-    #[serde(default)]
     pub expiration: String,
-    #[serde(default)]
     pub id: String,
-    #[serde(default)]
     pub memory: String,
-    #[serde(default)]
     pub name: String,
 }
 
@@ -12902,18 +12891,17 @@ pub struct MemberPatchRequest {
 /// `MskIamUser` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct MskIamUser {
-    #[serde(rename = "accessKeyId", default)]
+    #[serde(rename = "accessKeyId")]
     pub access_key_id: String,
-    #[serde(rename = "secretKey", default)]
+    #[serde(rename = "secretKey")]
     pub secret_key: String,
 }
 
 /// `MutualTLS` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct MutualTLS {
-    #[serde(default)]
     pub certificate: String,
-    #[serde(rename = "privateKey", default)]
+    #[serde(rename = "privateKey")]
     pub private_key: String,
 }
 
@@ -12988,23 +12976,26 @@ pub struct OrganizationPrivateEndpointsPatch {
 /// `OrganizationQuota` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct OrganizationQuota {
-    pub adjustable: bool,
-    pub description: String,
-    pub name: String,
-    #[serde(rename = "quotaCode")]
-    pub quota_code: OrganizationQuotaQuotacode,
-    pub scope: OrganizationQuotaScope,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adjustable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "quotaCode", skip_serializing_if = "Option::is_none")]
+    pub quota_code: Option<OrganizationQuotaQuotacode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<OrganizationQuotaScope>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub usage: Option<i64>,
-    pub value: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<i64>,
 }
 
 /// `PLAIN` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct PLAIN {
-    #[serde(default)]
     pub password: String,
-    #[serde(default)]
     pub username: String,
 }
 
@@ -13376,7 +13367,7 @@ pub struct RBACPolicy {
     #[serde(rename = "roleId", skip_serializing_if = "Option::is_none")]
     pub role_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tags: Option<RBACPolicyTags>,
+    pub tags: Option<RBACPolicyTagsResponse>,
     #[serde(rename = "tenantId", skip_serializing_if = "Option::is_none")]
     pub tenant_id: Option<String>,
 }
@@ -13395,9 +13386,22 @@ pub struct RBACPolicyCreateRequest {
 /// `RBACPolicyTags` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct RBACPolicyTags {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub grants: Option<Vec<String>>,
-    #[serde(rename = "roleV2", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "roleV2", skip_serializing_if = "Option::is_none")]
+    pub role_v2: Option<RBACPolicyTagsRolev2>,
+}
+
+/// `RBACPolicyTags` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`RBACPolicyTags`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct RBACPolicyTagsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grants: Option<Vec<String>>,
+    #[serde(rename = "roleV2", skip_serializing_if = "Option::is_none")]
     pub role_v2: Option<RBACPolicyTagsRolev2>,
 }
 
@@ -13452,60 +13456,47 @@ pub struct ResourceTagsV1Response {
 pub struct ReversePrivateEndpoint {
     #[serde(
         rename = "customPrivateDnsMappings",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
-    pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
-    #[serde(default)]
-    pub description: String,
-    #[serde(rename = "dnsNames", default)]
-    pub dns_names: Vec<String>,
-    #[serde(rename = "endpointId", default)]
-    pub endpoint_id: String,
+    pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMappingResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(rename = "dnsNames", skip_serializing_if = "Option::is_none")]
+    pub dns_names: Option<Vec<String>>,
+    #[serde(rename = "endpointId", skip_serializing_if = "Option::is_none")]
+    pub endpoint_id: Option<String>,
     #[serde(
         rename = "gcpServiceAttachment",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub gcp_service_attachment: Option<String>,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(
-        rename = "mskAuthentication",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(rename = "mskAuthentication", skip_serializing_if = "Option::is_none")]
     pub msk_authentication: Option<ReversePrivateEndpointMskauthentication>,
-    #[serde(
-        rename = "mskClusterArn",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "mskClusterArn", skip_serializing_if = "Option::is_none")]
     pub msk_cluster_arn: Option<String>,
-    #[serde(rename = "privateDnsNames", default)]
-    pub private_dns_names: Vec<String>,
-    #[serde(rename = "serviceId", default)]
-    pub service_id: uuid::Uuid,
-    #[serde(default)]
-    pub status: ReversePrivateEndpointStatus,
-    #[serde(default)]
-    pub r#type: ReversePrivateEndpointType,
+    #[serde(rename = "privateDnsNames", skip_serializing_if = "Option::is_none")]
+    pub private_dns_names: Option<Vec<String>>,
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<ReversePrivateEndpointStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ReversePrivateEndpointType>,
     #[serde(
         rename = "vpcEndpointServiceName",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_endpoint_service_name: Option<String>,
     #[serde(
         rename = "vpcResourceConfigurationId",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_resource_configuration_id: Option<String>,
     #[serde(
         rename = "vpcResourceShareArn",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub vpc_resource_share_arn: Option<String>,
 }
@@ -13623,26 +13614,21 @@ pub struct ScalingSchedulePostRequest {
 /// `ScimEnterpriseManager` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimEnterpriseManager {
-    #[serde(rename = "displayName", default)]
+    #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimEnterpriseUser` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimEnterpriseUser {
-    #[serde(rename = "costCenter", default)]
+    #[serde(rename = "costCenter")]
     pub cost_center: String,
-    #[serde(default)]
     pub department: String,
-    #[serde(default)]
     pub division: String,
-    #[serde(rename = "employeeNumber", default)]
+    #[serde(rename = "employeeNumber")]
     pub employee_number: String,
-    #[serde(default)]
     pub manager: ScimEnterpriseManager,
-    #[serde(default)]
     pub organization: String,
 }
 
@@ -13651,14 +13637,10 @@ pub struct ScimEnterpriseUser {
 pub struct ScimGroup {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
     pub id: uuid::Uuid,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub members: Option<Vec<ScimGroupMember>>,
     pub meta: ScimGroupMeta,
     pub schemas: Vec<String>,
@@ -13681,9 +13663,9 @@ pub struct ScimGroupListResponse {
 /// `ScimGroupMember` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimGroupMember {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub display: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     pub value: String,
 }
@@ -13694,7 +13676,7 @@ pub struct ScimGroupMeta {
     pub created: chrono::DateTime<chrono::Utc>,
     #[serde(rename = "lastModified")]
     pub last_modified: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
     #[serde(rename = "resourceType")]
     pub resource_type: String,
@@ -13705,13 +13687,9 @@ pub struct ScimGroupMeta {
 pub struct ScimGroupPostRequest {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub members: Option<Vec<ScimGroupMember>>,
     pub schemas: Vec<String>,
 }
@@ -13721,17 +13699,13 @@ pub struct ScimGroupPostRequest {
 pub struct ScimGroupPutRequest {
     #[serde(rename = "displayName")]
     pub display_name: String,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub members: Option<Vec<ScimGroupMember>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<ScimGroupMeta>,
     pub schemas: Vec<String>,
 }
@@ -13762,9 +13736,9 @@ pub struct ScimPatchOp {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimPatchOperation {
     pub op: ScimPatchOperationOp,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 }
 
@@ -13772,100 +13746,70 @@ pub struct ScimPatchOperation {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUser {
     pub active: bool,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(
-        rename = "displayName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<ScimUserGroup>>,
     pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ims: Option<Vec<ScimUserIm>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
     pub meta: ScimUserMeta,
     pub name: ScimUserName,
-    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none")]
     pub nick_name: Option<String>,
-    #[serde(
-        rename = "phoneNumbers",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none")]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(
-        rename = "preferredLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none")]
     pub preferred_language: Option<String>,
-    #[serde(
-        rename = "profileUrl",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none")]
     pub profile_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<ScimUserRole>>,
     pub schemas: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(rename = "userName")]
     pub user_name: String,
-    #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "userType", skip_serializing_if = "Option::is_none")]
     pub user_type: Option<String>,
-    #[serde(
-        rename = "x509Certificates",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none")]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
 /// `ScimUserAddress` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserAddress {
-    #[serde(default)]
     pub country: String,
-    #[serde(default)]
     pub formatted: String,
-    #[serde(default)]
     pub locality: String,
-    #[serde(rename = "postalCode", default)]
+    #[serde(rename = "postalCode")]
     pub postal_code: String,
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub region: String,
-    #[serde(rename = "streetAddress", default)]
+    #[serde(rename = "streetAddress")]
     pub street_address: String,
-    #[serde(default)]
     pub r#type: String,
 }
 
 /// `ScimUserEmail` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserEmail {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub primary: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
     pub value: String,
 }
@@ -13873,35 +13817,25 @@ pub struct ScimUserEmail {
 /// `ScimUserEntitlement` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserEntitlement {
-    #[serde(default)]
     pub display: String,
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimUserGroup` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserGroup {
-    #[serde(default)]
     pub display: String,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimUserIm` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserIm {
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
@@ -13911,7 +13845,7 @@ pub struct ScimUserMeta {
     pub created: chrono::DateTime<chrono::Utc>,
     #[serde(rename = "lastModified")]
     pub last_modified: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub location: Option<String>,
     #[serde(rename = "resourceType")]
     pub resource_type: String,
@@ -13920,221 +13854,159 @@ pub struct ScimUserMeta {
 /// `ScimUserName` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserName {
-    #[serde(rename = "familyName", default)]
+    #[serde(rename = "familyName")]
     pub family_name: String,
-    #[serde(default)]
     pub formatted: String,
-    #[serde(rename = "givenName", default)]
+    #[serde(rename = "givenName")]
     pub given_name: String,
-    #[serde(rename = "honorificPrefix", default)]
+    #[serde(rename = "honorificPrefix")]
     pub honorific_prefix: String,
-    #[serde(rename = "honorificSuffix", default)]
+    #[serde(rename = "honorificSuffix")]
     pub honorific_suffix: String,
-    #[serde(rename = "middleName", default)]
+    #[serde(rename = "middleName")]
     pub middle_name: String,
 }
 
 /// `ScimUserPhoneNumber` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserPhoneNumber {
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimUserPhoto` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserPhoto {
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimUserPostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserPostRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub active: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(
-        rename = "displayName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<ScimUserGroup>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ims: Option<Vec<ScimUserIm>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<ScimUserName>,
-    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none")]
     pub nick_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
-    #[serde(
-        rename = "phoneNumbers",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none")]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(
-        rename = "preferredLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none")]
     pub preferred_language: Option<String>,
-    #[serde(
-        rename = "profileUrl",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none")]
     pub profile_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<ScimUserRole>>,
     pub schemas: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(
         rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub urn_ietf_params_scim_schemas_extension_enterprise_2_0_user: Option<ScimEnterpriseUser>,
     #[serde(rename = "userName")]
     pub user_name: String,
-    #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "userType", skip_serializing_if = "Option::is_none")]
     pub user_type: Option<String>,
-    #[serde(
-        rename = "x509Certificates",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none")]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
 /// `ScimUserPutRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserPutRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub active: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub addresses: Option<Vec<ScimUserAddress>>,
-    #[serde(
-        rename = "displayName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "displayName", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
     pub emails: Vec<ScimUserEmail>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entitlements: Option<Vec<ScimUserEntitlement>>,
-    #[serde(
-        rename = "externalId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "externalId", skip_serializing_if = "Option::is_none")]
     pub external_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<ScimUserGroup>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ims: Option<Vec<ScimUserIm>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub locale: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub meta: Option<ScimUserMeta>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<ScimUserName>,
-    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "nickName", skip_serializing_if = "Option::is_none")]
     pub nick_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
-    #[serde(
-        rename = "phoneNumbers",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "phoneNumbers", skip_serializing_if = "Option::is_none")]
     pub phone_numbers: Option<Vec<ScimUserPhoneNumber>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub photos: Option<Vec<ScimUserPhoto>>,
-    #[serde(
-        rename = "preferredLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "preferredLanguage", skip_serializing_if = "Option::is_none")]
     pub preferred_language: Option<String>,
-    #[serde(
-        rename = "profileUrl",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "profileUrl", skip_serializing_if = "Option::is_none")]
     pub profile_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<ScimUserRole>>,
     pub schemas: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(
         rename = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub urn_ietf_params_scim_schemas_extension_enterprise_2_0_user: Option<ScimEnterpriseUser>,
     #[serde(rename = "userName")]
     pub user_name: String,
-    #[serde(rename = "userType", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "userType", skip_serializing_if = "Option::is_none")]
     pub user_type: Option<String>,
-    #[serde(
-        rename = "x509Certificates",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "x509Certificates", skip_serializing_if = "Option::is_none")]
     pub x509_certificates: Option<Vec<ScimX509Certificate>>,
 }
 
 /// `ScimUserRole` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimUserRole {
-    #[serde(default)]
     pub display: String,
-    #[serde(default)]
     pub primary: bool,
-    #[serde(default)]
     pub r#type: String,
-    #[serde(default)]
     pub value: String,
 }
 
 /// `ScimX509Certificate` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimX509Certificate {
-    #[serde(default)]
     pub value: String,
 }
 
@@ -14143,9 +14015,9 @@ pub struct ScimX509Certificate {
 pub struct ScimAuthenticationScheme {
     pub description: String,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub primary: Option<bool>,
-    #[serde(rename = "specUri", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "specUri", skip_serializing_if = "Option::is_none")]
     pub spec_uri: Option<String>,
     #[serde(rename = "type")]
     pub r#type: String,
@@ -14207,36 +14079,24 @@ pub struct ScimSchema {
 /// `ScimSchemaAttribute` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimSchemaAttribute {
-    #[serde(
-        rename = "canonicalValues",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "canonicalValues", skip_serializing_if = "Option::is_none")]
     pub canonical_values: Option<Vec<String>>,
-    #[serde(rename = "caseExact", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "caseExact", skip_serializing_if = "Option::is_none")]
     pub case_exact: Option<bool>,
     pub description: String,
     #[serde(rename = "multiValued")]
     pub multi_valued: bool,
     pub mutability: String,
     pub name: String,
-    #[serde(
-        rename = "referenceTypes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "referenceTypes", skip_serializing_if = "Option::is_none")]
     pub reference_types: Option<Vec<String>>,
     pub required: bool,
     pub returned: String,
-    #[serde(
-        rename = "subAttributes",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "subAttributes", skip_serializing_if = "Option::is_none")]
     pub sub_attributes: Option<Vec<ScimSchemaAttribute>>,
     #[serde(rename = "type")]
     pub r#type: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uniqueness: Option<String>,
 }
 
@@ -14277,11 +14137,7 @@ pub struct ScimServiceProviderConfig {
     pub bulk: ScimServiceProviderConfigBulk,
     #[serde(rename = "changePassword")]
     pub change_password: ScimBooleanFeature,
-    #[serde(
-        rename = "documentationUri",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "documentationUri", skip_serializing_if = "Option::is_none")]
     pub documentation_uri: Option<String>,
     pub etag: ScimBooleanFeature,
     pub filter: ScimServiceProviderConfigFilter,
@@ -14433,7 +14289,7 @@ pub struct Service {
 /// `ServiceAccount` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ServiceAccount {
-    #[serde(rename = "serviceAccountFile", default)]
+    #[serde(rename = "serviceAccountFile")]
     pub service_account_file: String,
 }
 
@@ -14830,8 +14686,7 @@ pub struct UpgradeWindowPutRequest {
 pub struct UpdateReversePrivateEndpoint {
     #[serde(
         rename = "customPrivateDnsMappings",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub custom_private_dns_mappings: Option<Vec<CustomPrivateDnsMapping>>,
 }
@@ -15096,12 +14951,13 @@ pub struct PostgresInstanceUpdateConfigResponse {
 /// Standard API response wrapper.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiResponse<T> {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none", default, rename = "requestId")]
+    #[serde(skip_serializing_if = "Option::is_none", rename = "requestId")]
     pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<T>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -7966,6 +7966,51 @@ impl std::fmt::Display for ClickStackAlertChannel {
     }
 }
 
+/// `ClickStackAlertChannel` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackAlertChannel`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `type` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `type` this crate does not know, or a payload that
+/// does not fit the variant its `type` selects, lands in `Unknown` with the
+/// raw JSON intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `type` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackAlertChannel`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackAlertChannelResponse {
+    ClickStackAlertChannelEmail(ClickStackAlertChannelEmailResponse),
+    ClickStackAlertChannelWebhook(ClickStackAlertChannelWebhookResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackAlertChannelResponse, "type" {
+        "email" => ClickStackAlertChannelEmail,
+        "webhook" => ClickStackAlertChannelWebhook,
+    }
+}
+
+impl std::fmt::Display for ClickStackAlertChannelResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackAlertChannelEmail(_) => write!(f, "ClickStackAlertChannelEmail"),
+            Self::ClickStackAlertChannelWebhook(_) => write!(f, "ClickStackAlertChannelWebhook"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackBarChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
@@ -7997,6 +8042,55 @@ impl std::fmt::Display for ClickStackBarChartConfig {
                 write!(f, "ClickStackBarBuilderChartConfig")
             }
             Self::ClickStackBarRawSqlChartConfig(_) => write!(f, "ClickStackBarRawSqlChartConfig"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackBarChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackBarChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackBarChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackBarChartConfigResponse {
+    ClickStackBarRawSqlChartConfig(ClickStackBarRawSqlChartConfigResponse),
+    ClickStackBarBuilderChartConfig(ClickStackBarBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackBarChartConfigResponse, "configType" {
+        "sql" => ClickStackBarRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackBarBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackBarChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackBarRawSqlChartConfig(_) => write!(f, "ClickStackBarRawSqlChartConfig"),
+            Self::ClickStackBarBuilderChartConfig(_) => {
+                write!(f, "ClickStackBarBuilderChartConfig")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -8042,6 +8136,57 @@ impl std::fmt::Display for ClickStackCategoricalBarChartConfig {
             }
             Self::ClickStackCategoricalBarRawSqlChartConfig(_) => {
                 write!(f, "ClickStackCategoricalBarRawSqlChartConfig")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackCategoricalBarChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackCategoricalBarChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackCategoricalBarChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackCategoricalBarChartConfigResponse {
+    ClickStackCategoricalBarRawSqlChartConfig(ClickStackCategoricalBarRawSqlChartConfigResponse),
+    ClickStackCategoricalBarBuilderChartConfig(ClickStackCategoricalBarBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackCategoricalBarChartConfigResponse, "configType" {
+        "sql" => ClickStackCategoricalBarRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackCategoricalBarBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackCategoricalBarChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackCategoricalBarRawSqlChartConfig(_) => {
+                write!(f, "ClickStackCategoricalBarRawSqlChartConfig")
+            }
+            Self::ClickStackCategoricalBarBuilderChartConfig(_) => {
+                write!(f, "ClickStackCategoricalBarBuilderChartConfig")
             }
             Self::Unknown(s) => write!(f, "{s}"),
         }
@@ -8128,6 +8273,57 @@ impl std::fmt::Display for ClickStackLineChartConfig {
     }
 }
 
+/// `ClickStackLineChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackLineChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackLineChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackLineChartConfigResponse {
+    ClickStackLineRawSqlChartConfig(ClickStackLineRawSqlChartConfigResponse),
+    ClickStackLineBuilderChartConfig(ClickStackLineBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackLineChartConfigResponse, "configType" {
+        "sql" => ClickStackLineRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackLineBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackLineChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackLineRawSqlChartConfig(_) => {
+                write!(f, "ClickStackLineRawSqlChartConfig")
+            }
+            Self::ClickStackLineBuilderChartConfig(_) => {
+                write!(f, "ClickStackLineBuilderChartConfig")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackNumberChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
@@ -8166,6 +8362,57 @@ impl std::fmt::Display for ClickStackNumberChartConfig {
     }
 }
 
+/// `ClickStackNumberChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackNumberChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackNumberChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackNumberChartConfigResponse {
+    ClickStackNumberRawSqlChartConfig(ClickStackNumberRawSqlChartConfigResponse),
+    ClickStackNumberBuilderChartConfig(ClickStackNumberBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackNumberChartConfigResponse, "configType" {
+        "sql" => ClickStackNumberRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackNumberBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackNumberChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackNumberRawSqlChartConfig(_) => {
+                write!(f, "ClickStackNumberRawSqlChartConfig")
+            }
+            Self::ClickStackNumberBuilderChartConfig(_) => {
+                write!(f, "ClickStackNumberBuilderChartConfig")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackNumberTileColorCondition` - one of multiple variants.
 ///
 /// Dispatched on the `operator` field; see the `discriminated_union!`
@@ -8192,6 +8439,60 @@ discriminated_union! {
 }
 
 impl std::fmt::Display for ClickStackNumberTileColorCondition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackNumericColorCondition(_) => {
+                write!(f, "ClickStackNumericColorCondition")
+            }
+            Self::ClickStackBetweenColorCondition(_) => {
+                write!(f, "ClickStackBetweenColorCondition")
+            }
+            Self::ClickStackEqualityColorCondition(_) => {
+                write!(f, "ClickStackEqualityColorCondition")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackNumberTileColorCondition` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackNumberTileColorCondition`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `operator` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `operator` this crate does not know, or a payload that
+/// does not fit the variant its `operator` selects, lands in `Unknown` with the
+/// raw JSON intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `operator` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackNumberTileColorCondition`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackNumberTileColorConditionResponse {
+    ClickStackNumericColorCondition(ClickStackNumericColorConditionResponse),
+    ClickStackBetweenColorCondition(ClickStackBetweenColorConditionResponse),
+    ClickStackEqualityColorCondition(ClickStackEqualityColorConditionResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackNumberTileColorConditionResponse, "operator" {
+        "gt" | "gte" | "lt" | "lte" => ClickStackNumericColorCondition,
+        "between" => ClickStackBetweenColorCondition,
+        "eq" | "neq" => ClickStackEqualityColorCondition,
+    }
+}
+
+impl std::fmt::Display for ClickStackNumberTileColorConditionResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ClickStackNumericColorCondition(_) => {
@@ -8250,6 +8551,54 @@ impl std::fmt::Display for ClickStackOnClick {
     }
 }
 
+/// `ClickStackOnClick` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackOnClick`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `type` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `type` this crate does not know, or a payload that
+/// does not fit the variant its `type` selects, lands in `Unknown` with the
+/// raw JSON intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `type` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackOnClick`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackOnClickResponse {
+    ClickStackOnClickSearch(ClickStackOnClickSearchResponse),
+    ClickStackOnClickDashboard(ClickStackOnClickDashboardResponse),
+    ClickStackOnClickExternal(ClickStackOnClickExternalResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackOnClickResponse, "type" {
+        "search" => ClickStackOnClickSearch,
+        "dashboard" => ClickStackOnClickDashboard,
+        "external" => ClickStackOnClickExternal,
+    }
+}
+
+impl std::fmt::Display for ClickStackOnClickResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackOnClickSearch(_) => write!(f, "ClickStackOnClickSearch"),
+            Self::ClickStackOnClickDashboard(_) => write!(f, "ClickStackOnClickDashboard"),
+            Self::ClickStackOnClickExternal(_) => write!(f, "ClickStackOnClickExternal"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackOnClickTarget` - one of multiple variants.
 ///
 /// Dispatched on the `mode` field; see the `discriminated_union!`
@@ -8280,6 +8629,55 @@ impl Default for ClickStackOnClickTarget {
 }
 
 impl std::fmt::Display for ClickStackOnClickTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackOnClickTargetIdVariant(_) => {
+                write!(f, "ClickStackOnClickTargetIdVariant")
+            }
+            Self::ClickStackOnClickTargetTemplateVariant(_) => {
+                write!(f, "ClickStackOnClickTargetTemplateVariant")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackOnClickTarget` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackOnClickTarget`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `mode` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `mode` this crate does not know, or a payload that
+/// does not fit the variant its `mode` selects, lands in `Unknown` with the
+/// raw JSON intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `mode` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackOnClickTarget`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackOnClickTargetResponse {
+    ClickStackOnClickTargetIdVariant(ClickStackOnClickTargetIdVariantResponse),
+    ClickStackOnClickTargetTemplateVariant(ClickStackOnClickTargetTemplateVariantResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackOnClickTargetResponse, "mode" {
+        "id" => ClickStackOnClickTargetIdVariant,
+        "template" => ClickStackOnClickTargetTemplateVariant,
+    }
+}
+
+impl std::fmt::Display for ClickStackOnClickTargetResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ClickStackOnClickTargetIdVariant(_) => {
@@ -8324,6 +8722,55 @@ impl std::fmt::Display for ClickStackPieChartConfig {
                 write!(f, "ClickStackPieBuilderChartConfig")
             }
             Self::ClickStackPieRawSqlChartConfig(_) => write!(f, "ClickStackPieRawSqlChartConfig"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackPieChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackPieChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackPieChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackPieChartConfigResponse {
+    ClickStackPieRawSqlChartConfig(ClickStackPieRawSqlChartConfigResponse),
+    ClickStackPieBuilderChartConfig(ClickStackPieBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackPieChartConfigResponse, "configType" {
+        "sql" => ClickStackPieRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackPieBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackPieChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackPieRawSqlChartConfig(_) => write!(f, "ClickStackPieRawSqlChartConfig"),
+            Self::ClickStackPieBuilderChartConfig(_) => {
+                write!(f, "ClickStackPieBuilderChartConfig")
+            }
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -8463,6 +8910,57 @@ impl std::fmt::Display for ClickStackTableChartConfig {
     }
 }
 
+/// `ClickStackTableChartConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackTableChartConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `configType` field exactly as the request union is (absent
+/// or non-string dispatches to the builder variant, unless the payload carries
+/// a raw-SQL-only key): dispatch reads the raw JSON rather than trying each
+/// variant's shape, so all-`Option` arms — which would match any object under
+/// `untagged` matching — cannot misroute a payload, and the `unless` guard
+/// keeps a raw-SQL payload with a dropped discriminator out of the total
+/// builder arm. A payload that does not fit the variant its discriminator
+/// selects lands in `Unknown` with the raw JSON intact.
+///
+/// Deliberately has no `Default`: response values are produced by
+/// deserialization, never constructed; build a [`ClickStackTableChartConfig`] instead when
+/// writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackTableChartConfigResponse {
+    ClickStackTableRawSqlChartConfig(ClickStackTableRawSqlChartConfigResponse),
+    ClickStackTableBuilderChartConfig(ClickStackTableBuilderChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackTableChartConfigResponse, "configType" {
+        "sql" => ClickStackTableRawSqlChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackTableBuilderChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackTableChartConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackTableRawSqlChartConfig(_) => {
+                write!(f, "ClickStackTableRawSqlChartConfig")
+            }
+            Self::ClickStackTableBuilderChartConfig(_) => {
+                write!(f, "ClickStackTableBuilderChartConfig")
+            }
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackTileConfig` - one of multiple variants.
 ///
 /// Dispatched on the `displayType` field; see the `discriminated_union!`
@@ -8510,6 +9008,79 @@ impl std::fmt::Display for ClickStackTileConfig {
             }
             Self::ClickStackLineChartConfig(_) => write!(f, "ClickStackLineChartConfig"),
             Self::ClickStackBarChartConfig(_) => write!(f, "ClickStackBarChartConfig"),
+            Self::ClickStackTableChartConfig(_) => write!(f, "ClickStackTableChartConfig"),
+            Self::ClickStackNumberChartConfig(_) => write!(f, "ClickStackNumberChartConfig"),
+            Self::ClickStackPieChartConfig(_) => write!(f, "ClickStackPieChartConfig"),
+            Self::ClickStackHeatmapChartConfig(_) => write!(f, "ClickStackHeatmapChartConfig"),
+            Self::ClickStackSearchChartConfig(_) => write!(f, "ClickStackSearchChartConfig"),
+            Self::ClickStackEventPatternsChartConfig(_) => {
+                write!(f, "ClickStackEventPatternsChartConfig")
+            }
+            Self::ClickStackMarkdownChartConfig(_) => write!(f, "ClickStackMarkdownChartConfig"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// `ClickStackTileConfig` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackTileConfig`]: each arm is the all-`Option`
+/// response variant of its request type, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `displayType` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `displayType` this crate does not know, or a payload that
+/// does not fit the variant its `displayType` selects, lands in `Unknown` with the
+/// raw JSON intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `displayType` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackTileConfig`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackTileConfigResponse {
+    ClickStackLineChartConfig(ClickStackLineChartConfigResponse),
+    ClickStackBarChartConfig(ClickStackBarChartConfigResponse),
+    ClickStackCategoricalBarChartConfig(ClickStackCategoricalBarChartConfigResponse),
+    ClickStackTableChartConfig(ClickStackTableChartConfigResponse),
+    ClickStackNumberChartConfig(ClickStackNumberChartConfigResponse),
+    ClickStackPieChartConfig(ClickStackPieChartConfigResponse),
+    ClickStackHeatmapChartConfig(ClickStackHeatmapChartConfigResponse),
+    ClickStackSearchChartConfig(ClickStackSearchChartConfigResponse),
+    ClickStackEventPatternsChartConfig(ClickStackEventPatternsChartConfigResponse),
+    ClickStackMarkdownChartConfig(ClickStackMarkdownChartConfigResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackTileConfigResponse, "displayType" {
+        "line" => ClickStackLineChartConfig,
+        "stacked_bar" => ClickStackBarChartConfig,
+        "bar" => ClickStackCategoricalBarChartConfig,
+        "table" => ClickStackTableChartConfig,
+        "number" => ClickStackNumberChartConfig,
+        "pie" => ClickStackPieChartConfig,
+        "heatmap" => ClickStackHeatmapChartConfig,
+        "search" => ClickStackSearchChartConfig,
+        "event_patterns" => ClickStackEventPatternsChartConfig,
+        "markdown" => ClickStackMarkdownChartConfig,
+    }
+}
+
+impl std::fmt::Display for ClickStackTileConfigResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackLineChartConfig(_) => write!(f, "ClickStackLineChartConfig"),
+            Self::ClickStackBarChartConfig(_) => write!(f, "ClickStackBarChartConfig"),
+            Self::ClickStackCategoricalBarChartConfig(_) => {
+                write!(f, "ClickStackCategoricalBarChartConfig")
+            }
             Self::ClickStackTableChartConfig(_) => write!(f, "ClickStackTableChartConfig"),
             Self::ClickStackNumberChartConfig(_) => write!(f, "ClickStackNumberChartConfig"),
             Self::ClickStackPieChartConfig(_) => write!(f, "ClickStackPieChartConfig"),
@@ -10635,138 +11206,164 @@ pub struct ClickStackAggregatedColumnResponse {
 /// `ClickStackAlertChannelEmail` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertChannelEmail {
-    #[serde(rename = "emailRecipients", default)]
+    #[serde(rename = "emailRecipients")]
     pub email_recipients: Vec<String>,
-    #[serde(default)]
     pub r#type: ClickStackAlertChannelEmailType,
+}
+
+/// `ClickStackAlertChannelEmail` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackAlertChannelEmail`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackAlertChannelEmailResponse {
+    #[serde(rename = "emailRecipients", skip_serializing_if = "Option::is_none")]
+    pub email_recipients: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackAlertChannelEmailType>,
 }
 
 /// `ClickStackAlertChannelWebhook` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertChannelWebhook {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub severity: Option<ClickStackAlertChannelWebhookSeverity>,
-    #[serde(
-        rename = "slackChannelId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "slackChannelId", skip_serializing_if = "Option::is_none")]
     pub slack_channel_id: Option<String>,
-    #[serde(default)]
     pub r#type: ClickStackAlertChannelWebhookType,
-    #[serde(rename = "webhookId", default)]
+    #[serde(rename = "webhookId")]
     pub webhook_id: String,
-    #[serde(
-        rename = "webhookService",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "webhookService", skip_serializing_if = "Option::is_none")]
+    pub webhook_service: Option<String>,
+}
+
+/// `ClickStackAlertChannelWebhook` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackAlertChannelWebhook`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackAlertChannelWebhookResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub severity: Option<ClickStackAlertChannelWebhookSeverity>,
+    #[serde(rename = "slackChannelId", skip_serializing_if = "Option::is_none")]
+    pub slack_channel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackAlertChannelWebhookType>,
+    #[serde(rename = "webhookId", skip_serializing_if = "Option::is_none")]
+    pub webhook_id: Option<String>,
+    #[serde(rename = "webhookService", skip_serializing_if = "Option::is_none")]
     pub webhook_service: Option<String>,
 }
 
 /// `ClickStackAlertExecutionError` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertExecutionError {
-    #[serde(default)]
-    pub message: String,
-    #[serde(default)]
-    pub timestamp: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub r#type: ClickStackAlertExecutionErrorType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackAlertExecutionErrorType>,
 }
 
 /// `ClickStackAlertResponse` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertResponse {
-    #[serde(default)]
-    pub channel: ClickStackAlertChannel,
-    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<ClickStackAlertChannelResponse>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(
-        rename = "dashboardId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none")]
     pub dashboard_id: Option<String>,
-    #[serde(rename = "executionErrors", default)]
-    pub execution_errors: Vec<ClickStackAlertExecutionError>,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "executionErrors", skip_serializing_if = "Option::is_none")]
+    pub execution_errors: Option<Vec<ClickStackAlertExecutionError>>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub interval: ClickStackAlertResponseInterval,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interval: Option<ClickStackAlertResponseInterval>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(
         rename = "numConsecutiveWindows",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub num_consecutive_windows: Option<i64>,
-    #[serde(
-        rename = "savedSearchId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none")]
     pub saved_search_id: Option<String>,
     #[serde(
         rename = "scheduleOffsetMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(
-        rename = "scheduleStartAt",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none")]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub silenced: Option<ClickStackAlertSilenced>,
-    #[serde(default)]
-    pub source: ClickStackAlertResponseSource,
-    #[serde(default)]
-    pub state: ClickStackAlertResponseState,
-    #[serde(rename = "teamId", default)]
-    pub team_id: String,
-    #[serde(default)]
-    pub threshold: f64,
-    #[serde(
-        rename = "thresholdMax",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<ClickStackAlertResponseSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ClickStackAlertResponseState>,
+    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threshold: Option<f64>,
+    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none")]
     pub threshold_max: Option<f64>,
-    #[serde(rename = "thresholdType", default)]
-    pub threshold_type: ClickStackAlertResponseThresholdtype,
-    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "thresholdType", skip_serializing_if = "Option::is_none")]
+    pub threshold_type: Option<ClickStackAlertResponseThresholdtype>,
+    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none")]
     pub tile_id: Option<String>,
-    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `ClickStackAlertSilenced` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertSilenced {
-    #[serde(default)]
-    pub at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub by: Option<String>,
-    #[serde(default)]
-    pub until: chrono::DateTime<chrono::Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub until: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `ClickStackBackgroundChart` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBackgroundChart {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ClickStackChartColor>,
     pub r#type: ClickStackBackgroundChartType,
+}
+
+/// `ClickStackBackgroundChart` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackBackgroundChart`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackBackgroundChartResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackBackgroundChartType>,
 }
 
 /// `ClickStackBarBuilderChartConfig` from the ClickHouse Cloud API.
@@ -10774,28 +11371,50 @@ pub struct ClickStackBackgroundChart {
 pub struct ClickStackBarBuilderChartConfig {
     #[serde(
         rename = "alignDateRangeToGranularity",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub align_date_range_to_granularity: Option<bool>,
-    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackBarBuilderChartConfigDisplaytype,
-    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
     pub fill_nulls: Option<bool>,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackBarBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackBarBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackBarBuilderChartConfigResponse {
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub align_date_range_to_granularity: Option<bool>,
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
+    pub as_ratio: Option<bool>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackBarBuilderChartConfigDisplaytype>,
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
+    pub fill_nulls: Option<bool>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackBarRawSqlChartConfig` from the ClickHouse Cloud API.
@@ -10803,38 +11422,78 @@ pub struct ClickStackBarBuilderChartConfig {
 pub struct ClickStackBarRawSqlChartConfig {
     #[serde(
         rename = "alignDateRangeToGranularity",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub align_date_range_to_granularity: Option<bool>,
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackBarRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackBarRawSqlChartConfigDisplaytype,
-    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
     pub fill_nulls: Option<bool>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackBarRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackBarRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackBarRawSqlChartConfigResponse {
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub align_date_range_to_granularity: Option<bool>,
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackBarRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackBarRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
+    pub fill_nulls: Option<bool>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackBetweenColorCondition` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackBetweenColorCondition {
     pub color: ClickStackChartColor,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub operator: ClickStackBetweenColorConditionOperator,
     pub value: Vec<f64>,
+}
+
+/// `ClickStackBetweenColorCondition` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackBetweenColorCondition`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackBetweenColorConditionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator: Option<ClickStackBetweenColorConditionOperator>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<Vec<f64>>,
 }
 
 /// `ClickStackCASLPermission` from the ClickHouse Cloud API.
@@ -10872,45 +11531,80 @@ pub struct ClickStackCASLPermissionResponse {
 /// `ClickStackCategoricalBarBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCategoricalBarBuilderChartConfig {
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackCategoricalBarBuilderChartConfigDisplaytype,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
     pub order_by: Option<String>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackCategoricalBarBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackCategoricalBarBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackCategoricalBarBuilderChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackCategoricalBarBuilderChartConfigDisplaytype>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
+    pub order_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackCategoricalBarRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCategoricalBarRawSqlChartConfig {
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackCategoricalBarRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackCategoricalBarRawSqlChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackCategoricalBarRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackCategoricalBarRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackCategoricalBarRawSqlChartConfigResponse {
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackCategoricalBarRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackCategoricalBarRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackConnection` from the ClickHouse Cloud API.
@@ -10946,61 +11640,39 @@ pub struct ClickStackConnection {
 /// `ClickStackCreateAlertRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCreateAlertRequest {
-    #[serde(default)]
     pub channel: ClickStackAlertChannel,
-    #[serde(
-        rename = "dashboardId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none")]
     pub dashboard_id: Option<String>,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(default)]
     pub interval: ClickStackCreateAlertRequestInterval,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(
         rename = "numConsecutiveWindows",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub num_consecutive_windows: Option<i64>,
-    #[serde(
-        rename = "savedSearchId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none")]
     pub saved_search_id: Option<String>,
     #[serde(
         rename = "scheduleOffsetMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(
-        rename = "scheduleStartAt",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none")]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(default)]
     pub source: ClickStackCreateAlertRequestSource,
-    #[serde(default)]
     pub threshold: f64,
-    #[serde(
-        rename = "thresholdMax",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none")]
     pub threshold_max: Option<f64>,
-    #[serde(rename = "thresholdType", default)]
+    #[serde(rename = "thresholdType")]
     pub threshold_type: ClickStackCreateAlertRequestThresholdtype,
-    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none")]
     pub tile_id: Option<String>,
 }
 
@@ -11027,30 +11699,18 @@ pub struct ClickStackCreateConnectionRequest {
 /// `ClickStackCreateDashboardRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCreateDashboardRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub containers: Option<Vec<ClickStackDashboardContainer>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Vec<ClickStackFilterInput>>,
     pub name: String,
-    #[serde(
-        rename = "savedFilterValues",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none")]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
-    #[serde(
-        rename = "savedQuery",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none")]
     pub saved_query: Option<String>,
-    #[serde(
-        rename = "savedQueryLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none")]
     pub saved_query_language: Option<ClickStackCreateDashboardRequestSavedquerylanguage>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     pub tiles: Vec<ClickStackTileInput>,
 }
@@ -11067,15 +11727,36 @@ pub struct ClickStackCreateRoleRequest {
 /// `ClickStackDashboardContainer` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackDashboardContainer {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bordered: Option<bool>,
     pub collapsed: bool,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub collapsible: Option<bool>,
     pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tabs: Option<Vec<ClickStackDashboardContainerTab>>,
     pub title: String,
+}
+
+/// `ClickStackDashboardContainer` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackDashboardContainer`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackDashboardContainerResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bordered: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsible: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tabs: Option<Vec<ClickStackDashboardContainerTabResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
 }
 
 /// `ClickStackDashboardContainerTab` from the ClickHouse Cloud API.
@@ -11085,50 +11766,72 @@ pub struct ClickStackDashboardContainerTab {
     pub title: String,
 }
 
+/// `ClickStackDashboardContainerTab` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackDashboardContainerTab`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackDashboardContainerTabResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
 /// `ClickStackDashboardResponse` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackDashboardResponse {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub containers: Option<Vec<ClickStackDashboardContainer>>,
-    #[serde(default)]
-    pub filters: Vec<ClickStackFilterResponse>,
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub name: String,
-    #[serde(
-        rename = "savedFilterValues",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub containers: Option<Vec<ClickStackDashboardContainerResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<Vec<ClickStackFilterResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none")]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValueResponse>>,
-    #[serde(
-        rename = "savedQuery",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none")]
     pub saved_query: Option<String>,
-    #[serde(
-        rename = "savedQueryLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none")]
     pub saved_query_language: Option<ClickStackDashboardResponseSavedquerylanguage>,
-    #[serde(default)]
-    pub tags: Vec<String>,
-    #[serde(default)]
-    pub tiles: Vec<ClickStackTileOutput>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tags: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tiles: Option<Vec<ClickStackTileOutput>>,
 }
 
 /// `ClickStackEqualityColorCondition` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackEqualityColorCondition {
     pub color: ClickStackChartColor,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub operator: ClickStackEqualityColorConditionOperator,
     /// A finite number or a string; the spec models this as `oneOf number|string`.
     pub value: serde_json::Value,
+}
+
+/// `ClickStackEqualityColorCondition` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackEqualityColorCondition`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackEqualityColorConditionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator: Option<ClickStackEqualityColorConditionOperator>,
+    /// A finite number or a string; the spec models this as `oneOf number|string`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<serde_json::Value>,
 }
 
 /// `ClickStackEventPatternsChartConfig` from the ClickHouse Cloud API.
@@ -11136,17 +11839,32 @@ pub struct ClickStackEqualityColorCondition {
 pub struct ClickStackEventPatternsChartConfig {
     #[serde(rename = "displayType")]
     pub display_type: ClickStackEventPatternsChartConfigDisplaytype,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub select: Option<String>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackEventPatternsChartConfigWherelanguage>,
+}
+
+/// `ClickStackEventPatternsChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackEventPatternsChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackEventPatternsChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackEventPatternsChartConfigDisplaytype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<String>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#where: Option<String>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackEventPatternsChartConfigWherelanguage>,
 }
 
@@ -11235,20 +11953,26 @@ pub struct ClickStackFilterSettingsColumnResponse {
 }
 
 /// `ClickStackGenericWebhook` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackGenericWebhook {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    pub name: String,
-    pub service: ClickStackGenericWebhookService,
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ClickStackGenericWebhookService>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -11257,42 +11981,62 @@ pub struct ClickStackGenericWebhook {
 pub struct ClickStackHeatmapChartConfig {
     #[serde(rename = "displayType")]
     pub display_type: ClickStackHeatmapChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
     pub select: Vec<ClickStackHeatmapSelectItem>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(rename = "where", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "where", skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackHeatmapChartConfigWherelanguage>,
+}
+
+/// `ClickStackHeatmapChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackHeatmapChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackHeatmapChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackHeatmapChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackHeatmapSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "where", skip_serializing_if = "Option::is_none")]
+    pub r#where: Option<String>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackHeatmapChartConfigWherelanguage>,
 }
 
 /// `ClickStackHeatmapSelectItem` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackHeatmapSelectItem {
-    #[serde(
-        rename = "countExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "countExpression", skip_serializing_if = "Option::is_none")]
     pub count_expression: Option<String>,
-    #[serde(
-        rename = "heatmapScaleType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "heatmapScaleType", skip_serializing_if = "Option::is_none")]
     pub heatmap_scale_type: Option<ClickStackHeatmapSelectItemHeatmapscaletype>,
     #[serde(rename = "valueExpression")]
     pub value_expression: String,
+}
+
+/// `ClickStackHeatmapSelectItem` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackHeatmapSelectItem`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackHeatmapSelectItemResponse {
+    #[serde(rename = "countExpression", skip_serializing_if = "Option::is_none")]
+    pub count_expression: Option<String>,
+    #[serde(rename = "heatmapScaleType", skip_serializing_if = "Option::is_none")]
+    pub heatmap_scale_type: Option<ClickStackHeatmapSelectItemHeatmapscaletype>,
+    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none")]
+    pub value_expression: Option<String>,
 }
 
 /// `ClickStackHighlightedAttributeExpression` from the ClickHouse Cloud API.
@@ -11322,18 +12066,24 @@ pub struct ClickStackHighlightedAttributeExpressionResponse {
 }
 
 /// `ClickStackIncidentIOWebhook` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackIncidentIOWebhook {
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    pub name: String,
-    pub service: ClickStackIncidentIOWebhookService,
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ClickStackIncidentIOWebhookService>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -11342,40 +12092,64 @@ pub struct ClickStackIncidentIOWebhook {
 pub struct ClickStackLineBuilderChartConfig {
     #[serde(
         rename = "alignDateRangeToGranularity",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub align_date_range_to_granularity: Option<bool>,
-    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
     #[serde(
         rename = "compareToPreviousPeriod",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub compare_to_previous_period: Option<bool>,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackLineBuilderChartConfigDisplaytype,
-    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
     pub fill_nulls: Option<bool>,
-    #[serde(
-        rename = "fitYAxisToData",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "fitYAxisToData", skip_serializing_if = "Option::is_none")]
     pub fit_y_axis_to_data: Option<bool>,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackLineBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackLineBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackLineBuilderChartConfigResponse {
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub align_date_range_to_granularity: Option<bool>,
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
+    pub as_ratio: Option<bool>,
+    #[serde(
+        rename = "compareToPreviousPeriod",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub compare_to_previous_period: Option<bool>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackLineBuilderChartConfigDisplaytype>,
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
+    pub fill_nulls: Option<bool>,
+    #[serde(rename = "fitYAxisToData", skip_serializing_if = "Option::is_none")]
+    pub fit_y_axis_to_data: Option<bool>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackLineRawSqlChartConfig` from the ClickHouse Cloud API.
@@ -11383,40 +12157,65 @@ pub struct ClickStackLineBuilderChartConfig {
 pub struct ClickStackLineRawSqlChartConfig {
     #[serde(
         rename = "alignDateRangeToGranularity",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub align_date_range_to_granularity: Option<bool>,
     #[serde(
         rename = "compareToPreviousPeriod",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub compare_to_previous_period: Option<bool>,
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackLineRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackLineRawSqlChartConfigDisplaytype,
-    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
     pub fill_nulls: Option<bool>,
-    #[serde(
-        rename = "fitYAxisToData",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "fitYAxisToData", skip_serializing_if = "Option::is_none")]
     pub fit_y_axis_to_data: Option<bool>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackLineRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackLineRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackLineRawSqlChartConfigResponse {
+    #[serde(
+        rename = "alignDateRangeToGranularity",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub align_date_range_to_granularity: Option<bool>,
+    #[serde(
+        rename = "compareToPreviousPeriod",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub compare_to_previous_period: Option<bool>,
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackLineRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackLineRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none")]
+    pub fill_nulls: Option<bool>,
+    #[serde(rename = "fitYAxisToData", skip_serializing_if = "Option::is_none")]
+    pub fit_y_axis_to_data: Option<bool>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackLogSource` from the ClickHouse Cloud API.
@@ -11649,7 +12448,20 @@ pub struct ClickStackLogSourceMetadataMaterializedViewsResponse {
 pub struct ClickStackMarkdownChartConfig {
     #[serde(rename = "displayType")]
     pub display_type: ClickStackMarkdownChartConfigDisplaytype,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub markdown: Option<String>,
+}
+
+/// `ClickStackMarkdownChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackMarkdownChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackMarkdownChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackMarkdownChartConfigDisplaytype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub markdown: Option<String>,
 }
 
@@ -11824,32 +12636,42 @@ pub struct ClickStackMetricTablesResponse {
 /// `ClickStackNumberBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumberBuilderChartConfig {
-    #[serde(
-        rename = "backgroundChart",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "backgroundChart", skip_serializing_if = "Option::is_none")]
     pub background_chart: Option<ClickStackBackgroundChart>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ClickStackChartColor>,
-    #[serde(
-        rename = "colorRules",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "colorRules", skip_serializing_if = "Option::is_none")]
     pub color_rules: Option<Vec<ClickStackNumberTileColorCondition>>,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackNumberBuilderChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackNumberBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackNumberBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackNumberBuilderChartConfigResponse {
+    #[serde(rename = "backgroundChart", skip_serializing_if = "Option::is_none")]
+    pub background_chart: Option<ClickStackBackgroundChartResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(rename = "colorRules", skip_serializing_if = "Option::is_none")]
+    pub color_rules: Option<Vec<ClickStackNumberTileColorConditionResponse>>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackNumberBuilderChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackNumberChartSeries` from the ClickHouse Cloud API.
@@ -11857,29 +12679,17 @@ pub struct ClickStackNumberBuilderChartConfig {
 pub struct ClickStackNumberChartSeries {
     #[serde(rename = "aggFn")]
     pub agg_fn: ClickStackNumberChartSeriesAggfn,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<f64>,
-    #[serde(
-        rename = "metricDataType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none")]
     pub metric_data_type: Option<ClickStackNumberChartSeriesMetricdatatype>,
-    #[serde(
-        rename = "metricName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none")]
     pub metric_name: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
@@ -11892,77 +12702,146 @@ pub struct ClickStackNumberChartSeries {
 /// `ClickStackNumberFormat` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumberFormat {
-    #[serde(default)]
     pub average: bool,
-    #[serde(rename = "currencySymbol", default)]
+    #[serde(rename = "currencySymbol")]
     pub currency_symbol: String,
-    #[serde(rename = "decimalBytes", default)]
+    #[serde(rename = "decimalBytes")]
     pub decimal_bytes: bool,
-    #[serde(default)]
     pub factor: f64,
-    #[serde(default)]
     pub mantissa: i64,
-    #[serde(rename = "numericUnit", default)]
+    #[serde(rename = "numericUnit")]
     pub numeric_unit: ClickStackNumberFormatNumericunit,
-    #[serde(default)]
     pub output: ClickStackNumberFormatOutput,
-    #[serde(rename = "thousandSeparated", default)]
+    #[serde(rename = "thousandSeparated")]
     pub thousand_separated: bool,
-    #[serde(default)]
     pub unit: String,
+}
+
+/// `ClickStackNumberFormat` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackNumberFormat`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackNumberFormatResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average: Option<bool>,
+    #[serde(rename = "currencySymbol", skip_serializing_if = "Option::is_none")]
+    pub currency_symbol: Option<String>,
+    #[serde(rename = "decimalBytes", skip_serializing_if = "Option::is_none")]
+    pub decimal_bytes: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub factor: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mantissa: Option<i64>,
+    #[serde(rename = "numericUnit", skip_serializing_if = "Option::is_none")]
+    pub numeric_unit: Option<ClickStackNumberFormatNumericunit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<ClickStackNumberFormatOutput>,
+    #[serde(rename = "thousandSeparated", skip_serializing_if = "Option::is_none")]
+    pub thousand_separated: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
 }
 
 /// `ClickStackNumberRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumberRawSqlChartConfig {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<ClickStackChartColor>,
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackNumberRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackNumberRawSqlChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackNumberRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackNumberRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackNumberRawSqlChartConfigResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackNumberRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackNumberRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackNumericColorCondition` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackNumericColorCondition {
     pub color: ClickStackChartColor,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub operator: ClickStackNumericColorConditionOperator,
     pub value: f64,
 }
 
+/// `ClickStackNumericColorCondition` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackNumericColorCondition`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackNumericColorConditionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub color: Option<ClickStackChartColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator: Option<ClickStackNumericColorConditionOperator>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+}
+
 /// `ClickStackOnClickDashboard` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackOnClickDashboard {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Vec<ClickStackOnClickFilterTemplate>>,
     pub target: ClickStackOnClickTarget,
     pub r#type: ClickStackOnClickDashboardType,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackOnClickDashboardWherelanguage>,
-    #[serde(
-        rename = "whereTemplate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none")]
+    pub where_template: Option<String>,
+}
+
+/// `ClickStackOnClickDashboard` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickDashboard`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickDashboardResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<Vec<ClickStackOnClickFilterTemplateResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<ClickStackOnClickTargetResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackOnClickDashboardType>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackOnClickDashboardWherelanguage>,
+    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none")]
     pub where_template: Option<String>,
 }
 
@@ -11974,6 +12853,19 @@ pub struct ClickStackOnClickExternal {
     pub url_template: String,
 }
 
+/// `ClickStackOnClickExternal` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickExternal`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickExternalResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackOnClickExternalType>,
+    #[serde(rename = "urlTemplate", skip_serializing_if = "Option::is_none")]
+    pub url_template: Option<String>,
+}
+
 /// `ClickStackOnClickFilterTemplate` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackOnClickFilterTemplate {
@@ -11982,24 +12874,50 @@ pub struct ClickStackOnClickFilterTemplate {
     pub template: String,
 }
 
+/// `ClickStackOnClickFilterTemplate` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickFilterTemplate`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickFilterTemplateResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackOnClickFilterTemplateKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+}
+
 /// `ClickStackOnClickSearch` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackOnClickSearch {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Vec<ClickStackOnClickFilterTemplate>>,
     pub target: ClickStackOnClickTarget,
     pub r#type: ClickStackOnClickSearchType,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackOnClickSearchWherelanguage>,
-    #[serde(
-        rename = "whereTemplate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none")]
+    pub where_template: Option<String>,
+}
+
+/// `ClickStackOnClickSearch` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickSearch`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickSearchResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<Vec<ClickStackOnClickFilterTemplateResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<ClickStackOnClickTargetResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackOnClickSearchType>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackOnClickSearchWherelanguage>,
+    #[serde(rename = "whereTemplate", skip_serializing_if = "Option::is_none")]
     pub where_template: Option<String>,
 }
 
@@ -12010,6 +12928,19 @@ pub struct ClickStackOnClickTargetIdVariant {
     pub mode: ClickStackOnClickTargetIdVariantMode,
 }
 
+/// `ClickStackOnClickTargetIdVariant` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickTargetIdVariant`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickTargetIdVariantResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ClickStackOnClickTargetIdVariantMode>,
+}
+
 /// `ClickStackOnClickTargetTemplateVariant` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackOnClickTargetTemplateVariant {
@@ -12017,64 +12948,118 @@ pub struct ClickStackOnClickTargetTemplateVariant {
     pub template: String,
 }
 
+/// `ClickStackOnClickTargetTemplateVariant` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackOnClickTargetTemplateVariant`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackOnClickTargetTemplateVariantResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ClickStackOnClickTargetTemplateVariantMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+}
+
 /// `ClickStackPagerDutyAPIWebhook` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPagerDutyAPIWebhook {
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    pub name: String,
-    pub service: ClickStackPagerDutyAPIWebhookService,
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ClickStackPagerDutyAPIWebhookService>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
 /// `ClickStackPieBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPieBuilderChartConfig {
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackPieBuilderChartConfigDisplaytype,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
     pub order_by: Option<String>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackPieBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackPieBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackPieBuilderChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackPieBuilderChartConfigDisplaytype>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<i64>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
+    pub order_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackPieRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPieRawSqlChartConfig {
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackPieRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackPieRawSqlChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackPieRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackPieRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackPieRawSqlChartConfigResponse {
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackPieRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackPieRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackPromqlSource` from the ClickHouse Cloud API.
@@ -12270,10 +13255,29 @@ pub struct ClickStackSearchChartConfig {
     pub select: String,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
     #[serde(rename = "whereLanguage")]
     pub where_language: ClickStackSearchChartConfigWherelanguage,
+}
+
+/// `ClickStackSearchChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSearchChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSearchChartConfigResponse {
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackSearchChartConfigDisplaytype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<String>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#where: Option<String>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackSearchChartConfigWherelanguage>,
 }
 
 /// `ClickStackSearchChartSeries` from the ClickHouse Cloud API.
@@ -12293,47 +13297,52 @@ pub struct ClickStackSearchChartSeries {
 pub struct ClickStackSelectItem {
     #[serde(rename = "aggFn")]
     pub agg_fn: ClickStackSelectItemAggfn,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<ClickStackSelectItemLevel>,
-    #[serde(
-        rename = "metricName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none")]
     pub metric_name: Option<String>,
-    #[serde(
-        rename = "metricType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricType", skip_serializing_if = "Option::is_none")]
     pub metric_type: Option<ClickStackSelectItemMetrictype>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(
-        rename = "periodAggFn",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "periodAggFn", skip_serializing_if = "Option::is_none")]
     pub period_agg_fn: Option<ClickStackSelectItemPeriodaggfn>,
-    #[serde(
-        rename = "valueExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none")]
     pub value_expression: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackSelectItemWherelanguage>,
+}
+
+/// `ClickStackSelectItem` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSelectItem`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSelectItemResponse {
+    #[serde(rename = "aggFn", skip_serializing_if = "Option::is_none")]
+    pub agg_fn: Option<ClickStackSelectItemAggfn>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub level: Option<ClickStackSelectItemLevel>,
+    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none")]
+    pub metric_name: Option<String>,
+    #[serde(rename = "metricType", skip_serializing_if = "Option::is_none")]
+    pub metric_type: Option<ClickStackSelectItemMetrictype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "periodAggFn", skip_serializing_if = "Option::is_none")]
+    pub period_agg_fn: Option<ClickStackSelectItemPeriodaggfn>,
+    #[serde(rename = "valueExpression", skip_serializing_if = "Option::is_none")]
+    pub value_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#where: Option<String>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackSelectItemWherelanguage>,
 }
 
@@ -12394,34 +13403,46 @@ pub struct ClickStackSessionSourceResponse {
 }
 
 /// `ClickStackSlackAPIWebhook` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSlackAPIWebhook {
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    pub name: String,
-    pub service: ClickStackSlackAPIWebhookService,
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ClickStackSlackAPIWebhookService>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
 /// `ClickStackSlackWebhook` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSlackWebhook {
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    pub name: String,
-    pub service: ClickStackSlackWebhookService,
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service: Option<ClickStackSlackWebhookService>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -12475,34 +13496,60 @@ pub struct ClickStackSourceFromResponse {
 /// `ClickStackTableBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTableBuilderChartConfig {
-    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackTableBuilderChartConfigDisplaytype,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
     #[serde(
         rename = "groupByColumnsOnLeft",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub group_by_columns_on_left: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub having: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none")]
     pub on_click: Option<ClickStackOnClick>,
-    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
     pub order_by: Option<String>,
-    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId", default)]
+    #[serde(rename = "sourceId")]
     pub source_id: String,
+}
+
+/// `ClickStackTableBuilderChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackTableBuilderChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackTableBuilderChartConfigResponse {
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
+    pub as_ratio: Option<bool>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackTableBuilderChartConfigDisplaytype>,
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<String>,
+    #[serde(
+        rename = "groupByColumnsOnLeft",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub group_by_columns_on_left: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub having: Option<String>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none")]
+    pub on_click: Option<ClickStackOnClickResponse>,
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
+    pub order_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub select: Option<Vec<ClickStackSelectItemResponse>>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
 }
 
 /// `ClickStackTableChartSeries` from the ClickHouse Cloud API.
@@ -12510,33 +13557,21 @@ pub struct ClickStackTableBuilderChartConfig {
 pub struct ClickStackTableChartSeries {
     #[serde(rename = "aggFn")]
     pub agg_fn: ClickStackTableChartSeriesAggfn,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     #[serde(rename = "groupBy")]
     pub group_by: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<f64>,
-    #[serde(
-        rename = "metricDataType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none")]
     pub metric_data_type: Option<ClickStackTableChartSeriesMetricdatatype>,
-    #[serde(
-        rename = "metricName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none")]
     pub metric_name: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "sortOrder", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sortOrder", skip_serializing_if = "Option::is_none")]
     pub sort_order: Option<ClickStackTableChartSeriesSortorder>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
@@ -12549,48 +13584,63 @@ pub struct ClickStackTableChartSeries {
 /// `ClickStackTableRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTableRawSqlChartConfig {
-    #[serde(rename = "configType", default)]
+    #[serde(rename = "configType")]
     pub config_type: ClickStackTableRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId", default)]
+    #[serde(rename = "connectionId")]
     pub connection_id: String,
-    #[serde(rename = "displayType", default)]
+    #[serde(rename = "displayType")]
     pub display_type: ClickStackTableRawSqlChartConfigDisplaytype,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
-    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none")]
     pub on_click: Option<ClickStackOnClick>,
-    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate", default)]
+    #[serde(rename = "sqlTemplate")]
     pub sql_template: String,
+}
+
+/// `ClickStackTableRawSqlChartConfig` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackTableRawSqlChartConfig`]: every field is `Option<T>`, so a field
+/// the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackTableRawSqlChartConfigResponse {
+    #[serde(rename = "configType", skip_serializing_if = "Option::is_none")]
+    pub config_type: Option<ClickStackTableRawSqlChartConfigConfigtype>,
+    #[serde(rename = "connectionId", skip_serializing_if = "Option::is_none")]
+    pub connection_id: Option<String>,
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
+    pub display_type: Option<ClickStackTableRawSqlChartConfigDisplaytype>,
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
+    pub number_format: Option<ClickStackNumberFormatResponse>,
+    #[serde(rename = "onClick", skip_serializing_if = "Option::is_none")]
+    pub on_click: Option<ClickStackOnClickResponse>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sqlTemplate", skip_serializing_if = "Option::is_none")]
+    pub sql_template: Option<String>,
 }
 
 /// `ClickStackTileInput` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTileInput {
     #[cfg(feature = "deprecated-fields")]
-    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none")]
     pub as_ratio: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<ClickStackTileConfig>,
-    #[serde(
-        rename = "containerId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "containerId", skip_serializing_if = "Option::is_none")]
     pub container_id: Option<String>,
     pub h: i64,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub name: String,
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub series: Option<Vec<ClickStackDashboardChartSeries>>,
-    #[serde(rename = "tabId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tabId", skip_serializing_if = "Option::is_none")]
     pub tab_id: Option<String>,
     pub w: i64,
     pub x: i64,
@@ -12598,24 +13648,29 @@ pub struct ClickStackTileInput {
 }
 
 /// `ClickStackTileOutput` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTileOutput {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub config: Option<ClickStackTileConfig>,
-    #[serde(
-        rename = "containerId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<ClickStackTileConfigResponse>,
+    #[serde(rename = "containerId", skip_serializing_if = "Option::is_none")]
     pub container_id: Option<String>,
-    pub h: i64,
-    pub id: String,
-    pub name: String,
-    #[serde(rename = "tabId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub h: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "tabId", skip_serializing_if = "Option::is_none")]
     pub tab_id: Option<String>,
-    pub w: i64,
-    pub x: i64,
-    pub y: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub w: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub x: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub y: Option<i64>,
 }
 
 /// `ClickStackTimeChartSeries` from the ClickHouse Cloud API.
@@ -12623,37 +13678,21 @@ pub struct ClickStackTileOutput {
 pub struct ClickStackTimeChartSeries {
     #[serde(rename = "aggFn")]
     pub agg_fn: ClickStackTimeChartSeriesAggfn,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
-    #[serde(
-        rename = "displayType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "displayType", skip_serializing_if = "Option::is_none")]
     pub display_type: Option<ClickStackTimeChartSeriesDisplaytype>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub field: Option<String>,
     #[serde(rename = "groupBy")]
     pub group_by: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub level: Option<f64>,
-    #[serde(
-        rename = "metricDataType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricDataType", skip_serializing_if = "Option::is_none")]
     pub metric_data_type: Option<ClickStackTimeChartSeriesMetricdatatype>,
-    #[serde(
-        rename = "metricName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricName", skip_serializing_if = "Option::is_none")]
     pub metric_name: Option<String>,
-    #[serde(
-        rename = "numberFormat",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "numberFormat", skip_serializing_if = "Option::is_none")]
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
@@ -12924,61 +13963,39 @@ pub struct ClickStackTraceSourceMetadataMaterializedViewsResponse {
 /// `ClickStackUpdateAlertRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackUpdateAlertRequest {
-    #[serde(default)]
     pub channel: ClickStackAlertChannel,
-    #[serde(
-        rename = "dashboardId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "dashboardId", skip_serializing_if = "Option::is_none")]
     pub dashboard_id: Option<String>,
-    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none")]
     pub group_by: Option<String>,
-    #[serde(default)]
     pub interval: ClickStackUpdateAlertRequestInterval,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<String>,
     #[serde(
         rename = "numConsecutiveWindows",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub num_consecutive_windows: Option<i64>,
-    #[serde(
-        rename = "savedSearchId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedSearchId", skip_serializing_if = "Option::is_none")]
     pub saved_search_id: Option<String>,
     #[serde(
         rename = "scheduleOffsetMinutes",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub schedule_offset_minutes: Option<i64>,
-    #[serde(
-        rename = "scheduleStartAt",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "scheduleStartAt", skip_serializing_if = "Option::is_none")]
     pub schedule_start_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(default)]
     pub source: ClickStackUpdateAlertRequestSource,
-    #[serde(default)]
     pub threshold: f64,
-    #[serde(
-        rename = "thresholdMax",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "thresholdMax", skip_serializing_if = "Option::is_none")]
     pub threshold_max: Option<f64>,
-    #[serde(rename = "thresholdType", default)]
+    #[serde(rename = "thresholdType")]
     pub threshold_type: ClickStackUpdateAlertRequestThresholdtype,
-    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tileId", skip_serializing_if = "Option::is_none")]
     pub tile_id: Option<String>,
 }
 
@@ -13005,30 +14022,18 @@ pub struct ClickStackUpdateConnectionRequest {
 /// `ClickStackUpdateDashboardRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackUpdateDashboardRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub containers: Option<Vec<ClickStackDashboardContainer>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Vec<ClickStackFilter>>,
     pub name: String,
-    #[serde(
-        rename = "savedFilterValues",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedFilterValues", skip_serializing_if = "Option::is_none")]
     pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
-    #[serde(
-        rename = "savedQuery",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQuery", skip_serializing_if = "Option::is_none")]
     pub saved_query: Option<String>,
-    #[serde(
-        rename = "savedQueryLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "savedQueryLanguage", skip_serializing_if = "Option::is_none")]
     pub saved_query_language: Option<ClickStackUpdateDashboardRequestSavedquerylanguage>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
     pub tiles: Vec<ClickStackTileInput>,
 }
@@ -13044,37 +14049,43 @@ pub struct ClickStackUpdateRoleRequest {
 }
 
 /// `ClickStackValidateDashboardError` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackValidateDashboardError {
-    pub message: String,
-    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
 }
 
 /// `ClickStackValidateDashboardResponse` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackValidateDashboardResponse {
-    pub errors: Vec<ClickStackValidateDashboardError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errors: Option<Vec<ClickStackValidateDashboardError>>,
+
     pub normalized: Option<ClickStackValidateDashboardResponseNormalized>,
-    pub valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid: Option<bool>,
 }
 
 /// `ClickStackWebhookInput` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackWebhookInput {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub headers: Option<ClickStackWebhookInputHeaders>,
     pub name: String,
-    #[serde(
-        rename = "queryParams",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "queryParams", skip_serializing_if = "Option::is_none")]
     pub query_params: Option<ClickStackWebhookInputQueryParams>,
-    #[serde(default)]
     pub service: ClickStackWebhookInputService,
     pub url: String,
 }
@@ -15530,6 +16541,14 @@ impl Default for ClickStackTileConfig {
 
 impl Default for ClickStackWebhook {
     fn default() -> Self {
-        Self::ClickStackSlackWebhook(ClickStackSlackWebhook::default())
+        // Every field of this response-only union's variants is `Option<T>`,
+        // so the derived `ClickStackSlackWebhook::default()` leaves `service`
+        // absent and serializes to `{}` — which deserializes back through the
+        // discriminator dispatch as `Unknown`, not as this variant. Naming the
+        // variant's own wire value keeps the default round-tripping.
+        Self::ClickStackSlackWebhook(ClickStackSlackWebhook {
+            service: Some(ClickStackSlackWebhookService::default()),
+            ..ClickStackSlackWebhook::default()
+        })
     }
 }

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -7873,7 +7873,10 @@ impl std::fmt::Display for BackupBucketProperties {
 }
 
 /// `ClickStackAlertChannel` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `type` field; see the `discriminated_union!`
+/// invocation below for the wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackAlertChannel {
     ClickStackAlertChannelEmail(ClickStackAlertChannelEmail),
@@ -7883,6 +7886,13 @@ pub enum ClickStackAlertChannel {
     /// Holds the raw payload as `serde_json::Value` so it round-trips
     /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackAlertChannel, "type" {
+        "email" => ClickStackAlertChannelEmail,
+        "webhook" => ClickStackAlertChannelWebhook,
+    }
 }
 
 impl std::fmt::Display for ClickStackAlertChannel {
@@ -10464,8 +10474,9 @@ pub struct ClickStackAggregatedColumn {
 /// `ClickStackAlertChannelEmail` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackAlertChannelEmail {
-    #[serde(rename = "emailRecipients")]
+    #[serde(rename = "emailRecipients", default)]
     pub email_recipients: Vec<String>,
+    #[serde(default)]
     pub r#type: ClickStackAlertChannelEmailType,
 }
 
@@ -10480,8 +10491,9 @@ pub struct ClickStackAlertChannelWebhook {
         default
     )]
     pub slack_channel_id: Option<String>,
+    #[serde(default)]
     pub r#type: ClickStackAlertChannelWebhookType,
-    #[serde(rename = "webhookId")]
+    #[serde(rename = "webhookId", default)]
     pub webhook_id: String,
     #[serde(
         rename = "webhookService",

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -12,11 +12,19 @@ use serde::{Deserialize, Serialize};
 /// `displayType`, `service`, `operator`) shares the same deserialization shape:
 /// buffer the payload as a [`serde_json::Value`], read the discriminator key,
 /// and route each known wire value to the matching variant via
-/// [`serde_json::from_value`]. Any unrecognized discriminator falls through to
-/// the enum's `Unknown(serde_json::Value)` catch-all, so unknown payloads
-/// round-trip losslessly instead of failing to deserialize. This explicit
-/// dispatch avoids the greedy first-match misrouting that `#[serde(untagged)]`
-/// derives suffer when variants share a discriminator.
+/// [`serde_json::from_value`]. This explicit dispatch avoids the greedy
+/// first-match misrouting that `#[serde(untagged)]` derives suffer when variants
+/// share a discriminator.
+///
+/// Once the payload buffers into a `Value`, deserialization cannot fail. Two
+/// routes reach the enum's `Unknown(serde_json::Value)` catch-all, which holds
+/// the payload verbatim so it round-trips losslessly:
+///
+/// * an unrecognized discriminator value, through the final catch-all arm;
+/// * a recognized discriminator whose payload does not fit the selected variant
+///   — e.g. the API changes a field from an array to a string — through
+///   [`crate::serde_helpers::deserialize_or_raw`]. Field-level tolerance covers
+///   a field the API stops sending; this covers a field whose shape it changes.
 ///
 /// The macro emits **only** the `Deserialize` impl. The enum declaration, its
 /// derives/serde attributes, and its `Display` impl must remain literal source
@@ -40,13 +48,14 @@ use serde::{Deserialize, Serialize};
 /// by a wire value of it (e.g. a ClickStack chart config carries
 /// `configType: "sql"` when it is a raw-SQL config and carries no `configType`
 /// at all when it is a builder config). Such a union adds a trailing `none` arm
-/// naming the variant the key's absence selects:
+/// naming the variant the key's absence selects, plus the keys whose presence
+/// disqualifies that variant:
 ///
 /// ```ignore
 /// discriminated_union! {
 ///     ClickStackLineChartConfig, "configType" {
 ///         "sql" => ClickStackLineRawSqlChartConfig,
-///         none => ClickStackLineBuilderChartConfig,
+///         none unless "connectionId" | "sqlTemplate" => ClickStackLineBuilderChartConfig,
 ///     }
 /// }
 /// ```
@@ -54,11 +63,16 @@ use serde::{Deserialize, Serialize};
 /// The `none` arm pins two semantics:
 ///
 /// * It deliberately conflates "key absent" and "key present but not a string":
-///   both produce a `None` scrutinee, so both dispatch to the absence variant.
-/// * When the absence variant is total — every field either `Option<T>` or
-///   `#[serde(default)]`, so it cannot fail to deserialize — the arm always
-///   succeeds. `Unknown` is then reachable only via unrecognized *string*
-///   values of the key.
+///   both produce a `None` scrutinee, so both take the arm.
+/// * The `unless` keys guard against a *dropped* discriminator. A total absence
+///   variant — one that cannot fail to deserialize, because none of its fields
+///   is required — would otherwise absorb any keyless payload, silently
+///   retyping a raw-SQL config as an empty builder config and discarding its
+///   `connectionId`/`sqlTemplate`. Listing keys that only the other variants
+///   carry routes such a payload to `Unknown` instead, where it survives
+///   intact. Unknown *added* keys are not listed and stay ignored. If the spec
+///   ever gives the absence variant one of the guard keys, drop that key from
+///   the list.
 ///
 /// Without a `none` arm, an absent or non-string discriminator falls to
 /// `Unknown` through the final catch-all.
@@ -70,7 +84,7 @@ macro_rules! discriminated_union {
     (
         $enum:ident, $key:literal {
             $( $( $wire:literal )|+ => $variant:ident, )+
-            $( none => $absent:ident, )?
+            $( none unless $( $guard:literal )|+ => $absent:ident, )?
         }
     ) => {
         impl<'de> Deserialize<'de> for $enum {
@@ -81,14 +95,22 @@ macro_rules! discriminated_union {
                 let value = serde_json::Value::deserialize(deserializer)?;
                 match value.get($key).and_then(|v| v.as_str()) {
                     $(
-                        $( Some($wire) )|+ => serde_json::from_value(value)
-                            .map($enum::$variant)
-                            .map_err(serde::de::Error::custom),
+                        $( Some($wire) )|+ => Ok(
+                            crate::serde_helpers::deserialize_or_raw(value)
+                                .map($enum::$variant)
+                                .unwrap_or_else($enum::Unknown),
+                        ),
                     )+
                     $(
-                        None => serde_json::from_value(value)
-                            .map($enum::$absent)
-                            .map_err(serde::de::Error::custom),
+                        None => Ok(
+                            if [$($guard),+].iter().any(|key| value.get(key).is_some()) {
+                                $enum::Unknown(value)
+                            } else {
+                                crate::serde_helpers::deserialize_or_raw(value)
+                                    .map($enum::$absent)
+                                    .unwrap_or_else($enum::Unknown)
+                            },
+                        ),
                     )?
                     _ => Ok($enum::Unknown(value)),
                 }
@@ -2936,12 +2958,18 @@ impl std::fmt::Display for ClickPipeStatePatchRequestCommand {
 }
 
 /// Inline enum for `ClickStackAlertChannelEmail.type`.
+///
+/// The spec gives both alert-channel variants the same `enum: ["webhook",
+/// "email"]`, so `#[default]` sits on `Email` rather than on the first value:
+/// this field discriminates the `ClickStackAlertChannel` union, and defaulting
+/// it to `webhook` would make `ClickStackAlertChannelEmail::default()`
+/// deserialize back as the webhook variant.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum ClickStackAlertChannelEmailType {
     #[serde(rename = "webhook")]
-    #[default]
     Webhook,
     #[serde(rename = "email")]
+    #[default]
     Email,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
@@ -7941,8 +7969,8 @@ impl std::fmt::Display for ClickStackAlertChannel {
 /// `ClickStackBarChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackBarChartConfig {
@@ -7958,7 +7986,7 @@ pub enum ClickStackBarChartConfig {
 discriminated_union! {
     ClickStackBarChartConfig, "configType" {
         "sql" => ClickStackBarRawSqlChartConfig,
-        none => ClickStackBarBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackBarBuilderChartConfig,
     }
 }
 
@@ -7977,8 +8005,8 @@ impl std::fmt::Display for ClickStackBarChartConfig {
 /// `ClickStackCategoricalBarChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackCategoricalBarChartConfig {
@@ -7994,7 +8022,7 @@ pub enum ClickStackCategoricalBarChartConfig {
 discriminated_union! {
     ClickStackCategoricalBarChartConfig, "configType" {
         "sql" => ClickStackCategoricalBarRawSqlChartConfig,
-        none => ClickStackCategoricalBarBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackCategoricalBarBuilderChartConfig,
     }
 }
 
@@ -8065,8 +8093,8 @@ impl std::fmt::Display for ClickStackDashboardChartSeries {
 /// `ClickStackLineChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackLineChartConfig {
@@ -8082,7 +8110,7 @@ pub enum ClickStackLineChartConfig {
 discriminated_union! {
     ClickStackLineChartConfig, "configType" {
         "sql" => ClickStackLineRawSqlChartConfig,
-        none => ClickStackLineBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackLineBuilderChartConfig,
     }
 }
 
@@ -8103,8 +8131,8 @@ impl std::fmt::Display for ClickStackLineChartConfig {
 /// `ClickStackNumberChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackNumberChartConfig {
@@ -8120,7 +8148,7 @@ pub enum ClickStackNumberChartConfig {
 discriminated_union! {
     ClickStackNumberChartConfig, "configType" {
         "sql" => ClickStackNumberRawSqlChartConfig,
-        none => ClickStackNumberBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackNumberBuilderChartConfig,
     }
 }
 
@@ -8268,8 +8296,8 @@ impl std::fmt::Display for ClickStackOnClickTarget {
 /// `ClickStackPieChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackPieChartConfig {
@@ -8285,7 +8313,7 @@ pub enum ClickStackPieChartConfig {
 discriminated_union! {
     ClickStackPieChartConfig, "configType" {
         "sql" => ClickStackPieRawSqlChartConfig,
-        none => ClickStackPieBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackPieBuilderChartConfig,
     }
 }
 
@@ -8346,8 +8374,8 @@ impl std::fmt::Display for ClickStackSource {
 /// `ClickStackTableChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
-/// builder variant); see the `discriminated_union!` invocation below for the
-/// wire values.
+/// builder variant, unless the payload carries a raw-SQL-only key); see the
+/// `discriminated_union!` invocation below for the wire values.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackTableChartConfig {
@@ -8363,7 +8391,7 @@ pub enum ClickStackTableChartConfig {
 discriminated_union! {
     ClickStackTableChartConfig, "configType" {
         "sql" => ClickStackTableRawSqlChartConfig,
-        none => ClickStackTableBuilderChartConfig,
+        none unless "connectionId" | "sqlTemplate" => ClickStackTableBuilderChartConfig,
     }
 }
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -8897,121 +8897,204 @@ pub struct ByocInfrastructurePostRequest {
 /// `ClickPipe` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipe {
-    #[serde(rename = "createdAt", default)]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    #[serde(default)]
-    pub destination: ClickPipeDestination,
-    #[serde(rename = "fieldMappings", default)]
-    pub field_mappings: Vec<ClickPipeFieldMapping>,
-    #[serde(default)]
-    pub id: uuid::Uuid,
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub scaling: ClickPipeScaling,
-    #[serde(rename = "serviceId", default)]
-    pub service_id: uuid::Uuid,
-    #[serde(default)]
-    pub settings: ClickPipeSettings,
-    #[serde(default)]
-    pub source: ClickPipeSource,
-    #[serde(default)]
-    pub state: ClickPipeState,
-    #[serde(rename = "updatedAt", default)]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub destination: Option<ClickPipeDestination>,
+    #[serde(rename = "fieldMappings", skip_serializing_if = "Option::is_none")]
+    pub field_mappings: Option<Vec<ClickPipeFieldMappingResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scaling: Option<ClickPipeScalingResponse>,
+    #[serde(rename = "serviceId", skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<uuid::Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeSettingsResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<ClickPipeSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<ClickPipeState>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// `ClickPipeBigQueryPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeBigQueryPipeSettings {
-    #[serde(rename = "allowNullableColumns", default)]
+    #[serde(rename = "allowNullableColumns")]
     pub allow_nullable_columns: bool,
-    #[serde(rename = "initialLoadParallelism", default)]
+    #[serde(rename = "initialLoadParallelism")]
     pub initial_load_parallelism: f64,
-    #[serde(rename = "replicationMode", default)]
+    #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeBigQueryPipeSettingsReplicationmode,
-    #[serde(rename = "snapshotNumRowsPerPartition", default)]
+    #[serde(rename = "snapshotNumRowsPerPartition")]
     pub snapshot_num_rows_per_partition: f64,
-    #[serde(rename = "snapshotNumberOfParallelTables", default)]
+    #[serde(rename = "snapshotNumberOfParallelTables")]
     pub snapshot_number_of_parallel_tables: f64,
+}
+
+/// `ClickPipeBigQueryPipeSettings` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeBigQueryPipeSettings`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeBigQueryPipeSettingsResponse {
+    #[serde(
+        rename = "allowNullableColumns",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_nullable_columns: Option<bool>,
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub initial_load_parallelism: Option<f64>,
+    #[serde(rename = "replicationMode", skip_serializing_if = "Option::is_none")]
+    pub replication_mode: Option<ClickPipeBigQueryPipeSettingsReplicationmode>,
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_num_rows_per_partition: Option<f64>,
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_number_of_parallel_tables: Option<f64>,
 }
 
 /// `ClickPipeBigQueryPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeBigQueryPipeTableMapping {
-    #[serde(rename = "excludedColumns", default)]
+    #[serde(rename = "excludedColumns")]
     pub excluded_columns: Vec<String>,
-    #[serde(rename = "sortingKeys", default)]
+    #[serde(rename = "sortingKeys")]
     pub sorting_keys: Vec<String>,
-    #[serde(rename = "sourceDatasetName", default)]
+    #[serde(rename = "sourceDatasetName")]
     pub source_dataset_name: String,
-    #[serde(rename = "sourceTable", default)]
+    #[serde(rename = "sourceTable")]
     pub source_table: String,
-    #[serde(rename = "tableEngine", default)]
+    #[serde(rename = "tableEngine")]
     pub table_engine: ClickPipeBigQueryPipeTableMappingTableengine,
-    #[serde(rename = "targetTable", default)]
+    #[serde(rename = "targetTable")]
     pub target_table: String,
-    #[serde(rename = "useCustomSortingKey", default)]
+    #[serde(rename = "useCustomSortingKey")]
     pub use_custom_sorting_key: bool,
+}
+
+/// `ClickPipeBigQueryPipeTableMapping` from the ClickHouse Cloud API, in
+/// response position.
+///
+/// Response variant of [`ClickPipeBigQueryPipeTableMapping`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeBigQueryPipeTableMappingResponse {
+    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
+    pub excluded_columns: Option<Vec<String>>,
+    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none")]
+    pub sorting_keys: Option<Vec<String>>,
+    #[serde(rename = "sourceDatasetName", skip_serializing_if = "Option::is_none")]
+    pub source_dataset_name: Option<String>,
+    #[serde(rename = "sourceTable", skip_serializing_if = "Option::is_none")]
+    pub source_table: Option<String>,
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
+    pub table_engine: Option<ClickPipeBigQueryPipeTableMappingTableengine>,
+    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none")]
+    pub target_table: Option<String>,
+    #[serde(
+        rename = "useCustomSortingKey",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_custom_sorting_key: Option<bool>,
 }
 
 /// `ClickPipeBigQuerySource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeBigQuerySource {
-    #[serde(default)]
-    pub settings: ClickPipeBigQueryPipeSettings,
-    #[serde(rename = "snapshotStagingPath", default)]
-    pub snapshot_staging_path: String,
-    #[serde(rename = "tableMappings", default)]
-    pub table_mappings: Vec<ClickPipeBigQueryPipeTableMapping>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeBigQueryPipeSettingsResponse>,
+    #[serde(
+        rename = "snapshotStagingPath",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_staging_path: Option<String>,
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipeBigQueryPipeTableMappingResponse>>,
 }
 
 /// `ClickPipeDestination` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeDestination {
-    #[serde(default)]
-    pub columns: Vec<ClickPipeDestinationColumn>,
-    #[serde(default)]
-    pub database: String,
-    #[serde(rename = "managedTable", default)]
-    pub managed_table: bool,
-    #[serde(default)]
-    pub table: String,
-    #[serde(rename = "tableDefinition", default)]
-    pub table_definition: ClickPipeDestinationTableDefinition,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<ClickPipeDestinationColumnResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    #[serde(rename = "managedTable", skip_serializing_if = "Option::is_none")]
+    pub managed_table: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub table: Option<String>,
+    #[serde(rename = "tableDefinition", skip_serializing_if = "Option::is_none")]
+    pub table_definition: Option<ClickPipeDestinationTableDefinitionResponse>,
 }
 
 /// `ClickPipeDestinationColumn` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeDestinationColumn {
-    #[serde(default)]
     pub name: String,
-    #[serde(default)]
     pub r#type: String,
+}
+
+/// `ClickPipeDestinationColumn` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeDestinationColumn`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeDestinationColumnResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
 }
 
 /// `ClickPipeDestinationTableDefinition` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeDestinationTableDefinition {
-    #[serde(default)]
     pub engine: ClickPipeDestinationTableEngine,
     // API rejects empty strings / empty arrays for these keys. Spec has no
     // `required` array so the description-heuristic treats them as required;
     // skip at serialize time when unset instead of modeling as Option<T>.
-    #[serde(
-        rename = "partitionBy",
-        skip_serializing_if = "String::is_empty",
-        default
-    )]
+    #[serde(rename = "partitionBy", skip_serializing_if = "String::is_empty")]
     pub partition_by: String,
-    #[serde(
-        rename = "primaryKey",
-        skip_serializing_if = "String::is_empty",
-        default
-    )]
+    #[serde(rename = "primaryKey", skip_serializing_if = "String::is_empty")]
     pub primary_key: String,
-    #[serde(rename = "sortingKey", skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(rename = "sortingKey", skip_serializing_if = "Vec::is_empty")]
     pub sorting_key: Vec<String>,
+}
+
+/// `ClickPipeDestinationTableDefinition` from the ClickHouse Cloud API, in
+/// response position.
+///
+/// Response variant of [`ClickPipeDestinationTableDefinition`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeDestinationTableDefinitionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub engine: Option<ClickPipeDestinationTableEngineResponse>,
+    #[serde(rename = "partitionBy", skip_serializing_if = "Option::is_none")]
+    pub partition_by: Option<String>,
+    #[serde(rename = "primaryKey", skip_serializing_if = "Option::is_none")]
+    pub primary_key: Option<String>,
+    #[serde(rename = "sortingKey", skip_serializing_if = "Option::is_none")]
+    pub sorting_key: Option<Vec<String>>,
 }
 
 /// `ClickPipeDestinationTableEngine` from the ClickHouse Cloud API.
@@ -9021,173 +9104,206 @@ pub struct ClickPipeDestinationTableEngine {
     // rejection for MergeTree/ReplacingMergeTree/Null engines. Spec has no
     // `required` array so the heuristic treats this as required; API rejects
     // empty values despite that.
-    #[serde(rename = "columnIds", skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(rename = "columnIds", skip_serializing_if = "Vec::is_empty")]
     pub column_ids: Vec<String>,
-    #[serde(default)]
     pub r#type: ClickPipeDestinationTableEngineType,
-    #[serde(
-        rename = "versionColumnId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "versionColumnId", skip_serializing_if = "Option::is_none")]
+    pub version_column_id: Option<String>,
+}
+
+/// `ClickPipeDestinationTableEngine` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeDestinationTableEngine`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeDestinationTableEngineResponse {
+    #[serde(rename = "columnIds", skip_serializing_if = "Option::is_none")]
+    pub column_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickPipeDestinationTableEngineType>,
+    #[serde(rename = "versionColumnId", skip_serializing_if = "Option::is_none")]
     pub version_column_id: Option<String>,
 }
 
 /// `ClickPipeFieldMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeFieldMapping {
-    #[serde(rename = "destinationField", default)]
+    #[serde(rename = "destinationField")]
     pub destination_field: String,
-    #[serde(rename = "sourceField", default)]
+    #[serde(rename = "sourceField")]
     pub source_field: String,
+}
+
+/// `ClickPipeFieldMapping` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickPipeFieldMapping`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeFieldMappingResponse {
+    #[serde(rename = "destinationField", skip_serializing_if = "Option::is_none")]
+    pub destination_field: Option<String>,
+    #[serde(rename = "sourceField", skip_serializing_if = "Option::is_none")]
+    pub source_field: Option<String>,
 }
 
 /// `ClickPipeKafkaOffset` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeKafkaOffset {
-    #[serde(default)]
     pub strategy: ClickPipeKafkaOffsetStrategy,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+/// `ClickPipeKafkaOffset` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickPipeKafkaOffset`]: every field is `Option<T>`, so
+/// a field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeKafkaOffsetResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strategy: Option<ClickPipeKafkaOffsetStrategy>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 }
 
 /// `ClickPipeKafkaSchemaRegistry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeKafkaSchemaRegistry {
-    #[serde(default)]
-    pub authentication: ClickPipeKafkaSchemaRegistryAuthentication,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipeKafkaSchemaRegistryAuthentication>,
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(default)]
-    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// `ClickPipeKafkaSchemaRegistryCredentials` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeKafkaSchemaRegistryCredentials {
-    #[serde(default)]
     pub password: String,
-    #[serde(default)]
     pub username: String,
 }
 
 /// `ClickPipeKafkaSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeKafkaSource {
-    #[serde(default)]
-    pub authentication: ClickPipeKafkaSourceAuthentication,
-    #[serde(default)]
-    pub brokers: String,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipeKafkaSourceAuthentication>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub brokers: Option<String>,
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(
-        rename = "consumerGroup",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "consumerGroup", skip_serializing_if = "Option::is_none")]
     pub consumer_group: Option<String>,
-    #[serde(
-        rename = "exactlyOnce",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "exactlyOnce", skip_serializing_if = "Option::is_none")]
     pub exactly_once: Option<bool>,
-    #[serde(default)]
-    pub format: ClickPipeKafkaSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<ClickPipeKafkaSourceFormat>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub offset: Option<ClickPipeKafkaOffset>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<ClickPipeKafkaOffsetResponse>,
     #[serde(
         rename = "reversePrivateEndpointIds",
-        default,
-        deserialize_with = "crate::serde_helpers::null_to_empty"
+        skip_serializing_if = "Option::is_none"
     )]
-    pub reverse_private_endpoint_ids: Vec<String>,
-    #[serde(
-        rename = "schemaRegistry",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    pub reverse_private_endpoint_ids: Option<Vec<String>>,
+    #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none")]
     pub schema_registry: Option<ClickPipeKafkaSchemaRegistry>,
-    #[serde(default)]
-    pub topics: String,
-    #[serde(default)]
-    pub r#type: ClickPipeKafkaSourceType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topics: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickPipeKafkaSourceType>,
 }
 
 /// `ClickPipeKinesisSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeKinesisSource {
-    #[serde(default)]
-    pub authentication: ClickPipeKinesisSourceAuthentication,
-    #[serde(default)]
-    pub format: ClickPipeKinesisSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipeKinesisSourceAuthentication>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<ClickPipeKinesisSourceFormat>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(rename = "iteratorType", default)]
-    pub iterator_type: ClickPipeKinesisSourceIteratortype,
-    #[serde(default)]
-    pub region: String,
-    #[serde(rename = "streamName", default)]
-    pub stream_name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iteratorType", skip_serializing_if = "Option::is_none")]
+    pub iterator_type: Option<ClickPipeKinesisSourceIteratortype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub region: Option<String>,
+    #[serde(rename = "streamName", skip_serializing_if = "Option::is_none")]
+    pub stream_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<i64>,
-    #[serde(
-        rename = "useEnhancedFanOut",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none")]
     pub use_enhanced_fan_out: Option<bool>,
 }
 
 /// `ClickPipeMongoDBPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMongoDBPipeSettings {
-    #[serde(
-        rename = "deleteOnMerge",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none")]
     pub delete_on_merge: Option<bool>,
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
     #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeMongoDBPipeSettingsReplicationmode,
     #[serde(
         rename = "snapshotNumRowsPerPartition",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_num_rows_per_partition: Option<i64>,
     #[serde(
         rename = "snapshotNumberOfParallelTables",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
     #[serde(
         rename = "useJsonNativeFormat",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_json_native_format: Option<bool>,
+}
+
+/// `ClickPipeMongoDBPipeSettings` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeMongoDBPipeSettings`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeMongoDBPipeSettingsResponse {
+    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none")]
+    pub delete_on_merge: Option<bool>,
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
+    pub pull_batch_size: Option<i64>,
+    #[serde(rename = "replicationMode", skip_serializing_if = "Option::is_none")]
+    pub replication_mode: Option<ClickPipeMongoDBPipeSettingsReplicationmode>,
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_num_rows_per_partition: Option<i64>,
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_number_of_parallel_tables: Option<i64>,
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sync_interval_seconds: Option<i64>,
+    #[serde(
+        rename = "useJsonNativeFormat",
+        skip_serializing_if = "Option::is_none"
     )]
     pub use_json_native_format: Option<bool>,
 }
@@ -9199,62 +9315,62 @@ pub struct ClickPipeMongoDBPipeTableMapping {
     pub source_collection: String,
     #[serde(rename = "sourceDatabaseName")]
     pub source_database_name: String,
-    #[serde(
-        rename = "tableEngine",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
     pub table_engine: Option<ClickPipeMongoDBPipeTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: String,
 }
 
+/// `ClickPipeMongoDBPipeTableMapping` from the ClickHouse Cloud API, in
+/// response position.
+///
+/// Response variant of [`ClickPipeMongoDBPipeTableMapping`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeMongoDBPipeTableMappingResponse {
+    #[serde(rename = "sourceCollection", skip_serializing_if = "Option::is_none")]
+    pub source_collection: Option<String>,
+    #[serde(rename = "sourceDatabaseName", skip_serializing_if = "Option::is_none")]
+    pub source_database_name: Option<String>,
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
+    pub table_engine: Option<ClickPipeMongoDBPipeTableMappingTableengine>,
+    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none")]
+    pub target_table: Option<String>,
+}
+
 /// `ClickPipeMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMongoDBSource {
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
-    #[serde(rename = "readPreference")]
-    pub read_preference: ClickPipeMongoDBSourceReadpreference,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub settings: Option<ClickPipeMongoDBPipeSettings>,
+    #[serde(rename = "readPreference", skip_serializing_if = "Option::is_none")]
+    pub read_preference: Option<ClickPipeMongoDBSourceReadpreference>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeMongoDBPipeSettingsResponse>,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(
-        rename = "tableMappings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
-    pub table_mappings: Option<Vec<ClickPipeMongoDBPipeTableMapping>>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipeMongoDBPipeTableMappingResponse>>,
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
-    pub uri: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
 }
 
 /// `ClickPipeMutateBigQuerySource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutateBigQuerySource {
-    #[serde(default)]
     pub credentials: ServiceAccount,
-    #[serde(default)]
     pub settings: ClickPipeBigQueryPipeSettings,
-    #[serde(rename = "snapshotStagingPath", default)]
+    #[serde(rename = "snapshotStagingPath")]
     pub snapshot_staging_path: String,
-    #[serde(rename = "tableMappings", default)]
+    #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeBigQueryPipeTableMapping>,
 }
 
@@ -9266,74 +9382,49 @@ pub struct ClickPipeMutateDestination {
     // pipes (Postgres, MySQL, BigQuery)" — all four must be omitted entirely
     // for database pipes. Modeled with skip-when-empty / Option so callers can
     // build a single destination type and database pipes serialize cleanly.
-    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub columns: Vec<ClickPipeDestinationColumn>,
-    #[serde(default)]
     pub database: String,
-    #[serde(
-        rename = "managedTable",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "managedTable", skip_serializing_if = "Option::is_none")]
     pub managed_table: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub roles: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub table: Option<String>,
-    #[serde(
-        rename = "tableDefinition",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableDefinition", skip_serializing_if = "Option::is_none")]
     pub table_definition: Option<ClickPipeDestinationTableDefinition>,
 }
 
 /// `ClickPipeMutateKafkaSchemaRegistry` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutateKafkaSchemaRegistry {
-    #[serde(default)]
     pub authentication: ClickPipeMutateKafkaSchemaRegistryAuthentication,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(default)]
     pub credentials: ClickPipeKafkaSchemaRegistryCredentials,
-    #[serde(default)]
     pub url: String,
 }
 
 /// `ClickPipeMutateMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutateMongoDBSource {
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials: Option<PLAIN>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
     #[serde(rename = "readPreference")]
     pub read_preference: ClickPipeMutateMongoDBSourceReadpreference,
     pub settings: ClickPipeMongoDBPipeSettings,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeMongoDBPipeTableMapping>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
     pub uri: String,
 }
@@ -9341,83 +9432,64 @@ pub struct ClickPipeMutateMongoDBSource {
 /// `ClickPipeMutateMySQLSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutateMySQLSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipeMutateMySQLSourceAuthentication>,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials: Option<PLAIN>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
     pub host: String,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
     pub port: i64,
-    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none")]
     pub server_id: Option<i64>,
     pub settings: ClickPipeMySQLPipeSettings,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
     #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipeMySQLPipeTableMapping>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickPipeMutateMySQLSourceType>,
 }
 
 /// `ClickPipeMutatePostgresSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMutatePostgresSource {
-    #[serde(default)]
     pub authentication: ClickPipeMutatePostgresSourceAuthentication,
     // caCertificate is `undefinedOr(isValidPEMCertificate)` server-side — sending
     // `""` (the bare-String default) fails PEM validation. Modeled as
     // `Option<String>` so callers can omit it.
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(default)]
     pub credentials: PLAIN,
-    #[serde(default)]
     pub database: String,
-    #[serde(rename = "disableTls", default)]
+    #[serde(rename = "disableTls")]
     pub disable_tls: bool,
-    #[serde(default)]
     pub host: String,
     // iamRole only applies to RDS-style Postgres + IAM_ROLE auth. Spec marks
     // it required but the server rejects "" for Basic-auth Postgres. Modeled
     // as Option<String> so callers can omit it; same pattern as ca_certificate.
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(default)]
     pub port: i64,
-    #[serde(default)]
     pub settings: ClickPipePostgresPipeSettings,
-    #[serde(rename = "skipCertVerification", default)]
+    #[serde(rename = "skipCertVerification")]
     pub skip_cert_verification: bool,
-    #[serde(rename = "tableMappings", default)]
+    #[serde(rename = "tableMappings")]
     pub table_mappings: Vec<ClickPipePostgresPipeTableMapping>,
     // tlsHost is only set when the broker cert SAN doesn't match `host`.
     // Optional in practice; server rejects "" with PEM-style validation.
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickPipeMutatePostgresSourceType>,
 }
 
@@ -9426,99 +9498,141 @@ pub struct ClickPipeMutatePostgresSource {
 pub struct ClickPipeMySQLPipeSettings {
     #[serde(
         rename = "allowNullableColumns",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub allow_nullable_columns: Option<bool>,
-    #[serde(
-        rename = "deleteOnMerge",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none")]
     pub delete_on_merge: Option<bool>,
     #[serde(
         rename = "initialLoadParallelism",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub initial_load_parallelism: Option<i64>,
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
     #[serde(
         rename = "replicationMechanism",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub replication_mechanism: Option<ClickPipeMySQLPipeSettingsReplicationmechanism>,
     #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipeMySQLPipeSettingsReplicationmode,
     #[serde(
         rename = "snapshotNumRowsPerPartition",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_num_rows_per_partition: Option<i64>,
     #[serde(
         rename = "snapshotNumberOfParallelTables",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
+    #[serde(rename = "useCompression", skip_serializing_if = "Option::is_none")]
+    pub use_compression: Option<bool>,
+}
+
+/// `ClickPipeMySQLPipeSettings` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeMySQLPipeSettings`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeMySQLPipeSettingsResponse {
     #[serde(
-        rename = "useCompression",
-        skip_serializing_if = "Option::is_none",
-        default
+        rename = "allowNullableColumns",
+        skip_serializing_if = "Option::is_none"
     )]
+    pub allow_nullable_columns: Option<bool>,
+    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none")]
+    pub delete_on_merge: Option<bool>,
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub initial_load_parallelism: Option<i64>,
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
+    pub pull_batch_size: Option<i64>,
+    #[serde(
+        rename = "replicationMechanism",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replication_mechanism: Option<ClickPipeMySQLPipeSettingsReplicationmechanism>,
+    #[serde(rename = "replicationMode", skip_serializing_if = "Option::is_none")]
+    pub replication_mode: Option<ClickPipeMySQLPipeSettingsReplicationmode>,
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_num_rows_per_partition: Option<i64>,
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_number_of_parallel_tables: Option<i64>,
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sync_interval_seconds: Option<i64>,
+    #[serde(rename = "useCompression", skip_serializing_if = "Option::is_none")]
     pub use_compression: Option<bool>,
 }
 
 /// `ClickPipeMySQLPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLPipeTableMapping {
-    #[serde(
-        rename = "excludedColumns",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
     pub excluded_columns: Option<Vec<String>>,
-    #[serde(
-        rename = "partitionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
     pub partition_key: Option<String>,
-    #[serde(
-        rename = "sortingKeys",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none")]
     pub sorting_keys: Option<Vec<String>>,
     #[serde(rename = "sourceSchemaName")]
     pub source_schema_name: String,
     #[serde(rename = "sourceTable")]
     pub source_table: String,
-    #[serde(
-        rename = "tableEngine",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
     pub table_engine: Option<ClickPipeMySQLPipeTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: String,
     #[serde(
         rename = "useCustomSortingKey",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_custom_sorting_key: Option<bool>,
+}
+
+/// `ClickPipeMySQLPipeTableMapping` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipeMySQLPipeTableMapping`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeMySQLPipeTableMappingResponse {
+    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
+    pub excluded_columns: Option<Vec<String>>,
+    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
+    pub partition_key: Option<String>,
+    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none")]
+    pub sorting_keys: Option<Vec<String>>,
+    #[serde(rename = "sourceSchemaName", skip_serializing_if = "Option::is_none")]
+    pub source_schema_name: Option<String>,
+    #[serde(rename = "sourceTable", skip_serializing_if = "Option::is_none")]
+    pub source_table: Option<String>,
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
+    pub table_engine: Option<ClickPipeMySQLPipeTableMappingTableengine>,
+    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none")]
+    pub target_table: Option<String>,
+    #[serde(
+        rename = "useCustomSortingKey",
+        skip_serializing_if = "Option::is_none"
     )]
     pub use_custom_sorting_key: Option<bool>,
 }
@@ -9526,132 +9640,96 @@ pub struct ClickPipeMySQLPipeTableMapping {
 /// `ClickPipeMySQLSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeMySQLSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipeMySQLSourceAuthentication>,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
-    pub host: String,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    pub port: i64,
-    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i64>,
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none")]
     pub server_id: Option<i64>,
-    pub settings: ClickPipeMySQLPipeSettings,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipeMySQLPipeSettingsResponse>,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappings")]
-    pub table_mappings: Vec<ClickPipeMySQLPipeTableMapping>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipeMySQLPipeTableMappingResponse>>,
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickPipeMySQLSourceType>,
 }
 
 /// `ClickPipeObjectStorageSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeObjectStorageSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipeObjectStorageSourceAuthentication>,
-    #[serde(
-        rename = "azureContainerName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none")]
     pub azure_container_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compression: Option<ClickPipeObjectStorageSourceCompression>,
-    #[serde(
-        rename = "connectionString",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none")]
     pub connection_string: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
-    #[serde(default)]
-    pub format: ClickPipeObjectStorageSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<ClickPipeObjectStorageSourceFormat>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(
-        rename = "isContinuous",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "isContinuous", skip_serializing_if = "Option::is_none")]
     pub is_continuous: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none")]
     pub queue_url: Option<String>,
-    #[serde(
-        rename = "skipInitialLoad",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none")]
     pub skip_initial_load: Option<bool>,
-    #[serde(
-        rename = "startAfter",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none")]
     pub start_after: Option<String>,
-    #[serde(default)]
-    pub r#type: ClickPipeObjectStorageSourceType,
-    #[serde(default)]
-    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickPipeObjectStorageSourceType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 /// `ClickPipePatchDestination` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchDestination {
-    #[serde(default)]
     pub columns: Vec<ClickPipeDestinationColumn>,
 }
 
 /// `ClickPipePatchKafkaSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchKafkaSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipePatchKafkaSourceAuthentication>,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(default)]
     pub credentials: serde_json::Value,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(
-        rename = "reversePrivateEndpointIds",
-        default,
-        deserialize_with = "crate::serde_helpers::null_to_empty"
-    )]
+    #[serde(rename = "reversePrivateEndpointIds")]
     pub reverse_private_endpoint_ids: Vec<String>,
 }
 
 /// `ClickPipePatchKinesisSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchKinesisSource {
-    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none")]
     pub access_key: Option<MskIamUser>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipePatchKinesisSourceAuthentication>,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
 }
 
@@ -9662,11 +9740,7 @@ pub struct ClickPipePatchMongoDBPipeRemoveTableMapping {
     pub source_collection: Option<String>,
     #[serde(rename = "sourceDatabaseName")]
     pub source_database_name: Option<String>,
-    #[serde(
-        rename = "tableEngine",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
     pub table_engine: Option<ClickPipePatchMongoDBPipeRemoveTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: Option<String>,
@@ -9675,16 +9749,11 @@ pub struct ClickPipePatchMongoDBPipeRemoveTableMapping {
 /// `ClickPipePatchMongoDBPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMongoDBPipeSettings {
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
 }
@@ -9692,47 +9761,29 @@ pub struct ClickPipePatchMongoDBPipeSettings {
 /// `ClickPipePatchMongoDBSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMongoDBSource {
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials: Option<PLAIN>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
-    #[serde(
-        rename = "readPreference",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "readPreference", skip_serializing_if = "Option::is_none")]
     pub read_preference: Option<ClickPipePatchMongoDBSourceReadpreference>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<ClickPipePatchMongoDBPipeSettings>,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(
-        rename = "tableMappingsToAdd",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableMappingsToAdd", skip_serializing_if = "Option::is_none")]
     pub table_mappings_to_add: Option<Vec<ClickPipeMongoDBPipeTableMapping>>,
     #[serde(
         rename = "tableMappingsToRemove",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub table_mappings_to_remove: Option<Vec<ClickPipePatchMongoDBPipeRemoveTableMapping>>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
     pub uri: Option<String>,
 }
@@ -9740,21 +9791,13 @@ pub struct ClickPipePatchMongoDBSource {
 /// `ClickPipePatchMySQLPipeRemoveTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLPipeRemoveTableMapping {
-    #[serde(
-        rename = "partitionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
     pub partition_key: Option<String>,
     #[serde(rename = "sourceSchemaName")]
     pub source_schema_name: Option<String>,
     #[serde(rename = "sourceTable")]
     pub source_table: Option<String>,
-    #[serde(
-        rename = "tableEngine",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
     pub table_engine: Option<ClickPipePatchMySQLPipeRemoveTableMappingTableengine>,
     #[serde(rename = "targetTable")]
     pub target_table: Option<String>,
@@ -9763,172 +9806,100 @@ pub struct ClickPipePatchMySQLPipeRemoveTableMapping {
 /// `ClickPipePatchMySQLPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLPipeSettings {
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
-    #[serde(
-        rename = "useCompression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "useCompression", skip_serializing_if = "Option::is_none")]
     pub use_compression: Option<bool>,
 }
 
 /// `ClickPipePatchMySQLSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchMySQLSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipePatchMySQLSourceAuthentication>,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credentials: Option<PLAIN>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
     pub host: Option<String>,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
     pub port: Option<i64>,
-    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "serverId", skip_serializing_if = "Option::is_none")]
     pub server_id: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<ClickPipePatchMySQLPipeSettings>,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(
-        rename = "tableMappingsToAdd",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableMappingsToAdd", skip_serializing_if = "Option::is_none")]
     pub table_mappings_to_add: Option<Vec<ClickPipeMySQLPipeTableMapping>>,
     #[serde(
         rename = "tableMappingsToRemove",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub table_mappings_to_remove: Option<Vec<ClickPipePatchMySQLPipeRemoveTableMapping>>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
 }
 
 /// `ClickPipePatchObjectStorageSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchObjectStorageSource {
-    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none")]
     pub access_key: Option<MskIamUser>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipePatchObjectStorageSourceAuthentication>,
-    #[serde(
-        rename = "azureContainerName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none")]
     pub azure_container_name: Option<String>,
-    #[serde(
-        rename = "connectionString",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none")]
     pub connection_string: Option<String>,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(
-        rename = "serviceAccountKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "serviceAccountKey", skip_serializing_if = "Option::is_none")]
     pub service_account_key: Option<String>,
-    #[serde(
-        rename = "skipInitialLoad",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none")]
     pub skip_initial_load: Option<bool>,
-    #[serde(
-        rename = "startAfter",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none")]
     pub start_after: Option<String>,
 }
 
 /// `ClickPipePatchPostgresPipeRemoveTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresPipeRemoveTableMapping {
-    #[serde(
-        rename = "partitionByExpr",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "partitionByExpr", skip_serializing_if = "Option::is_none")]
     pub partition_by_expr: Option<String>,
-    #[serde(
-        rename = "partitionKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
     pub partition_key: Option<String>,
-    #[serde(
-        rename = "sourceSchemaName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sourceSchemaName", skip_serializing_if = "Option::is_none")]
     pub source_schema_name: Option<String>,
-    #[serde(
-        rename = "sourceTable",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sourceTable", skip_serializing_if = "Option::is_none")]
     pub source_table: Option<String>,
-    #[serde(
-        rename = "tableEngine",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
     pub table_engine: Option<ClickPipePatchPostgresPipeRemoveTableMappingTableengine>,
-    #[serde(
-        rename = "targetTable",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none")]
     pub target_table: Option<String>,
 }
 
 /// `ClickPipePatchPostgresPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresPipeSettings {
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
 }
@@ -9936,50 +9907,35 @@ pub struct ClickPipePatchPostgresPipeSettings {
 /// `ClickPipePatchPostgresSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPostgresSource {
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(default)]
     pub credentials: PLAIN,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
-    #[serde(
-        rename = "disableTls",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
     pub disable_tls: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<i64>,
-    #[serde(default)]
     pub settings: ClickPipePatchPostgresPipeSettings,
     #[serde(
         rename = "skipCertVerification",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub skip_cert_verification: Option<bool>,
-    #[serde(rename = "tableMappingsToAdd", default)]
+    #[serde(rename = "tableMappingsToAdd")]
     pub table_mappings_to_add: Vec<ClickPipePostgresPipeTableMapping>,
-    #[serde(rename = "tableMappingsToRemove", default)]
+    #[serde(rename = "tableMappingsToRemove")]
     pub table_mappings_to_remove: Vec<ClickPipePatchPostgresPipeRemoveTableMapping>,
-    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
     pub tls_host: Option<String>,
 }
 
 /// `ClickPipePatchPubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchPubSubSource {
-    #[serde(
-        rename = "ackDeadline",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
     pub ack_deadline: Option<i64>,
     pub authentication: Option<ClickPipePatchPubSubSourceAuthentication>,
     #[serde(rename = "serviceAccountKey")]
@@ -9989,246 +9945,165 @@ pub struct ClickPipePatchPubSubSource {
 /// `ClickPipePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub destination: Option<ClickPipePatchDestination>,
-    #[serde(
-        rename = "fieldMappings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "fieldMappings", skip_serializing_if = "Option::is_none")]
     pub field_mappings: Option<Vec<ClickPipeFieldMapping>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<ClickPipeSettings>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<ClickPipePatchSource>,
 }
 
 /// `ClickPipePatchSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePatchSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kafka: Option<ClickPipePatchKafkaSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kinesis: Option<ClickPipePatchKinesisSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mongodb: Option<ClickPipePatchMongoDBSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mysql: Option<ClickPipePatchMySQLSource>,
-    #[serde(
-        rename = "objectStorage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none")]
     pub object_storage: Option<ClickPipePatchObjectStorageSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub postgres: Option<ClickPipePatchPostgresSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pubsub: Option<ClickPipePatchPubSubSource>,
-    #[serde(rename = "validateSamples", default)]
+    #[serde(rename = "validateSamples")]
     pub validate_samples: bool,
 }
 
 /// `ClickPipePostKafkaSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostKafkaSource {
-    #[serde(default)]
     pub authentication: ClickPipePostKafkaSourceAuthentication,
-    #[serde(default)]
     pub brokers: String,
-    #[serde(
-        rename = "caCertificate",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
     pub ca_certificate: Option<String>,
-    #[serde(
-        rename = "consumerGroup",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "consumerGroup", skip_serializing_if = "Option::is_none")]
     pub consumer_group: Option<String>,
-    #[serde(default)]
     pub credentials: serde_json::Value,
-    #[serde(
-        rename = "exactlyOnce",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "exactlyOnce", skip_serializing_if = "Option::is_none")]
     pub exactly_once: Option<bool>,
-    #[serde(default)]
     pub format: ClickPipePostKafkaSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub offset: Option<ClickPipeKafkaOffset>,
-    #[serde(
-        rename = "reversePrivateEndpointIds",
-        default,
-        deserialize_with = "crate::serde_helpers::null_to_empty"
-    )]
+    #[serde(rename = "reversePrivateEndpointIds")]
     pub reverse_private_endpoint_ids: Vec<String>,
-    #[serde(
-        rename = "schemaRegistry",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "schemaRegistry", skip_serializing_if = "Option::is_none")]
     pub schema_registry: Option<ClickPipeMutateKafkaSchemaRegistry>,
-    #[serde(default)]
     pub topics: String,
-    #[serde(default)]
     pub r#type: ClickPipePostKafkaSourceType,
 }
 
 /// `ClickPipePostKinesisSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostKinesisSource {
-    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none")]
     pub access_key: Option<MskIamUser>,
-    #[serde(default)]
     pub authentication: ClickPipePostKinesisSourceAuthentication,
-    #[serde(default)]
     pub format: ClickPipePostKinesisSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(rename = "iteratorType", default)]
+    #[serde(rename = "iteratorType")]
     pub iterator_type: ClickPipePostKinesisSourceIteratortype,
-    #[serde(default)]
     pub region: String,
-    #[serde(rename = "streamName", default)]
+    #[serde(rename = "streamName")]
     pub stream_name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<i64>,
-    #[serde(
-        rename = "useEnhancedFanOut",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "useEnhancedFanOut", skip_serializing_if = "Option::is_none")]
     pub use_enhanced_fan_out: Option<bool>,
 }
 
 /// `ClickPipeSchemaDiscoveryField` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSchemaDiscoveryField {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub r#type: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub optional: Option<bool>,
 }
 
 /// `ClickPipeSchemaDiscoveryRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSchemaDiscoveryRequest {
-    #[serde(default)]
     pub source: ClickPipeSchemaDiscoverySource,
 }
 
 /// `ClickPipeSchemaDiscoveryResponse` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSchemaDiscoveryResponse {
-    #[serde(default)]
-    pub fields: Vec<ClickPipeSchemaDiscoveryField>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fields: Option<Vec<ClickPipeSchemaDiscoveryField>>,
 }
 
 /// `ClickPipeSchemaDiscoverySource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSchemaDiscoverySource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kafka: Option<ClickPipePostKafkaSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kinesis: Option<ClickPipePostKinesisSource>,
 }
 
 /// `ClickPipePostObjectStorageSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostObjectStorageSource {
-    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "accessKey", skip_serializing_if = "Option::is_none")]
     pub access_key: Option<MskIamUser>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication: Option<ClickPipePostObjectStorageSourceAuthentication>,
-    #[serde(
-        rename = "azureContainerName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "azureContainerName", skip_serializing_if = "Option::is_none")]
     pub azure_container_name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub compression: Option<ClickPipePostObjectStorageSourceCompression>,
-    #[serde(
-        rename = "connectionString",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "connectionString", skip_serializing_if = "Option::is_none")]
     pub connection_string: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
-    #[serde(default)]
     pub format: ClickPipePostObjectStorageSourceFormat,
-    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
     pub iam_role: Option<String>,
-    #[serde(
-        rename = "isContinuous",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "isContinuous", skip_serializing_if = "Option::is_none")]
     pub is_continuous: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
-    #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "queueUrl", skip_serializing_if = "Option::is_none")]
     pub queue_url: Option<String>,
-    #[serde(
-        rename = "serviceAccountKey",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "serviceAccountKey", skip_serializing_if = "Option::is_none")]
     pub service_account_key: Option<String>,
-    #[serde(
-        rename = "skipInitialLoad",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "skipInitialLoad", skip_serializing_if = "Option::is_none")]
     pub skip_initial_load: Option<bool>,
-    #[serde(
-        rename = "startAfter",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "startAfter", skip_serializing_if = "Option::is_none")]
     pub start_after: Option<String>,
-    #[serde(default)]
     pub r#type: ClickPipePostObjectStorageSourceType,
-    #[serde(default)]
     pub url: String,
 }
 
 /// `ClickPipePostPubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostPubSubSource {
-    #[serde(
-        rename = "ackDeadline",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
     pub ack_deadline: Option<i64>,
     pub authentication: ClickPipePostPubSubSourceAuthentication,
-    #[serde(
-        rename = "enableOrdering",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none")]
     pub enable_ordering: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
     pub format: ClickPipePostPubSubSourceFormat,
     #[serde(rename = "projectId")]
     pub project_id: String,
-    #[serde(
-        rename = "seekTimestamp",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none")]
     pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(rename = "seekType")]
     pub seek_type: ClickPipePostPubSubSourceSeektype,
@@ -10240,108 +10115,137 @@ pub struct ClickPipePostPubSubSource {
 /// `ClickPipePostRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostRequest {
-    #[serde(default)]
     pub destination: ClickPipeMutateDestination,
     // Empty arrays rejected by some API paths and never useful on create —
     // skip when empty. Non-Option to match the spec description heuristic.
-    #[serde(
-        rename = "fieldMappings",
-        skip_serializing_if = "Vec::is_empty",
-        default
-    )]
+    #[serde(rename = "fieldMappings", skip_serializing_if = "Vec::is_empty")]
     pub field_mappings: Vec<ClickPipeFieldMapping>,
-    #[serde(default)]
     pub name: String,
     // scaling block default-serializes as {replicas: 0, ...} which the API
     // rejects ("replicas: Not between 1 and 40"). Modeled as Option so the
     // whole block is omitted when the caller doesn't set it.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scaling: Option<ClickPipeScaling>,
     // settings default-serializes as `{}` which the API also rejects.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<ClickPipeSettings>,
-    #[serde(default)]
     pub source: ClickPipePostSource,
 }
 
 /// `ClickPipePostSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bigquery: Option<ClickPipeMutateBigQuerySource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kafka: Option<ClickPipePostKafkaSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kinesis: Option<ClickPipePostKinesisSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mongodb: Option<ClickPipeMutateMongoDBSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mysql: Option<ClickPipeMutateMySQLSource>,
-    #[serde(
-        rename = "objectStorage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none")]
     pub object_storage: Option<ClickPipePostObjectStorageSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub postgres: Option<ClickPipeMutatePostgresSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pubsub: Option<ClickPipePostPubSubSource>,
-    #[serde(rename = "validateSamples", default)]
+    #[serde(rename = "validateSamples")]
     pub validate_samples: bool,
 }
 
 /// `ClickPipePostgresPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostgresPipeSettings {
-    #[serde(rename = "allowNullableColumns", default)]
+    #[serde(rename = "allowNullableColumns")]
     pub allow_nullable_columns: bool,
-    #[serde(rename = "deleteOnMerge", default)]
+    #[serde(rename = "deleteOnMerge")]
     pub delete_on_merge: bool,
-    #[serde(rename = "enableFailoverSlots", default)]
+    #[serde(rename = "enableFailoverSlots")]
     pub enable_failover_slots: bool,
     #[serde(
         rename = "initialLoadParallelism",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub initial_load_parallelism: Option<i64>,
-    #[serde(
-        rename = "publicationName",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "publicationName", skip_serializing_if = "Option::is_none")]
     pub publication_name: Option<String>,
-    #[serde(
-        rename = "pullBatchSize",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
     pub pull_batch_size: Option<i64>,
-    #[serde(rename = "replicationMode", default)]
+    #[serde(rename = "replicationMode")]
     pub replication_mode: ClickPipePostgresPipeSettingsReplicationmode,
     #[serde(
         rename = "replicationSlotName",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub replication_slot_name: Option<String>,
     #[serde(
         rename = "snapshotNumRowsPerPartition",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_num_rows_per_partition: Option<i64>,
     #[serde(
         rename = "snapshotNumberOfParallelTables",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub snapshot_number_of_parallel_tables: Option<i64>,
     #[serde(
         rename = "syncIntervalSeconds",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sync_interval_seconds: Option<i64>,
+}
+
+/// `ClickPipePostgresPipeSettings` from the ClickHouse Cloud API, in response
+/// position.
+///
+/// Response variant of [`ClickPipePostgresPipeSettings`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostgresPipeSettingsResponse {
+    #[serde(
+        rename = "allowNullableColumns",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub allow_nullable_columns: Option<bool>,
+    #[serde(rename = "deleteOnMerge", skip_serializing_if = "Option::is_none")]
+    pub delete_on_merge: Option<bool>,
+    #[serde(
+        rename = "enableFailoverSlots",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub enable_failover_slots: Option<bool>,
+    #[serde(
+        rename = "initialLoadParallelism",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub initial_load_parallelism: Option<i64>,
+    #[serde(rename = "publicationName", skip_serializing_if = "Option::is_none")]
+    pub publication_name: Option<String>,
+    #[serde(rename = "pullBatchSize", skip_serializing_if = "Option::is_none")]
+    pub pull_batch_size: Option<i64>,
+    #[serde(rename = "replicationMode", skip_serializing_if = "Option::is_none")]
+    pub replication_mode: Option<ClickPipePostgresPipeSettingsReplicationmode>,
+    #[serde(
+        rename = "replicationSlotName",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replication_slot_name: Option<String>,
+    #[serde(
+        rename = "snapshotNumRowsPerPartition",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_num_rows_per_partition: Option<i64>,
+    #[serde(
+        rename = "snapshotNumberOfParallelTables",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub snapshot_number_of_parallel_tables: Option<i64>,
+    #[serde(
+        rename = "syncIntervalSeconds",
+        skip_serializing_if = "Option::is_none"
     )]
     pub sync_interval_seconds: Option<i64>,
 }
@@ -10349,220 +10253,291 @@ pub struct ClickPipePostgresPipeSettings {
 /// `ClickPipePostgresPipeTableMapping` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostgresPipeTableMapping {
-    #[serde(rename = "excludedColumns", default)]
+    #[serde(rename = "excludedColumns")]
     pub excluded_columns: Vec<String>,
-    #[serde(rename = "partitionByExpr", default)]
+    #[serde(rename = "partitionByExpr")]
     pub partition_by_expr: String,
-    #[serde(rename = "partitionKey", default)]
+    #[serde(rename = "partitionKey")]
     pub partition_key: String,
-    #[serde(rename = "sortingKeys", default)]
+    #[serde(rename = "sortingKeys")]
     pub sorting_keys: Vec<String>,
-    #[serde(rename = "sourceSchemaName", default)]
+    #[serde(rename = "sourceSchemaName")]
     pub source_schema_name: String,
-    #[serde(rename = "sourceTable", default)]
+    #[serde(rename = "sourceTable")]
     pub source_table: String,
-    #[serde(rename = "tableEngine", default)]
+    #[serde(rename = "tableEngine")]
     pub table_engine: ClickPipePostgresPipeTableMappingTableengine,
-    #[serde(rename = "targetTable", default)]
+    #[serde(rename = "targetTable")]
     pub target_table: String,
-    #[serde(rename = "useCustomSortingKey", default)]
+    #[serde(rename = "useCustomSortingKey")]
     pub use_custom_sorting_key: bool,
+}
+
+/// `ClickPipePostgresPipeTableMapping` from the ClickHouse Cloud API, in
+/// response position.
+///
+/// Response variant of [`ClickPipePostgresPipeTableMapping`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipePostgresPipeTableMappingResponse {
+    #[serde(rename = "excludedColumns", skip_serializing_if = "Option::is_none")]
+    pub excluded_columns: Option<Vec<String>>,
+    #[serde(rename = "partitionByExpr", skip_serializing_if = "Option::is_none")]
+    pub partition_by_expr: Option<String>,
+    #[serde(rename = "partitionKey", skip_serializing_if = "Option::is_none")]
+    pub partition_key: Option<String>,
+    #[serde(rename = "sortingKeys", skip_serializing_if = "Option::is_none")]
+    pub sorting_keys: Option<Vec<String>>,
+    #[serde(rename = "sourceSchemaName", skip_serializing_if = "Option::is_none")]
+    pub source_schema_name: Option<String>,
+    #[serde(rename = "sourceTable", skip_serializing_if = "Option::is_none")]
+    pub source_table: Option<String>,
+    #[serde(rename = "tableEngine", skip_serializing_if = "Option::is_none")]
+    pub table_engine: Option<ClickPipePostgresPipeTableMappingTableengine>,
+    #[serde(rename = "targetTable", skip_serializing_if = "Option::is_none")]
+    pub target_table: Option<String>,
+    #[serde(
+        rename = "useCustomSortingKey",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_custom_sorting_key: Option<bool>,
 }
 
 /// `ClickPipePostgresSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePostgresSource {
-    #[serde(default)]
-    pub authentication: ClickPipePostgresSourceAuthentication,
-    #[serde(rename = "caCertificate", default)]
-    pub ca_certificate: String,
-    #[serde(default)]
-    pub database: String,
-    #[serde(rename = "disableTls", default)]
-    pub disable_tls: bool,
-    #[serde(default)]
-    pub host: String,
-    #[serde(rename = "iamRole", default)]
-    pub iam_role: String,
-    #[serde(default)]
-    pub port: i64,
-    #[serde(default)]
-    pub settings: ClickPipePostgresPipeSettings,
-    #[serde(rename = "skipCertVerification", default)]
-    pub skip_cert_verification: bool,
-    #[serde(rename = "tableMappings", default)]
-    pub table_mappings: Vec<ClickPipePostgresPipeTableMapping>,
-    #[serde(rename = "tlsHost", default)]
-    pub tls_host: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipePostgresSourceAuthentication>,
+    #[serde(rename = "caCertificate", skip_serializing_if = "Option::is_none")]
+    pub ca_certificate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database: Option<String>,
+    #[serde(rename = "disableTls", skip_serializing_if = "Option::is_none")]
+    pub disable_tls: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    #[serde(rename = "iamRole", skip_serializing_if = "Option::is_none")]
+    pub iam_role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub port: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<ClickPipePostgresPipeSettingsResponse>,
+    #[serde(
+        rename = "skipCertVerification",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub skip_cert_verification: Option<bool>,
+    #[serde(rename = "tableMappings", skip_serializing_if = "Option::is_none")]
+    pub table_mappings: Option<Vec<ClickPipePostgresPipeTableMappingResponse>>,
+    #[serde(rename = "tlsHost", skip_serializing_if = "Option::is_none")]
+    pub tls_host: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickPipePostgresSourceType>,
 }
 
 /// `ClickPipePubSubSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipePubSubSource {
-    #[serde(
-        rename = "ackDeadline",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "ackDeadline", skip_serializing_if = "Option::is_none")]
     pub ack_deadline: Option<i64>,
-    pub authentication: ClickPipePubSubSourceAuthentication,
-    #[serde(
-        rename = "enableOrdering",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authentication: Option<ClickPipePubSubSourceAuthentication>,
+    #[serde(rename = "enableOrdering", skip_serializing_if = "Option::is_none")]
     pub enable_ordering: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filter: Option<String>,
-    pub format: ClickPipePubSubSourceFormat,
-    #[serde(rename = "projectId")]
-    pub project_id: String,
-    #[serde(
-        rename = "seekTimestamp",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub format: Option<ClickPipePubSubSourceFormat>,
+    #[serde(rename = "projectId", skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
+    #[serde(rename = "seekTimestamp", skip_serializing_if = "Option::is_none")]
     pub seek_timestamp: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(rename = "seekType")]
-    pub seek_type: ClickPipePubSubSourceSeektype,
-    pub topic: String,
+    #[serde(rename = "seekType", skip_serializing_if = "Option::is_none")]
+    pub seek_type: Option<ClickPipePubSubSourceSeektype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
 }
 
 /// `ClickPipeScaling` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeScaling {
     #[cfg(feature = "deprecated-fields")]
-    #[serde(default)]
     pub concurrency: i64,
-    #[serde(rename = "replicaCpuMillicores", default)]
+    #[serde(rename = "replicaCpuMillicores")]
     pub replica_cpu_millicores: i64,
-    #[serde(rename = "replicaMemoryGb", default)]
+    #[serde(rename = "replicaMemoryGb")]
     pub replica_memory_gb: f64,
-    #[serde(default)]
     pub replicas: i64,
+}
+
+/// `ClickPipeScaling` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickPipeScaling`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeScalingResponse {
+    #[cfg(feature = "deprecated-fields")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<i64>,
+    #[serde(
+        rename = "replicaCpuMillicores",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replica_cpu_millicores: Option<i64>,
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub replica_memory_gb: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replicas: Option<i64>,
 }
 
 /// `ClickPipeScalingPatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeScalingPatchRequest {
     #[cfg(feature = "deprecated-fields")]
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<i64>,
     #[serde(
         rename = "replicaCpuMillicores",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub replica_cpu_millicores: Option<i64>,
-    #[serde(
-        rename = "replicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub replica_memory_gb: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub replicas: Option<i64>,
 }
 
 /// `ClickPipeSettings` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSettings {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_download_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_insert_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_min_insert_block_size_bytes: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_distributed_insert_select: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_view_processing: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_concurrency: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_max_file_count: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_max_insert_bytes: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_polling_interval_ms: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_use_cluster_function: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming_max_insert_wait_ms: Option<i64>,
+}
+
+/// `ClickPipeSettings` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickPipeSettings`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickPipeSettingsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_max_download_threads: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_max_insert_threads: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_max_threads: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_min_insert_block_size_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_parallel_distributed_insert_select: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clickhouse_parallel_view_processing: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_storage_concurrency: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_storage_max_file_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_storage_max_insert_bytes: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_storage_polling_interval_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_storage_use_cluster_function: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub streaming_max_insert_wait_ms: Option<i64>,
 }
 
 /// `ClickPipeSettingsPutRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSettingsPutRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_download_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_insert_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_max_threads: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_min_insert_block_size_bytes: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_distributed_insert_select: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub clickhouse_parallel_view_processing: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_concurrency: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_max_file_count: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_max_insert_bytes: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_polling_interval_ms: Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub object_storage_use_cluster_function: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub streaming_max_insert_wait_ms: Option<i64>,
 }
 
 /// `ClickPipeSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeSource {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bigquery: Option<ClickPipeBigQuerySource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kafka: Option<ClickPipeKafkaSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kinesis: Option<ClickPipeKinesisSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mongodb: Option<ClickPipeMongoDBSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mysql: Option<ClickPipeMySQLSource>,
-    #[serde(
-        rename = "objectStorage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "objectStorage", skip_serializing_if = "Option::is_none")]
     pub object_storage: Option<ClickPipeObjectStorageSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub postgres: Option<ClickPipePostgresSource>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pubsub: Option<ClickPipePubSubSource>,
 }
 
 /// `ClickPipeStatePatchRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipeStatePatchRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<ClickPipeStatePatchRequestCommand>,
 }
 
 /// `ClickPipesCdcScaling` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickPipesCdcScaling {
-    #[serde(rename = "replicaCpuMillicores", default)]
-    pub replica_cpu_millicores: i64,
-    #[serde(rename = "replicaMemoryGb", default)]
-    pub replica_memory_gb: f64,
+    #[serde(
+        rename = "replicaCpuMillicores",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub replica_cpu_millicores: Option<i64>,
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
+    pub replica_memory_gb: Option<f64>,
 }
 
 /// `ClickPipesCdcScalingPatchRequest` from the ClickHouse Cloud API.
@@ -10570,15 +10545,10 @@ pub struct ClickPipesCdcScaling {
 pub struct ClickPipesCdcScalingPatchRequest {
     #[serde(
         rename = "replicaCpuMillicores",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub replica_cpu_millicores: Option<i64>,
-    #[serde(
-        rename = "replicaMemoryGb",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "replicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub replica_memory_gb: Option<f64>,
 }
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -8371,6 +8371,60 @@ impl std::fmt::Display for ClickStackSource {
     }
 }
 
+/// `ClickStackSource` - one of multiple variants, in response position.
+///
+/// Response variant of [`ClickStackSource`]: each arm is the all-`Option`
+/// response variant of its request struct, so a field the API drops or sends as
+/// `null` deserializes to `None` instead of failing.
+///
+/// Dispatched on the `kind` field, exactly as the request union is: dispatch
+/// reads the raw JSON rather than trying each variant's shape, so all-`Option`
+/// arms — which would match any object under `untagged` matching — cannot
+/// misroute a payload. A `kind` this crate does not know, or a payload that does
+/// not fit the variant its `kind` selects, lands in `Unknown` with the raw JSON
+/// intact.
+///
+/// Deliberately has no `Default`: every arm's default would serialize to `{}`,
+/// which carries no `kind` and so would not deserialize back to the same
+/// variant. Build a [`ClickStackSource`] instead when writing.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum ClickStackSourceResponse {
+    ClickStackLogSource(ClickStackLogSourceResponse),
+    ClickStackTraceSource(ClickStackTraceSourceResponse),
+    ClickStackMetricSource(ClickStackMetricSourceResponse),
+    ClickStackSessionSource(ClickStackSessionSourceResponse),
+    ClickStackPromqlSource(ClickStackPromqlSourceResponse),
+    /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
+    Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackSourceResponse, "kind" {
+        "log" => ClickStackLogSource,
+        "trace" => ClickStackTraceSource,
+        "metric" => ClickStackMetricSource,
+        "session" => ClickStackSessionSource,
+        "promql" => ClickStackPromqlSource,
+    }
+}
+
+impl std::fmt::Display for ClickStackSourceResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ClickStackLogSource(_) => write!(f, "ClickStackLogSource"),
+            Self::ClickStackTraceSource(_) => write!(f, "ClickStackTraceSource"),
+            Self::ClickStackMetricSource(_) => write!(f, "ClickStackMetricSource"),
+            Self::ClickStackSessionSource(_) => write!(f, "ClickStackSessionSource"),
+            Self::ClickStackPromqlSource(_) => write!(f, "ClickStackPromqlSource"),
+            Self::Unknown(s) => write!(f, "{s}"),
+        }
+    }
+}
+
 /// `ClickStackTableChartConfig` - one of multiple variants.
 ///
 /// Dispatched on the `configType` field (absent or non-string dispatches to the
@@ -10559,11 +10613,22 @@ pub struct ClickStackAggregatedColumn {
     pub agg_fn: String,
     #[serde(rename = "mvColumn")]
     pub mv_column: String,
-    #[serde(
-        rename = "sourceColumn",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sourceColumn", skip_serializing_if = "Option::is_none")]
+    pub source_column: Option<String>,
+}
+
+/// `ClickStackAggregatedColumn` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackAggregatedColumn`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackAggregatedColumnResponse {
+    #[serde(rename = "aggFn", skip_serializing_if = "Option::is_none")]
+    pub agg_fn: Option<String>,
+    #[serde(rename = "mvColumn", skip_serializing_if = "Option::is_none")]
+    pub mv_column: Option<String>,
+    #[serde(rename = "sourceColumn", skip_serializing_if = "Option::is_none")]
     pub source_column: Option<String>,
 }
 
@@ -10776,13 +10841,32 @@ pub struct ClickStackBetweenColorCondition {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCASLPermission {
     pub action: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub conditions: Option<ClickStackCASLPermissionConditions>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub integration: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub inverted: Option<bool>,
     pub subject: String,
+}
+
+/// `ClickStackCASLPermission` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackCASLPermission`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackCASLPermissionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<ClickStackCASLPermissionConditions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub integration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inverted: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
 }
 
 /// `ClickStackCategoricalBarBuilderChartConfig` from the ClickHouse Cloud API.
@@ -10830,28 +10914,33 @@ pub struct ClickStackCategoricalBarRawSqlChartConfig {
 }
 
 /// `ClickStackConnection` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackConnection {
-    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub host: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
     #[serde(
         rename = "hyperdxSettingPrefix",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub hyperdx_setting_prefix: Option<String>,
-    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     #[serde(
         rename = "isPrometheusEndpoint",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub is_prometheus_endpoint: Option<bool>,
-    pub name: String,
-    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
-    pub username: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
 }
 
 /// `ClickStackCreateAlertRequest` from the ClickHouse Cloud API.
@@ -10921,18 +11010,16 @@ pub struct ClickStackCreateConnectionRequest {
     pub host: String,
     #[serde(
         rename = "hyperdxSettingPrefix",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub hyperdx_setting_prefix: Option<String>,
     #[serde(
         rename = "isPrometheusEndpoint",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub is_prometheus_endpoint: Option<bool>,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
     pub username: String,
 }
@@ -10971,7 +11058,7 @@ pub struct ClickStackCreateDashboardRequest {
 /// `ClickStackCreateRoleRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCreateRoleRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub name: String,
     pub permissions: Vec<ClickStackCASLPermission>,
@@ -11004,7 +11091,7 @@ pub struct ClickStackDashboardResponse {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub containers: Option<Vec<ClickStackDashboardContainer>>,
     #[serde(default)]
-    pub filters: Vec<ClickStackFilter>,
+    pub filters: Vec<ClickStackFilterResponse>,
     #[serde(default)]
     pub id: String,
     #[serde(default)]
@@ -11014,7 +11101,7 @@ pub struct ClickStackDashboardResponse {
         skip_serializing_if = "Option::is_none",
         default
     )]
-    pub saved_filter_values: Option<Vec<ClickStackSavedFilterValue>>,
+    pub saved_filter_values: Option<Vec<ClickStackSavedFilterValueResponse>>,
     #[serde(
         rename = "savedQuery",
         skip_serializing_if = "Option::is_none",
@@ -11066,61 +11153,64 @@ pub struct ClickStackEventPatternsChartConfig {
 /// `ClickStackFilter` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilter {
-    #[serde(
-        rename = "appliesToSourceIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
     pub applies_to_source_ids: Option<Vec<String>>,
     pub expression: String,
     pub id: String,
     pub name: String,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(
-        rename = "sourceMetricType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sourceMetricType", skip_serializing_if = "Option::is_none")]
     pub source_metric_type: Option<ClickStackFilterSourcemetrictype>,
     pub r#type: ClickStackFilterType,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
+    pub where_language: Option<ClickStackFilterWherelanguage>,
+}
+
+/// `ClickStackFilter` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackFilter`]: every field is `Option<T>`, so a
+/// field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackFilterResponse {
+    #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
+    pub applies_to_source_ids: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(rename = "sourceMetricType", skip_serializing_if = "Option::is_none")]
+    pub source_metric_type: Option<ClickStackFilterSourcemetrictype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackFilterType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#where: Option<String>,
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackFilterWherelanguage>,
 }
 
 /// `ClickStackFilterInput` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackFilterInput {
-    #[serde(
-        rename = "appliesToSourceIds",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "appliesToSourceIds", skip_serializing_if = "Option::is_none")]
     pub applies_to_source_ids: Option<Vec<String>>,
     pub expression: String,
     pub name: String,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(
-        rename = "sourceMetricType",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sourceMetricType", skip_serializing_if = "Option::is_none")]
     pub source_metric_type: Option<ClickStackFilterInputSourcemetrictype>,
     pub r#type: ClickStackFilterInputType,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackFilterInputWherelanguage>,
 }
 
@@ -11129,6 +11219,19 @@ pub struct ClickStackFilterInput {
 pub struct ClickStackFilterSettingsColumn {
     pub label: String,
     pub name: String,
+}
+
+/// `ClickStackFilterSettingsColumn` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackFilterSettingsColumn`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackFilterSettingsColumnResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
 }
 
 /// `ClickStackGenericWebhook` from the ClickHouse Cloud API.
@@ -11195,16 +11298,27 @@ pub struct ClickStackHeatmapSelectItem {
 /// `ClickStackHighlightedAttributeExpression` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackHighlightedAttributeExpression {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
-    #[serde(
-        rename = "luceneExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "luceneExpression", skip_serializing_if = "Option::is_none")]
     pub lucene_expression: Option<String>,
     #[serde(rename = "sqlExpression")]
     pub sql_expression: String,
+}
+
+/// `ClickStackHighlightedAttributeExpression` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackHighlightedAttributeExpression`]: every
+/// field is `Option<T>`, so a field the API drops or sends as `null`
+/// deserializes to `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackHighlightedAttributeExpressionResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alias: Option<String>,
+    #[serde(rename = "luceneExpression", skip_serializing_if = "Option::is_none")]
+    pub lucene_expression: Option<String>,
+    #[serde(rename = "sqlExpression", skip_serializing_if = "Option::is_none")]
+    pub sql_expression: Option<String>,
 }
 
 /// `ClickStackIncidentIOWebhook` from the ClickHouse Cloud API.
@@ -11308,134 +11422,198 @@ pub struct ClickStackLineRawSqlChartConfig {
 /// `ClickStackLogSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLogSource {
-    #[serde(
-        rename = "bodyExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "bodyExpression", skip_serializing_if = "Option::is_none")]
     pub body_expression: Option<String>,
     pub connection: String,
     #[serde(rename = "defaultTableSelectExpression")]
     pub default_table_select_expression: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
     #[serde(
         rename = "displayedTimestampValueExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub displayed_timestamp_value_expression: Option<String>,
     #[serde(
         rename = "eventAttributesExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub event_attributes_expression: Option<String>,
-    #[serde(
-        rename = "filterSettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none")]
     pub filter_settings: Option<ClickStackSourceFilterSettings>,
     pub from: ClickStackSourceFrom,
     #[serde(
         rename = "highlightedRowAttributeExpressions",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub highlighted_row_attribute_expressions:
         Option<Vec<ClickStackHighlightedAttributeExpression>>,
     #[serde(
         rename = "highlightedTraceAttributeExpressions",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub highlighted_trace_attribute_expressions:
         Option<Vec<ClickStackHighlightedAttributeExpression>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(
         rename = "implicitColumnExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub implicit_column_expression: Option<String>,
     pub kind: ClickStackLogSourceKind,
     #[serde(
         rename = "knownColumnsListExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub known_columns_list_expression: Option<String>,
-    #[serde(
-        rename = "materializedViews",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none")]
     pub materialized_views: Option<Vec<ClickStackMaterializedView>>,
     #[serde(
         rename = "metadataMaterializedViews",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub metadata_materialized_views: Option<ClickStackLogSourceMetadataMaterializedViews>,
-    #[serde(
-        rename = "metricSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none")]
     pub metric_source_id: Option<String>,
     pub name: String,
-    #[serde(
-        rename = "querySettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
     #[serde(
         rename = "resourceAttributesExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub resource_attributes_expression: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
     #[serde(
         rename = "serviceNameExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub service_name_expression: Option<String>,
     #[serde(
         rename = "severityTextExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub severity_text_expression: Option<String>,
-    #[serde(
-        rename = "spanIdExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "spanIdExpression", skip_serializing_if = "Option::is_none")]
     pub span_id_expression: Option<String>,
     #[serde(rename = "timestampValueExpression")]
     pub timestamp_value_expression: String,
-    #[serde(
-        rename = "traceIdExpression",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "traceIdExpression", skip_serializing_if = "Option::is_none")]
     pub trace_id_expression: Option<String>,
-    #[serde(
-        rename = "traceSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "traceSourceId", skip_serializing_if = "Option::is_none")]
     pub trace_source_id: Option<String>,
     #[serde(
         rename = "useTextIndexForImplicitColumn",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_text_index_for_implicit_column:
+        Option<ClickStackLogSourceUsetextindexforimplicitcolumn>,
+}
+
+/// `ClickStackLogSource` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackLogSource`]: every field is `Option<T>`, so
+/// a field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackLogSourceResponse {
+    #[serde(rename = "bodyExpression", skip_serializing_if = "Option::is_none")]
+    pub body_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    #[serde(
+        rename = "defaultTableSelectExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_table_select_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    #[serde(
+        rename = "displayedTimestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub displayed_timestamp_value_expression: Option<String>,
+    #[serde(
+        rename = "eventAttributesExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub event_attributes_expression: Option<String>,
+    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none")]
+    pub filter_settings: Option<ClickStackSourceFilterSettingsResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<ClickStackSourceFromResponse>,
+    #[serde(
+        rename = "highlightedRowAttributeExpressions",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub highlighted_row_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpressionResponse>>,
+    #[serde(
+        rename = "highlightedTraceAttributeExpressions",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub highlighted_trace_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpressionResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "implicitColumnExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub implicit_column_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackLogSourceKind>,
+    #[serde(
+        rename = "knownColumnsListExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub known_columns_list_expression: Option<String>,
+    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none")]
+    pub materialized_views: Option<Vec<ClickStackMaterializedViewResponse>>,
+    #[serde(
+        rename = "metadataMaterializedViews",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub metadata_materialized_views: Option<ClickStackLogSourceMetadataMaterializedViewsResponse>,
+    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none")]
+    pub metric_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
+    pub query_settings: Option<Vec<ClickStackQuerySettingResponse>>,
+    #[serde(
+        rename = "resourceAttributesExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resource_attributes_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(
+        rename = "serviceNameExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_name_expression: Option<String>,
+    #[serde(
+        rename = "severityTextExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub severity_text_expression: Option<String>,
+    #[serde(rename = "spanIdExpression", skip_serializing_if = "Option::is_none")]
+    pub span_id_expression: Option<String>,
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp_value_expression: Option<String>,
+    #[serde(rename = "traceIdExpression", skip_serializing_if = "Option::is_none")]
+    pub trace_id_expression: Option<String>,
+    #[serde(rename = "traceSourceId", skip_serializing_if = "Option::is_none")]
+    pub trace_source_id: Option<String>,
+    #[serde(
+        rename = "useTextIndexForImplicitColumn",
+        skip_serializing_if = "Option::is_none"
     )]
     pub use_text_index_for_implicit_column:
         Option<ClickStackLogSourceUsetextindexforimplicitcolumn>,
@@ -11444,12 +11622,26 @@ pub struct ClickStackLogSource {
 /// `ClickStackLogSourceMetadataMaterializedViews` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackLogSourceMetadataMaterializedViews {
-    #[serde(default)]
     pub granularity: String,
-    #[serde(rename = "keyRollupTable", default)]
+    #[serde(rename = "keyRollupTable")]
     pub key_rollup_table: String,
-    #[serde(rename = "kvRollupTable", default)]
+    #[serde(rename = "kvRollupTable")]
     pub kv_rollup_table: String,
+}
+
+/// `ClickStackLogSourceMetadataMaterializedViews` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackLogSourceMetadataMaterializedViews`]: every
+/// field is `Option<T>`, so a field the API drops or sends as `null`
+/// deserializes to `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackLogSourceMetadataMaterializedViewsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<String>,
+    #[serde(rename = "keyRollupTable", skip_serializing_if = "Option::is_none")]
+    pub key_rollup_table: Option<String>,
+    #[serde(rename = "kvRollupTable", skip_serializing_if = "Option::is_none")]
+    pub kv_rollup_table: Option<String>,
 }
 
 /// `ClickStackMarkdownChartConfig` from the ClickHouse Cloud API.
@@ -11477,7 +11669,7 @@ pub struct ClickStackMaterializedView {
     pub database_name: String,
     #[serde(rename = "dimensionColumns")]
     pub dimension_columns: String,
-    #[serde(rename = "minDate", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "minDate", skip_serializing_if = "Option::is_none")]
     pub min_date: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(rename = "minGranularity")]
     pub min_granularity: ClickStackMaterializedViewMingranularity,
@@ -11487,37 +11679,91 @@ pub struct ClickStackMaterializedView {
     pub timestamp_column: String,
 }
 
+/// `ClickStackMaterializedView` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackMaterializedView`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackMaterializedViewResponse {
+    #[serde(rename = "aggregatedColumns", skip_serializing_if = "Option::is_none")]
+    pub aggregated_columns: Option<Vec<ClickStackAggregatedColumnResponse>>,
+    #[serde(rename = "databaseName", skip_serializing_if = "Option::is_none")]
+    pub database_name: Option<String>,
+    #[serde(rename = "dimensionColumns", skip_serializing_if = "Option::is_none")]
+    pub dimension_columns: Option<String>,
+    #[serde(rename = "minDate", skip_serializing_if = "Option::is_none")]
+    pub min_date: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(rename = "minGranularity", skip_serializing_if = "Option::is_none")]
+    pub min_granularity: Option<ClickStackMaterializedViewMingranularity>,
+    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none")]
+    pub table_name: Option<String>,
+    #[serde(rename = "timestampColumn", skip_serializing_if = "Option::is_none")]
+    pub timestamp_column: Option<String>,
+}
+
 /// `ClickStackMetricSource` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackMetricSource {
     pub connection: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
     pub from: ClickStackMetricSourceFrom,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub kind: ClickStackMetricSourceKind,
-    #[serde(
-        rename = "logSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none")]
     pub log_source_id: Option<String>,
     #[serde(rename = "metricTables")]
     pub metric_tables: ClickStackMetricTables,
     pub name: String,
-    #[serde(
-        rename = "querySettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
     #[serde(rename = "resourceAttributesExpression")]
     pub resource_attributes_expression: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
     #[serde(rename = "timestampValueExpression")]
     pub timestamp_value_expression: String,
+}
+
+/// `ClickStackMetricSource` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackMetricSource`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackMetricSourceResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<ClickStackMetricSourceFromResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackMetricSourceKind>,
+    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none")]
+    pub log_source_id: Option<String>,
+    #[serde(rename = "metricTables", skip_serializing_if = "Option::is_none")]
+    pub metric_tables: Option<ClickStackMetricTablesResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
+    pub query_settings: Option<Vec<ClickStackQuerySettingResponse>>,
+    #[serde(
+        rename = "resourceAttributesExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resource_attributes_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp_value_expression: Option<String>,
 }
 
 /// `ClickStackMetricSourceFrom` from the ClickHouse Cloud API.
@@ -11525,23 +11771,54 @@ pub struct ClickStackMetricSource {
 pub struct ClickStackMetricSourceFrom {
     #[serde(rename = "databaseName")]
     pub database_name: String,
-    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none")]
+    pub table_name: Option<String>,
+}
+
+/// `ClickStackMetricSourceFrom` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackMetricSourceFrom`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackMetricSourceFromResponse {
+    #[serde(rename = "databaseName", skip_serializing_if = "Option::is_none")]
+    pub database_name: Option<String>,
+    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none")]
     pub table_name: Option<String>,
 }
 
 /// `ClickStackMetricTables` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackMetricTables {
-    #[serde(rename = "exponential histogram", default)]
+    #[serde(rename = "exponential histogram")]
     pub exponential_histogram: String,
-    #[serde(default)]
     pub gauge: String,
-    #[serde(default)]
     pub histogram: String,
-    #[serde(default)]
     pub sum: String,
-    #[serde(default)]
     pub summary: String,
+}
+
+/// `ClickStackMetricTables` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackMetricTables`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackMetricTablesResponse {
+    #[serde(
+        rename = "exponential histogram",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub exponential_histogram: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gauge: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub histogram: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sum: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
 }
 
 /// `ClickStackNumberBuilderChartConfig` from the ClickHouse Cloud API.
@@ -11804,23 +12081,49 @@ pub struct ClickStackPieRawSqlChartConfig {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPromqlSource {
     pub connection: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
     pub from: ClickStackSourceFrom,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub kind: ClickStackPromqlSourceKind,
     pub name: String,
-    #[serde(
-        rename = "querySettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
     #[serde(rename = "timestampValueExpression")]
     pub timestamp_value_expression: String,
+}
+
+/// `ClickStackPromqlSource` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackPromqlSource`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackPromqlSourceResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<ClickStackSourceFromResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackPromqlSourceKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
+    pub query_settings: Option<Vec<ClickStackQuerySettingResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp_value_expression: Option<String>,
 }
 
 /// `ClickStackQuerySetting` from the ClickHouse Cloud API.
@@ -11830,19 +12133,38 @@ pub struct ClickStackQuerySetting {
     pub value: String,
 }
 
+/// `ClickStackQuerySetting` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackQuerySetting`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackQuerySettingResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub setting: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+}
+
 /// `ClickStackRole` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackRole {
-    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    pub id: String,
-    #[serde(rename = "isPredefined")]
-    pub is_predefined: bool,
-    pub name: String,
-    pub permissions: Vec<ClickStackCASLPermission>,
-    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "isPredefined", skip_serializing_if = "Option::is_none")]
+    pub is_predefined: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<Vec<ClickStackCASLPermissionResponse>>,
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -11850,38 +12172,52 @@ pub struct ClickStackRole {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSavedFilterValue {
     pub condition: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackSavedFilterValueType>,
+}
+
+/// `ClickStackSavedFilterValue` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSavedFilterValue`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSavedFilterValueResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickStackSavedFilterValueType>,
 }
 
 /// `ClickStackSavedSearch` from the ClickHouse Cloud API.
+///
+/// Used in response position only: every field is `Option<T>`, so a field the
+/// API drops or sends as `null` deserializes to `None` instead of failing.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSavedSearch {
-    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "createdAt", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub filters: Option<Vec<ClickStackSavedSearchFilter>>,
-    pub id: String,
-    pub name: String,
-    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<Vec<ClickStackSavedSearchFilterResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
     pub order_by: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub select: Option<String>,
-    #[serde(rename = "sourceId")]
-    pub source_id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none")]
+    pub source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "teamId", skip_serializing_if = "Option::is_none")]
     pub team_id: Option<String>,
-    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "updatedAt", skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackSavedSearchWherelanguage>,
 }
 
@@ -11889,31 +12225,40 @@ pub struct ClickStackSavedSearch {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSavedSearchFilter {
     pub condition: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub r#type: Option<ClickStackSavedSearchFilterType>,
+}
+
+/// `ClickStackSavedSearchFilter` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSavedSearchFilter`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSavedSearchFilterResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#type: Option<ClickStackSavedSearchFilterType>,
 }
 
 /// `ClickStackSavedSearchInput` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSavedSearchInput {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<Vec<ClickStackSavedSearchFilter>>,
     pub name: String,
-    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none")]
     pub order_by: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub select: Option<String>,
     #[serde(rename = "sourceId")]
     pub source_id: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub r#where: Option<String>,
-    #[serde(
-        rename = "whereLanguage",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "whereLanguage", skip_serializing_if = "Option::is_none")]
     pub where_language: Option<ClickStackSavedSearchInputWherelanguage>,
 }
 
@@ -11996,29 +12341,56 @@ pub struct ClickStackSelectItem {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSessionSource {
     pub connection: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
     pub from: ClickStackSourceFrom,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     pub kind: ClickStackSessionSourceKind,
     pub name: String,
-    #[serde(
-        rename = "querySettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
     #[serde(
         rename = "timestampValueExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub timestamp_value_expression: Option<String>,
     #[serde(rename = "traceSourceId")]
     pub trace_source_id: String,
+}
+
+/// `ClickStackSessionSource` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSessionSource`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSessionSourceResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<ClickStackSourceFromResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackSessionSourceKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
+    pub query_settings: Option<Vec<ClickStackQuerySettingResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp_value_expression: Option<String>,
+    #[serde(rename = "traceSourceId", skip_serializing_if = "Option::is_none")]
+    pub trace_source_id: Option<String>,
 }
 
 /// `ClickStackSlackAPIWebhook` from the ClickHouse Cloud API.
@@ -12063,6 +12435,21 @@ pub struct ClickStackSourceFilterSettings {
     pub table_name: String,
 }
 
+/// `ClickStackSourceFilterSettings` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSourceFilterSettings`]: every field is
+/// `Option<T>`, so a field the API drops or sends as `null` deserializes to
+/// `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSourceFilterSettingsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<Vec<ClickStackFilterSettingsColumnResponse>>,
+    #[serde(rename = "databaseName", skip_serializing_if = "Option::is_none")]
+    pub database_name: Option<String>,
+    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none")]
+    pub table_name: Option<String>,
+}
+
 /// `ClickStackSourceFrom` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackSourceFrom {
@@ -12070,6 +12457,19 @@ pub struct ClickStackSourceFrom {
     pub database_name: String,
     #[serde(rename = "tableName")]
     pub table_name: String,
+}
+
+/// `ClickStackSourceFrom` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackSourceFrom`]: every field is `Option<T>`, so
+/// a field the API drops or sends as `null` deserializes to `None` instead of
+/// failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackSourceFromResponse {
+    #[serde(rename = "databaseName", skip_serializing_if = "Option::is_none")]
+    pub database_name: Option<String>,
+    #[serde(rename = "tableName", skip_serializing_if = "Option::is_none")]
+    pub table_name: Option<String>,
 }
 
 /// `ClickStackTableBuilderChartConfig` from the ClickHouse Cloud API.
@@ -12267,9 +12667,9 @@ pub struct ClickStackTimeChartSeries {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTraceSource {
     pub connection: String,
-    #[serde(rename = "defaultTableSelectExpression", default)]
+    #[serde(rename = "defaultTableSelectExpression")]
     pub default_table_select_expression: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disabled: Option<bool>,
     #[serde(rename = "durationExpression")]
     pub duration_expression: String,
@@ -12277,103 +12677,70 @@ pub struct ClickStackTraceSource {
     pub duration_precision: i64,
     #[serde(
         rename = "eventAttributesExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub event_attributes_expression: Option<String>,
-    #[serde(
-        rename = "filterSettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none")]
     pub filter_settings: Option<ClickStackSourceFilterSettings>,
     pub from: ClickStackSourceFrom,
     #[serde(
         rename = "highlightedRowAttributeExpressions",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub highlighted_row_attribute_expressions:
         Option<Vec<ClickStackHighlightedAttributeExpression>>,
     #[serde(
         rename = "highlightedTraceAttributeExpressions",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub highlighted_trace_attribute_expressions:
         Option<Vec<ClickStackHighlightedAttributeExpression>>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     #[serde(
         rename = "implicitColumnExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub implicit_column_expression: Option<String>,
     pub kind: ClickStackTraceSourceKind,
     #[serde(
         rename = "knownColumnsListExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub known_columns_list_expression: Option<String>,
-    #[serde(
-        rename = "logSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none")]
     pub log_source_id: Option<String>,
-    #[serde(
-        rename = "materializedViews",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none")]
     pub materialized_views: Option<Vec<ClickStackMaterializedView>>,
     #[serde(
         rename = "metadataMaterializedViews",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub metadata_materialized_views: Option<ClickStackTraceSourceMetadataMaterializedViews>,
-    #[serde(
-        rename = "metricSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none")]
     pub metric_source_id: Option<String>,
     pub name: String,
     #[serde(rename = "parentSpanIdExpression")]
     pub parent_span_id_expression: String,
-    #[serde(
-        rename = "querySettings",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
     pub query_settings: Option<Vec<ClickStackQuerySetting>>,
     #[serde(
         rename = "resourceAttributesExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub resource_attributes_expression: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub section: Option<String>,
     #[serde(
         rename = "serviceNameExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub service_name_expression: Option<String>,
-    #[serde(
-        rename = "sessionSourceId",
-        skip_serializing_if = "Option::is_none",
-        default
-    )]
+    #[serde(rename = "sessionSourceId", skip_serializing_if = "Option::is_none")]
     pub session_source_id: Option<String>,
     #[serde(
         rename = "spanEventsValueExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub span_events_value_expression: Option<String>,
     #[serde(rename = "spanIdExpression")]
@@ -12384,14 +12751,12 @@ pub struct ClickStackTraceSource {
     pub span_name_expression: String,
     #[serde(
         rename = "statusCodeExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub status_code_expression: Option<String>,
     #[serde(
         rename = "statusMessageExpression",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub status_message_expression: Option<String>,
     #[serde(rename = "timestampValueExpression")]
@@ -12400,8 +12765,132 @@ pub struct ClickStackTraceSource {
     pub trace_id_expression: String,
     #[serde(
         rename = "useTextIndexForImplicitColumn",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub use_text_index_for_implicit_column:
+        Option<ClickStackTraceSourceUsetextindexforimplicitcolumn>,
+}
+
+/// `ClickStackTraceSource` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackTraceSource`]: every field is `Option<T>`,
+/// so a field the API drops or sends as `null` deserializes to `None` instead
+/// of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackTraceSourceResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub connection: Option<String>,
+    #[serde(
+        rename = "defaultTableSelectExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub default_table_select_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled: Option<bool>,
+    #[serde(rename = "durationExpression", skip_serializing_if = "Option::is_none")]
+    pub duration_expression: Option<String>,
+    #[serde(rename = "durationPrecision", skip_serializing_if = "Option::is_none")]
+    pub duration_precision: Option<i64>,
+    #[serde(
+        rename = "eventAttributesExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub event_attributes_expression: Option<String>,
+    #[serde(rename = "filterSettings", skip_serializing_if = "Option::is_none")]
+    pub filter_settings: Option<ClickStackSourceFilterSettingsResponse>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<ClickStackSourceFromResponse>,
+    #[serde(
+        rename = "highlightedRowAttributeExpressions",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub highlighted_row_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpressionResponse>>,
+    #[serde(
+        rename = "highlightedTraceAttributeExpressions",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub highlighted_trace_attribute_expressions:
+        Option<Vec<ClickStackHighlightedAttributeExpressionResponse>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(
+        rename = "implicitColumnExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub implicit_column_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ClickStackTraceSourceKind>,
+    #[serde(
+        rename = "knownColumnsListExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub known_columns_list_expression: Option<String>,
+    #[serde(rename = "logSourceId", skip_serializing_if = "Option::is_none")]
+    pub log_source_id: Option<String>,
+    #[serde(rename = "materializedViews", skip_serializing_if = "Option::is_none")]
+    pub materialized_views: Option<Vec<ClickStackMaterializedViewResponse>>,
+    #[serde(
+        rename = "metadataMaterializedViews",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub metadata_materialized_views: Option<ClickStackTraceSourceMetadataMaterializedViewsResponse>,
+    #[serde(rename = "metricSourceId", skip_serializing_if = "Option::is_none")]
+    pub metric_source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(
+        rename = "parentSpanIdExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub parent_span_id_expression: Option<String>,
+    #[serde(rename = "querySettings", skip_serializing_if = "Option::is_none")]
+    pub query_settings: Option<Vec<ClickStackQuerySettingResponse>>,
+    #[serde(
+        rename = "resourceAttributesExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub resource_attributes_expression: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section: Option<String>,
+    #[serde(
+        rename = "serviceNameExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_name_expression: Option<String>,
+    #[serde(rename = "sessionSourceId", skip_serializing_if = "Option::is_none")]
+    pub session_source_id: Option<String>,
+    #[serde(
+        rename = "spanEventsValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub span_events_value_expression: Option<String>,
+    #[serde(rename = "spanIdExpression", skip_serializing_if = "Option::is_none")]
+    pub span_id_expression: Option<String>,
+    #[serde(rename = "spanKindExpression", skip_serializing_if = "Option::is_none")]
+    pub span_kind_expression: Option<String>,
+    #[serde(rename = "spanNameExpression", skip_serializing_if = "Option::is_none")]
+    pub span_name_expression: Option<String>,
+    #[serde(
+        rename = "statusCodeExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub status_code_expression: Option<String>,
+    #[serde(
+        rename = "statusMessageExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub status_message_expression: Option<String>,
+    #[serde(
+        rename = "timestampValueExpression",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp_value_expression: Option<String>,
+    #[serde(rename = "traceIdExpression", skip_serializing_if = "Option::is_none")]
+    pub trace_id_expression: Option<String>,
+    #[serde(
+        rename = "useTextIndexForImplicitColumn",
+        skip_serializing_if = "Option::is_none"
     )]
     pub use_text_index_for_implicit_column:
         Option<ClickStackTraceSourceUsetextindexforimplicitcolumn>,
@@ -12410,12 +12899,26 @@ pub struct ClickStackTraceSource {
 /// `ClickStackTraceSourceMetadataMaterializedViews` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTraceSourceMetadataMaterializedViews {
-    #[serde(default)]
     pub granularity: String,
-    #[serde(rename = "keyRollupTable", default)]
+    #[serde(rename = "keyRollupTable")]
     pub key_rollup_table: String,
-    #[serde(rename = "kvRollupTable", default)]
+    #[serde(rename = "kvRollupTable")]
     pub kv_rollup_table: String,
+}
+
+/// `ClickStackTraceSourceMetadataMaterializedViews` from the ClickHouse Cloud API, in response position.
+///
+/// Response variant of [`ClickStackTraceSourceMetadataMaterializedViews`]:
+/// every field is `Option<T>`, so a field the API drops or sends as `null`
+/// deserializes to `None` instead of failing.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+pub struct ClickStackTraceSourceMetadataMaterializedViewsResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub granularity: Option<String>,
+    #[serde(rename = "keyRollupTable", skip_serializing_if = "Option::is_none")]
+    pub key_rollup_table: Option<String>,
+    #[serde(rename = "kvRollupTable", skip_serializing_if = "Option::is_none")]
+    pub kv_rollup_table: Option<String>,
 }
 
 /// `ClickStackUpdateAlertRequest` from the ClickHouse Cloud API.
@@ -12485,18 +12988,16 @@ pub struct ClickStackUpdateConnectionRequest {
     pub host: String,
     #[serde(
         rename = "hyperdxSettingPrefix",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub hyperdx_setting_prefix: Option<String>,
     #[serde(
         rename = "isPrometheusEndpoint",
-        skip_serializing_if = "Option::is_none",
-        default
+        skip_serializing_if = "Option::is_none"
     )]
     pub is_prometheus_endpoint: Option<bool>,
     pub name: String,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password: Option<String>,
     pub username: String,
 }
@@ -12535,9 +13036,9 @@ pub struct ClickStackUpdateDashboardRequest {
 /// `ClickStackUpdateRoleRequest` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackUpdateRoleRequest {
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     pub permissions: Vec<ClickStackCASLPermission>,
 }

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -1,6 +1,13 @@
 //! Typed models for ClickHouse Cloud API schemas.
 //!
-//! Auto-generated from the OpenAPI specification.
+//! Derived from the OpenAPI specification and kept in step with it by the drift
+//! analyzer, which parses this file — every model struct, enum and type alias
+//! must be declared here as literal source.
+//!
+//! Request models are strict and response models have every field `Option<T>`; a
+//! schema used in both directions appears twice, as `{Name}` and
+//! `{Name}Response`. `#[serde(default)]` is banned. See the crate-level docs for
+//! the policy and the reasoning behind it.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -12,11 +12,11 @@ use serde::{Deserialize, Serialize};
 /// `displayType`, `service`, `operator`) shares the same deserialization shape:
 /// buffer the payload as a [`serde_json::Value`], read the discriminator key,
 /// and route each known wire value to the matching variant via
-/// [`serde_json::from_value`]. Any unrecognized or missing discriminator falls
-/// through to the enum's `Unknown(serde_json::Value)` catch-all, so unknown
-/// payloads round-trip losslessly instead of failing to deserialize. This
-/// explicit dispatch avoids the greedy first-match misrouting that
-/// `#[serde(untagged)]` derives suffer when variants share a discriminator.
+/// [`serde_json::from_value`]. Any unrecognized discriminator falls through to
+/// the enum's `Unknown(serde_json::Value)` catch-all, so unknown payloads
+/// round-trip losslessly instead of failing to deserialize. This explicit
+/// dispatch avoids the greedy first-match misrouting that `#[serde(untagged)]`
+/// derives suffer when variants share a discriminator.
 ///
 /// The macro emits **only** the `Deserialize` impl. The enum declaration, its
 /// derives/serde attributes, and its `Display` impl must remain literal source
@@ -36,13 +36,41 @@ use serde::{Deserialize, Serialize};
 /// }
 /// ```
 ///
+/// Some unions discriminate one variant by the *absence* of the key rather than
+/// by a wire value of it (e.g. a ClickStack chart config carries
+/// `configType: "sql"` when it is a raw-SQL config and carries no `configType`
+/// at all when it is a builder config). Such a union adds a trailing `none` arm
+/// naming the variant the key's absence selects:
+///
+/// ```ignore
+/// discriminated_union! {
+///     ClickStackLineChartConfig, "configType" {
+///         "sql" => ClickStackLineRawSqlChartConfig,
+///         none => ClickStackLineBuilderChartConfig,
+///     }
+/// }
+/// ```
+///
+/// The `none` arm pins two semantics:
+///
+/// * It deliberately conflates "key absent" and "key present but not a string":
+///   both produce a `None` scrutinee, so both dispatch to the absence variant.
+/// * When the absence variant is total — every field either `Option<T>` or
+///   `#[serde(default)]`, so it cannot fail to deserialize — the arm always
+///   succeeds. `Unknown` is then reachable only via unrecognized *string*
+///   values of the key.
+///
+/// Without a `none` arm, an absent or non-string discriminator falls to
+/// `Unknown` through the final catch-all.
+///
 /// New discriminated unions in this module should use this macro rather than
 /// hand-writing the impl. Enums whose variants need multi-level or nested
 /// dispatch do not fit this single-key shape and must stay hand-written.
 macro_rules! discriminated_union {
     (
         $enum:ident, $key:literal {
-            $( $( $wire:literal )|+ => $variant:ident ),+ $(,)?
+            $( $( $wire:literal )|+ => $variant:ident, )+
+            $( none => $absent:ident, )?
         }
     ) => {
         impl<'de> Deserialize<'de> for $enum {
@@ -57,6 +85,11 @@ macro_rules! discriminated_union {
                             .map($enum::$variant)
                             .map_err(serde::de::Error::custom),
                     )+
+                    $(
+                        None => serde_json::from_value(value)
+                            .map($enum::$absent)
+                            .map_err(serde::de::Error::custom),
+                    )?
                     _ => Ok($enum::Unknown(value)),
                 }
             }
@@ -7906,13 +7939,27 @@ impl std::fmt::Display for ClickStackAlertChannel {
 }
 
 /// `ClickStackBarChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackBarChartConfig {
     ClickStackBarBuilderChartConfig(ClickStackBarBuilderChartConfig),
     ClickStackBarRawSqlChartConfig(ClickStackBarRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackBarChartConfig, "configType" {
+        "sql" => ClickStackBarRawSqlChartConfig,
+        none => ClickStackBarBuilderChartConfig,
+    }
 }
 
 impl std::fmt::Display for ClickStackBarChartConfig {
@@ -7928,13 +7975,27 @@ impl std::fmt::Display for ClickStackBarChartConfig {
 }
 
 /// `ClickStackCategoricalBarChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackCategoricalBarChartConfig {
     ClickStackCategoricalBarBuilderChartConfig(ClickStackCategoricalBarBuilderChartConfig),
     ClickStackCategoricalBarRawSqlChartConfig(ClickStackCategoricalBarRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackCategoricalBarChartConfig, "configType" {
+        "sql" => ClickStackCategoricalBarRawSqlChartConfig,
+        none => ClickStackCategoricalBarBuilderChartConfig,
+    }
 }
 
 impl Default for ClickStackCategoricalBarChartConfig {
@@ -8002,13 +8063,27 @@ impl std::fmt::Display for ClickStackDashboardChartSeries {
 }
 
 /// `ClickStackLineChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackLineChartConfig {
     ClickStackLineBuilderChartConfig(ClickStackLineBuilderChartConfig),
     ClickStackLineRawSqlChartConfig(ClickStackLineRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackLineChartConfig, "configType" {
+        "sql" => ClickStackLineRawSqlChartConfig,
+        none => ClickStackLineBuilderChartConfig,
+    }
 }
 
 impl std::fmt::Display for ClickStackLineChartConfig {
@@ -8026,13 +8101,27 @@ impl std::fmt::Display for ClickStackLineChartConfig {
 }
 
 /// `ClickStackNumberChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackNumberChartConfig {
     ClickStackNumberBuilderChartConfig(ClickStackNumberBuilderChartConfig),
     ClickStackNumberRawSqlChartConfig(ClickStackNumberRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackNumberChartConfig, "configType" {
+        "sql" => ClickStackNumberRawSqlChartConfig,
+        none => ClickStackNumberBuilderChartConfig,
+    }
 }
 
 impl std::fmt::Display for ClickStackNumberChartConfig {
@@ -8177,13 +8266,27 @@ impl std::fmt::Display for ClickStackOnClickTarget {
 }
 
 /// `ClickStackPieChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackPieChartConfig {
     ClickStackPieBuilderChartConfig(ClickStackPieBuilderChartConfig),
     ClickStackPieRawSqlChartConfig(ClickStackPieRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackPieChartConfig, "configType" {
+        "sql" => ClickStackPieRawSqlChartConfig,
+        none => ClickStackPieBuilderChartConfig,
+    }
 }
 
 impl std::fmt::Display for ClickStackPieChartConfig {
@@ -8241,13 +8344,27 @@ impl std::fmt::Display for ClickStackSource {
 }
 
 /// `ClickStackTableChartConfig` - one of multiple variants.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Dispatched on the `configType` field (absent or non-string dispatches to the
+/// builder variant); see the `discriminated_union!` invocation below for the
+/// wire values.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum ClickStackTableChartConfig {
     ClickStackTableBuilderChartConfig(ClickStackTableBuilderChartConfig),
     ClickStackTableRawSqlChartConfig(ClickStackTableRawSqlChartConfig),
     /// Catch-all for unknown or newly-added values.
+    ///
+    /// Holds the raw payload as `serde_json::Value` so it round-trips
+    /// losslessly; its `Display` emits the payload as compact JSON.
     Unknown(serde_json::Value),
+}
+
+discriminated_union! {
+    ClickStackTableChartConfig, "configType" {
+        "sql" => ClickStackTableRawSqlChartConfig,
+        none => ClickStackTableBuilderChartConfig,
+    }
 }
 
 impl std::fmt::Display for ClickStackTableChartConfig {
@@ -10619,7 +10736,7 @@ pub struct ClickStackBarBuilderChartConfig {
     pub align_date_range_to_granularity: Option<bool>,
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
     pub as_ratio: Option<bool>,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackBarBuilderChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
@@ -10631,8 +10748,9 @@ pub struct ClickStackBarBuilderChartConfig {
         default
     )]
     pub number_format: Option<ClickStackNumberFormat>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
@@ -10645,11 +10763,11 @@ pub struct ClickStackBarRawSqlChartConfig {
         default
     )]
     pub align_date_range_to_granularity: Option<bool>,
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackBarRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackBarRawSqlChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
@@ -10661,7 +10779,7 @@ pub struct ClickStackBarRawSqlChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 
@@ -10691,7 +10809,7 @@ pub struct ClickStackCASLPermission {
 /// `ClickStackCategoricalBarBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCategoricalBarBuilderChartConfig {
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackCategoricalBarBuilderChartConfigDisplaytype,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
@@ -10705,19 +10823,20 @@ pub struct ClickStackCategoricalBarBuilderChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
     pub order_by: Option<String>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
 /// `ClickStackCategoricalBarRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackCategoricalBarRawSqlChartConfig {
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackCategoricalBarRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackCategoricalBarRawSqlChartConfigDisplaytype,
     #[serde(
         rename = "numberFormat",
@@ -10727,7 +10846,7 @@ pub struct ClickStackCategoricalBarRawSqlChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 
@@ -11142,7 +11261,7 @@ pub struct ClickStackLineBuilderChartConfig {
         default
     )]
     pub compare_to_previous_period: Option<bool>,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackLineBuilderChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
@@ -11160,8 +11279,9 @@ pub struct ClickStackLineBuilderChartConfig {
         default
     )]
     pub number_format: Option<ClickStackNumberFormat>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
@@ -11180,11 +11300,11 @@ pub struct ClickStackLineRawSqlChartConfig {
         default
     )]
     pub compare_to_previous_period: Option<bool>,
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackLineRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackLineRawSqlChartConfigDisplaytype,
     #[serde(rename = "fillNulls", skip_serializing_if = "Option::is_none", default)]
     pub fill_nulls: Option<bool>,
@@ -11202,7 +11322,7 @@ pub struct ClickStackLineRawSqlChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 
@@ -11462,7 +11582,7 @@ pub struct ClickStackNumberBuilderChartConfig {
         default
     )]
     pub color_rules: Option<Vec<ClickStackNumberTileColorCondition>>,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackNumberBuilderChartConfigDisplaytype,
     #[serde(
         rename = "numberFormat",
@@ -11470,8 +11590,9 @@ pub struct ClickStackNumberBuilderChartConfig {
         default
     )]
     pub number_format: Option<ClickStackNumberFormat>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
@@ -11540,11 +11661,11 @@ pub struct ClickStackNumberFormat {
 pub struct ClickStackNumberRawSqlChartConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub color: Option<ClickStackChartColor>,
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackNumberRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackNumberRawSqlChartConfigDisplaytype,
     #[serde(
         rename = "numberFormat",
@@ -11554,7 +11675,7 @@ pub struct ClickStackNumberRawSqlChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 
@@ -11659,7 +11780,7 @@ pub struct ClickStackPagerDutyAPIWebhook {
 /// `ClickStackPieBuilderChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPieBuilderChartConfig {
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackPieBuilderChartConfigDisplaytype,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
@@ -11673,19 +11794,20 @@ pub struct ClickStackPieBuilderChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
     pub order_by: Option<String>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
 /// `ClickStackPieRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackPieRawSqlChartConfig {
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackPieRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackPieRawSqlChartConfigDisplaytype,
     #[serde(
         rename = "numberFormat",
@@ -11695,7 +11817,7 @@ pub struct ClickStackPieRawSqlChartConfig {
     pub number_format: Option<ClickStackNumberFormat>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 
@@ -11976,7 +12098,7 @@ pub struct ClickStackSourceFrom {
 pub struct ClickStackTableBuilderChartConfig {
     #[serde(rename = "asRatio", skip_serializing_if = "Option::is_none", default)]
     pub as_ratio: Option<bool>,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackTableBuilderChartConfigDisplaytype,
     #[serde(rename = "groupBy", skip_serializing_if = "Option::is_none", default)]
     pub group_by: Option<String>,
@@ -11998,8 +12120,9 @@ pub struct ClickStackTableBuilderChartConfig {
     pub on_click: Option<ClickStackOnClick>,
     #[serde(rename = "orderBy", skip_serializing_if = "Option::is_none", default)]
     pub order_by: Option<String>,
+    #[serde(default)]
     pub select: Vec<ClickStackSelectItem>,
-    #[serde(rename = "sourceId")]
+    #[serde(rename = "sourceId", default)]
     pub source_id: String,
 }
 
@@ -12047,11 +12170,11 @@ pub struct ClickStackTableChartSeries {
 /// `ClickStackTableRawSqlChartConfig` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ClickStackTableRawSqlChartConfig {
-    #[serde(rename = "configType")]
+    #[serde(rename = "configType", default)]
     pub config_type: ClickStackTableRawSqlChartConfigConfigtype,
-    #[serde(rename = "connectionId")]
+    #[serde(rename = "connectionId", default)]
     pub connection_id: String,
-    #[serde(rename = "displayType")]
+    #[serde(rename = "displayType", default)]
     pub display_type: ClickStackTableRawSqlChartConfigDisplaytype,
     #[serde(
         rename = "numberFormat",
@@ -12063,7 +12186,7 @@ pub struct ClickStackTableRawSqlChartConfig {
     pub on_click: Option<ClickStackOnClick>,
     #[serde(rename = "sourceId", skip_serializing_if = "Option::is_none", default)]
     pub source_id: Option<String>,
-    #[serde(rename = "sqlTemplate")]
+    #[serde(rename = "sqlTemplate", default)]
     pub sql_template: String,
 }
 

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -13611,6 +13611,16 @@ pub struct ScalingSchedulePostRequest {
     pub entries: Vec<ScalingScheduleEntryRequest>,
 }
 
+// The `Scim*` family below is strict in both directions, deliberately. The spec
+// defines the SCIM schemas but declares no SCIM path, so no `Client` method
+// sends or returns one: the family is reachable from neither a request root nor
+// a response root, and the analyzer resolves such operation-unreferenced schemas
+// in request position. Making the SCIM list/response envelopes all-`Option`
+// would therefore report `FieldOptionalityMismatch` drift while protecting no
+// actual response. `scim_models_are_outside_the_response_tree` in
+// `tests/spec_coverage_test.rs` pins that premise: if SCIM operations are ever
+// added to `client.rs`, the envelopes they return must be split first.
+
 /// `ScimEnterpriseManager` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ScimEnterpriseManager {

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -14068,7 +14068,7 @@ pub struct ClickStackValidateDashboardError {
 pub struct ClickStackValidateDashboardResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<ClickStackValidateDashboardError>>,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub normalized: Option<ClickStackValidateDashboardResponseNormalized>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub valid: Option<bool>,

--- a/crates/clickhouse-cloud-api/src/serde_helpers.rs
+++ b/crates/clickhouse-cloud-api/src/serde_helpers.rs
@@ -15,3 +15,21 @@ where
 {
     Option::<Vec<T>>::deserialize(d).map(Option::unwrap_or_default)
 }
+
+/// Deserialize a buffered payload into `T`, handing the payload back unchanged
+/// if it does not fit `T`.
+///
+/// Used by the `discriminated_union!` macro in `models.rs` so a union whose
+/// discriminator selects a variant the rest of the payload no longer fits
+/// degrades to that union's `Unknown(serde_json::Value)` catch-all instead of
+/// failing the whole response. Field-level tolerance covers a field the API
+/// stops sending; this covers a field whose *shape* the API changes.
+pub fn deserialize_or_raw<T>(value: serde_json::Value) -> Result<T, serde_json::Value>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match serde_json::from_value(value.clone()) {
+        Ok(parsed) => Ok(parsed),
+        Err(_) => Err(value),
+    }
+}

--- a/crates/clickhouse-cloud-api/src/serde_helpers.rs
+++ b/crates/clickhouse-cloud-api/src/serde_helpers.rs
@@ -1,21 +1,5 @@
 //! Serde helpers used by generated models.
 
-use serde::{Deserialize, Deserializer};
-
-/// Deserialize a `Vec<T>` field, treating an explicit JSON `null` the same as
-/// an empty array. Required because the ClickHouse Cloud API emits `null` for
-/// some array-valued fields that its OpenAPI spec declares as non-nullable
-/// `array`s (e.g. `reversePrivateEndpointIds` on Kafka sources). With plain
-/// `#[serde(default)]`, a missing field works but an explicit `null` fails
-/// with "invalid type: null, expected a sequence".
-pub fn null_to_empty<'de, T, D>(d: D) -> Result<Vec<T>, D::Error>
-where
-    T: Deserialize<'de>,
-    D: Deserializer<'de>,
-{
-    Option::<Vec<T>>::deserialize(d).map(Option::unwrap_or_default)
-}
-
 /// Deserialize a buffered payload into `T`, handing the payload back unchanged
 /// if it does not fit `T`.
 ///

--- a/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
@@ -87,7 +87,9 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                         let services = resp.result.ok_or("postgres list returned no result")?;
                         let leftover: Vec<_> = services
                             .into_iter()
-                            .filter(|s| filters_match_tags(&filters, &s.tags))
+                            .filter(|s| {
+                                filters_match_tags(&filters, s.tags.as_deref().unwrap_or_default())
+                            })
                             .collect();
                         Ok(leftover)
                     }
@@ -151,27 +153,31 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
         let pg_created = pg_create_resp?
             .result
             .ok_or("postgres create returned no result")?;
-        let postgres_id = pg_created.id.to_string();
+        let postgres_id = pg_created
+            .id
+            .ok_or("postgres create returned no id")?
+            .to_string();
         // The create response is the only API surface guaranteed to return
         // credentials: from July 31, 2026 the get endpoint stops echoing
         // `password` and `connectionString`, so capture everything
         // credential-derived here rather than from the polled get below.
-        let pg_username = pg_created.username.clone();
-        let pg_password = pg_created.password.clone();
+        let pg_username = pg_created.username.clone().unwrap_or_default();
+        let pg_password = pg_created.password.clone().unwrap_or_default();
+        let pg_connection_string = pg_created.connection_string.clone().unwrap_or_default();
         assert!(
-            !pg_created.connection_string.is_empty(),
-            "postgres create returned empty connection string"
+            !pg_connection_string.is_empty(),
+            "postgres create returned no connection string"
         );
-        let pg_port = parse_pg_port(&pg_created.connection_string).unwrap_or(5432);
-        let pg_database = parse_pg_database(&pg_created.connection_string)
-            .unwrap_or_else(|| "postgres".to_string());
+        let pg_port = parse_pg_port(&pg_connection_string).unwrap_or(5432);
+        let pg_database =
+            parse_pg_database(&pg_connection_string).unwrap_or_else(|| "postgres".to_string());
         assert!(
             !pg_username.is_empty(),
-            "postgres create returned empty username"
+            "postgres create returned no username"
         );
         assert!(
             !pg_password.is_empty(),
-            "postgres create returned empty password"
+            "postgres create returned no password"
         );
         cleanup.register_postgres(postgres_id.clone());
         eprintln!("  provisioned postgres id <redacted>");
@@ -197,7 +203,11 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                 async move {
                     let resp = client.postgres_service_get(&org_id, &postgres_id).await?;
                     let svc = resp.result.ok_or("postgres get returned no result")?;
-                    if svc.state.to_string() == "running" {
+                    if svc
+                        .state
+                        .as_ref()
+                        .is_some_and(|state| state.to_string() == "running")
+                    {
                         Ok(Some(svc))
                     } else {
                         Ok(None)
@@ -227,7 +237,8 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
         );
         let (pg_ready, ch_ready) = tokio::try_join!(pg_ready_fut, ch_ready_fut)?;
 
-        assert!(!pg_ready.hostname.is_empty(), "empty pg hostname");
+        let pg_hostname = pg_ready.hostname.clone().unwrap_or_default();
+        assert!(!pg_hostname.is_empty(), "postgres get returned no hostname");
         let ch_endpoint = ch_ready
             .endpoints
             .iter()
@@ -248,7 +259,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
             .await
             .ok();
         let pg_client = connect_postgres(
-            &pg_ready.hostname,
+            &pg_hostname,
             pg_port,
             &pg_database,
             &pg_username,
@@ -280,7 +291,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                         password: pg_password.clone(),
                     },
                     database: pg_database.clone(),
-                    host: pg_ready.hostname.clone(),
+                    host: pg_hostname.clone(),
                     port: pg_port as i64,
                     settings: ClickPipePostgresPipeSettings {
                         // `cdc` does snapshot + ongoing replication. The API

--- a/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
@@ -185,8 +185,9 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
         let ch_created = ch_create_resp?
             .result
             .ok_or("service create returned no result")?;
-        let clickhouse_id = ch_created.service.id.to_string();
-        let clickhouse_password = ch_created.password.clone();
+        let clickhouse_service = require_field(ch_created.service, "service")?;
+        let clickhouse_id = require_field(clickhouse_service.id, "service.id")?.to_string();
+        let clickhouse_password = require_field(ch_created.password.clone(), "password")?;
         cleanup.register_service(clickhouse_id.clone());
         eprintln!("  provisioned clickhouse id <redacted>");
 
@@ -226,7 +227,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                 async move {
                     let resp = client.instance_get(&org_id, &clickhouse_id).await?;
                     let svc = resp.result.ok_or("service get returned no result")?;
-                    let state = svc.state.to_string();
+                    let state = service_state(&svc);
                     if matches!(state.as_str(), "running" | "idle") {
                         Ok(Some(svc))
                     } else {
@@ -239,12 +240,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
 
         let pg_hostname = pg_ready.hostname.clone().unwrap_or_default();
         assert!(!pg_hostname.is_empty(), "postgres get returned no hostname");
-        let ch_endpoint = ch_ready
-            .endpoints
-            .iter()
-            .find(|e| matches!(e.protocol, ServiceEndpointProtocol::Https))
-            .ok_or("ClickHouse service has no https endpoint")?
-            .clone();
+        let ch_endpoint = https_endpoint(&ch_ready)?;
         let ch_username = ch_endpoint
             .username
             .clone()
@@ -372,8 +368,8 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
         log_phase("Verify seed rows in ClickHouse");
 
         let ch_query = ClickHouseQuery::new(
-            &ch_endpoint.host,
-            ch_endpoint.port as u16,
+            &require_field(ch_endpoint.host.clone(), "endpoints[].host")?,
+            require_field(ch_endpoint.port, "endpoints[].port")? as u16,
             &ch_username,
             &clickhouse_password,
         );
@@ -482,16 +478,16 @@ fn duration_from_env_or(name: &str, default_secs: u64) -> TestResult<Duration> {
     }
 }
 
-fn filters_match_tags(filters: &[String], tags: &[ResourceTagsV1]) -> bool {
+fn filters_match_tags(filters: &[String], tags: &[ResourceTagsV1Response]) -> bool {
     filters.iter().all(|filter| {
         let Some(expr) = filter.strip_prefix("tag:") else {
             return true;
         };
         let Some((key, value)) = expr.split_once('=') else {
-            return tags.iter().any(|t| t.key == expr);
+            return tags.iter().any(|t| t.key.as_deref() == Some(expr));
         };
         tags.iter()
-            .any(|t| t.key == key && t.value.as_deref() == Some(value))
+            .any(|t| t.key.as_deref() == Some(key) && t.value.as_deref() == Some(value))
     })
 }
 

--- a/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
@@ -327,7 +327,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
             .await?
             .result
             .ok_or("clickpipe create returned no result")?;
-        let clickpipe_id = pipe.id.to_string();
+        let clickpipe_id = clickpipe_id(&pipe)?;
         cleanup.register_clickpipe(clickhouse_id.clone(), clickpipe_id.clone());
         eprintln!("  provisioned clickpipe id <redacted>");
 
@@ -350,12 +350,14 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
                         .await?;
                     let pipe = resp.result.ok_or("clickpipe get returned no result")?;
                     match pipe.state {
-                        ClickPipeState::Running => Ok(Some(pipe)),
-                        ClickPipeState::Failed | ClickPipeState::InternalError => Err(format!(
-                            "clickpipe entered terminal failure state {}",
-                            pipe.state
-                        )
-                        .into()),
+                        Some(ClickPipeState::Running) => Ok(Some(pipe)),
+                        Some(ClickPipeState::Failed) | Some(ClickPipeState::InternalError) => {
+                            Err(format!(
+                                "clickpipe entered terminal failure state {}",
+                                clickpipe_state(&pipe)
+                            )
+                            .into())
+                        }
                         _ => Ok(None),
                     }
                 }

--- a/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/smoke_test.rs
@@ -111,8 +111,12 @@ async fn assert_create_shape_accepted(
     {
         Ok(resp) => {
             if let Some(pipe) = resp.result {
-                eprintln!("  pipe created: id={} state={}", pipe.id, pipe.state);
-                cleanup.register_clickpipe(ctx.service_id.clone(), pipe.id.to_string());
+                eprintln!(
+                    "  pipe created: id={} state={}",
+                    field_string(pipe.id.as_ref()),
+                    clickpipe_state(&pipe)
+                );
+                cleanup.register_clickpipe(ctx.service_id.clone(), clickpipe_id(&pipe)?);
             }
             Ok(())
         }

--- a/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/stages/mod.rs
@@ -118,7 +118,7 @@ pub async fn create_pipe_and_wait_running(
         .await?
         .result
         .ok_or("clickpipe create returned no result")?;
-    let clickpipe_id = pipe.id.to_string();
+    let clickpipe_id = clickpipe_id(&pipe)?;
     cleanup.register_clickpipe(ch.service_id.clone(), clickpipe_id.clone());
     eprintln!("  provisioned clickpipe id <redacted>");
 
@@ -137,12 +137,16 @@ pub async fn create_pipe_and_wait_running(
                     .await?;
                 let pipe = resp.result.ok_or("clickpipe get returned no result")?;
                 match pipe.state {
-                    ClickPipeState::Running | ClickPipeState::Completed => Ok(Some(pipe)),
-                    ClickPipeState::Failed | ClickPipeState::InternalError => Err(format!(
-                        "clickpipe entered terminal failure state {}",
-                        pipe.state
-                    )
-                    .into()),
+                    Some(ClickPipeState::Running) | Some(ClickPipeState::Completed) => {
+                        Ok(Some(pipe))
+                    }
+                    Some(ClickPipeState::Failed) | Some(ClickPipeState::InternalError) => {
+                        Err(format!(
+                            "clickpipe entered terminal failure state {}",
+                            clickpipe_state(&pipe)
+                        )
+                        .into())
+                    }
                     _ => Ok(None),
                 }
             }
@@ -158,7 +162,10 @@ pub async fn create_pipe_and_wait_running(
         .await?
         .result
         .ok_or("clickpipe list returned no result")?;
-    if !pipes.iter().any(|p| p.id.to_string() == clickpipe_id) {
+    if !pipes
+        .iter()
+        .any(|p| p.id.map(|id| id.to_string()).as_deref() == Some(clickpipe_id.as_str()))
+    {
         return Err(format!("clickpipe {clickpipe_id} missing from list response").into());
     }
 

--- a/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
@@ -11,7 +11,25 @@
 
 pub use crate::common::support::*;
 
+use clickhouse_cloud_api::models::ClickPipe;
 use std::time::Duration;
+
+// ── ClickPipe response accessors ─────────────────────────────────────
+//
+// Every field of the `ClickPipe` response model is `Option<T>`, so tests read
+// through these instead of unwrapping: an id a test cannot proceed without is
+// an explicit error, and a state used only for logging or matching degrades to
+// an empty string (which matches no known state).
+
+/// A pipe's id as a string — every follow-up call needs it.
+pub fn clickpipe_id(pipe: &ClickPipe) -> TestResult<String> {
+    Ok(require_field(pipe.id.as_ref(), "id")?.to_string())
+}
+
+/// A pipe's state as a string, or an empty string when the API omitted it.
+pub fn clickpipe_state(pipe: &ClickPipe) -> String {
+    field_string(pipe.state.as_ref())
+}
 
 // ── AWS Cleanup Registry ─────────────────────────────────────────────
 //

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -2951,8 +2951,8 @@ async fn create_postgres_service() {
     };
     let resp = c.postgres_service_create("org-1", &body).await.unwrap();
     let pg = resp.result.unwrap();
-    assert_eq!(pg.name, "pg-svc");
-    assert_eq!(pg.password, "generated-pw");
+    assert_eq!(pg.name.as_deref(), Some("pg-svc"));
+    assert_eq!(pg.password.as_deref(), Some("generated-pw"));
 }
 
 #[tokio::test]
@@ -2974,7 +2974,7 @@ async fn list_postgres_services() {
     let resp = c.postgres_service_get_list("org-1").await.unwrap();
     let services = resp.result.unwrap();
     assert_eq!(services.len(), 1);
-    assert_eq!(services[0].name, "pg-1");
+    assert_eq!(services[0].name.as_deref(), Some("pg-1"));
 }
 
 #[tokio::test]
@@ -2994,8 +2994,11 @@ async fn get_postgres_service() {
 
     let resp = c.postgres_service_get("org-1", "pg-1").await.unwrap();
     let pg = resp.result.unwrap();
-    assert_eq!(pg.name, "pg-1");
-    assert_eq!(pg.connection_string, "postgres://user@host/db");
+    assert_eq!(pg.name.as_deref(), Some("pg-1"));
+    assert_eq!(
+        pg.connection_string.as_deref(),
+        Some("postgres://user@host/db")
+    );
 }
 
 #[tokio::test]
@@ -3021,7 +3024,7 @@ async fn update_postgres_service() {
         .await
         .unwrap();
     let pg = resp.result.unwrap();
-    assert_eq!(pg.name, "pg-1");
+    assert_eq!(pg.name.as_deref(), Some("pg-1"));
 }
 
 #[tokio::test]
@@ -3061,7 +3064,7 @@ async fn update_postgres_service_state() {
         .await
         .unwrap();
     let pg = resp.result.unwrap();
-    assert_eq!(pg.name, "pg-1");
+    assert_eq!(pg.name.as_deref(), Some("pg-1"));
 }
 
 #[tokio::test]
@@ -3087,7 +3090,7 @@ async fn set_postgres_password() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.password, "new-pg-password");
+    assert_eq!(result.password.as_deref(), Some("new-pg-password"));
 }
 
 #[tokio::test]
@@ -3129,7 +3132,10 @@ async fn get_postgres_config() {
         .unwrap();
     let config = resp.result.unwrap();
     assert_eq!(
-        config.pg_config.max_connections,
+        config
+            .pg_config
+            .expect("pgConfig in response")
+            .max_connections,
         Some(serde_json::json!(100))
     );
 }
@@ -3165,7 +3171,10 @@ async fn replace_postgres_config() {
     let result = resp.result.unwrap();
     assert_eq!(result.message, Some("Configuration updated".to_string()));
     assert_eq!(
-        result.pg_config.max_connections,
+        result
+            .pg_config
+            .expect("pgConfig in response")
+            .max_connections,
         Some(serde_json::json!(200))
     );
 }
@@ -3200,7 +3209,10 @@ async fn patch_postgres_config() {
         .unwrap();
     let result = resp.result.unwrap();
     assert_eq!(
-        result.pg_config.max_connections,
+        result
+            .pg_config
+            .expect("pgConfig in response")
+            .max_connections,
         Some(serde_json::json!(150))
     );
 }
@@ -3231,7 +3243,7 @@ async fn create_postgres_read_replica() {
         .await
         .unwrap();
     let pg = resp.result.unwrap();
-    assert!(!pg.is_primary);
+    assert_eq!(pg.is_primary, Some(false));
 }
 
 #[tokio::test]
@@ -3263,7 +3275,7 @@ async fn restore_postgres_service() {
         .await
         .unwrap();
     let pg = resp.result.unwrap();
-    assert_eq!(pg.name, "pg-1-restored");
+    assert_eq!(pg.name.as_deref(), Some("pg-1-restored"));
 }
 
 // ===========================================================================

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1714,7 +1714,7 @@ async fn list_reverse_private_endpoints() {
         .unwrap();
     let endpoints = resp.result.unwrap();
     assert_eq!(endpoints.len(), 1);
-    assert_eq!(endpoints[0].description, "MSK endpoint");
+    assert_eq!(endpoints[0].description.as_deref(), Some("MSK endpoint"));
 }
 
 #[tokio::test]
@@ -1745,7 +1745,7 @@ async fn create_reverse_private_endpoint() {
         .await
         .unwrap();
     let rpe = resp.result.unwrap();
-    assert_eq!(rpe.description, "New RPE");
+    assert_eq!(rpe.description.as_deref(), Some("New RPE"));
 }
 
 #[tokio::test]
@@ -1769,7 +1769,7 @@ async fn get_reverse_private_endpoint() {
         .await
         .unwrap();
     let rpe = resp.result.unwrap();
-    assert_eq!(rpe.description, "My RPE");
+    assert_eq!(rpe.description.as_deref(), Some("My RPE"));
 }
 
 #[tokio::test]
@@ -2885,9 +2885,9 @@ async fn list_quotas() {
     assert_eq!(quotas.len(), 1);
     assert_eq!(
         quotas[0].quota_code,
-        OrganizationQuotaQuotacode::Services_per_organization
+        Some(OrganizationQuotaQuotacode::Services_per_organization)
     );
-    assert_eq!(quotas[0].scope, OrganizationQuotaScope::Organization);
+    assert_eq!(quotas[0].scope, Some(OrganizationQuotaScope::Organization));
     assert_eq!(quotas[0].usage, Some(3));
 }
 
@@ -2917,9 +2917,9 @@ async fn get_quota() {
     let quota = resp.result.unwrap();
     assert_eq!(
         quota.quota_code,
-        OrganizationQuotaQuotacode::Replicas_per_warehouse
+        Some(OrganizationQuotaQuotacode::Replicas_per_warehouse)
     );
-    assert_eq!(quota.scope, OrganizationQuotaScope::Warehouse);
+    assert_eq!(quota.scope, Some(OrganizationQuotaScope::Warehouse));
     assert_eq!(quota.usage, None);
 }
 

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -57,7 +57,7 @@ async fn list_organizations() {
     assert_eq!(resp.status, Some(200.0));
     let orgs = resp.result.unwrap();
     assert_eq!(orgs.len(), 1);
-    assert_eq!(orgs[0].name, "Test Org");
+    assert_eq!(orgs[0].name.as_deref(), Some("Test Org"));
 }
 
 #[tokio::test]
@@ -81,7 +81,7 @@ async fn get_organization() {
     let client = Client::with_base_url(mock_server.uri(), "my-key", "my-secret");
     let resp = client.organization_get("org-123").await.unwrap();
     let org = resp.result.unwrap();
-    assert_eq!(org.name, "My Org");
+    assert_eq!(org.name.as_deref(), Some("My Org"));
 }
 
 #[tokio::test]
@@ -106,7 +106,7 @@ async fn update_organization() {
     };
     let resp = c.organization_update("org-1", &body).await.unwrap();
     let org = resp.result.unwrap();
-    assert_eq!(org.name, "Renamed Org");
+    assert_eq!(org.name.as_deref(), Some("Renamed Org"));
 }
 
 #[tokio::test]
@@ -133,7 +133,7 @@ async fn get_usage_cost_with_query_params() {
         .await
         .unwrap();
     let cost = resp.result.unwrap();
-    assert_eq!(cost.grand_total_chc, 50.25);
+    assert_eq!(cost.grand_total_chc, Some(50.25));
 }
 
 #[tokio::test]
@@ -178,8 +178,8 @@ async fn get_private_endpoint_config() {
         .unwrap();
     let config = resp.result.unwrap();
     assert_eq!(
-        config.endpoint_service_id,
-        "com.amazonaws.vpce.us-east-1.vpce-svc-abc"
+        config.endpoint_service_id.as_deref(),
+        Some("com.amazonaws.vpce.us-east-1.vpce-svc-abc")
     );
 }
 
@@ -208,7 +208,7 @@ async fn list_activities() {
     let resp = c.activity_get_list("org-1", None, None).await.unwrap();
     let activities = resp.result.unwrap();
     assert_eq!(activities.len(), 1);
-    assert_eq!(activities[0].id, "act-1");
+    assert_eq!(activities[0].id.as_deref(), Some("act-1"));
 }
 
 #[tokio::test]
@@ -246,7 +246,7 @@ async fn get_activity() {
 
     let resp = c.activity_get("org-1", "act-1").await.unwrap();
     let activity = resp.result.unwrap();
-    assert_eq!(activity.id, "act-1");
+    assert_eq!(activity.id.as_deref(), Some("act-1"));
 }
 
 // ===========================================================================
@@ -280,7 +280,7 @@ async fn create_byoc_infrastructure() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.display_name, "My BYOC");
+    assert_eq!(config.display_name.as_deref(), Some("My BYOC"));
 }
 
 #[tokio::test]
@@ -307,7 +307,7 @@ async fn update_byoc_infrastructure() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.display_name, "Renamed BYOC");
+    assert_eq!(config.display_name.as_deref(), Some("Renamed BYOC"));
 }
 
 #[tokio::test]
@@ -350,7 +350,7 @@ async fn list_invitations() {
     let resp = c.invitation_get_list("org-1").await.unwrap();
     let invitations = resp.result.unwrap();
     assert_eq!(invitations.len(), 1);
-    assert_eq!(invitations[0].email, "alice@example.com");
+    assert_eq!(invitations[0].email.as_deref(), Some("alice@example.com"));
 }
 
 #[tokio::test]
@@ -382,7 +382,7 @@ async fn create_invitation() {
     };
     let resp = client.invitation_create("org-1", &body).await.unwrap();
     let inv = resp.result.unwrap();
-    assert_eq!(inv.email, "newuser@example.com");
+    assert_eq!(inv.email.as_deref(), Some("newuser@example.com"));
 }
 
 #[tokio::test]
@@ -401,7 +401,7 @@ async fn get_invitation() {
 
     let resp = c.invitation_get("org-1", "inv-1").await.unwrap();
     let inv = resp.result.unwrap();
-    assert_eq!(inv.email, "bob@example.com");
+    assert_eq!(inv.email.as_deref(), Some("bob@example.com"));
     #[cfg(feature = "deprecated-fields")]
     assert_eq!(inv.role, InvitationRole::Admin);
 }
@@ -447,7 +447,7 @@ async fn list_api_keys() {
     let resp = client.openapi_key_get_list("org-1").await.unwrap();
     let keys = resp.result.unwrap();
     assert_eq!(keys.len(), 1);
-    assert_eq!(keys[0].name, "Production Key");
+    assert_eq!(keys[0].name.as_deref(), Some("Production Key"));
 }
 
 #[tokio::test]
@@ -475,9 +475,12 @@ async fn create_api_key() {
     };
     let resp = c.openapi_key_create("org-1", &body).await.unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.key_id, "key-id-abc");
-    assert_eq!(result.key_secret, "key-secret-xyz");
-    assert_eq!(result.key.name, "New Key");
+    assert_eq!(result.key_id.as_deref(), Some("key-id-abc"));
+    assert_eq!(result.key_secret.as_deref(), Some("key-secret-xyz"));
+    assert_eq!(
+        result.key.as_ref().and_then(|key| key.name.as_deref()),
+        Some("New Key")
+    );
 }
 
 #[tokio::test]
@@ -497,9 +500,9 @@ async fn get_api_key() {
 
     let resp = c.openapi_key_get("org-1", "key-1").await.unwrap();
     let key = resp.result.unwrap();
-    assert_eq!(key.name, "My Key");
-    assert_eq!(key.state, ApiKeyState::Enabled);
-    assert_eq!(key.key_suffix, "abc");
+    assert_eq!(key.name.as_deref(), Some("My Key"));
+    assert_eq!(key.state, Some(ApiKeyState::Enabled));
+    assert_eq!(key.key_suffix.as_deref(), Some("abc"));
 }
 
 #[tokio::test]
@@ -525,7 +528,7 @@ async fn update_api_key() {
     };
     let resp = c.openapi_key_update("org-1", "key-1", &body).await.unwrap();
     let key = resp.result.unwrap();
-    assert_eq!(key.name, "Renamed Key");
+    assert_eq!(key.name.as_deref(), Some("Renamed Key"));
 }
 
 #[tokio::test]
@@ -600,7 +603,7 @@ async fn get_member() {
 
     let resp = c.member_get("org-1", "user-1").await.unwrap();
     let member = resp.result.unwrap();
-    assert_eq!(member.name, "Alice");
+    assert_eq!(member.name.as_deref(), Some("Alice"));
     #[cfg(feature = "deprecated-fields")]
     assert_eq!(member.role, MemberRole::Admin);
 }
@@ -627,7 +630,7 @@ async fn update_member() {
     };
     let resp = c.member_update("org-1", "user-1", &body).await.unwrap();
     let member = resp.result.unwrap();
-    assert_eq!(member.email, "alice@example.com");
+    assert_eq!(member.email.as_deref(), Some("alice@example.com"));
     #[cfg(feature = "deprecated-fields")]
     assert_eq!(member.role, MemberRole::Admin);
 }
@@ -676,9 +679,9 @@ async fn list_services() {
     let resp = client.instance_get_list("org-123", &[]).await.unwrap();
     let services = resp.result.unwrap();
     assert_eq!(services.len(), 1);
-    assert_eq!(services[0].name, "svc-1");
-    assert_eq!(services[0].provider, ServiceProvider::Aws);
-    assert_eq!(services[0].state, ServiceState::Running);
+    assert_eq!(services[0].name.as_deref(), Some("svc-1"));
+    assert_eq!(services[0].provider, Some(ServiceProvider::Aws));
+    assert_eq!(services[0].state, Some(ServiceState::Running));
 }
 
 #[tokio::test]
@@ -718,7 +721,7 @@ async fn create_service() {
     };
     let resp = client.instance_create("org-123", &body).await.unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.password, "generated-password-123");
+    assert_eq!(result.password.as_deref(), Some("generated-password-123"));
 }
 
 #[tokio::test]
@@ -752,9 +755,9 @@ async fn get_service_details() {
     let client = Client::with_base_url(mock_server.uri(), "key", "secret");
     let resp = client.instance_get("org-1", "svc-1").await.unwrap();
     let svc = resp.result.unwrap();
-    assert_eq!(svc.name, "prod-service");
-    assert_eq!(svc.provider, ServiceProvider::Gcp);
-    assert_eq!(svc.num_replicas, 3.0);
+    assert_eq!(svc.name.as_deref(), Some("prod-service"));
+    assert_eq!(svc.provider, Some(ServiceProvider::Gcp));
+    assert_eq!(svc.num_replicas, Some(3.0));
 }
 
 #[tokio::test]
@@ -780,7 +783,7 @@ async fn update_service() {
     };
     let resp = c.instance_update("org-1", "svc-1", &body).await.unwrap();
     let svc = resp.result.unwrap();
-    assert_eq!(svc.name, "renamed-svc");
+    assert_eq!(svc.name.as_deref(), Some("renamed-svc"));
 }
 
 #[tokio::test]
@@ -828,7 +831,7 @@ async fn update_service_state() {
         .await
         .unwrap();
     let svc = resp.result.unwrap();
-    assert_eq!(svc.state, ServiceState::Stopping);
+    assert_eq!(svc.state, Some(ServiceState::Stopping));
 }
 
 #[tokio::test]
@@ -856,7 +859,7 @@ async fn update_service_password() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.password, "new-password-abc");
+    assert_eq!(result.password.as_deref(), Some("new-password-abc"));
 }
 
 // ===========================================================================
@@ -891,7 +894,7 @@ async fn update_replica_scaling() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.num_replicas, 5.0);
+    assert_eq!(result.num_replicas, Some(5.0));
 }
 
 #[tokio::test]
@@ -919,7 +922,7 @@ async fn update_scaling_deprecated() {
         .await
         .unwrap();
     let svc = resp.result.unwrap();
-    assert_eq!(svc.num_replicas, 3.0);
+    assert_eq!(svc.num_replicas, Some(3.0));
 }
 
 #[tokio::test]
@@ -949,7 +952,7 @@ async fn create_private_endpoint() {
         .await
         .unwrap();
     let pe = resp.result.unwrap();
-    assert_eq!(pe.description, "My PE");
+    assert_eq!(pe.description.as_deref(), Some("My PE"));
 }
 
 #[tokio::test]
@@ -972,10 +975,10 @@ async fn get_private_endpoint_config_for_service() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.endpoint_service_id, "vpce-svc-abc");
+    assert_eq!(config.endpoint_service_id.as_deref(), Some("vpce-svc-abc"));
     assert_eq!(
-        config.private_dns_hostname,
-        "svc-1.private.clickhouse.cloud"
+        config.private_dns_hostname.as_deref(),
+        Some("svc-1.private.clickhouse.cloud")
     );
 }
 
@@ -1037,8 +1040,8 @@ async fn get_query_endpoint() {
         .await
         .unwrap();
     let qe = resp.result.unwrap();
-    assert_eq!(qe.id, "qe-1");
-    assert_eq!(qe.allowed_origins, "*");
+    assert_eq!(qe.id.as_deref(), Some("qe-1"));
+    assert_eq!(qe.allowed_origins.as_deref(), Some("*"));
 }
 
 #[tokio::test]
@@ -1070,7 +1073,7 @@ async fn upsert_query_endpoint() {
         .await
         .unwrap();
     let qe = resp.result.unwrap();
-    assert_eq!(qe.allowed_origins, "https://example.com");
+    assert_eq!(qe.allowed_origins.as_deref(), Some("https://example.com"));
 }
 
 #[tokio::test]
@@ -1124,8 +1127,8 @@ async fn list_backups() {
     let resp = client.backup_get_list("org-1", "svc-1").await.unwrap();
     let backups = resp.result.unwrap();
     assert_eq!(backups.len(), 1);
-    assert_eq!(backups[0].status, BackupStatus::Done);
-    assert_eq!(backups[0].r#type, BackupType::Full);
+    assert_eq!(backups[0].status, Some(BackupStatus::Done));
+    assert_eq!(backups[0].r#type, Some(BackupType::Full));
 }
 
 #[tokio::test]
@@ -1145,8 +1148,8 @@ async fn get_single_backup() {
 
     let resp = c.backup_get("org-1", "svc-1", "bak-1").await.unwrap();
     let backup = resp.result.unwrap();
-    assert_eq!(backup.status, BackupStatus::Done);
-    assert_eq!(backup.size_in_bytes, 2048.0);
+    assert_eq!(backup.status, Some(BackupStatus::Done));
+    assert_eq!(backup.size_in_bytes, Some(2048.0));
 }
 
 #[tokio::test]
@@ -1167,8 +1170,8 @@ async fn get_backup_configuration() {
 
     let resp = c.backup_configuration_get("org-1", "svc-1").await.unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.backup_period_in_hours, 24.0);
-    assert_eq!(config.backup_start_time, "02:00");
+    assert_eq!(config.backup_period_in_hours, Some(24.0));
+    assert_eq!(config.backup_start_time.as_deref(), Some("02:00"));
 }
 
 #[tokio::test]
@@ -1202,7 +1205,7 @@ async fn update_backup_configuration() {
         .await
         .unwrap();
     let config = resp.result.unwrap();
-    assert_eq!(config.backup_period_in_hours, 12.0);
+    assert_eq!(config.backup_period_in_hours, Some(12.0));
 }
 
 // ===========================================================================
@@ -3305,7 +3308,7 @@ async fn bearer_auth_sends_token() {
     let resp = client.organization_get_list().await.unwrap();
     let orgs = resp.result.unwrap();
     assert_eq!(orgs.len(), 1);
-    assert_eq!(orgs[0].name, "Bearer Org");
+    assert_eq!(orgs[0].name.as_deref(), Some("Bearer Org"));
 }
 
 #[tokio::test]
@@ -3737,7 +3740,7 @@ async fn usage_cost_with_filters() {
         .await
         .unwrap();
     let cost = resp.result.unwrap();
-    assert_eq!(cost.grand_total_chc, 10.0);
+    assert_eq!(cost.grand_total_chc, Some(10.0));
 }
 
 #[tokio::test]
@@ -3863,9 +3866,9 @@ async fn upgrade_window_get_returns_window() {
 
     let resp = c.upgrade_window_get("org-1", "svc-1").await.unwrap();
     let window = resp.result.unwrap();
-    assert_eq!(window.weekday, 2);
-    assert_eq!(window.start_hour_utc, 6);
-    assert_eq!(window.duration, 21600);
+    assert_eq!(window.weekday, Some(2));
+    assert_eq!(window.start_hour_utc, Some(6));
+    assert_eq!(window.duration, Some(21600));
 }
 
 #[tokio::test]
@@ -3895,8 +3898,8 @@ async fn upgrade_window_update_sends_body() {
         .await
         .unwrap();
     let window = resp.result.unwrap();
-    assert_eq!(window.weekday, 2);
-    assert_eq!(window.start_hour_utc, 6);
+    assert_eq!(window.weekday, Some(2));
+    assert_eq!(window.start_hour_utc, Some(6));
 }
 
 #[tokio::test]

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1944,7 +1944,7 @@ async fn list_saved_searches() {
         .unwrap();
     let searches = resp.result.unwrap();
     assert_eq!(searches.len(), 1);
-    assert_eq!(searches[0].source_id, "source-1");
+    assert_eq!(searches[0].source_id.as_deref(), Some("source-1"));
 }
 
 #[tokio::test]
@@ -1976,7 +1976,7 @@ async fn create_saved_search() {
         .click_stack_create_saved_search("org-1", "svc-1", &body)
         .await
         .unwrap();
-    assert_eq!(resp.result.unwrap().id, "search-1");
+    assert_eq!(resp.result.unwrap().id.as_deref(), Some("search-1"));
 }
 
 #[tokio::test]
@@ -2405,8 +2405,8 @@ async fn create_connection() {
         .await
         .unwrap();
     let conn = resp.result.unwrap();
-    assert_eq!(conn.id, "conn-1");
-    assert_eq!(conn.name, "Production ClickHouse");
+    assert_eq!(conn.id.as_deref(), Some("conn-1"));
+    assert_eq!(conn.name.as_deref(), Some("Production ClickHouse"));
 }
 
 #[tokio::test]
@@ -2431,7 +2431,7 @@ async fn get_connection() {
         .await
         .unwrap();
     let conn = resp.result.unwrap();
-    assert_eq!(conn.id, "conn-1");
+    assert_eq!(conn.id.as_deref(), Some("conn-1"));
 }
 
 #[tokio::test]
@@ -2465,7 +2465,7 @@ async fn update_connection() {
         .await
         .unwrap();
     let conn = resp.result.unwrap();
-    assert_eq!(conn.name, "Updated Connection");
+    assert_eq!(conn.name.as_deref(), Some("Updated Connection"));
 }
 
 #[tokio::test]
@@ -2552,9 +2552,9 @@ async fn create_role() {
         .await
         .unwrap();
     let role = resp.result.unwrap();
-    assert_eq!(role.id, "role-1");
-    assert_eq!(role.name, "Deploy Bot");
-    assert!(!role.is_predefined);
+    assert_eq!(role.id.as_deref(), Some("role-1"));
+    assert_eq!(role.name.as_deref(), Some("Deploy Bot"));
+    assert_eq!(role.is_predefined, Some(false));
 }
 
 #[tokio::test]
@@ -2579,8 +2579,8 @@ async fn get_role() {
         .await
         .unwrap();
     let role = resp.result.unwrap();
-    assert_eq!(role.id, "role-1");
-    assert!(role.is_predefined);
+    assert_eq!(role.id.as_deref(), Some("role-1"));
+    assert_eq!(role.is_predefined, Some(true));
 }
 
 #[tokio::test]
@@ -2616,8 +2616,9 @@ async fn update_role() {
         .await
         .unwrap();
     let role = resp.result.unwrap();
-    assert_eq!(role.permissions.len(), 1);
-    assert_eq!(role.permissions[0].action, "manage");
+    let permissions = role.permissions.unwrap_or_default();
+    assert_eq!(permissions.len(), 1);
+    assert_eq!(permissions[0].action.as_deref(), Some("manage"));
 }
 
 #[tokio::test]

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -1326,13 +1326,14 @@ async fn list_click_pipes() {
     let resp = c.click_pipe_get_list("org-1", "svc-1").await.unwrap();
     let pipes = resp.result.unwrap();
     assert_eq!(pipes.len(), 1);
-    assert_eq!(pipes[0].name, "kafka-pipe");
+    assert_eq!(pipes[0].name.as_deref(), Some("kafka-pipe"));
 }
 
 /// Mirror the shape the live API actually returns for a Kafka pipe — including
 /// `reversePrivateEndpointIds: null`, which the spec declares as a required
-/// array but the server happily emits as null when unset. Before the fix,
-/// this fails with `invalid type: null, expected a sequence`.
+/// array but the server happily emits as null when unset. Response fields are
+/// `Option<T>`, so `null` lands as `None` rather than failing with
+/// `invalid type: null, expected a sequence`.
 #[tokio::test]
 async fn list_click_pipes_with_null_array_fields() {
     let (s, c) = setup().await;
@@ -1383,13 +1384,13 @@ async fn list_click_pipes_with_null_array_fields() {
     let resp = c.click_pipe_get_list("org-1", "svc-1").await.unwrap();
     let pipes = resp.result.unwrap();
     assert_eq!(pipes.len(), 1);
-    assert_eq!(pipes[0].name, "kafka-pipe");
+    assert_eq!(pipes[0].name.as_deref(), Some("kafka-pipe"));
     let kafka = pipes[0]
         .source
-        .kafka
         .as_ref()
+        .and_then(|source| source.kafka.as_ref())
         .expect("kafka source present");
-    assert!(kafka.reverse_private_endpoint_ids.is_empty());
+    assert_eq!(kafka.reverse_private_endpoint_ids, None);
 }
 
 #[tokio::test]
@@ -1413,7 +1414,7 @@ async fn create_click_pipe() {
     };
     let resp = c.click_pipe_create("org-1", "svc-1", &body).await.unwrap();
     let pipe = resp.result.unwrap();
-    assert_eq!(pipe.name, "new-pipe");
+    assert_eq!(pipe.name.as_deref(), Some("new-pipe"));
 }
 
 #[tokio::test]
@@ -1434,7 +1435,7 @@ async fn get_click_pipe() {
 
     let resp = c.click_pipe_get("org-1", "svc-1", "pipe-1").await.unwrap();
     let pipe = resp.result.unwrap();
-    assert_eq!(pipe.name, "my-pipe");
+    assert_eq!(pipe.name.as_deref(), Some("my-pipe"));
 }
 
 #[tokio::test]
@@ -1465,7 +1466,7 @@ async fn update_click_pipe() {
         .await
         .unwrap();
     let pipe = resp.result.unwrap();
-    assert_eq!(pipe.name, "renamed-pipe");
+    assert_eq!(pipe.name.as_deref(), Some("renamed-pipe"));
 }
 
 #[tokio::test]
@@ -1512,7 +1513,7 @@ async fn update_click_pipe_state() {
         .await
         .unwrap();
     let pipe = resp.result.unwrap();
-    assert_eq!(pipe.state, ClickPipeState::Stopped);
+    assert_eq!(pipe.state, Some(ClickPipeState::Stopped));
 }
 
 #[tokio::test]
@@ -1622,10 +1623,11 @@ async fn click_pipe_schema_discovery_kafka() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.fields.len(), 2);
-    assert_eq!(result.fields[0].name, "user_id");
-    assert_eq!(result.fields[0].r#type, "Int64");
-    assert_eq!(result.fields[1].optional, Some(true));
+    let fields = result.fields.expect("fields should populate");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name.as_deref(), Some("user_id"));
+    assert_eq!(fields[0].r#type.as_deref(), Some("Int64"));
+    assert_eq!(fields[1].optional, Some(true));
 }
 
 // ===========================================================================
@@ -1652,8 +1654,8 @@ async fn get_cdc_scaling() {
         .await
         .unwrap();
     let scaling = resp.result.unwrap();
-    assert_eq!(scaling.replica_cpu_millicores, 2000);
-    assert_eq!(scaling.replica_memory_gb, 8.0);
+    assert_eq!(scaling.replica_cpu_millicores, Some(2000));
+    assert_eq!(scaling.replica_memory_gb, Some(8.0));
 }
 
 #[tokio::test]
@@ -1683,7 +1685,7 @@ async fn update_cdc_scaling() {
         .await
         .unwrap();
     let scaling = resp.result.unwrap();
-    assert_eq!(scaling.replica_cpu_millicores, 4000);
+    assert_eq!(scaling.replica_cpu_millicores, Some(4000));
 }
 
 // ===========================================================================

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -2716,8 +2716,8 @@ async fn update_webhook() {
     // The response union resolves to a concrete Slack webhook variant.
     match resp.result.unwrap() {
         ClickStackWebhook::ClickStackSlackWebhook(w) => {
-            assert_eq!(w.id, "webhook-1");
-            assert_eq!(w.name, "Updated Alerts");
+            assert_eq!(w.id.as_deref(), Some("webhook-1"));
+            assert_eq!(w.name.as_deref(), Some("Updated Alerts"));
         }
         other => panic!("expected Slack webhook variant, got {other}"),
     }
@@ -2756,8 +2756,8 @@ async fn create_webhook_incidentio_response() {
     // rather than greedily matching the structurally-identical Slack variant.
     match resp.result.unwrap() {
         ClickStackWebhook::ClickStackIncidentIOWebhook(w) => {
-            assert_eq!(w.id, "webhook-2");
-            assert_eq!(w.name, "Incident Alerts");
+            assert_eq!(w.id.as_deref(), Some("webhook-2"));
+            assert_eq!(w.name.as_deref(), Some("Incident Alerts"));
         }
         other => panic!("expected IncidentIO webhook variant, got {other}"),
     }
@@ -2797,7 +2797,7 @@ async fn update_webhook_generic_response() {
     // optional `body` field, which the greedy Slack match would have discarded.
     match resp.result.unwrap() {
         ClickStackWebhook::ClickStackGenericWebhook(w) => {
-            assert_eq!(w.id, "webhook-3");
+            assert_eq!(w.id.as_deref(), Some("webhook-3"));
             assert_eq!(w.body.as_deref(), Some("{\"text\": \"{{ message }}\"}"));
         }
         other => panic!("expected Generic webhook variant, got {other}"),
@@ -2853,9 +2853,10 @@ async fn validate_dashboard() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert!(!result.valid);
-    assert_eq!(result.errors.len(), 1);
-    assert_eq!(result.errors[0].path, "tiles.0.config");
+    assert_eq!(result.valid, Some(false));
+    let errors = result.errors.as_ref().expect("errors should populate");
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].path.as_deref(), Some("tiles.0.config"));
     assert_eq!(result.normalized, None);
 }
 

--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -877,9 +877,11 @@ async fn restore_scaling_schedule(
         entries: restore
             .pre_state
             .entries
-            .iter()
-            .map(scaling_schedule_entry_to_request)
-            .collect(),
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(ScalingScheduleEntryRequest::try_from)
+            .collect::<Result<Vec<_>, _>>()?,
     };
     match client
         .scaling_schedule_upsert(org_id, &restore.service_id, &body)
@@ -898,10 +900,7 @@ async fn restore_upgrade_window(
     restore: &UpgradeWindowRestore,
 ) -> TestResult<()> {
     eprintln!("  cleanup: restoring upgrade window pre-state");
-    let body = UpgradeWindowPutRequest {
-        start_hour_utc: restore.pre_state.start_hour_utc,
-        weekday: restore.pre_state.weekday,
-    };
+    let body = UpgradeWindowPutRequest::try_from(restore.pre_state.clone())?;
     match client
         .upgrade_window_update(org_id, &restore.service_id, &body)
         .await
@@ -913,23 +912,42 @@ async fn restore_upgrade_window(
     }
 }
 
-pub fn scaling_schedule_entry_to_request(
-    entry: &ScalingScheduleEntry,
-) -> ScalingScheduleEntryRequest {
-    ScalingScheduleEntryRequest {
-        autoscaling_mode: Some(entry.autoscaling_mode.clone()),
-        end_hour_utc: entry.end_hour_utc,
-        idle_scaling: entry.idle_scaling,
-        idle_timeout_minutes: entry.idle_timeout_minutes,
-        max_replica_memory_gb: entry.max_replica_memory_gb,
-        max_replicas: entry.max_replicas,
-        min_replica_memory_gb: entry.min_replica_memory_gb,
-        min_replicas: entry.min_replicas,
-        name: entry.name.clone(),
-        num_replicas: None,
-        start_hour_utc: entry.start_hour_utc,
-        weekdays: entry.weekdays.clone(),
-    }
+/// Requires a response field a test cannot proceed without.
+///
+/// Every response model field is `Option<T>`, so a test that needs a value says
+/// so here instead of unwrapping and panicking on a field the API dropped.
+pub fn require_field<T>(value: Option<T>, field: &str) -> TestResult<T> {
+    value.ok_or_else(|| format!("the API response is missing required field '{field}'").into())
+}
+
+/// A response field rendered as a string, or an empty string when the API
+/// omitted it (which matches no real value).
+pub fn field_string<T: fmt::Display>(value: Option<T>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
+/// A service's state as a string, or an empty string when the API omitted it
+/// (which matches no known state).
+pub fn service_state(service: &Service) -> String {
+    service
+        .state
+        .as_ref()
+        .map(|state| state.to_string())
+        .unwrap_or_default()
+}
+
+/// The service's HTTPS endpoint, which every query helper needs.
+pub fn https_endpoint(service: &Service) -> TestResult<ServiceEndpoint> {
+    service
+        .endpoints
+        .as_ref()
+        .and_then(|endpoints| {
+            endpoints
+                .iter()
+                .find(|e| e.protocol == Some(ServiceEndpointProtocol::Https))
+        })
+        .cloned()
+        .ok_or_else(|| "ClickHouse service has no https endpoint".into())
 }
 
 async fn ensure_service_gone(
@@ -945,7 +963,7 @@ async fn ensure_service_gone(
     match client.instance_get(org_id, service_id).await {
         Ok(resp) => {
             if let Some(svc) = resp.result {
-                let state = svc.state.to_string();
+                let state = service_state(&svc);
                 if matches!(state.as_str(), "running" | "idle" | "starting" | "awaking") {
                     eprintln!("  cleanup: stopping service before delete");
                     let _ = client
@@ -968,11 +986,8 @@ async fn ensure_service_gone(
                             let service_id = service_id.to_string();
                             async move {
                                 let resp = client.instance_get(&org_id, &service_id).await?;
-                                let state = resp
-                                    .result
-                                    .as_ref()
-                                    .map(|s| s.state.to_string())
-                                    .unwrap_or_default();
+                                let state =
+                                    resp.result.as_ref().map(service_state).unwrap_or_default();
                                 if matches!(
                                     state.as_str(),
                                     "stopped" | "idle" | "degraded" | "failed"
@@ -1344,8 +1359,9 @@ pub async fn provision_clickhouse(
         .await?
         .result
         .ok_or("service create returned no result")?;
-    let service_id = created.service.id.to_string();
-    let password = created.password.clone();
+    let service = require_field(created.service, "service")?;
+    let service_id = require_field(service.id, "service.id")?.to_string();
+    let password = require_field(created.password, "password")?;
     cleanup.register_service(service_id.clone());
     eprintln!("  provisioned clickhouse id <redacted>");
 
@@ -1360,7 +1376,7 @@ pub async fn provision_clickhouse(
             async move {
                 let resp = client.instance_get(&org_id, &service_id).await?;
                 let svc = resp.result.ok_or("service get returned no result")?;
-                let state = svc.state.to_string();
+                let state = service_state(&svc);
                 if matches!(state.as_str(), "running" | "idle") {
                     Ok(Some(svc))
                 } else {
@@ -1371,27 +1387,19 @@ pub async fn provision_clickhouse(
     )
     .await?;
 
-    if svc.iam_role.is_empty() {
-        return Err(
-            "provisioned service has no iamRole populated — cannot establish ClickPipes trust"
-                .into(),
-        );
-    }
+    let iam_role = svc.iam_role.clone().filter(|role| !role.is_empty()).ok_or(
+        "provisioned service has no iamRole populated — cannot establish ClickPipes trust",
+    )?;
 
-    let https_endpoint = svc
-        .endpoints
-        .iter()
-        .find(|e| matches!(e.protocol, ServiceEndpointProtocol::Https))
-        .ok_or("ClickHouse service has no https endpoint")?
-        .clone();
+    let https_endpoint = https_endpoint(&svc)?;
     let username = https_endpoint
         .username
         .clone()
         .unwrap_or_else(|| "default".to_string());
 
     let query = ClickHouseQuery::new(
-        &https_endpoint.host,
-        https_endpoint.port as u16,
+        &require_field(https_endpoint.host.clone(), "endpoints[].host")?,
+        require_field(https_endpoint.port, "endpoints[].port")? as u16,
         &username,
         &password,
     );
@@ -1399,7 +1407,7 @@ pub async fn provision_clickhouse(
     Ok(ProvisionedClickHouse {
         service_id,
         password,
-        iam_role: svc.iam_role,
+        iam_role,
         https_endpoint,
         username,
         query,
@@ -1425,19 +1433,20 @@ pub async fn attach_clickhouse(
     // a query is what actually triggers the wake. Send `SELECT 1` and poll
     // until the state field flips to `running` so subsequent pipe-creates
     // succeed.
-    let state = svc.state.to_string();
+    let state = service_state(&svc);
     if state == "idle" {
         eprintln!("  service is idle — sending wake query");
-        let https = svc
-            .endpoints
-            .iter()
-            .find(|e| matches!(e.protocol, ServiceEndpointProtocol::Https))
-            .ok_or("service has no https endpoint to wake")?;
+        let https = https_endpoint(&svc)?;
         let username = https
             .username
             .clone()
             .unwrap_or_else(|| "default".to_string());
-        let wake_query = ClickHouseQuery::new(&https.host, https.port as u16, &username, password);
+        let wake_query = ClickHouseQuery::new(
+            &require_field(https.host.clone(), "endpoints[].host")?,
+            require_field(https.port, "endpoints[].port")? as u16,
+            &username,
+            password,
+        );
         let _ = wake_query.run_query("SELECT 1 FORMAT TabSeparated").await?;
 
         svc = poll_until(
@@ -1451,7 +1460,7 @@ pub async fn attach_clickhouse(
                 async move {
                     let resp = client.instance_get(&org_id, &service_id).await?;
                     let svc = resp.result.ok_or("service get returned no result")?;
-                    if svc.state.to_string() == "running" {
+                    if service_state(&svc) == "running" {
                         Ok(Some(svc))
                     } else {
                         Ok(None)
@@ -1465,26 +1474,20 @@ pub async fn attach_clickhouse(
             format!("service {service_id} is in state {state}, expected running or idle").into(),
         );
     }
-    if svc.iam_role.is_empty() {
-        return Err(
-            "attached service has no iamRole populated — cannot establish ClickPipes trust".into(),
-        );
-    }
+    let iam_role =
+        svc.iam_role.clone().filter(|role| !role.is_empty()).ok_or(
+            "attached service has no iamRole populated — cannot establish ClickPipes trust",
+        )?;
 
-    let https_endpoint = svc
-        .endpoints
-        .iter()
-        .find(|e| matches!(e.protocol, ServiceEndpointProtocol::Https))
-        .ok_or("ClickHouse service has no https endpoint")?
-        .clone();
+    let https_endpoint = https_endpoint(&svc)?;
     let username = https_endpoint
         .username
         .clone()
         .unwrap_or_else(|| "default".to_string());
 
     let query = ClickHouseQuery::new(
-        &https_endpoint.host,
-        https_endpoint.port as u16,
+        &require_field(https_endpoint.host.clone(), "endpoints[].host")?,
+        require_field(https_endpoint.port, "endpoints[].port")? as u16,
         &username,
         password,
     );
@@ -1493,7 +1496,7 @@ pub async fn attach_clickhouse(
     Ok(ProvisionedClickHouse {
         service_id: service_id.to_string(),
         password: password.to_string(),
-        iam_role: svc.iam_role,
+        iam_role,
         https_endpoint,
         username,
         query,

--- a/crates/clickhouse-cloud-api/tests/integration_org_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_org_test.rs
@@ -51,7 +51,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             })
             .await?
             .expect("blocking steps always return a value");
-        assert_eq!(org.id.to_string(), ctx.org_id);
+        assert_eq!(field_string(org.id), ctx.org_id);
 
         // ── Members ─────────────────────────────────────────────────
         //
@@ -82,7 +82,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
         if let Some(members) = members.as_ref() {
             let secondary_present = members
                 .iter()
-                .any(|m| m.user_id == secondary_user_id);
+                .any(|m| m.user_id.as_deref() == Some(secondary_user_id.as_str()));
             assert!(
                 secondary_present,
                 "member list did not include configured secondary user"
@@ -93,7 +93,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             // is wider than the secondary user alone.
             let distinct_users = members
                 .iter()
-                .map(|m| m.user_id.as_str())
+                .filter_map(|m| m.user_id.as_deref())
                 .collect::<std::collections::HashSet<_>>();
             assert!(
                 distinct_users.len() >= 2,
@@ -115,10 +115,16 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             .await?;
 
         if let Some(secondary_member) = secondary_member {
-            assert_eq!(secondary_member.user_id, secondary_user_id);
+            assert_eq!(
+                secondary_member.user_id.as_deref(),
+                Some(secondary_user_id.as_str())
+            );
             assert!(
-                !secondary_member.email.is_empty(),
-                "secondary member email was empty"
+                secondary_member
+                    .email
+                    .as_deref()
+                    .is_some_and(|email| !email.is_empty()),
+                "secondary member email was absent or empty"
             );
 
             // Custom Roles round-trip. Orgs that have migrated to Custom
@@ -134,7 +140,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             let original_role_ids: Vec<String> = secondary_member
                 .assigned_roles
                 .iter()
-                .map(|ar| ar.role_id.to_string())
+                .flatten()
+                .map(|ar| field_string(ar.role_id))
                 .collect();
 
             let org_roles = failures
@@ -158,7 +165,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                     original_role_ids.iter().map(|s| s.as_str()).collect();
                 let candidate_extra = org_roles
                     .iter()
-                    .map(|r| r.id.clone())
+                    .filter_map(|r| r.id.clone())
                     .find(|id| !originals.contains(id.as_str()));
 
                 let target_role_ids: Option<Vec<String>> = match candidate_extra {
@@ -251,7 +258,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                                     member
                                                         .assigned_roles
                                                         .iter()
-                                                        .map(|ar| ar.role_id.to_string())
+                                                        .flatten()
+                                                        .map(|ar| field_string(ar.role_id))
                                                         .collect();
                                                 if got == want {
                                                     Ok(Some(()))
@@ -321,7 +329,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                                     member
                                                         .assigned_roles
                                                         .iter()
-                                                        .map(|ar| ar.role_id.to_string())
+                                                        .flatten()
+                                                        .map(|ar| field_string(ar.role_id))
                                                         .collect();
                                                 if got == want {
                                                     Ok(Some(()))
@@ -388,10 +397,11 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             .await?;
 
         if let Some(invitation) = invitation {
-            let invitation_id = invitation.id.to_string();
+            let invitation_id = field_string(invitation.id);
             cleanup.register_invitation(invitation_id.clone());
             assert_eq!(
-                invitation.email, invitation_email_for_assert,
+                invitation.email.as_deref(),
+                Some(invitation_email_for_assert.as_str()),
                 "invitation create echoed unexpected email"
             );
             #[cfg(feature = "deprecated-fields")]
@@ -417,7 +427,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                 .ok_or("invitation list returned no result")?;
                             if !list
                                 .iter()
-                                .any(|inv| inv.id.to_string() == invitation_id_for_list)
+                                .any(|inv| field_string(inv.id) == invitation_id_for_list)
                             {
                                 return Err(format!(
                                     "invitation list did not include new invitation {invitation_id_for_list}"
@@ -443,16 +453,16 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                         let fetched = resp
                             .result
                             .ok_or("invitation get returned no result")?;
-                        if fetched.id.to_string() != id {
+                        if field_string(fetched.id) != id {
                             return Err(format!(
-                                "invitation get returned wrong id {}; wanted {id}",
+                                "invitation get returned wrong id {:?}; wanted {id}",
                                 fetched.id
                             )
                             .into());
                         }
-                        if fetched.email != want_email {
+                        if fetched.email.as_deref() != Some(want_email.as_str()) {
                             return Err(format!(
-                                "invitation get returned wrong email {}; wanted {want_email}",
+                                "invitation get returned wrong email {:?}; wanted {want_email}",
                                 fetched.email
                             )
                             .into());
@@ -607,7 +617,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                         let roles = resp
                             .result
                             .ok_or("roles list returned no result")?;
-                        Ok(roles.into_iter().map(|r| r.id).collect::<Vec<_>>())
+                        Ok(roles.into_iter().flat_map(|r| r.id).collect::<Vec<_>>())
                     }
                 },
             )
@@ -639,9 +649,9 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                     let role = resp
                         .result
                         .ok_or("role create returned no result")?;
-                    if role.name != role_name {
+                    if role.name.as_deref() != Some(role_name.as_str()) {
                         return Err(format!(
-                            "created role name mismatch: expected {role_name}, got {}",
+                            "created role name mismatch: expected {role_name}, got {:?}",
                             role.name
                         )
                         .into());
@@ -654,8 +664,9 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
         // Register for cleanup before any further mutation so a failure
         // mid-phase still reclaims the resource via teardown.
         let role_id = if let Some(role) = created_role.as_ref() {
-            cleanup.register_role(role.id.clone());
-            Some(role.id.clone())
+            let role_id = require_field(role.id.clone(), "id")?;
+            cleanup.register_role(role_id.clone());
+            Some(role_id)
         } else {
             None
         };
@@ -678,7 +689,10 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let roles = resp
                                 .result
                                 .ok_or("roles list returned no result")?;
-                            if !roles.iter().any(|r| r.id == role_id) {
+                            if !roles
+                                .iter()
+                                .any(|r| r.id.as_deref() == Some(role_id.as_str()))
+                            {
                                 return Err(format!(
                                     "created role {role_id} not visible in roles list"
                                 )
@@ -715,21 +729,21 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let role = resp
                                 .result
                                 .ok_or("role get returned no result")?;
-                            if role.id != role_id {
+                            if role.id.as_deref() != Some(role_id.as_str()) {
                                 return Err(format!(
-                                    "role id mismatch: expected {role_id}, got {}",
+                                    "role id mismatch: expected {role_id}, got {:?}",
                                     role.id
                                 )
                                 .into());
                             }
-                            if role.name != expected_name {
+                            if role.name.as_deref() != Some(expected_name.as_str()) {
                                 return Err(format!(
-                                    "role name mismatch: expected {expected_name}, got {}",
+                                    "role name mismatch: expected {expected_name}, got {:?}",
                                     role.name
                                 )
                                 .into());
                             }
-                            if !matches!(role.r#type, RBACRoleType::Custom) {
+                            if !matches!(role.r#type, Some(RBACRoleType::Custom)) {
                                 return Err(format!(
                                     "expected custom role type, got {:?}",
                                     role.r#type
@@ -739,7 +753,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let actual_permissions: Vec<String> = role
                                 .policies
                                 .iter()
-                                .flat_map(|p| p.permissions.iter().cloned())
+                                .flatten()
+                                .flat_map(|p| p.permissions.iter().flatten().cloned())
                                 .collect();
                             for expected in &expected_permissions {
                                 if !actual_permissions.iter().any(|p| p == expected) {
@@ -830,7 +845,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let actual_permissions: Vec<String> = role
                                 .policies
                                 .iter()
-                                .flat_map(|p| p.permissions.iter().cloned())
+                                .flatten()
+                                .flat_map(|p| p.permissions.iter().flatten().cloned())
                                 .collect();
                             for expected in &expected_permissions {
                                 if !actual_permissions.iter().any(|p| p == expected) {
@@ -961,7 +977,9 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                                         return Ok(None);
                                     }
                                     let hit = entries.into_iter().find(|a| {
-                                        a.created_at.timestamp() as u64 >= window_start_secs
+                                        a.created_at.is_some_and(|created_at| {
+                                            created_at.timestamp() as u64 >= window_start_secs
+                                        })
                                     });
                                     Ok(hit)
                                 }
@@ -982,7 +1000,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             .await?;
 
         if let Some(activity) = recent_activity {
-            let activity_id = activity.id.clone();
+            let activity_id = require_field(activity.id.clone(), "id")?;
             failures
                 .run(
                     &ctx,
@@ -997,19 +1015,23 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let fetched = resp.result.ok_or_else(|| {
                                 "activity_get returned no result".to_string()
                             })?;
-                            if fetched.id != activity_id {
+                            if fetched.id.as_deref() != Some(activity_id.as_str()) {
                                 return Err(format!(
-                                    "activity_get returned id {} but requested {}",
+                                    "activity_get returned id {:?} but requested {}",
                                     fetched.id, activity_id
                                 )
                                 .into());
                             }
-                            if fetched.organization_id.is_empty() {
+                            if fetched
+                                .organization_id
+                                .as_deref()
+                                .is_none_or(str::is_empty)
+                            {
                                 return Err(
-                                    "activity_get returned empty organizationId".into()
+                                    "activity_get returned no organizationId".into()
                                 );
                             }
-                            if fetched.created_at.timestamp() == 0 {
+                            if fetched.created_at.is_none_or(|at| at.timestamp() == 0) {
                                 return Err(
                                     "activity_get returned zero createdAt".into()
                                 );
@@ -1059,10 +1081,12 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                     let created = resp
                         .result
                         .ok_or_else(|| "openapi_key_create returned no result".to_string())?;
-                    if created.key.name != key_name {
+                    let created_key_name =
+                        created.key.as_ref().and_then(|key| key.name.as_deref());
+                    if created_key_name != Some(key_name.as_str()) {
                         return Err(format!(
                             "openapi_key_create returned name {:?}, expected {:?}",
-                            created.key.name, key_name
+                            created_key_name, key_name
                         )
                         .into());
                     }
@@ -1072,7 +1096,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             .await?;
 
         if let Some(created_key) = created_key {
-            let api_key_uuid = created_key.key.id.to_string();
+            let api_key_uuid = field_string(created_key.key.and_then(|key| key.id));
             cleanup.register_api_key(api_key_uuid.clone());
 
             // openapi_key_get — assert fields match what create returned.
@@ -1089,21 +1113,21 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                         let key = resp
                             .result
                             .ok_or_else(|| "openapi_key_get returned no result".to_string())?;
-                        if key.id.to_string() != api_key_uuid {
+                        if field_string(key.id) != api_key_uuid {
                             return Err(format!(
-                                "openapi_key_get returned id {}, expected {}",
+                                "openapi_key_get returned id {:?}, expected {}",
                                 key.id, api_key_uuid
                             )
                             .into());
                         }
-                        if key.name != expected_name {
+                        if key.name.as_deref() != Some(expected_name.as_str()) {
                             return Err(format!(
                                 "openapi_key_get returned name {:?}, expected {:?}",
                                 key.name, expected_name
                             )
                             .into());
                         }
-                        if !matches!(key.state, ApiKeyState::Enabled) {
+                        if !matches!(key.state, Some(ApiKeyState::Enabled)) {
                             return Err(format!(
                                 "openapi_key_get returned state {:?}, expected Enabled",
                                 key.state
@@ -1127,7 +1151,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                         let keys = resp
                             .result
                             .ok_or_else(|| "openapi_key_get_list returned no result".to_string())?;
-                        if !keys.iter().any(|k| k.id.to_string() == api_key_uuid) {
+                        if !keys.iter().any(|k| field_string(k.id) == api_key_uuid) {
                             return Err(format!(
                                 "openapi_key_get_list did not contain newly created key {api_key_uuid} (found {} keys)",
                                 keys.len()
@@ -1162,7 +1186,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let patched_key = patched
                                 .result
                                 .ok_or_else(|| "openapi_key_update returned no result".to_string())?;
-                            if !matches!(patched_key.state, ApiKeyState::Disabled) {
+                            if !matches!(patched_key.state, Some(ApiKeyState::Disabled)) {
                                 return Err(format!(
                                     "openapi_key_update -> disabled returned state {:?}",
                                     patched_key.state
@@ -1175,7 +1199,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let key = resp
                                 .result
                                 .ok_or_else(|| "openapi_key_get after disable returned no result".to_string())?;
-                            if !matches!(key.state, ApiKeyState::Disabled) {
+                            if !matches!(key.state, Some(ApiKeyState::Disabled)) {
                                 return Err(format!(
                                     "openapi_key_get after disable returned state {:?}, expected Disabled",
                                     key.state
@@ -1194,7 +1218,7 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             let restored_key = restored
                                 .result
                                 .ok_or_else(|| "openapi_key_update -> enabled returned no result".to_string())?;
-                            if !matches!(restored_key.state, ApiKeyState::Enabled) {
+                            if !matches!(restored_key.state, Some(ApiKeyState::Enabled)) {
                                 return Err(format!(
                                     "openapi_key_update -> enabled returned state {:?}",
                                     restored_key.state

--- a/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
@@ -37,7 +37,12 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                             .ok_or("postgres list returned no result")?;
                         let leftover: Vec<_> = services
                             .into_iter()
-                            .filter(|s| filters_match_tags(&filters, &s.tags))
+                            .filter(|s| {
+                                filters_match_tags(
+                                    &filters,
+                                    s.tags.as_deref().unwrap_or_default(),
+                                )
+                            })
                             .collect();
                         Ok(leftover)
                     }
@@ -77,7 +82,10 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
 
-        let postgres_id = created.id.to_string();
+        let postgres_id = created
+            .id
+            .ok_or("postgres create returned no id")?
+            .to_string();
         eprintln!("postgres_id: <redacted>");
         cleanup.register_postgres(postgres_id.clone());
 
@@ -86,16 +94,19 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
         // `password` and `connectionString`, so assert them here rather
         // than on the polled get below.
         assert!(
-            !created.username.is_empty(),
-            "postgres create returned empty username"
+            created.username.as_deref().is_some_and(|v| !v.is_empty()),
+            "postgres create returned no username"
         );
         assert!(
-            !created.password.is_empty(),
-            "postgres create returned empty password"
+            created.password.as_deref().is_some_and(|v| !v.is_empty()),
+            "postgres create returned no password"
         );
         assert!(
-            !created.connection_string.is_empty(),
-            "postgres create returned empty connection string"
+            created
+                .connection_string
+                .as_deref()
+                .is_some_and(|v| !v.is_empty()),
+            "postgres create returned no connection string"
         );
 
         let ready = failures
@@ -123,7 +134,9 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                                     let svc = resp
                                         .result
                                         .ok_or("postgres get returned no result")?;
-                                    if svc.state.to_string() == "running" {
+                                    if svc.state.as_ref().is_some_and(|state| {
+                                        state.to_string() == "running"
+                                    }) {
                                         Ok(Some(svc))
                                     } else {
                                         Ok(None)
@@ -138,13 +151,19 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
 
-        assert_eq!(ready.name, ctx.postgres_service_name());
-        assert_eq!(ready.size.to_string(), size.to_string());
-        assert_eq!(ready.region, ctx.region);
-        assert_eq!(ready.provider.to_string(), ctx.provider);
+        assert_eq!(ready.name.as_deref(), Some(ctx.postgres_service_name().as_str()));
+        assert_eq!(
+            ready.size.as_ref().map(ToString::to_string),
+            Some(size.to_string())
+        );
+        assert_eq!(ready.region.as_deref(), Some(ctx.region.as_str()));
+        assert_eq!(
+            ready.provider.as_ref().map(ToString::to_string),
+            Some(ctx.provider.clone())
+        );
         assert!(
-            !ready.hostname.is_empty(),
-            "running postgres service returned empty hostname"
+            ready.hostname.as_deref().is_some_and(|v| !v.is_empty()),
+            "running postgres service returned no hostname"
         );
 
         let listed = failures
@@ -165,7 +184,9 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
         assert!(
-            listed.iter().any(|s| s.id.to_string() == postgres_id),
+            listed
+                .iter()
+                .any(|s| s.id.is_some_and(|id| id.to_string() == postgres_id)),
             "created postgres service was not visible in list"
         );
 
@@ -252,8 +273,8 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
         if let Some(baseline) = baseline {
             let baseline_max = baseline
                 .pg_config
-                .max_connections
                 .as_ref()
+                .and_then(|c| c.max_connections.as_ref())
                 .and_then(pg_config_value_as_i64)
                 .unwrap_or(100);
             let target = baseline_max + 7;
@@ -261,8 +282,8 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             // service is deleted at the end, so drift on reset is harmless.
             let baseline_autovacuum = baseline
                 .pg_config
-                .autovacuum_max_workers
                 .as_ref()
+                .and_then(|c| c.autovacuum_max_workers.as_ref())
                 .and_then(pg_config_value_as_i64)
                 .unwrap_or(3);
             let autovacuum_target = baseline_autovacuum + 1;
@@ -320,8 +341,10 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                                         let resp = client
                                             .postgres_instance_config_get(&org_id, &postgres_id)
                                             .await?;
-                                        let pg_config =
-                                            resp.result.map(|r| r.pg_config).unwrap_or_default();
+                                        let pg_config = resp
+                                            .result
+                                            .and_then(|r| r.pg_config)
+                                            .unwrap_or_default();
                                         let observed = pg_config
                                             .max_connections
                                             .as_ref()
@@ -424,7 +447,7 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                             .postgres_service_get(&org_id, &postgres_id)
                             .await?;
                         let svc = resp.result.ok_or("postgres get returned no result")?;
-                        let has_phase_tag = svc.tags.iter().any(|t| {
+                        let has_phase_tag = svc.tags.iter().flatten().any(|t| {
                             t.key == "phase" && t.value.as_deref() == Some("patched")
                         });
                         if !has_phase_tag {
@@ -499,7 +522,11 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                             let svc = resp
                                 .result
                                 .ok_or("postgres get returned no result")?;
-                            if svc.state.to_string() == "running" {
+                            if svc
+                                .state
+                                .as_ref()
+                                .is_some_and(|state| state.to_string() == "running")
+                            {
                                 Ok(Some(()))
                             } else {
                                 Ok(None)
@@ -604,7 +631,10 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
 
-        let replica_id = replica.id.to_string();
+        let replica_id = replica
+            .id
+            .ok_or("postgres read replica create returned no id")?
+            .to_string();
         eprintln!("postgres_replica_id: <redacted>");
         // Register before any further interaction so a panic in a later
         // step cannot leak the replica.
@@ -616,8 +646,12 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
         // whole run down. We deliberately do NOT wait for `running`: see the
         // phase header comment.
         let replica_is_primary_on_create = replica.is_primary;
-        let replica_name_on_create = replica.name.clone();
-        let replica_state_on_create = replica.state.to_string();
+        let replica_name_on_create = replica.name.clone().unwrap_or_default();
+        let replica_state_on_create = replica
+            .state
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_default();
         let expected_replica_name = ctx.postgres_replica_name();
         failures
             .run(
@@ -625,7 +659,7 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                 StepKind::NonBlocking,
                 "verify replica create response shape",
                 || async move {
-                    if replica_is_primary_on_create {
+                    if replica_is_primary_on_create != Some(false) {
                         return Err(format!(
                             "expected replica `{replica_name_on_create}` to have isPrimary=false on create response"
                         )
@@ -662,11 +696,12 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                         let services = resp
                             .result
                             .ok_or("postgres list returned no result")?;
-                        let primary_seen =
-                            services.iter().any(|s| s.id.to_string() == primary_id);
+                        let primary_seen = services
+                            .iter()
+                            .any(|s| s.id.is_some_and(|id| id.to_string() == primary_id));
                         let replica_entry = services
                             .iter()
-                            .find(|s| s.id.to_string() == replica_id);
+                            .find(|s| s.id.is_some_and(|id| id.to_string() == replica_id));
                         if !primary_seen {
                             return Err(
                                 "primary postgres service no longer visible in list after replica create"
@@ -679,7 +714,7 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                                     .into(),
                             );
                         };
-                        if replica_entry.is_primary {
+                        if replica_entry.is_primary != Some(false) {
                             return Err(
                                 "replica entry in list reported isPrimary=true".into(),
                             );
@@ -713,26 +748,30 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                         let svc = resp
                             .result
                             .ok_or("postgres replica get returned no result")?;
-                        if svc.is_primary {
+                        if svc.is_primary != Some(false) {
                             return Err(
-                                "GET on replica id returned isPrimary=true".into(),
+                                "GET on replica id did not return isPrimary=false".into(),
                             );
                         }
                         // A read replica inherits provider+region from its
                         // primary. These are the closest "primary reference"
                         // signals the current API surface exposes on the
                         // PostgresService model.
-                        if svc.provider.to_string() != expected_provider {
+                        let provider = svc
+                            .provider
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .unwrap_or_default();
+                        if provider != expected_provider {
                             return Err(format!(
-                                "replica provider `{}` did not match primary `{}`",
-                                svc.provider, expected_provider
+                                "replica provider `{provider}` did not match primary `{expected_provider}`"
                             )
                             .into());
                         }
-                        if svc.region != expected_region {
+                        let region = svc.region.clone().unwrap_or_default();
+                        if region != expected_region {
                             return Err(format!(
-                                "replica region `{}` did not match primary `{}`",
-                                svc.region, expected_region
+                                "replica region `{region}` did not match primary `{expected_region}`"
                             )
                             .into());
                         }

--- a/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_postgres_test.rs
@@ -448,7 +448,8 @@ async fn cloud_postgres_crud_lifecycle() -> TestResult<()> {
                             .await?;
                         let svc = resp.result.ok_or("postgres get returned no result")?;
                         let has_phase_tag = svc.tags.iter().flatten().any(|t| {
-                            t.key == "phase" && t.value.as_deref() == Some("patched")
+                            t.key.as_deref() == Some("phase")
+                                && t.value.as_deref() == Some("patched")
                         });
                         if !has_phase_tag {
                             return Err("patched `phase=patched` tag not present on service after PATCH".into());
@@ -950,16 +951,16 @@ fn pg_config_value_as_i64(value: &serde_json::Value) -> Option<i64> {
     }
 }
 
-fn filters_match_tags(filters: &[String], tags: &[ResourceTagsV1]) -> bool {
+fn filters_match_tags(filters: &[String], tags: &[ResourceTagsV1Response]) -> bool {
     filters.iter().all(|filter| {
         let Some(expr) = filter.strip_prefix("tag:") else {
             return true;
         };
         let Some((key, value)) = expr.split_once('=') else {
-            return tags.iter().any(|t| t.key == expr);
+            return tags.iter().any(|t| t.key.as_deref() == Some(expr));
         };
         tags.iter()
-            .any(|t| t.key == key && t.value.as_deref() == Some(value))
+            .any(|t| t.key.as_deref() == Some(key) && t.value.as_deref() == Some(value))
     })
 }
 

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -44,7 +44,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             })
             .await?
             .expect("blocking steps always return a value");
-        assert_eq!(org.id.to_string(), ctx.org_id);
+        assert_eq!(field_string(org.id), ctx.org_id);
         let current_org_name = org.name.clone();
 
         let org_list = failures
@@ -65,7 +65,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
         assert!(
             org_list
                 .iter()
-                .any(|o| o.id.to_string() == ctx.org_id),
+                .any(|o| field_string(o.id) == ctx.org_id),
             "org list did not include target org {}",
             ctx.org_id
         );
@@ -80,13 +80,13 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         .organization_update(
                             &org_id,
                             &OrganizationPatchRequest {
-                                name: Some(name),
+                                name,
                                 ..Default::default()
                             },
                         )
                         .await?;
                     let updated = resp.result.ok_or("org update returned no result")?;
-                    let updated_id = updated.id.to_string();
+                    let updated_id = field_string(updated.id);
                     if updated_id != org_id {
                         return Err(
                             format!("org update returned unexpected org id {updated_id}").into()
@@ -168,8 +168,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
 
-        let service = &created.service;
-        let service_id = service.id.to_string();
+        let service = require_field(created.service, "service")?;
+        let service_id = require_field(service.id, "service.id")?.to_string();
         let _password = created.password.clone();
         eprintln!("service_id: <redacted>");
         cleanup.register_service(service_id.clone());
@@ -196,7 +196,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                     let resp =
                                         client.instance_get(&org_id, &service_id).await?;
                                     let svc = resp.result.ok_or("service get returned no result")?;
-                                    let state = svc.state.to_string();
+                                    let state = service_state(&svc);
                                     if matches!(state.as_str(), "running" | "idle") {
                                         Ok(Some(svc))
                                     } else {
@@ -212,10 +212,10 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             .await?
             .expect("blocking steps always return a value");
 
-        assert_eq!(ready.name, ctx.service_name());
-        assert_eq!(ready.min_replica_memory_gb, base_memory_gb);
-        assert_eq!(ready.max_replica_memory_gb, base_memory_gb);
-        assert_eq!(ready.num_replicas, base_replicas);
+        assert_eq!(ready.name, Some(ctx.service_name()));
+        assert_eq!(ready.min_replica_memory_gb, Some(base_memory_gb));
+        assert_eq!(ready.max_replica_memory_gb, Some(base_memory_gb));
+        assert_eq!(ready.num_replicas, Some(base_replicas));
 
         let listed = failures
             .run(
@@ -239,7 +239,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
         assert!(
             listed
                 .iter()
-                .any(|s| s.id.to_string() == service_id),
+                .any(|s| field_string(s.id) == service_id),
             "created service was not visible in service list"
         );
 
@@ -284,7 +284,12 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
         // query endpoint. Management endpoints (GET/DELETE /keys/{id}) and the
         // endpoint binding's `openApiKeys` array reference the API key's
         // resource UUID instead — `query_key.key.id`.
-        let api_key_uuid = query_key.key.id.to_string();
+        // Every response field is `Option<T>`: require the credential pair and
+        // the key's resource UUID once here rather than at each use below.
+        let key_id = require_field(query_key.key_id.clone(), "keyId")?;
+        let key_secret = require_field(query_key.key_secret.clone(), "keySecret")?;
+        let api_key_uuid =
+            require_field(query_key.key.as_ref().and_then(|key| key.id), "key.id")?.to_string();
         cleanup.register_api_key(api_key_uuid.clone());
 
         // Before binding the key to a query endpoint, calling the Query API
@@ -300,8 +305,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 || {
                     let client = client.clone();
                     let service_id = service_id.clone();
-                    let key_id = query_key.key_id.clone();
-                    let key_secret = query_key.key_secret.clone();
+                    let key_id = key_id.clone();
+                    let key_secret = key_secret.clone();
                     async move {
                         match client
                             .run_query(
@@ -396,26 +401,36 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                             .ok_or("query endpoint get returned no result")?;
                         if endpoint.id != initial_endpoint.id {
                             return Err(format!(
-                                "get returned different endpoint id: {} (upsert) vs {} (get)",
+                                "get returned different endpoint id: {:?} (upsert) vs {:?} (get)",
                                 initial_endpoint.id, endpoint.id
                             )
                             .into());
                         }
-                        if !endpoint.roles.iter().any(|r| r == "sql_console_admin") {
+                        if !endpoint
+                            .roles
+                            .iter()
+                            .flatten()
+                            .any(|r| r == "sql_console_admin")
+                        {
                             return Err(format!(
                                 "get missing sql_console_admin role: {:?}",
                                 endpoint.roles
                             )
                             .into());
                         }
-                        if !endpoint.open_api_keys.contains(&api_key_uuid) {
+                        if !endpoint
+                            .open_api_keys
+                            .iter()
+                            .flatten()
+                            .any(|key| key == &api_key_uuid)
+                        {
                             return Err(format!(
                                 "get missing our key from openApiKeys: {:?}",
                                 endpoint.open_api_keys
                             )
                             .into());
                         }
-                        if endpoint.allowed_origins != "*" {
+                        if endpoint.allowed_origins.as_deref() != Some("*") {
                             return Err(format!(
                                 "get returned unexpected allowedOrigins: {:?}",
                                 endpoint.allowed_origins
@@ -435,8 +450,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             .run(&ctx, StepKind::Blocking, "run SELECT 1 via Query API", || {
                 let client = client.clone();
                 let service_id = service_id.clone();
-                let key_id = query_key.key_id.clone();
-                let key_secret = query_key.key_secret.clone();
+                let key_id = key_id.clone();
+                let key_secret = key_secret.clone();
                 async move {
                     poll_until(
                         "query API SELECT 1",
@@ -506,8 +521,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 || {
                     let client = client.clone();
                     let service_id = service_id.clone();
-                    let key_id = query_key.key_id.clone();
-                    let key_secret = query_key.key_secret.clone();
+                    let key_id = key_id.clone();
+                    let key_secret = key_secret.clone();
                     async move {
                         async fn exec(
                             client: &clickhouse_cloud_api::Client,
@@ -616,19 +631,29 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                             .ok_or("re-upsert returned no result")?;
                         if endpoint.id != initial_endpoint.id {
                             return Err(format!(
-                                "re-upsert changed endpoint id: {} -> {}",
+                                "re-upsert changed endpoint id: {:?} -> {:?}",
                                 initial_endpoint.id, endpoint.id
                             )
                             .into());
                         }
-                        if !endpoint.open_api_keys.contains(&api_key_uuid) {
+                        if !endpoint
+                            .open_api_keys
+                            .iter()
+                            .flatten()
+                            .any(|key| key == &api_key_uuid)
+                        {
                             return Err(format!(
                                 "re-upsert dropped our key from openApiKeys: {:?}",
                                 endpoint.open_api_keys
                             )
                             .into());
                         }
-                        if !endpoint.roles.iter().any(|r| r == "sql_console_admin") {
+                        if !endpoint
+                            .roles
+                            .iter()
+                            .flatten()
+                            .any(|r| r == "sql_console_admin")
+                        {
                             return Err(format!(
                                 "re-upsert dropped sql_console_admin role: {:?}",
                                 endpoint.roles
@@ -649,8 +674,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 || {
                     let client = client.clone();
                     let service_id = service_id.clone();
-                    let key_id = query_key.key_id.clone();
-                    let key_secret = query_key.key_secret.clone();
+                    let key_id = key_id.clone();
+                    let key_secret = key_secret.clone();
                     async move {
                         let response = client
                             .run_query(
@@ -780,7 +805,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         async move {
                             let resp = client.instance_get(&org_id, &service_id).await?;
                             let svc = resp.result.ok_or("service get returned no result")?;
-                            let state = svc.state.to_string();
+                            let state = service_state(&svc);
                             if matches!(state.as_str(), "idle" | "stopped") {
                                 Ok(Some(()))
                             } else {
@@ -818,7 +843,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         async move {
                             let resp = client.instance_get(&org_id, &service_id).await?;
                             let svc = resp.result.ok_or("service get returned no result")?;
-                            let state = svc.state.to_string();
+                            let state = service_state(&svc);
                             if matches!(state.as_str(), "running" | "idle") {
                                 Ok(Some(()))
                             } else {
@@ -879,7 +904,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let resp = client.instance_get(&org_id, &service_id).await?;
                                 let svc =
                                     resp.result.ok_or("service get returned no result")?;
-                                if svc.name == expected_name {
+                                if svc.name.as_deref() == Some(expected_name.as_str()) {
                                     Ok(Some(svc))
                                 } else {
                                     Ok(None)
@@ -892,7 +917,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             )
             .await?
             .expect("blocking steps always return a value");
-        assert_eq!(updated.name, ctx.updated_service_name());
+        assert_eq!(updated.name, Some(ctx.updated_service_name()));
 
         let renamed_list = failures
             .run(
@@ -922,10 +947,12 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let services = resp
                                     .result
                                     .ok_or("service list returned no result")?;
-                                let found = services.iter().find(|s| {
-                                    s.id.to_string() == service_id
-                                });
-                                if found.is_some_and(|s| s.name == expected_name) {
+                                let found = services
+                                    .iter()
+                                    .find(|s| field_string(s.id) == service_id);
+                                if found.is_some_and(|s| {
+                                    s.name.as_deref() == Some(expected_name.as_str())
+                                }) {
                                     Ok(Some(services))
                                 } else {
                                     Ok(None)
@@ -940,9 +967,9 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             .expect("blocking steps always return a value");
         let renamed_svc = renamed_list
             .iter()
-            .find(|s| s.id.to_string() == service_id);
+            .find(|s| field_string(s.id) == service_id);
         assert_eq!(
-            renamed_svc.map(|s| s.name.as_str()),
+            renamed_svc.and_then(|s| s.name.as_deref()),
             Some(ctx.updated_service_name().as_str())
         );
 
@@ -986,7 +1013,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 &org_id,
                                 &service_id,
                                 &ServicePatchRequest {
-                                    enable_core_dumps: Some(current_value),
+                                    enable_core_dumps: current_value,
                                     ..Default::default()
                                 },
                             )
@@ -1073,7 +1100,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         let schema = resp
                             .result
                             .ok_or("clickhouse settings schema returned no result")?;
-                        if schema.settings.is_empty() {
+                        if schema.settings.iter().flatten().count() == 0 {
                             return Err("clickhouse settings schema returned no entries".into());
                         }
                         Ok(schema)
@@ -1114,13 +1141,17 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 schema
                     .settings
                     .iter()
-                    .find(|entry| entry.name == *name)
+                    .flatten()
+                    .find(|entry| entry.name.as_deref() == Some(*name))
                     .cloned()
             });
 
             if let Some(entry) = chosen {
-                let setting_name = entry.name.clone();
-                eprintln!("  chose setting: {setting_name} (type: {})", entry.r#type);
+                let setting_name = require_field(entry.name.clone(), "settings[].name")?;
+                eprintln!(
+                    "  chose setting: {setting_name} (type: {})",
+                    field_string(entry.r#type.as_deref())
+                );
 
                 let list_resp = failures
                     .run(
@@ -1141,7 +1172,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let list = resp.result.ok_or(
                                     "clickhouse settings list returned no result",
                                 )?;
-                                if list.settings.is_empty() {
+                                if list.settings.iter().flatten().count() == 0 {
                                     return Err(
                                         "clickhouse settings list returned no entries".into(),
                                     );
@@ -1155,8 +1186,9 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 let original_value = list_resp.as_ref().and_then(|list| {
                     list.settings
                         .iter()
-                        .find(|s| s.name == setting_name)
-                        .map(|s| s.value.clone())
+                        .flatten()
+                        .find(|s| s.name.as_deref() == Some(setting_name.as_str()))
+                        .and_then(|s| s.value.clone())
                 });
 
                 if let Some(original) = original_value {
@@ -1259,7 +1291,9 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                                     let got = resp.result.ok_or(
                                                         "clickhouse setting get returned no result",
                                                     )?;
-                                                    if got.value == expected {
+                                                    if got.value.as_deref()
+                                                        == Some(expected.as_str())
+                                                    {
                                                         Ok(Some(()))
                                                     } else {
                                                         Ok(None)
@@ -1302,8 +1336,12 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 // updated, and skip the mutation phase. The earlier
                 // `clickhouse settings schema get` step still records
                 // coverage of the schema endpoint.
-                let exposed: Vec<&str> =
-                    schema.settings.iter().map(|s| s.name.as_str()).collect();
+                let exposed: Vec<&str> = schema
+                    .settings
+                    .iter()
+                    .flatten()
+                    .filter_map(|s| s.name.as_deref())
+                    .collect();
                 eprintln!(
                     "  SKIP clickhouse settings round-trip: none of {:?} matched the \
                      {} settings the cloud schema currently exposes: {:?}",
@@ -1354,22 +1392,22 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         let config = resp.result.ok_or(
                             "instance_private_endpoint_config_get returned no result",
                         )?;
-                        if config.endpoint_service_id.is_empty() {
-                            return Err(
-                                "private endpoint config returned empty endpointServiceId"
-                                    .into(),
-                            );
-                        }
-                        if config.private_dns_hostname.is_empty() {
-                            return Err(
-                                "private endpoint config returned empty privateDnsHostname"
-                                    .into(),
-                            );
-                        }
+                        let endpoint_service_id = config
+                            .endpoint_service_id
+                            .filter(|id| !id.is_empty())
+                            .ok_or(
+                                "private endpoint config returned no endpointServiceId",
+                            )?;
+                        let private_dns_hostname = config
+                            .private_dns_hostname
+                            .filter(|host| !host.is_empty())
+                            .ok_or(
+                                "private endpoint config returned no privateDnsHostname",
+                            )?;
                         eprintln!(
                             "  private endpoint config: endpointServiceId len={} privateDnsHostname len={}",
-                            config.endpoint_service_id.len(),
-                            config.private_dns_hostname.len()
+                            endpoint_service_id.len(),
+                            private_dns_hostname.len()
                         );
                         Ok(())
                     }
@@ -1416,20 +1454,22 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let endpoint = resp.result.ok_or(
                                     "instance_private_endpoint_create returned no result",
                                 )?;
-                                if endpoint.id != synthetic_endpoint_id {
+                                let endpoint_id =
+                                    require_field(endpoint.id, "id")?;
+                                if endpoint_id != synthetic_endpoint_id {
                                     return Err(format!(
                                         "private endpoint create returned unexpected id: \
                                          got {}, expected {}",
-                                        endpoint.id, synthetic_endpoint_id
+                                        endpoint_id, synthetic_endpoint_id
                                     )
                                     .into());
                                 }
                                 eprintln!(
                                     "  private endpoint create unexpectedly succeeded \
-                                     (provider={}, region={}); registering inline cleanup",
+                                     (provider={:?}, region={:?}); registering inline cleanup",
                                     endpoint.cloud_provider, endpoint.region
                                 );
-                                *created_endpoint_id = Some(endpoint.id);
+                                *created_endpoint_id = Some(endpoint_id);
                                 Ok(())
                             }
                             Err(clickhouse_cloud_api::Error::Api { status, message })
@@ -2011,13 +2051,13 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             // rejects upserts with an empty `entries` array, and there is
             // nothing meaningful to restore. Cleanup of synthetic entries
             // is still covered by the service-delete teardown below.
-            if !pre_state.entries.is_empty() {
+            if pre_state.entries.iter().flatten().count() > 0 {
                 cleanup
                     .register_scaling_schedule_restore(service_id.clone(), pre_state.clone());
             }
             eprintln!(
                 "  captured scaling_schedule pre-state: {} entries",
-                pre_state.entries.len()
+                pre_state.entries.iter().flatten().count()
             );
 
             // 9a. Upsert a synthetic-but-inert schedule.
@@ -2082,24 +2122,27 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let schedule = resp.result.ok_or(
                                     "scaling_schedule get returned no result after upsert",
                                 )?;
-                                if schedule.entries.len() != 1 {
+                                let entries =
+                                    schedule.entries.as_deref().unwrap_or_default();
+                                if entries.len() != 1 {
                                     return Err(format!(
                                         "expected 1 entry after upsert, got {}",
-                                        schedule.entries.len()
+                                        entries.len()
                                     )
                                     .into());
                                 }
-                                let entry = &schedule.entries[0];
-                                if entry.name != expected_name {
+                                let entry = &entries[0];
+                                if entry.name.as_deref() != Some(expected_name.as_str()) {
                                     return Err(format!(
                                         "upserted entry name mismatch: got {:?}, expected {:?}",
                                         entry.name, expected_name
                                     )
                                     .into());
                                 }
-                                if entry.start_hour_utc != 1 || entry.end_hour_utc != 2 {
+                                if entry.start_hour_utc != Some(1) || entry.end_hour_utc != Some(2)
+                                {
                                     return Err(format!(
-                                        "upserted entry window mismatch: got {}-{} UTC, expected 1-2",
+                                        "upserted entry window mismatch: got {:?}-{:?} UTC, expected 1-2",
                                         entry.start_hour_utc, entry.end_hour_utc
                                     )
                                     .into());
@@ -2212,7 +2255,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             // returns the service to its original empty state on its own.
             if let Some(window) = pre_state {
                 eprintln!(
-                    "  captured upgrade_window pre-state: weekday={}, startHourUtc={}",
+                    "  captured upgrade_window pre-state: weekday={:?}, startHourUtc={:?}",
                     window.weekday, window.start_hour_utc,
                 );
                 cleanup.register_upgrade_window_restore(service_id.clone(), window);
@@ -2266,11 +2309,11 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                                 let window = resp
                                     .result
                                     .ok_or("upgrade_window get returned no result")?;
-                                if window.weekday != expected_weekday
-                                    || window.start_hour_utc != expected_start
+                                if window.weekday != Some(expected_weekday)
+                                    || window.start_hour_utc != Some(expected_start)
                                 {
                                     return Err(format!(
-                                        "upgrade_window get mismatch: expected weekday={expected_weekday} startHourUtc={expected_start}, got weekday={got_w} startHourUtc={got_h}",
+                                        "upgrade_window get mismatch: expected weekday={expected_weekday} startHourUtc={expected_start}, got weekday={got_w:?} startHourUtc={got_h:?}",
                                         got_w = window.weekday,
                                         got_h = window.start_hour_utc,
                                     )
@@ -2366,12 +2409,13 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         let result = resp
                             .result
                             .ok_or("password update returned no result")?;
-                        if result.password.is_empty() {
-                            return Err("password update response had empty password".into());
-                        }
+                        let password = result
+                            .password
+                            .filter(|password| !password.is_empty())
+                            .ok_or("password update response had no password")?;
                         eprintln!(
                             "  password rotated (length={}, run_id={})",
-                            result.password.len(),
+                            password.len(),
                             run_id
                         );
                         Ok(())
@@ -2409,7 +2453,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                         async move {
                             let resp = client.instance_get(&org_id, &service_id).await?;
                             let svc = resp.result.ok_or("service get returned no result")?;
-                            let state = svc.state.to_string();
+                            let state = service_state(&svc);
                             if matches!(state.as_str(), "idle" | "stopped") {
                                 Ok(Some(()))
                             } else {
@@ -2504,7 +2548,10 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
 }
 
 fn has_ip_entry(svc: &Service, source: &str) -> bool {
-    svc.ip_access_list.iter().any(|e| e.source == source)
+    svc.ip_access_list
+        .iter()
+        .flatten()
+        .any(|e| e.source.as_deref() == Some(source))
 }
 
 async fn poll_for_ip_presence(
@@ -2576,9 +2623,9 @@ async fn scale_service_and_wait(
             async move {
                 let resp = client.instance_get(&org_id, &service_id).await?;
                 let svc = resp.result.ok_or("service get returned no result")?;
-                if min_memory_gb.is_none_or(|v| svc.min_replica_memory_gb == v)
-                    && max_memory_gb.is_none_or(|v| svc.max_replica_memory_gb == v)
-                    && replicas.is_none_or(|v| svc.num_replicas == v)
+                if min_memory_gb.is_none_or(|v| svc.min_replica_memory_gb == Some(v))
+                    && max_memory_gb.is_none_or(|v| svc.max_replica_memory_gb == Some(v))
+                    && replicas.is_none_or(|v| svc.num_replicas == Some(v))
                 {
                     Ok(Some(()))
                 } else {

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -2224,13 +2224,13 @@ fn deserialize_clickstack_log_source_with_metadata_materialized_views() {
             "kvRollupTable": "logs_kv_1h"
         }
     }"#;
-    let src: ClickStackLogSource = serde_json::from_str(json).unwrap();
+    let src: ClickStackLogSourceResponse = serde_json::from_str(json).unwrap();
     let mv = src
         .metadata_materialized_views
         .expect("metadataMaterializedViews should populate");
-    assert_eq!(mv.granularity, "1 hour");
-    assert_eq!(mv.key_rollup_table, "logs_keys_1h");
-    assert_eq!(mv.kv_rollup_table, "logs_kv_1h");
+    assert_eq!(mv.granularity.as_deref(), Some("1 hour"));
+    assert_eq!(mv.key_rollup_table.as_deref(), Some("logs_keys_1h"));
+    assert_eq!(mv.kv_rollup_table.as_deref(), Some("logs_kv_1h"));
 }
 
 #[test]
@@ -2275,10 +2275,11 @@ fn deserialize_clickstack_trace_source_default_table_select_expression() {
     assert_eq!(v["defaultTableSelectExpression"], "Timestamp, SpanName");
 
     // `defaultTableSelectExpression` is in the spec `required[]` for trace
-    // sources, but responses stay tolerant of a server-side field drop: it
-    // carries `serde(default)`, so a missing field degrades to "" instead of
+    // sources, so the request variant types it as `String`. Responses stay
+    // tolerant of a server-side field drop through the response variant, where
+    // it is `Option<String>`: a missing field lands as `None` instead of
     // failing the whole payload (and, via the `kind`-dispatched
-    // `ClickStackSource` union, the whole list response).
+    // `ClickStackSourceResponse` union, the whole list response).
     let missing = r#"{
         "id": "trace-1",
         "kind": "trace",
@@ -2294,14 +2295,18 @@ fn deserialize_clickstack_trace_source_default_table_select_expression() {
         "spanNameExpression": "SpanName",
         "spanKindExpression": "SpanKind"
     }"#;
-    let src: ClickStackTraceSource = serde_json::from_str(missing).unwrap();
-    assert_eq!(src.default_table_select_expression, "");
-    match serde_json::from_str::<ClickStackSource>(missing).unwrap() {
-        ClickStackSource::ClickStackTraceSource(src) => {
-            assert_eq!(src.default_table_select_expression, "");
+    let src: ClickStackTraceSourceResponse = serde_json::from_str(missing).unwrap();
+    assert_eq!(src.default_table_select_expression, None);
+    match serde_json::from_str::<ClickStackSourceResponse>(missing).unwrap() {
+        ClickStackSourceResponse::ClickStackTraceSource(src) => {
+            assert_eq!(src.default_table_select_expression, None);
         }
         other => panic!("expected trace variant, got {other:?}"),
     }
+    // The dropped field is absent from the re-serialized payload rather than
+    // sent back as `null`.
+    let v = serde_json::to_value(&src).unwrap();
+    assert!(v.get("defaultTableSelectExpression").is_none());
 }
 
 #[test]
@@ -2504,6 +2509,357 @@ fn clickstack_source_serializes_as_inner_log_struct() {
         serde_json::to_value(&source).unwrap(),
         serde_json::to_value(&log).unwrap()
     );
+}
+
+#[test]
+fn clickstack_source_response_dispatches_on_kind_alone() {
+    // The response variants are all-`Option`, so every one of them matches any
+    // JSON object: under `untagged` shape matching the first arm would swallow
+    // all five kinds. Dispatch reads `kind` off the raw JSON instead, so a
+    // payload carrying nothing but its discriminator still resolves to the right
+    // variant.
+    for (kind, expected) in [
+        ("log", "ClickStackLogSource"),
+        ("trace", "ClickStackTraceSource"),
+        ("metric", "ClickStackMetricSource"),
+        ("session", "ClickStackSessionSource"),
+        ("promql", "ClickStackPromqlSource"),
+    ] {
+        let json = format!(r#"{{"kind":"{kind}"}}"#);
+        let source: ClickStackSourceResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(source.to_string(), expected, "wrong variant for {kind}");
+    }
+}
+
+#[test]
+fn clickstack_source_response_treats_dropped_and_null_fields_as_absent() {
+    // Both halves of the tolerance contract on one payload: `connection` is sent
+    // as an explicit `null` (which `serde(default)` would not have absorbed) and
+    // every other field of the schema is dropped outright.
+    let json = r#"{"kind":"log","connection":null,"name":"logs"}"#;
+    let source: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let ClickStackSourceResponse::ClickStackLogSource(log) = source else {
+        panic!("expected the log variant");
+    };
+    assert_eq!(log.connection, None);
+    assert_eq!(log.from, None);
+    assert_eq!(log.timestamp_value_expression, None);
+    assert_eq!(log.name.as_deref(), Some("logs"));
+
+    // Absent fields are omitted on the way out, not re-emitted as `null`.
+    let v = serde_json::to_value(&log).unwrap();
+    assert_eq!(v, serde_json::json!({"kind": "log", "name": "logs"}));
+}
+
+#[test]
+fn clickstack_source_response_unknown_kind_round_trips() {
+    let json = r#"{"kind":"future_kind","name":"x"}"#;
+    assert_unknown_variant_round_trips(json, |s: &ClickStackSourceResponse| {
+        matches!(s, ClickStackSourceResponse::Unknown(_))
+    });
+}
+
+#[test]
+fn clickstack_source_response_nested_objects_are_tolerant() {
+    // The nested objects of a source are response variants too, so a dropped
+    // field inside `from`, `filterSettings` or `materializedViews` does not fail
+    // the source.
+    let json = r#"{
+        "kind": "log",
+        "from": {"databaseName": "default"},
+        "filterSettings": {"columns": [{"name": "ServiceName"}]},
+        "materializedViews": [{"tableName": "logs_1h", "aggregatedColumns": [{"aggFn": "sum"}]}],
+        "querySettings": [{"setting": "max_threads"}]
+    }"#;
+    let source: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let ClickStackSourceResponse::ClickStackLogSource(log) = source else {
+        panic!("expected the log variant");
+    };
+    let from = log.from.expect("from present");
+    assert_eq!(from.database_name.as_deref(), Some("default"));
+    assert_eq!(from.table_name, None);
+    let filter_settings = log.filter_settings.expect("filterSettings present");
+    assert_eq!(filter_settings.table_name, None);
+    let columns = filter_settings.columns.expect("columns present");
+    assert_eq!(columns[0].name.as_deref(), Some("ServiceName"));
+    assert_eq!(columns[0].label, None);
+    let views = log.materialized_views.expect("materializedViews present");
+    assert_eq!(views[0].min_granularity, None);
+    let aggregated = views[0]
+        .aggregated_columns
+        .as_deref()
+        .expect("aggregatedColumns present");
+    assert_eq!(aggregated[0].agg_fn.as_deref(), Some("sum"));
+    assert_eq!(aggregated[0].mv_column, None);
+    let query_settings = log.query_settings.expect("querySettings present");
+    assert_eq!(query_settings[0].value, None);
+}
+
+#[test]
+fn clickstack_source_try_from_response_converts_every_kind() {
+    // One spec-complete payload per kind, each carrying the nested objects that
+    // kind owns, so every conversion in the source tree is exercised: a source
+    // fetched and written back unchanged must produce the JSON it came from.
+    let payloads = [
+        serde_json::json!({
+            "kind": "log",
+            "name": "logs",
+            "connection": "conn-1",
+            "defaultTableSelectExpression": "*",
+            "from": {"databaseName": "default", "tableName": "logs"},
+            "timestampValueExpression": "ts",
+            "filterSettings": {
+                "columns": [{"label": "Service", "name": "ServiceName"}],
+                "databaseName": "default",
+                "tableName": "logs_filters",
+            },
+            "highlightedRowAttributeExpressions": [{"sqlExpression": "ServiceName"}],
+            "materializedViews": [{
+                "aggregatedColumns": [{"aggFn": "sum", "mvColumn": "count"}],
+                "databaseName": "default",
+                "dimensionColumns": "ServiceName",
+                "minGranularity": "1 hour",
+                "tableName": "logs_1h",
+                "timestampColumn": "ts",
+            }],
+            "metadataMaterializedViews": {
+                "granularity": "1 hour",
+                "keyRollupTable": "logs_keys_1h",
+                "kvRollupTable": "logs_kv_1h",
+            },
+            "querySettings": [{"setting": "max_threads", "value": "4"}],
+        }),
+        serde_json::json!({
+            "kind": "trace",
+            "name": "traces",
+            "connection": "conn-1",
+            "defaultTableSelectExpression": "*",
+            "durationExpression": "Duration",
+            "durationPrecision": 9,
+            "from": {"databaseName": "default", "tableName": "traces"},
+            "parentSpanIdExpression": "ParentSpanId",
+            "spanIdExpression": "SpanId",
+            "spanKindExpression": "SpanKind",
+            "spanNameExpression": "SpanName",
+            "timestampValueExpression": "Timestamp",
+            "traceIdExpression": "TraceId",
+            "metadataMaterializedViews": {
+                "granularity": "1 hour",
+                "keyRollupTable": "traces_keys_1h",
+                "kvRollupTable": "traces_kv_1h",
+            },
+        }),
+        serde_json::json!({
+            "kind": "metric",
+            "name": "metrics",
+            "connection": "conn-1",
+            "from": {"databaseName": "default", "tableName": "metrics"},
+            "metricTables": {
+                "exponential histogram": "otel_metrics_exponential_histogram",
+                "gauge": "otel_metrics_gauge",
+                "histogram": "otel_metrics_histogram",
+                "sum": "otel_metrics_sum",
+                "summary": "otel_metrics_summary",
+            },
+            "resourceAttributesExpression": "ResourceAttributes",
+            "timestampValueExpression": "TimeUnix",
+        }),
+        serde_json::json!({
+            "kind": "session",
+            "name": "sessions",
+            "connection": "conn-1",
+            "from": {"databaseName": "default", "tableName": "sessions"},
+            "traceSourceId": "trace-1",
+        }),
+        serde_json::json!({
+            "kind": "promql",
+            "name": "prometheus",
+            "connection": "conn-1",
+            "from": {"databaseName": "default", "tableName": "metrics"},
+            "timestampValueExpression": "timestamp",
+        }),
+    ];
+
+    for payload in payloads {
+        let response: ClickStackSourceResponse = serde_json::from_value(payload.clone()).unwrap();
+        let request = ClickStackSource::try_from(response)
+            .unwrap_or_else(|e| panic!("{} should convert: {e}", payload["kind"]));
+        assert_eq!(serde_json::to_value(&request).unwrap(), payload);
+    }
+}
+
+#[test]
+fn clickstack_source_try_from_response_converts_a_complete_source() {
+    let json = r#"{
+        "id": "src-1",
+        "kind": "log",
+        "name": "logs",
+        "connection": "conn-1",
+        "defaultTableSelectExpression": "*",
+        "from": {"databaseName": "default", "tableName": "logs"},
+        "timestampValueExpression": "ts",
+        "querySettings": [{"setting": "max_threads", "value": "4"}]
+    }"#;
+    let response: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let request = ClickStackSource::try_from(response).expect("conversion should succeed");
+    let ClickStackSource::ClickStackLogSource(log) = &request else {
+        panic!("expected the log variant");
+    };
+    assert_eq!(log.connection, "conn-1");
+    assert_eq!(log.from.table_name, "logs");
+    assert_eq!(
+        log.query_settings.as_deref(),
+        Some(
+            [ClickStackQuerySetting {
+                setting: "max_threads".to_string(),
+                value: "4".to_string(),
+            }]
+            .as_slice()
+        )
+    );
+    // A write-back of an untouched source is byte-identical to what was fetched.
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        serde_json::from_str::<serde_json::Value>(json).unwrap()
+    );
+}
+
+#[test]
+fn clickstack_source_try_from_response_names_every_missing_required_field() {
+    let response: ClickStackSourceResponse =
+        serde_json::from_str(r#"{"kind":"log","name":"logs"}"#).unwrap();
+    let error = ClickStackSource::try_from(response).expect_err("conversion should fail");
+    assert_eq!(
+        error.fields(),
+        [
+            "connection",
+            "defaultTableSelectExpression",
+            "from",
+            "timestampValueExpression"
+        ]
+    );
+    assert_eq!(
+        error.to_string(),
+        "the API response is missing required field(s): connection, \
+         defaultTableSelectExpression, from, timestampValueExpression"
+    );
+}
+
+#[test]
+fn clickstack_source_try_from_response_reports_a_nested_missing_field() {
+    // A nested object reports its own wire name: `from` is present, so the
+    // failure is `tableName` inside it.
+    let json = r#"{
+        "kind": "log",
+        "name": "logs",
+        "connection": "conn-1",
+        "defaultTableSelectExpression": "*",
+        "from": {"databaseName": "default"},
+        "timestampValueExpression": "ts"
+    }"#;
+    let response: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let error = ClickStackSource::try_from(response).expect_err("conversion should fail");
+    assert_eq!(error.fields(), ["tableName"]);
+
+    // The same holds for an element of a nested list.
+    let json = r#"{
+        "kind": "log",
+        "name": "logs",
+        "connection": "conn-1",
+        "defaultTableSelectExpression": "*",
+        "from": {"databaseName": "default", "tableName": "logs"},
+        "timestampValueExpression": "ts",
+        "querySettings": [{"setting": "max_threads"}]
+    }"#;
+    let response: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let error = ClickStackSource::try_from(response).expect_err("conversion should fail");
+    assert_eq!(error.fields(), ["value"]);
+}
+
+#[test]
+fn clickstack_source_try_from_response_passes_an_unknown_kind_through() {
+    // A source kind this crate does not model must still be writable back: the
+    // request union's `Unknown` arm holds the raw payload and serializes it
+    // verbatim.
+    let json = r#"{"kind":"future_kind","name":"x"}"#;
+    let response: ClickStackSourceResponse = serde_json::from_str(json).unwrap();
+    let request = ClickStackSource::try_from(response).expect("Unknown converts losslessly");
+    assert!(matches!(request, ClickStackSource::Unknown(_)));
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        serde_json::from_str::<serde_json::Value>(json).unwrap()
+    );
+}
+
+#[test]
+fn shared_clickstack_source_types_stay_strict_on_the_request_side() {
+    // Sources are sent as well as returned, so each type in the source tree
+    // splits: the request variant keeps the schema's required fields as `T` and
+    // rejects a payload that omits one, while the response variant accepts any
+    // object.
+    macro_rules! assert_split_strictness {
+        ($($request:ty => $response:ty),+ $(,)?) => {
+            $(
+                assert!(
+                    serde_json::from_str::<$request>("{}").is_err(),
+                    "{} accepted a payload missing its required fields",
+                    stringify!($request),
+                );
+                assert_eq!(
+                    serde_json::from_str::<$response>("{}").unwrap(),
+                    <$response>::default(),
+                    "{} rejected an empty payload",
+                    stringify!($response),
+                );
+            )+
+        };
+    }
+
+    assert_split_strictness!(
+        ClickStackAggregatedColumn => ClickStackAggregatedColumnResponse,
+        ClickStackCASLPermission => ClickStackCASLPermissionResponse,
+        ClickStackFilter => ClickStackFilterResponse,
+        ClickStackFilterSettingsColumn => ClickStackFilterSettingsColumnResponse,
+        ClickStackHighlightedAttributeExpression => ClickStackHighlightedAttributeExpressionResponse,
+        ClickStackLogSource => ClickStackLogSourceResponse,
+        ClickStackLogSourceMetadataMaterializedViews => ClickStackLogSourceMetadataMaterializedViewsResponse,
+        ClickStackMaterializedView => ClickStackMaterializedViewResponse,
+        ClickStackMetricSource => ClickStackMetricSourceResponse,
+        ClickStackMetricSourceFrom => ClickStackMetricSourceFromResponse,
+        ClickStackMetricTables => ClickStackMetricTablesResponse,
+        ClickStackPromqlSource => ClickStackPromqlSourceResponse,
+        ClickStackQuerySetting => ClickStackQuerySettingResponse,
+        ClickStackSavedFilterValue => ClickStackSavedFilterValueResponse,
+        ClickStackSavedSearchFilter => ClickStackSavedSearchFilterResponse,
+        ClickStackSessionSource => ClickStackSessionSourceResponse,
+        ClickStackSourceFilterSettings => ClickStackSourceFilterSettingsResponse,
+        ClickStackSourceFrom => ClickStackSourceFromResponse,
+        ClickStackTraceSource => ClickStackTraceSourceResponse,
+        ClickStackTraceSourceMetadataMaterializedViews => ClickStackTraceSourceMetadataMaterializedViewsResponse,
+    );
+}
+
+#[test]
+fn clickstack_response_only_models_accept_an_empty_payload() {
+    // Connections, roles and saved searches are only ever returned — the create
+    // and update bodies are separate schemas — so they are all-`Option` in place
+    // instead of splitting, and none of their fields can fail a response.
+    assert_eq!(
+        serde_json::from_str::<ClickStackConnection>("{}").unwrap(),
+        ClickStackConnection::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickStackRole>("{}").unwrap(),
+        ClickStackRole::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickStackSavedSearch>("{}").unwrap(),
+        ClickStackSavedSearch::default()
+    );
+    // Their request counterparts stay strict.
+    assert!(serde_json::from_str::<ClickStackCreateConnectionRequest>("{}").is_err());
+    assert!(serde_json::from_str::<ClickStackCreateRoleRequest>("{}").is_err());
+    assert!(serde_json::from_str::<ClickStackSavedSearchInput>("{}").is_err());
 }
 
 #[test]
@@ -3893,10 +4249,13 @@ fn deserialize_clickstack_connection_with_null_prefix() {
         "updatedAt": "2025-06-15T10:30:00.000Z"
     }"#;
     let conn: ClickStackConnection = serde_json::from_str(json).unwrap();
-    assert_eq!(conn.id, "507f1f77bcf86cd799439012");
-    assert_eq!(conn.name, "Production ClickHouse");
-    assert_eq!(conn.host, "https://clickhouse.example.com:8443");
-    assert_eq!(conn.username, "default");
+    assert_eq!(conn.id.as_deref(), Some("507f1f77bcf86cd799439012"));
+    assert_eq!(conn.name.as_deref(), Some("Production ClickHouse"));
+    assert_eq!(
+        conn.host.as_deref(),
+        Some("https://clickhouse.example.com:8443")
+    );
+    assert_eq!(conn.username.as_deref(), Some("default"));
     assert_eq!(conn.hyperdx_setting_prefix, None);
     assert_eq!(conn.is_prometheus_endpoint, Some(false));
     assert!(conn.created_at.is_some());
@@ -3948,14 +4307,15 @@ fn deserialize_clickstack_role_with_nested_conditions() {
         ]
     }"#;
     let role: ClickStackRole = serde_json::from_str(json).unwrap();
-    assert_eq!(role.id, "role-1");
-    assert_eq!(role.name, "Deploy Bot");
-    assert!(!role.is_predefined);
-    assert_eq!(role.permissions.len(), 1);
+    assert_eq!(role.id.as_deref(), Some("role-1"));
+    assert_eq!(role.name.as_deref(), Some("Deploy Bot"));
+    assert_eq!(role.is_predefined, Some(false));
+    let permissions = role.permissions.as_deref().expect("permissions present");
+    assert_eq!(permissions.len(), 1);
 
-    let perm = &role.permissions[0];
-    assert_eq!(perm.action, "read");
-    assert_eq!(perm.subject, "dashboard");
+    let perm = &permissions[0];
+    assert_eq!(perm.action.as_deref(), Some("read"));
+    assert_eq!(perm.subject.as_deref(), Some("dashboard"));
     assert_eq!(perm.inverted, Some(false));
     assert_eq!(perm.integration, Some("mongodb".to_string()));
 
@@ -3969,15 +4329,15 @@ fn deserialize_clickstack_role_with_nested_conditions() {
 #[test]
 fn clickstack_role_round_trip() {
     let role = ClickStackRole {
-        id: "role-1".to_string(),
-        name: "Deploy Bot".to_string(),
-        is_predefined: false,
-        permissions: vec![ClickStackCASLPermission {
-            action: "manage".to_string(),
-            subject: "all".to_string(),
+        id: Some("role-1".to_string()),
+        name: Some("Deploy Bot".to_string()),
+        is_predefined: Some(false),
+        permissions: Some(vec![ClickStackCASLPermissionResponse {
+            action: Some("manage".to_string()),
+            subject: Some("all".to_string()),
             conditions: Some(serde_json::json!({ "teamId": "team-1" })),
             ..Default::default()
-        }],
+        }]),
         ..Default::default()
     };
     let v = serde_json::to_value(&role).unwrap();
@@ -4063,9 +4423,12 @@ fn deserialize_clickstack_saved_search_full_round_trip() {
         "updatedAt": "2025-06-15T10:30:00.000Z"
     }"#;
     let search: ClickStackSavedSearch = serde_json::from_str(json).unwrap();
-    assert_eq!(search.id, "507f1f77bcf86cd799439011");
-    assert_eq!(search.name, "Production Errors");
-    assert_eq!(search.source_id, "507f1f77bcf86cd799439012");
+    assert_eq!(search.id.as_deref(), Some("507f1f77bcf86cd799439011"));
+    assert_eq!(search.name.as_deref(), Some("Production Errors"));
+    assert_eq!(
+        search.source_id.as_deref(),
+        Some("507f1f77bcf86cd799439012")
+    );
     assert_eq!(
         search.where_language,
         Some(ClickStackSavedSearchWherelanguage::Lucene)
@@ -4077,8 +4440,8 @@ fn deserialize_clickstack_saved_search_full_round_trip() {
         Some(ClickStackSavedSearchFilterType::Sql)
     );
     assert_eq!(
-        filters[0].condition,
-        "ServiceName IN ('checkout', 'payments')"
+        filters[0].condition.as_deref(),
+        Some("ServiceName IN ('checkout', 'payments')")
     );
     assert_eq!(search.team_id, Some("507f1f77bcf86cd799439013".to_string()));
 

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -429,7 +429,7 @@ fn deserialize_clickstack_dashboard_response() {
         "updatedAt": "2024-01-02T00:00:00Z"
     }"#;
     let dash: ClickStackDashboardResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(dash.name, "My Dashboard");
+    assert_eq!(dash.name.as_deref(), Some("My Dashboard"));
 }
 
 #[test]
@@ -1525,8 +1525,8 @@ fn upgrade_window_response_converts_back_into_a_put_body() {
 #[test]
 fn clickstack_dashboard_minimal_response() {
     let d: ClickStackDashboardResponse = serde_json::from_str("{}").unwrap();
-    assert_eq!(d.id, "");
-    assert_eq!(d.name, "");
+    assert_eq!(d.id, None);
+    assert_eq!(d.name, None);
 }
 
 // ===========================================================================
@@ -1936,12 +1936,13 @@ fn deserialize_clickstack_dashboard_with_containers() {
     let dash: ClickStackDashboardResponse = serde_json::from_str(json).unwrap();
     let containers = dash.containers.expect("containers should populate");
     assert_eq!(containers.len(), 1);
-    assert_eq!(containers[0].id, "c-1");
-    assert!(!containers[0].collapsed);
+    assert_eq!(containers[0].id.as_deref(), Some("c-1"));
+    assert_eq!(containers[0].collapsed, Some(false));
     let tabs = containers[0].tabs.as_ref().expect("tabs populated");
-    assert_eq!(tabs[0].title, "Tab 1");
-    assert_eq!(dash.tiles[0].container_id.as_deref(), Some("c-1"));
-    assert_eq!(dash.tiles[0].tab_id.as_deref(), Some("t-1"));
+    assert_eq!(tabs[0].title.as_deref(), Some("Tab 1"));
+    let tiles = dash.tiles.expect("tiles should populate");
+    assert_eq!(tiles[0].container_id.as_deref(), Some("c-1"));
+    assert_eq!(tiles[0].tab_id.as_deref(), Some("t-1"));
 }
 
 #[test]
@@ -2134,19 +2135,22 @@ fn clickstack_alert_channel_known_variants_deserialize() {
 }
 
 #[test]
-fn clickstack_alert_channel_known_type_sparse_payload_defaults() {
-    // A recognized `type` dispatches hard to its variant, and the variant's own
-    // fields are tolerant: a server that drops `emailRecipients` degrades to the
-    // default rather than failing the response.
+fn clickstack_alert_channel_response_known_type_sparse_payload_is_tolerant() {
+    // A recognized `type` dispatches hard to its variant, and the response
+    // variant's all-`Option` fields are tolerant: a server that drops
+    // `emailRecipients` surfaces `None` rather than failing the response.
     let json = r#"{"type":"email"}"#;
-    let channel: ClickStackAlertChannel = serde_json::from_str(json).unwrap();
+    let channel: ClickStackAlertChannelResponse = serde_json::from_str(json).unwrap();
     match channel {
-        ClickStackAlertChannel::ClickStackAlertChannelEmail(v) => {
-            assert_eq!(v.r#type, ClickStackAlertChannelEmailType::Email);
-            assert!(v.email_recipients.is_empty());
+        ClickStackAlertChannelResponse::ClickStackAlertChannelEmail(v) => {
+            assert_eq!(v.r#type, Some(ClickStackAlertChannelEmailType::Email));
+            assert_eq!(v.email_recipients, None);
         }
         other => panic!("expected email variant, got {other}"),
     }
+    // The request variant stays strict: the same sparse payload is not a valid
+    // channel to *send*.
+    assert!(serde_json::from_str::<ClickStackAlertChannelEmail>(r#"{"type":"email"}"#).is_err());
 }
 
 #[test]
@@ -2203,9 +2207,10 @@ fn clickstack_alert_channel_default_round_trips_to_the_same_variant() {
     let round_tripped: ClickStackAlertChannel = serde_json::from_str(&json).unwrap();
     assert_eq!(round_tripped, default);
 
-    // A response that drops `channel` entirely lands on that same default.
+    // A response that drops `channel` entirely surfaces the absence instead of
+    // fabricating a default channel.
     let response: ClickStackAlertResponse = serde_json::from_str(r#"{"name":"my-alert"}"#).unwrap();
-    assert_eq!(response.channel, default);
+    assert_eq!(response.channel, None);
 }
 
 #[test]
@@ -2860,6 +2865,258 @@ fn clickstack_response_only_models_accept_an_empty_payload() {
     assert!(serde_json::from_str::<ClickStackCreateConnectionRequest>("{}").is_err());
     assert!(serde_json::from_str::<ClickStackCreateRoleRequest>("{}").is_err());
     assert!(serde_json::from_str::<ClickStackSavedSearchInput>("{}").is_err());
+}
+
+#[test]
+fn shared_clickstack_dashboard_types_stay_strict_on_the_request_side() {
+    // Dashboard containers, tiles' chart configs, select items, number formats,
+    // color conditions, on-click targets and alert channels are sent as well as
+    // returned, so each splits: the request variant keeps the schema's required
+    // fields as `T` and rejects a payload that omits one, while the response
+    // variant accepts any object.
+    macro_rules! assert_split_strictness {
+        ($($request:ty => $response:ty),+ $(,)?) => {
+            $(
+                assert!(
+                    serde_json::from_str::<$request>("{}").is_err(),
+                    "{} accepted a payload missing its required fields",
+                    stringify!($request),
+                );
+                assert_eq!(
+                    serde_json::from_str::<$response>("{}").unwrap(),
+                    <$response>::default(),
+                    "{} rejected an empty payload",
+                    stringify!($response),
+                );
+            )+
+        };
+    }
+
+    assert_split_strictness!(
+        ClickStackAlertChannelEmail => ClickStackAlertChannelEmailResponse,
+        ClickStackAlertChannelWebhook => ClickStackAlertChannelWebhookResponse,
+        ClickStackBackgroundChart => ClickStackBackgroundChartResponse,
+        ClickStackBarBuilderChartConfig => ClickStackBarBuilderChartConfigResponse,
+        ClickStackBarRawSqlChartConfig => ClickStackBarRawSqlChartConfigResponse,
+        ClickStackBetweenColorCondition => ClickStackBetweenColorConditionResponse,
+        ClickStackCategoricalBarBuilderChartConfig => ClickStackCategoricalBarBuilderChartConfigResponse,
+        ClickStackCategoricalBarRawSqlChartConfig => ClickStackCategoricalBarRawSqlChartConfigResponse,
+        ClickStackDashboardContainer => ClickStackDashboardContainerResponse,
+        ClickStackDashboardContainerTab => ClickStackDashboardContainerTabResponse,
+        ClickStackEqualityColorCondition => ClickStackEqualityColorConditionResponse,
+        ClickStackEventPatternsChartConfig => ClickStackEventPatternsChartConfigResponse,
+        ClickStackHeatmapChartConfig => ClickStackHeatmapChartConfigResponse,
+        ClickStackHeatmapSelectItem => ClickStackHeatmapSelectItemResponse,
+        ClickStackLineBuilderChartConfig => ClickStackLineBuilderChartConfigResponse,
+        ClickStackLineRawSqlChartConfig => ClickStackLineRawSqlChartConfigResponse,
+        ClickStackMarkdownChartConfig => ClickStackMarkdownChartConfigResponse,
+        ClickStackNumberBuilderChartConfig => ClickStackNumberBuilderChartConfigResponse,
+        ClickStackNumberFormat => ClickStackNumberFormatResponse,
+        ClickStackNumberRawSqlChartConfig => ClickStackNumberRawSqlChartConfigResponse,
+        ClickStackNumericColorCondition => ClickStackNumericColorConditionResponse,
+        ClickStackOnClickDashboard => ClickStackOnClickDashboardResponse,
+        ClickStackOnClickExternal => ClickStackOnClickExternalResponse,
+        ClickStackOnClickFilterTemplate => ClickStackOnClickFilterTemplateResponse,
+        ClickStackOnClickSearch => ClickStackOnClickSearchResponse,
+        ClickStackOnClickTargetIdVariant => ClickStackOnClickTargetIdVariantResponse,
+        ClickStackOnClickTargetTemplateVariant => ClickStackOnClickTargetTemplateVariantResponse,
+        ClickStackPieBuilderChartConfig => ClickStackPieBuilderChartConfigResponse,
+        ClickStackPieRawSqlChartConfig => ClickStackPieRawSqlChartConfigResponse,
+        ClickStackSearchChartConfig => ClickStackSearchChartConfigResponse,
+        ClickStackSelectItem => ClickStackSelectItemResponse,
+        ClickStackTableBuilderChartConfig => ClickStackTableBuilderChartConfigResponse,
+        ClickStackTableRawSqlChartConfig => ClickStackTableRawSqlChartConfigResponse,
+    );
+}
+
+#[test]
+fn clickstack_alert_and_dashboard_response_models_accept_an_empty_payload() {
+    // Alerts, dashboards, tiles, validation results and webhooks are only ever
+    // returned — their request bodies are separate schemas — so they are
+    // all-`Option` in place instead of splitting, and none of their fields can
+    // fail a response.
+    macro_rules! assert_accepts_empty {
+        ($($model:ty),+ $(,)?) => {
+            $(
+                assert_eq!(
+                    serde_json::from_str::<$model>("{}").unwrap(),
+                    <$model>::default(),
+                    "{} rejected an empty payload",
+                    stringify!($model),
+                );
+            )+
+        };
+    }
+
+    assert_accepts_empty!(
+        ClickStackAlertExecutionError,
+        ClickStackAlertResponse,
+        ClickStackAlertSilenced,
+        ClickStackDashboardResponse,
+        ClickStackGenericWebhook,
+        ClickStackIncidentIOWebhook,
+        ClickStackPagerDutyAPIWebhook,
+        ClickStackSlackAPIWebhook,
+        ClickStackSlackWebhook,
+        ClickStackTileOutput,
+        ClickStackValidateDashboardError,
+        ClickStackValidateDashboardResponse,
+    );
+}
+
+#[test]
+fn clickstack_dashboard_response_null_fields_deserialize_to_none() {
+    // An explicit JSON `null` — not just a missing key — must land as `None`:
+    // `Option<T>` absorbs it natively, which `serde(default)` never did.
+    let json = r#"{"id":null,"name":null,"tiles":null,"filters":null,"tags":null}"#;
+    let dash: ClickStackDashboardResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(dash, ClickStackDashboardResponse::default());
+    // Absent fields are omitted on serialize, not emitted as `null`.
+    assert_eq!(serde_json::to_value(&dash).unwrap(), serde_json::json!({}));
+}
+
+#[test]
+fn clickstack_tile_config_response_raw_sql_body_without_config_type_falls_to_sub_union_unknown() {
+    // Every field of a response builder variant is `Option`, so the builder arm
+    // is total and would absorb a raw-SQL payload whose server dropped
+    // `configType`, silently retyping it and losing `connectionId` and
+    // `sqlTemplate`. The `none unless` guard routes it to Unknown, which keeps
+    // the payload verbatim.
+    let json = r#"{"displayType":"line","connectionId":"conn-1","sqlTemplate":"SELECT 1"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfigResponse| {
+        matches!(
+            cfg,
+            ClickStackTileConfigResponse::ClickStackLineChartConfig(
+                ClickStackLineChartConfigResponse::Unknown(_)
+            )
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_response_dispatches_raw_sql_variant() {
+    // A `configType: "sql"` payload dispatches to the raw-SQL response variant
+    // even when the raw-SQL-required fields are missing: response tolerance is
+    // per-field, not per-variant.
+    let json = r#"{"displayType":"line","configType":"sql"}"#;
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
+    match cfg {
+        ClickStackTileConfigResponse::ClickStackLineChartConfig(
+            ClickStackLineChartConfigResponse::ClickStackLineRawSqlChartConfig(r),
+        ) => {
+            assert_eq!(r.connection_id, None);
+            assert_eq!(r.sql_template, None);
+        }
+        other => panic!("expected line raw-SQL variant, got {other}"),
+    }
+}
+
+#[test]
+fn clickstack_tile_config_response_changed_field_shape_falls_to_sub_union_unknown() {
+    // A recognized discriminator whose payload no longer fits the variant —
+    // here `sqlTemplate` as a number — must not fail the response: the element
+    // lands in the lossless Unknown catch-all and round-trips verbatim.
+    let json = r#"{"displayType":"line","configType":"sql","sqlTemplate":5}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfigResponse| {
+        matches!(
+            cfg,
+            ClickStackTileConfigResponse::ClickStackLineChartConfig(
+                ClickStackLineChartConfigResponse::Unknown(_)
+            )
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_response_unknown_display_type_round_trips() {
+    let json = r#"{"displayType":"hologram","select":[]}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfigResponse| {
+        matches!(cfg, ClickStackTileConfigResponse::Unknown(_))
+    });
+}
+
+#[test]
+fn clickstack_alert_channel_response_dispatches_and_absorbs_changed_shapes() {
+    // Known discriminators dispatch to their response variants.
+    let email: ClickStackAlertChannelResponse =
+        serde_json::from_str(r#"{"type":"email","emailRecipients":["a@b.c"]}"#).unwrap();
+    match email {
+        ClickStackAlertChannelResponse::ClickStackAlertChannelEmail(v) => {
+            assert_eq!(
+                v.email_recipients.as_deref(),
+                Some(&["a@b.c".to_string()][..])
+            );
+        }
+        other => panic!("expected email variant, got {other}"),
+    }
+    // A recognized `type` whose payload no longer fits the variant — here
+    // `emailRecipients` as a string — lands in Unknown intact.
+    let json = r#"{"type":"email","emailRecipients":"a@b.c"}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackAlertChannelResponse| {
+        matches!(c, ClickStackAlertChannelResponse::Unknown(_))
+    });
+    // As does an unrecognized `type`.
+    let json = r#"{"type":"future_channel","foo":1}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackAlertChannelResponse| {
+        matches!(c, ClickStackAlertChannelResponse::Unknown(_))
+    });
+}
+
+#[test]
+fn clickstack_on_click_response_dispatches_on_type_and_mode() {
+    let json = r#"{"type":"external","urlTemplate":"https://example.com/{{id}}"}"#;
+    let on_click: ClickStackOnClickResponse = serde_json::from_str(json).unwrap();
+    match on_click {
+        ClickStackOnClickResponse::ClickStackOnClickExternal(e) => {
+            assert_eq!(
+                e.url_template.as_deref(),
+                Some("https://example.com/{{id}}")
+            );
+        }
+        other => panic!("expected external variant, got {other}"),
+    }
+    // A search on-click whose server dropped `target` still dispatches; the
+    // absence is a `None`, not a failure.
+    let json = r#"{"type":"search"}"#;
+    let on_click: ClickStackOnClickResponse = serde_json::from_str(json).unwrap();
+    match on_click {
+        ClickStackOnClickResponse::ClickStackOnClickSearch(s) => assert_eq!(s.target, None),
+        other => panic!("expected search variant, got {other}"),
+    }
+    let json = r#"{"mode":"template","template":"{{rowId}}"}"#;
+    let target: ClickStackOnClickTargetResponse = serde_json::from_str(json).unwrap();
+    match target {
+        ClickStackOnClickTargetResponse::ClickStackOnClickTargetTemplateVariant(t) => {
+            assert_eq!(t.template.as_deref(), Some("{{rowId}}"));
+        }
+        other => panic!("expected template variant, got {other}"),
+    }
+    // Missing discriminators land in Unknown: these unions have no absence arm.
+    let json = r#"{"urlTemplate":"https://example.com"}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackOnClickResponse| {
+        matches!(c, ClickStackOnClickResponse::Unknown(_))
+    });
+    let json = r#"{"template":"{{rowId}}"}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackOnClickTargetResponse| {
+        matches!(c, ClickStackOnClickTargetResponse::Unknown(_))
+    });
+}
+
+#[test]
+fn clickstack_number_tile_color_condition_response_dispatches_on_operator() {
+    let json = r#"{"operator":"between","value":[1.0, 2.0]}"#;
+    let cond: ClickStackNumberTileColorConditionResponse = serde_json::from_str(json).unwrap();
+    match cond {
+        ClickStackNumberTileColorConditionResponse::ClickStackBetweenColorCondition(b) => {
+            assert_eq!(b.value.as_deref(), Some(&[1.0, 2.0][..]));
+            assert_eq!(b.color, None);
+        }
+        other => panic!("expected between variant, got {other}"),
+    }
+    let json = r#"{"operator":"someday","value":7}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackNumberTileColorConditionResponse| {
+        matches!(c, ClickStackNumberTileColorConditionResponse::Unknown(_))
+    });
 }
 
 #[test]
@@ -3736,50 +3993,56 @@ fn clickstack_tile_config_unknown_display_type_round_trips() {
 }
 
 #[test]
-fn clickstack_tile_config_line_novel_shape_defaults_to_builder() {
+fn clickstack_tile_config_response_line_novel_shape_dispatches_to_builder() {
     // A known `displayType` carrying no `configType` dispatches to the builder
-    // variant: the novel member is ignored and the builder's strict fields fall
-    // back to their serde defaults instead of failing the response.
+    // variant: the novel member is ignored and the builder's all-`Option`
+    // response fields surface `None` instead of failing the response.
     let json = r#"{"displayType":"line","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackLineChartConfig(
-            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackLineChartConfig(
+            ClickStackLineChartConfigResponse::ClickStackLineBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected line builder variant, got {other}"),
     }
 }
 
 #[test]
-fn clickstack_tile_config_line_minimal_body_defaults_to_builder() {
+fn clickstack_tile_config_response_line_minimal_body_dispatches_to_builder() {
     // The bare discriminator with no `configType` key at all: key absence is the
-    // builder discriminator, and every builder field defaults.
+    // builder discriminator, and every other builder response field is absent.
     let json = r#"{"displayType":"line"}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackLineChartConfig(
-            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackLineChartConfig(
+            ClickStackLineChartConfigResponse::ClickStackLineBuilderChartConfig(b),
         ) => {
-            assert_eq!(b, ClickStackLineBuilderChartConfig::default());
+            assert_eq!(
+                b,
+                ClickStackLineBuilderChartConfigResponse {
+                    display_type: Some(ClickStackLineBuilderChartConfigDisplaytype::Line),
+                    ..ClickStackLineBuilderChartConfigResponse::default()
+                }
+            );
         }
         other => panic!("expected line builder variant, got {other}"),
     }
 }
 
 #[test]
-fn clickstack_tile_config_non_string_config_type_defaults_to_builder() {
+fn clickstack_tile_config_response_non_string_config_type_dispatches_to_builder() {
     // A non-string `configType` is deliberately conflated with an absent one:
     // both dispatch to the builder variant rather than to Unknown.
     let json = r#"{"displayType":"line","configType":123,"sourceId":"src-1"}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackLineChartConfig(
-            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackLineChartConfig(
+            ClickStackLineChartConfigResponse::ClickStackLineBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "src-1");
+            assert_eq!(b.source_id.as_deref(), Some("src-1"));
         }
         other => panic!("expected line builder variant, got {other}"),
     }
@@ -3989,17 +4252,20 @@ fn clickstack_tile_config_pie_raw_sql_variant() {
 }
 
 #[test]
-fn clickstack_tile_config_categorical_bar_novel_shape_defaults_to_builder() {
+fn clickstack_tile_config_response_categorical_bar_novel_shape_dispatches_to_builder() {
     // A "bar" body with no `configType` dispatches to the categorical bar builder
-    // variant, whose strict fields default rather than failing the response.
+    // variant, whose all-`Option` response fields surface `None` rather than
+    // failing the response.
     let json = r#"{"displayType":"bar","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackCategoricalBarChartConfig(
-            ClickStackCategoricalBarChartConfig::ClickStackCategoricalBarBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackCategoricalBarChartConfig(
+            ClickStackCategoricalBarChartConfigResponse::ClickStackCategoricalBarBuilderChartConfig(
+                b,
+            ),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected categorical bar builder variant, got {other}"),
     }
@@ -4021,17 +4287,18 @@ fn clickstack_tile_config_categorical_bar_unrecognized_config_type_falls_to_sub_
 }
 
 #[test]
-fn clickstack_tile_config_stacked_bar_novel_shape_defaults_to_builder() {
+fn clickstack_tile_config_response_stacked_bar_novel_shape_dispatches_to_builder() {
     // A "stacked_bar" body with no `configType` dispatches to the bar builder
-    // variant, whose strict fields default rather than failing the response.
+    // variant, whose all-`Option` response fields surface `None` rather than
+    // failing the response.
     let json = r#"{"displayType":"stacked_bar","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackBarChartConfig(
-            ClickStackBarChartConfig::ClickStackBarBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackBarChartConfig(
+            ClickStackBarChartConfigResponse::ClickStackBarBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected bar builder variant, got {other}"),
     }
@@ -4051,17 +4318,18 @@ fn clickstack_tile_config_stacked_bar_unrecognized_config_type_falls_to_sub_unio
 }
 
 #[test]
-fn clickstack_tile_config_table_novel_shape_defaults_to_builder() {
+fn clickstack_tile_config_response_table_novel_shape_dispatches_to_builder() {
     // A "table" body with no `configType` dispatches to the table builder
-    // variant, whose strict fields default rather than failing the response.
+    // variant, whose all-`Option` response fields surface `None` rather than
+    // failing the response.
     let json = r#"{"displayType":"table","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackTableChartConfig(
-            ClickStackTableChartConfig::ClickStackTableBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackTableChartConfig(
+            ClickStackTableChartConfigResponse::ClickStackTableBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected table builder variant, got {other}"),
     }
@@ -4083,17 +4351,18 @@ fn clickstack_tile_config_table_unrecognized_config_type_falls_to_sub_union_unkn
 }
 
 #[test]
-fn clickstack_tile_config_number_novel_shape_defaults_to_builder() {
+fn clickstack_tile_config_response_number_novel_shape_dispatches_to_builder() {
     // A "number" body with no `configType` dispatches to the number builder
-    // variant, whose strict fields default rather than failing the response.
+    // variant, whose all-`Option` response fields surface `None` rather than
+    // failing the response.
     let json = r#"{"displayType":"number","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackNumberChartConfig(
-            ClickStackNumberChartConfig::ClickStackNumberBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackNumberChartConfig(
+            ClickStackNumberChartConfigResponse::ClickStackNumberBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected number builder variant, got {other}"),
     }
@@ -4115,17 +4384,18 @@ fn clickstack_tile_config_number_unrecognized_config_type_falls_to_sub_union_unk
 }
 
 #[test]
-fn clickstack_tile_config_pie_novel_shape_defaults_to_builder() {
-    // A "pie" body with no `configType` dispatches to the pie builder variant,
-    // whose strict fields default rather than failing the response.
+fn clickstack_tile_config_response_pie_novel_shape_dispatches_to_builder() {
+    // A "pie" body with no `configType` dispatches to the pie builder
+    // variant, whose all-`Option` response fields surface `None` rather than
+    // failing the response.
     let json = r#"{"displayType":"pie","somethingNew":true}"#;
-    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    let cfg: ClickStackTileConfigResponse = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackPieChartConfig(
-            ClickStackPieChartConfig::ClickStackPieBuilderChartConfig(b),
+        ClickStackTileConfigResponse::ClickStackPieChartConfig(
+            ClickStackPieChartConfigResponse::ClickStackPieBuilderChartConfig(b),
         ) => {
-            assert_eq!(b.source_id, "");
-            assert!(b.select.is_empty());
+            assert_eq!(b.source_id, None);
+            assert_eq!(b.select, None);
         }
         other => panic!("expected pie builder variant, got {other}"),
     }
@@ -4545,8 +4815,8 @@ fn deserialize_clickstack_webhook_dispatches_slack() {
     let w: ClickStackWebhook = serde_json::from_str(json).unwrap();
     match w {
         ClickStackWebhook::ClickStackSlackWebhook(s) => {
-            assert_eq!(s.id, "webhook-1");
-            assert_eq!(s.name, "Slack Alerts");
+            assert_eq!(s.id.as_deref(), Some("webhook-1"));
+            assert_eq!(s.name.as_deref(), Some("Slack Alerts"));
         }
         other => panic!("expected Slack webhook variant, got {other}"),
     }
@@ -4565,8 +4835,8 @@ fn deserialize_clickstack_webhook_dispatches_incidentio() {
     let w: ClickStackWebhook = serde_json::from_str(json).unwrap();
     match w {
         ClickStackWebhook::ClickStackIncidentIOWebhook(i) => {
-            assert_eq!(i.id, "webhook-2");
-            assert_eq!(i.name, "Incident Alerts");
+            assert_eq!(i.id.as_deref(), Some("webhook-2"));
+            assert_eq!(i.name.as_deref(), Some("Incident Alerts"));
         }
         other => panic!("expected IncidentIO webhook variant, got {other}"),
     }
@@ -4586,7 +4856,7 @@ fn deserialize_clickstack_webhook_dispatches_generic_preserves_body() {
     let w: ClickStackWebhook = serde_json::from_str(json).unwrap();
     match w {
         ClickStackWebhook::ClickStackGenericWebhook(g) => {
-            assert_eq!(g.id, "webhook-3");
+            assert_eq!(g.id.as_deref(), Some("webhook-3"));
             assert_eq!(g.body.as_deref(), Some("{\"text\": \"{{ message }}\"}"));
         }
         other => panic!("expected Generic webhook variant, got {other}"),
@@ -4605,8 +4875,8 @@ fn deserialize_clickstack_webhook_dispatches_slack_api() {
     let w: ClickStackWebhook = serde_json::from_str(json).unwrap();
     match w {
         ClickStackWebhook::ClickStackSlackAPIWebhook(s) => {
-            assert_eq!(s.id, "webhook-4");
-            assert_eq!(s.name, "Slack API Alerts");
+            assert_eq!(s.id.as_deref(), Some("webhook-4"));
+            assert_eq!(s.name.as_deref(), Some("Slack API Alerts"));
         }
         other => panic!("expected SlackAPI webhook variant, got {other}"),
     }
@@ -4624,8 +4894,8 @@ fn deserialize_clickstack_webhook_dispatches_pagerduty_api() {
     let w: ClickStackWebhook = serde_json::from_str(json).unwrap();
     match w {
         ClickStackWebhook::ClickStackPagerDutyAPIWebhook(p) => {
-            assert_eq!(p.id, "webhook-5");
-            assert_eq!(p.name, "PagerDuty Alerts");
+            assert_eq!(p.id.as_deref(), Some("webhook-5"));
+            assert_eq!(p.name.as_deref(), Some("PagerDuty Alerts"));
         }
         other => panic!("expected PagerDutyAPI webhook variant, got {other}"),
     }
@@ -4657,11 +4927,12 @@ fn clickstack_validate_dashboard_response_round_trip() {
         "normalized": {"name": "My Dashboard", "tiles": [{"id": "t1"}]}
     }"#;
     let resp: ClickStackValidateDashboardResponse = serde_json::from_str(json).unwrap();
-    assert!(!resp.valid);
-    assert_eq!(resp.errors.len(), 2);
-    assert_eq!(resp.errors[0].path, "tiles.0.config");
-    assert_eq!(resp.errors[0].message, "Required");
-    assert_eq!(resp.errors[1].path, "");
+    assert_eq!(resp.valid, Some(false));
+    let errors = resp.errors.as_ref().expect("errors should populate");
+    assert_eq!(errors.len(), 2);
+    assert_eq!(errors[0].path.as_deref(), Some("tiles.0.config"));
+    assert_eq!(errors[0].message.as_deref(), Some("Required"));
+    assert_eq!(errors[1].path.as_deref(), Some(""));
 
     // `normalized` is a free-form Value; its arbitrary payload is preserved.
     let normalized = resp.normalized.as_ref().unwrap();
@@ -4681,11 +4952,11 @@ fn clickstack_validate_dashboard_response_round_trip() {
 fn clickstack_validate_dashboard_response_valid_null_normalized() {
     let json = r#"{"valid": true, "errors": [], "normalized": null}"#;
     let resp: ClickStackValidateDashboardResponse = serde_json::from_str(json).unwrap();
-    assert!(resp.valid);
-    assert!(resp.errors.is_empty());
+    assert_eq!(resp.valid, Some(true));
+    assert_eq!(resp.errors.as_deref(), Some(&[][..]));
     assert_eq!(resp.normalized, None);
 
-    // A required-but-nullable field still serializes (as null), not omitted.
+    // The nullable free-form field still serializes (as null), not omitted.
     let v = serde_json::to_value(&resp).unwrap();
     assert!(v.get("normalized").is_some());
     assert!(v["normalized"].is_null());

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -26,12 +26,18 @@ where
 /// inline `enum` values for the discriminating field (both alert channels
 /// declare `["webhook", "email"]`), so a variant defaulting its discriminator to
 /// another variant's value would silently retype the value on the next
-/// deserialize. Add new unions with a `Default` impl here.
+/// deserialize. The covered list is enforced structurally, not by convention:
+/// it must equal the set of hand-written `impl Default for` blocks in
+/// `models.rs` (via the analyzer's `model_types_with_manual_default_impl`), so
+/// a new union gaining a `Default` without a list entry fails this test.
 #[test]
 fn discriminated_union_defaults_round_trip_to_the_same_variant() {
+    let mut covered: Vec<&str> = Vec::new();
+
     macro_rules! assert_default_round_trips {
         ($($union:ty),+ $(,)?) => {
             $({
+                covered.push(stringify!($union));
                 let default = <$union>::default();
                 let json = serde_json::to_string(&default).unwrap();
                 let parsed: $union = serde_json::from_str(&json).unwrap();
@@ -63,6 +69,20 @@ fn discriminated_union_defaults_round_trip_to_the_same_variant() {
         ClickStackTableChartConfig,
         ClickStackTileConfig,
         ClickStackWebhook,
+    );
+
+    covered.sort_unstable();
+    let manual_default_impls = clickhouse_openapi_analyzer::model_types_with_manual_default_impl(
+        include_str!("../src/models.rs"),
+    )
+    .unwrap();
+    assert_eq!(
+        covered,
+        manual_default_impls
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        "the covered list must equal the manual `impl Default for` blocks in models.rs"
     );
 }
 

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -1363,6 +1363,101 @@ fn shared_leaves_stay_strict_on_the_request_side() {
 }
 
 #[test]
+fn infrastructure_responses_tolerate_dropped_and_null_fields() {
+    // Reverse private endpoints and quotas are response-only, so every field is
+    // `Option<T>`: a dropped key and an explicit `null` both land as `None`.
+    // `null` is the case `#[serde(default)]` never covered.
+    let dropped: ReversePrivateEndpoint = serde_json::from_str("{}").unwrap();
+    let nulled: ReversePrivateEndpoint = serde_json::from_str(
+        r#"{"id":null,"description":null,"status":null,"type":null,"dnsNames":null,
+            "privateDnsNames":null,"endpointId":null,"serviceId":null,
+            "customPrivateDnsMappings":null}"#,
+    )
+    .unwrap();
+    assert_eq!(dropped, ReversePrivateEndpoint::default());
+    assert_eq!(nulled, ReversePrivateEndpoint::default());
+    // A `null` on a list field is the residual case the previous
+    // `#[serde(default)]` policy still failed on.
+    assert_eq!(nulled.dns_names, None);
+    assert_eq!(nulled.custom_private_dns_mappings, None);
+
+    let quota: OrganizationQuota = serde_json::from_str(r#"{"name":"Services"}"#).unwrap();
+    assert_eq!(quota.name.as_deref(), Some("Services"));
+    assert_eq!(quota.quota_code, None);
+    assert_eq!(quota.value, None);
+    assert_eq!(quota.adjustable, None);
+}
+
+#[test]
+fn reverse_private_endpoint_omits_absent_fields_when_serialized() {
+    // Absence stays absent in `--json` output, including inside the nested
+    // response variant of the shared `customPrivateDnsMapping` schema.
+    let rpe = ReversePrivateEndpoint {
+        description: Some("MSK endpoint".to_string()),
+        custom_private_dns_mappings: Some(vec![CustomPrivateDnsMappingResponse {
+            private_dns_name: None,
+        }]),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(&rpe).unwrap(),
+        serde_json::json!({
+            "description": "MSK endpoint",
+            "customPrivateDnsMappings": [{}],
+        })
+    );
+}
+
+#[test]
+fn infrastructure_shared_leaves_stay_strict_on_the_request_side() {
+    // `customPrivateDnsMapping` and `RBACPolicyTags` are sent as well as
+    // returned, so each splits: only the `{Name}Response` variant is used by a
+    // response type, and neither variant fabricates a value for a missing key.
+    let mapping = CustomPrivateDnsMapping {
+        private_dns_name: Some("db.internal".to_string()),
+    };
+    assert_eq!(
+        serde_json::to_value(&mapping).unwrap(),
+        serde_json::json!({ "privateDnsName": "db.internal" })
+    );
+    // Both schemas are all-optional upstream, so the request variants accept an
+    // empty object too — what the split guarantees is that the response variant
+    // can never regain a required field.
+    assert_eq!(
+        serde_json::from_str::<CustomPrivateDnsMappingResponse>("{}").unwrap(),
+        CustomPrivateDnsMappingResponse::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<RBACPolicyTagsResponse>(r#"{"grants":null,"roleV2":null}"#).unwrap(),
+        RBACPolicyTagsResponse::default()
+    );
+    let policy: RBACPolicy = serde_json::from_str(r#"{"tags":{"grants":["select"]}}"#).unwrap();
+    assert_eq!(
+        policy.tags,
+        Some(RBACPolicyTagsResponse {
+            grants: Some(vec!["select".to_string()]),
+            role_v2: None,
+        })
+    );
+}
+
+#[test]
+fn reverse_private_endpoint_request_rejects_a_missing_required_field() {
+    // The request side is strict: without `#[serde(default)]` a payload missing
+    // `description` or `type` is rejected rather than silently defaulted.
+    assert!(serde_json::from_str::<CreateReversePrivateEndpoint>("{}").is_err());
+    let body = CreateReversePrivateEndpoint {
+        description: "New RPE".to_string(),
+        r#type: CreateReversePrivateEndpointType::MSK_MULTI_VPC,
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(&body).unwrap(),
+        serde_json::json!({ "description": "New RPE", "type": "MSK_MULTI_VPC" })
+    );
+}
+
+#[test]
 fn resource_tag_response_converts_back_into_a_request_tag() {
     let tag = ResourceTagsV1::try_from(ResourceTagsV1Response {
         key: Some("env".to_string()),
@@ -1652,10 +1747,10 @@ fn deserialize_reverse_private_endpoint() {
         "status": "available"
     }"#;
     let rpe: ReversePrivateEndpoint = serde_json::from_str(json).unwrap();
-    assert_eq!(rpe.description, "MSK endpoint");
+    assert_eq!(rpe.description.as_deref(), Some("MSK endpoint"));
     assert_eq!(
         rpe.status,
-        ReversePrivateEndpointStatus::Other("available".to_string())
+        Some(ReversePrivateEndpointStatus::Other("available".to_string()))
     );
 }
 
@@ -4100,12 +4195,12 @@ fn organization_quota_typed_enums_round_trip() {
     let quota: OrganizationQuota = serde_json::from_str(json).unwrap();
     assert_eq!(
         quota.quota_code,
-        OrganizationQuotaQuotacode::Replicas_per_warehouse
+        Some(OrganizationQuotaQuotacode::Replicas_per_warehouse)
     );
-    assert_eq!(quota.scope, OrganizationQuotaScope::Warehouse);
-    assert_eq!(quota.value, 20);
+    assert_eq!(quota.scope, Some(OrganizationQuotaScope::Warehouse));
+    assert_eq!(quota.value, Some(20));
     assert_eq!(quota.usage, Some(3));
-    assert!(quota.adjustable);
+    assert_eq!(quota.adjustable, Some(true));
 
     let v = serde_json::to_value(&quota).unwrap();
     assert_eq!(v["quotaCode"], "replicas-per-warehouse");
@@ -4130,9 +4225,9 @@ fn organization_quota_usage_optional_omitted() {
     let quota: OrganizationQuota = serde_json::from_str(json).unwrap();
     assert_eq!(
         quota.quota_code,
-        OrganizationQuotaQuotacode::Services_per_organization
+        Some(OrganizationQuotaQuotacode::Services_per_organization)
     );
-    assert_eq!(quota.scope, OrganizationQuotaScope::Organization);
+    assert_eq!(quota.scope, Some(OrganizationQuotaScope::Organization));
     assert_eq!(quota.usage, None);
 
     let v = serde_json::to_value(&quota).unwrap();

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -287,8 +287,8 @@ fn deserialize_clickpipe() {
         "updatedAt": "2024-06-01T01:00:00Z"
     }"#;
     let pipe: ClickPipe = serde_json::from_str(json).unwrap();
-    assert_eq!(pipe.name, "my-pipe");
-    assert_eq!(pipe.state, ClickPipeState::Running);
+    assert_eq!(pipe.name.as_deref(), Some("my-pipe"));
+    assert_eq!(pipe.state, Some(ClickPipeState::Running));
 }
 
 #[test]
@@ -1027,8 +1027,8 @@ fn service_ignores_extra_fields() {
 fn clickpipe_ignores_extra_fields() {
     let json = r#"{"name":"pipe","state":"Running","newFeatureFlag":true}"#;
     let pipe: ClickPipe = serde_json::from_str(json).unwrap();
-    assert_eq!(pipe.name, "pipe");
-    assert_eq!(pipe.state, ClickPipeState::Running);
+    assert_eq!(pipe.name.as_deref(), Some("pipe"));
+    assert_eq!(pipe.state, Some(ClickPipeState::Running));
 }
 
 #[test]
@@ -1189,9 +1189,10 @@ fn organization_minimal_response() {
 #[test]
 fn clickpipe_minimal_response() {
     let pipe: ClickPipe = serde_json::from_str("{}").unwrap();
-    assert_eq!(pipe.id, uuid::Uuid::default());
-    assert_eq!(pipe.name, "");
-    assert_eq!(pipe.state, ClickPipeState::default());
+    assert_eq!(pipe, ClickPipe::default());
+    assert_eq!(pipe.id, None);
+    assert_eq!(pipe.name, None);
+    assert_eq!(pipe.state, None);
 }
 
 #[test]
@@ -1763,8 +1764,8 @@ fn deserialize_clickpipe_kafka_source() {
         "securityProtocol": "SASL_SSL"
     }"#;
     let src: ClickPipeKafkaSource = serde_json::from_str(json).unwrap();
-    assert_eq!(src.brokers, "broker1:9092,broker2:9092");
-    assert_eq!(src.topics, "my-topic");
+    assert_eq!(src.brokers.as_deref(), Some("broker1:9092,broker2:9092"));
+    assert_eq!(src.topics.as_deref(), Some("my-topic"));
 }
 
 #[test]
@@ -1779,10 +1780,11 @@ fn deserialize_clickpipe_destination() {
         ]
     }"#;
     let dest: ClickPipeDestination = serde_json::from_str(json).unwrap();
-    assert_eq!(dest.database, "default");
-    assert_eq!(dest.table, "events");
-    assert_eq!(dest.columns.len(), 2);
-    assert_eq!(dest.columns[0].name, "id");
+    assert_eq!(dest.database.as_deref(), Some("default"));
+    assert_eq!(dest.table.as_deref(), Some("events"));
+    let columns = dest.columns.expect("columns should populate");
+    assert_eq!(columns.len(), 2);
+    assert_eq!(columns[0].name.as_deref(), Some("id"));
 }
 
 #[test]
@@ -1791,10 +1793,10 @@ fn deserialize_clickpipe_scaling() {
         "replicas": 3,
         "concurrency": 2
     }"#;
-    let s: ClickPipeScaling = serde_json::from_str(json).unwrap();
-    assert_eq!(s.replicas, 3);
+    let s: ClickPipeScalingResponse = serde_json::from_str(json).unwrap();
+    assert_eq!(s.replicas, Some(3));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(s.concurrency, 2);
+    assert_eq!(s.concurrency, Some(2));
 }
 
 // ===========================================================================
@@ -1848,14 +1850,14 @@ fn deserialize_clickpipe_pubsub_source() {
         "filter": "attribute.foo = \"bar\""
     }"#;
     let src: ClickPipePubSubSource = serde_json::from_str(json).unwrap();
-    assert_eq!(src.topic, "projects/p/topics/t");
-    assert_eq!(src.project_id, "my-project");
+    assert_eq!(src.topic.as_deref(), Some("projects/p/topics/t"));
+    assert_eq!(src.project_id.as_deref(), Some("my-project"));
     assert_eq!(
         src.authentication,
-        ClickPipePubSubSourceAuthentication::ServiceAccount
+        Some(ClickPipePubSubSourceAuthentication::ServiceAccount)
     );
-    assert_eq!(src.format, ClickPipePubSubSourceFormat::JSONEachRow);
-    assert_eq!(src.seek_type, ClickPipePubSubSourceSeektype::Latest);
+    assert_eq!(src.format, Some(ClickPipePubSubSourceFormat::JSONEachRow));
+    assert_eq!(src.seek_type, Some(ClickPipePubSubSourceSeektype::Latest));
     assert_eq!(src.ack_deadline, Some(60));
     assert_eq!(src.enable_ordering, Some(true));
 }
@@ -1894,8 +1896,11 @@ fn deserialize_clickpipe_source_with_pubsub() {
     }"#;
     let src: ClickPipeSource = serde_json::from_str(json).unwrap();
     let pubsub = src.pubsub.expect("pubsub field should populate");
-    assert_eq!(pubsub.topic, "projects/p/topics/t");
-    assert_eq!(pubsub.format, ClickPipePubSubSourceFormat::JSONEachRow);
+    assert_eq!(pubsub.topic.as_deref(), Some("projects/p/topics/t"));
+    assert_eq!(
+        pubsub.format,
+        Some(ClickPipePubSubSourceFormat::JSONEachRow)
+    );
 }
 
 // ===========================================================================
@@ -2568,11 +2573,12 @@ fn click_pipe_schema_discovery_response_round_trip() {
         ]
     }"#;
     let resp: ClickPipeSchemaDiscoveryResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.fields.len(), 2);
-    assert_eq!(resp.fields[0].name, "user_id");
-    assert_eq!(resp.fields[0].r#type, "Int64");
-    assert_eq!(resp.fields[0].optional, Some(false));
-    assert_eq!(resp.fields[1].optional, Some(true));
+    let fields = resp.fields.clone().expect("fields should populate");
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name.as_deref(), Some("user_id"));
+    assert_eq!(fields[0].r#type.as_deref(), Some("Int64"));
+    assert_eq!(fields[0].optional, Some(false));
+    assert_eq!(fields[1].optional, Some(true));
 
     let v = serde_json::to_value(&resp).unwrap();
     assert_eq!(v["fields"][0]["name"], "user_id");
@@ -2732,15 +2738,156 @@ fn clickstack_filter_input_applies_to_source_ids_round_trip() {
 
 #[test]
 fn clickpipe_postgres_table_mapping_partition_by_expr_round_trip() {
-    let json = r#"{"partitionByExpr": "toYYYYMM(created_at)"}"#;
-    let mapping: ClickPipePostgresPipeTableMapping = serde_json::from_str(json).unwrap();
-    assert_eq!(mapping.partition_by_expr, "toYYYYMM(created_at)");
+    // `partitionByExpr` is required and non-nullable, so the request variant
+    // types it as `String` and always sends it.
+    let mapping = ClickPipePostgresPipeTableMapping {
+        partition_by_expr: "toYYYYMM(created_at)".to_string(),
+        ..Default::default()
+    };
     let v = serde_json::to_value(&mapping).unwrap();
     assert_eq!(v["partitionByExpr"], "toYYYYMM(created_at)");
 
-    // The field is required (non-nullable), so the default is the empty string.
-    let mapping: ClickPipePostgresPipeTableMapping = serde_json::from_str("{}").unwrap();
-    assert_eq!(mapping.partition_by_expr, "");
+    // The response variant types it as `Option<String>`: present, dropped, and
+    // explicitly `null` all deserialize.
+    let mapping: ClickPipePostgresPipeTableMappingResponse =
+        serde_json::from_str(r#"{"partitionByExpr": "toYYYYMM(created_at)"}"#).unwrap();
+    assert_eq!(
+        mapping.partition_by_expr.as_deref(),
+        Some("toYYYYMM(created_at)")
+    );
+    let mapping: ClickPipePostgresPipeTableMappingResponse =
+        serde_json::from_str(r#"{"partitionByExpr": null}"#).unwrap();
+    assert_eq!(mapping.partition_by_expr, None);
+    let mapping: ClickPipePostgresPipeTableMappingResponse = serde_json::from_str("{}").unwrap();
+    assert_eq!(mapping.partition_by_expr, None);
+}
+
+#[test]
+fn clickpipe_response_tolerates_dropped_and_null_fields() {
+    // The whole ClickPipe response tree is all-`Option`, so a dropped key and
+    // an explicit `null` both land as `None` — at the top level and inside the
+    // nested source/destination/scaling/settings shapes.
+    let dropped: ClickPipe = serde_json::from_str("{}").unwrap();
+    let nulled: ClickPipe = serde_json::from_str(
+        r#"{"id":null,"serviceId":null,"name":null,"state":null,"createdAt":null,
+            "updatedAt":null,"scaling":null,"settings":null,"source":null,
+            "destination":null,"fieldMappings":null}"#,
+    )
+    .unwrap();
+    assert_eq!(dropped, ClickPipe::default());
+    assert_eq!(nulled, ClickPipe::default());
+    // `null` on a list field is the residual case the previous
+    // `#[serde(default)]` policy still failed on.
+    assert_eq!(nulled.field_mappings, None);
+
+    let nested: ClickPipe = serde_json::from_str(
+        r#"{"source":{"postgres":{"host":"pg.example","settings":null,
+            "tableMappings":null}},
+            "destination":{"columns":null,"tableDefinition":{"engine":null,
+            "sortingKey":null}},
+            "scaling":{},"settings":{}}"#,
+    )
+    .unwrap();
+    let postgres = nested
+        .source
+        .and_then(|source| source.postgres)
+        .expect("postgres source should populate");
+    assert_eq!(postgres.host.as_deref(), Some("pg.example"));
+    assert_eq!(postgres.settings, None);
+    assert_eq!(postgres.table_mappings, None);
+    let destination = nested.destination.expect("destination should populate");
+    assert_eq!(destination.columns, None);
+    assert_eq!(
+        destination.table_definition,
+        Some(ClickPipeDestinationTableDefinitionResponse::default())
+    );
+    assert_eq!(nested.scaling, Some(ClickPipeScalingResponse::default()));
+    assert_eq!(nested.settings, Some(ClickPipeSettingsResponse::default()));
+}
+
+#[test]
+fn clickpipe_response_omits_absent_fields_when_serialized() {
+    // Absence stays absent in `--json` output, including inside the response
+    // variants of the shared nested pipe schemas.
+    let pipe = ClickPipe {
+        name: Some("my-pipe".to_string()),
+        scaling: Some(ClickPipeScalingResponse {
+            replicas: Some(2),
+            ..Default::default()
+        }),
+        field_mappings: Some(vec![ClickPipeFieldMappingResponse {
+            source_field: Some("id".to_string()),
+            destination_field: None,
+        }]),
+        destination: Some(ClickPipeDestination {
+            table: Some("events".to_string()),
+            table_definition: Some(ClickPipeDestinationTableDefinitionResponse {
+                engine: Some(ClickPipeDestinationTableEngineResponse {
+                    r#type: Some(ClickPipeDestinationTableEngineType::MergeTree),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(&pipe).unwrap(),
+        serde_json::json!({
+            "name": "my-pipe",
+            "scaling": { "replicas": 2 },
+            "fieldMappings": [{ "sourceField": "id" }],
+            "destination": {
+                "table": "events",
+                "tableDefinition": { "engine": { "type": "MergeTree" } },
+            },
+        })
+    );
+}
+
+#[test]
+fn shared_clickpipe_nested_types_stay_strict_on_the_request_side() {
+    // The pipe settings, table mappings, destination shapes, field mappings and
+    // scaling blocks are sent as well as returned, so each splits: the request
+    // variant keeps the schema's required fields as `T`, and only the response
+    // variant is all-`Option`.
+    let mapping = ClickPipeFieldMapping {
+        source_field: "id".to_string(),
+        destination_field: "row_id".to_string(),
+    };
+    assert_eq!(
+        serde_json::to_value(&mapping).unwrap(),
+        serde_json::json!({ "sourceField": "id", "destinationField": "row_id" })
+    );
+    // A request payload missing a required field is rejected, not defaulted.
+    assert!(serde_json::from_str::<ClickPipeFieldMapping>("{}").is_err());
+    assert!(serde_json::from_str::<ClickPipeDestinationColumn>("{}").is_err());
+    assert!(serde_json::from_str::<ClickPipeScaling>("{}").is_err());
+    assert!(serde_json::from_str::<ClickPipePostgresPipeTableMapping>("{}").is_err());
+    // The response variants accept the same payload.
+    assert_eq!(
+        serde_json::from_str::<ClickPipeFieldMappingResponse>("{}").unwrap(),
+        ClickPipeFieldMappingResponse::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickPipeDestinationColumnResponse>("{}").unwrap(),
+        ClickPipeDestinationColumnResponse::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickPipeScalingResponse>("{}").unwrap(),
+        ClickPipeScalingResponse::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ClickPipePostgresPipeTableMappingResponse>("{}").unwrap(),
+        ClickPipePostgresPipeTableMappingResponse::default()
+    );
+    // `ClickPipeSettings` is an all-optional schema in both directions, so the
+    // split is visible only in the type name the settings endpoints return.
+    assert_eq!(
+        serde_json::from_str::<ClickPipeSettingsResponse>("{}").unwrap(),
+        ClickPipeSettingsResponse::default()
+    );
 }
 
 #[test]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -511,7 +511,7 @@ fn deserialize_postgres_service() {
         "state": "running"
     }"#;
     let pg: PostgresService = serde_json::from_str(json).unwrap();
-    assert_eq!(pg.name, "my-postgres");
+    assert_eq!(pg.name.as_deref(), Some("my-postgres"));
 }
 
 #[test]
@@ -1067,7 +1067,7 @@ fn invitation_ignores_extra_fields() {
 fn postgres_service_ignores_extra_fields() {
     let json = r#"{"name":"pg","state":"running","maintenanceWindow":"sun-02:00"}"#;
     let pg: PostgresService = serde_json::from_str(json).unwrap();
-    assert_eq!(pg.name, "pg");
+    assert_eq!(pg.name.as_deref(), Some("pg"));
 }
 
 #[test]
@@ -1195,8 +1195,79 @@ fn clickpipe_minimal_response() {
 fn postgres_service_minimal_response() {
     let pg: PostgresService =
         serde_json::from_str(r#"{"id":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}"#).unwrap();
-    assert_eq!(pg.name, "");
-    assert_eq!(pg.state, PgStateProperty::default());
+    // Every response field is `Option<T>`: an omitted key is `None`, not a
+    // fabricated zero value.
+    assert_eq!(pg.name, None);
+    assert_eq!(pg.state, None);
+}
+
+#[test]
+fn postgres_service_response_tolerates_dropped_and_null_fields() {
+    // A response field the API stops sending, and one it sends as an explicit
+    // `null`, must both land as `None` rather than failing the response. `null`
+    // is the case `#[serde(default)]` never covered: it only fills a missing
+    // key.
+    let dropped: PostgresService = serde_json::from_str("{}").unwrap();
+    let nulled: PostgresService = serde_json::from_str(
+        r#"{"id":null,"name":null,"state":null,"tags":null,"storageSize":null,"createdAt":null}"#,
+    )
+    .unwrap();
+    assert_eq!(dropped, PostgresService::default());
+    assert_eq!(nulled, PostgresService::default());
+    assert_eq!(nulled.tags, None);
+    assert_eq!(nulled.storage_size, None);
+}
+
+#[test]
+fn postgres_service_response_omits_absent_fields_when_serialized() {
+    // Absent means absent: a response field that was not returned is omitted
+    // from `--json` output rather than emitted as `null`.
+    let pg = PostgresService {
+        name: Some("pg-1".to_string()),
+        ..Default::default()
+    };
+    let json = serde_json::to_value(&pg).unwrap();
+    assert_eq!(json, serde_json::json!({ "name": "pg-1" }));
+}
+
+#[test]
+fn postgres_instance_config_response_converts_back_into_a_request_body() {
+    let response = PostgresInstanceConfigResponse {
+        pg_config: Some(PgConfigResponse {
+            max_connections: Some(serde_json::json!(200)),
+            ..Default::default()
+        }),
+        pg_bouncer_config: Some(PgBouncerConfigResponse {}),
+    };
+    let request = PostgresInstanceConfig::try_from(response).unwrap();
+    assert_eq!(
+        request.pg_config.max_connections,
+        Some(serde_json::json!(200))
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        serde_json::json!({ "pgConfig": { "max_connections": 200 }, "pgBouncerConfig": {} })
+    );
+}
+
+#[test]
+fn postgres_instance_config_response_conversion_reports_missing_required_fields() {
+    // Both nested objects are required in a write body, so the write-back
+    // conversion must fail loudly instead of inventing empty objects.
+    let missing_bouncer = PostgresInstanceConfig::try_from(PostgresInstanceConfigResponse {
+        pg_config: Some(PgConfigResponse::default()),
+        pg_bouncer_config: None,
+    })
+    .unwrap_err();
+    assert_eq!(missing_bouncer.fields(), ["pgBouncerConfig"]);
+
+    let missing_both =
+        PostgresInstanceConfig::try_from(PostgresInstanceConfigResponse::default()).unwrap_err();
+    assert_eq!(missing_both.fields(), ["pgBouncerConfig", "pgConfig"]);
+    assert_eq!(
+        missing_both.to_string(),
+        "the API response is missing required field(s): pgBouncerConfig, pgConfig"
+    );
 }
 
 #[test]
@@ -1386,9 +1457,9 @@ fn deserialize_postgres_instance_config() {
         },
         "pgBouncerConfig": {}
     }"#;
-    let config: PostgresInstanceConfig = serde_json::from_str(json).unwrap();
+    let config: PostgresInstanceConfigResponse = serde_json::from_str(json).unwrap();
     assert_eq!(
-        config.pg_config.max_connections,
+        config.pg_config.unwrap().max_connections,
         Some(serde_json::json!(200))
     );
 }
@@ -1410,31 +1481,17 @@ fn deserialize_postgres_instance_config_string_wrapped_numbers() {
         },
         "pgBouncerConfig": {}
     }"#;
-    let config: PostgresInstanceConfig = serde_json::from_str(json).unwrap();
+    let config: PostgresInstanceConfigResponse = serde_json::from_str(json).unwrap();
+    let pg_config = config.pg_config.expect("pgConfig present in the payload");
+    assert_eq!(pg_config.max_connections, Some(serde_json::json!("100")));
+    assert_eq!(pg_config.random_page_cost, Some(serde_json::json!("1.1")));
+    assert_eq!(pg_config.max_worker_processes, Some(serde_json::json!(8)));
+    assert_eq!(pg_config.autovacuum_naptime, Some(serde_json::json!("5s")));
     assert_eq!(
-        config.pg_config.max_connections,
-        Some(serde_json::json!("100"))
-    );
-    assert_eq!(
-        config.pg_config.random_page_cost,
-        Some(serde_json::json!("1.1"))
-    );
-    assert_eq!(
-        config.pg_config.max_worker_processes,
-        Some(serde_json::json!(8))
-    );
-    assert_eq!(
-        config.pg_config.autovacuum_naptime,
-        Some(serde_json::json!("5s"))
-    );
-    assert_eq!(
-        config.pg_config.autovacuum_vacuum_scale_factor,
+        pg_config.autovacuum_vacuum_scale_factor,
         Some(serde_json::json!("0.2"))
     );
-    assert_eq!(
-        config.pg_config.autovacuum_max_workers,
-        Some(serde_json::json!(3))
-    );
+    assert_eq!(pg_config.autovacuum_max_workers, Some(serde_json::json!(3)));
 }
 
 #[test]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -4956,10 +4956,13 @@ fn clickstack_validate_dashboard_response_valid_null_normalized() {
     assert_eq!(resp.errors.as_deref(), Some(&[][..]));
     assert_eq!(resp.normalized, None);
 
-    // The nullable free-form field still serializes (as null), not omitted.
+    // An explicit `null` lands as `None` and, like every absent response
+    // field, is omitted on the way out rather than re-emitted as `null`.
     let v = serde_json::to_value(&resp).unwrap();
-    assert!(v.get("normalized").is_some());
-    assert!(v["normalized"].is_null());
+    assert!(
+        v.get("normalized").is_none(),
+        "absent response fields must be omitted from --json output"
+    );
 }
 
 #[test]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -77,29 +77,31 @@ fn deserialize_organization() {
         "enableCoreDumps": false
     }"#;
     let org: Organization = serde_json::from_str(json).unwrap();
-    assert_eq!(org.name, "My Organization");
+    assert_eq!(org.name.as_deref(), Some("My Organization"));
     assert_eq!(
         org.id,
-        "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-            .parse::<uuid::Uuid>()
-            .unwrap()
+        Some(
+            "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+                .parse::<uuid::Uuid>()
+                .unwrap()
+        )
     );
-    assert!(!org.enable_core_dumps);
+    assert_eq!(org.enable_core_dumps, Some(false));
 }
 
 #[test]
 fn serialize_organization() {
     let org = Organization {
-        id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890".parse().unwrap(),
-        name: "Test Org".to_string(),
+        id: Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890".parse().unwrap()),
+        name: Some("Test Org".to_string()),
         ..Default::default()
     };
     let json = serde_json::to_value(&org).unwrap();
     assert_eq!(json["name"], "Test Org");
     assert_eq!(json["id"], "a1b2c3d4-e5f6-7890-abcd-ef1234567890");
-    // Default fields are still serialized (no skip_serializing_if on required fields)
-    assert!(json.get("createdAt").is_some());
-    assert!(json.get("enableCoreDumps").is_some());
+    // Absent response fields are omitted, not emitted as `null`.
+    assert!(json.get("createdAt").is_none());
+    assert!(json.get("enableCoreDumps").is_none());
 }
 
 #[test]
@@ -123,8 +125,8 @@ fn deserialize_api_response_with_org_list() {
     assert_eq!(resp.request_id, Some("req-uuid-123".to_string()));
     let result = resp.result.unwrap();
     assert_eq!(result.len(), 2);
-    assert_eq!(result[0].name, "Org 1");
-    assert_eq!(result[1].name, "Org 2");
+    assert_eq!(result[0].name.as_deref(), Some("Org 1"));
+    assert_eq!(result[1].name.as_deref(), Some("Org 2"));
 }
 
 #[test]
@@ -174,15 +176,15 @@ fn deserialize_service() {
         "tags": []
     }"#;
     let svc: Service = serde_json::from_str(json).unwrap();
-    assert_eq!(svc.name, "my-service");
-    assert_eq!(svc.provider, ServiceProvider::Aws);
-    assert_eq!(svc.region, ServiceRegion::Us_east_1);
-    assert_eq!(svc.state, ServiceState::Running);
+    assert_eq!(svc.name.as_deref(), Some("my-service"));
+    assert_eq!(svc.provider, Some(ServiceProvider::Aws));
+    assert_eq!(svc.region, Some(ServiceRegion::Us_east_1));
+    assert_eq!(svc.state, Some(ServiceState::Running));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(svc.tier, ServiceTier::Production);
-    assert_eq!(svc.num_replicas, 3.0);
-    assert!(svc.idle_scaling);
-    assert!(svc.is_primary);
+    assert_eq!(svc.tier, Some(ServiceTier::Production));
+    assert_eq!(svc.num_replicas, Some(3.0));
+    assert_eq!(svc.idle_scaling, Some(true));
+    assert_eq!(svc.is_primary, Some(true));
 }
 
 #[test]
@@ -253,10 +255,10 @@ fn deserialize_backup() {
         "backupName": "backup-2024-06-01"
     }"#;
     let backup: Backup = serde_json::from_str(json).unwrap();
-    assert_eq!(backup.status, BackupStatus::Done);
-    assert_eq!(backup.r#type, BackupType::Full);
-    assert_eq!(backup.size_in_bytes, 1073741824.0);
-    assert_eq!(backup.duration_in_seconds, 300.0);
+    assert_eq!(backup.status, Some(BackupStatus::Done));
+    assert_eq!(backup.r#type, Some(BackupType::Full));
+    assert_eq!(backup.size_in_bytes, Some(1073741824.0));
+    assert_eq!(backup.duration_in_seconds, Some(300.0));
 }
 
 #[test]
@@ -270,8 +272,8 @@ fn deserialize_api_key() {
         "expireAt": "2025-01-01T00:00:00Z"
     }"#;
     let key: ApiKey = serde_json::from_str(json).unwrap();
-    assert_eq!(key.name, "My API Key");
-    assert_eq!(key.state, ApiKeyState::Enabled);
+    assert_eq!(key.name.as_deref(), Some("My API Key"));
+    assert_eq!(key.state, Some(ApiKeyState::Enabled));
 }
 
 #[test]
@@ -299,10 +301,10 @@ fn deserialize_member() {
         "joinedAt": "2024-01-01T00:00:00Z"
     }"#;
     let member: Member = serde_json::from_str(json).unwrap();
-    assert_eq!(member.name, "John Doe");
-    assert_eq!(member.email, "john@example.com");
+    assert_eq!(member.name.as_deref(), Some("John Doe"));
+    assert_eq!(member.email.as_deref(), Some("john@example.com"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(member.role, MemberRole::Admin);
+    assert_eq!(member.role, Some(MemberRole::Admin));
 }
 
 #[test]
@@ -314,9 +316,9 @@ fn deserialize_invitation() {
         "createdAt": "2024-06-01T00:00:00Z"
     }"#;
     let inv: Invitation = serde_json::from_str(json).unwrap();
-    assert_eq!(inv.email, "new@example.com");
+    assert_eq!(inv.email.as_deref(), Some("new@example.com"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(inv.role, InvitationRole::Developer);
+    assert_eq!(inv.role, Some(InvitationRole::Developer));
 }
 
 #[test]
@@ -327,9 +329,9 @@ fn deserialize_backup_configuration() {
         "backupStartTime": "02:00"
     }"#;
     let config: BackupConfiguration = serde_json::from_str(json).unwrap();
-    assert_eq!(config.backup_period_in_hours, 24.0);
-    assert_eq!(config.backup_retention_period_in_hours, 168.0);
-    assert_eq!(config.backup_start_time, "02:00");
+    assert_eq!(config.backup_period_in_hours, Some(24.0));
+    assert_eq!(config.backup_retention_period_in_hours, Some(168.0));
+    assert_eq!(config.backup_start_time.as_deref(), Some("02:00"));
 }
 
 #[test]
@@ -352,7 +354,7 @@ fn deserialize_usage_cost() {
         "grandTotalCHC": 50.25
     }"#;
     let cost: UsageCost = serde_json::from_str(json).unwrap();
-    assert_eq!(cost.grand_total_chc, 50.25);
+    assert_eq!(cost.grand_total_chc, Some(50.25));
 }
 
 #[test]
@@ -375,20 +377,22 @@ fn deserialize_private_endpoint_config() {
         "privateDnsHostname": "abc.vpce.clickhouse.cloud"
     }"#;
     let config: PrivateEndpointConfig = serde_json::from_str(json).unwrap();
-    assert_eq!(config.endpoint_service_id, "vpce-svc-123456");
+    assert_eq!(
+        config.endpoint_service_id.as_deref(),
+        Some("vpce-svc-123456")
+    );
 }
 
 #[test]
-fn required_fields_always_serialized() {
+fn absent_response_fields_are_omitted_when_serialized() {
     let org = Organization {
-        name: "Test".to_string(),
+        name: Some("Test".to_string()),
         ..Default::default()
     };
     let json = serde_json::to_value(&org).unwrap();
-    // Required fields are always present (even with default values)
-    assert!(json.get("id").is_some());
-    assert!(json.get("createdAt").is_some());
-    assert_eq!(json["name"], "Test");
+    // Absent means absent: a field the API did not return is omitted from
+    // `--json` output rather than emitted as `null`.
+    assert_eq!(json, serde_json::json!({ "name": "Test" }));
 }
 
 #[test]
@@ -399,9 +403,9 @@ fn deserialize_service_endpoint() {
         "port": 9440
     }"#;
     let ep: ServiceEndpoint = serde_json::from_str(json).unwrap();
-    assert_eq!(ep.protocol, ServiceEndpointProtocol::Nativesecure);
-    assert_eq!(ep.host, "abc123.clickhouse.cloud");
-    assert_eq!(ep.port, 9440.0);
+    assert_eq!(ep.protocol, Some(ServiceEndpointProtocol::Nativesecure));
+    assert_eq!(ep.host.as_deref(), Some("abc123.clickhouse.cloud"));
+    assert_eq!(ep.port, Some(9440.0));
 }
 
 #[test]
@@ -489,16 +493,18 @@ fn deserialize_activity() {
         "createdAt": "2024-06-01T00:00:00Z"
     }"#;
     let activity: Activity = serde_json::from_str(json).unwrap();
-    assert_eq!(activity.actor_type, ActivityActortype::Api);
+    assert_eq!(activity.actor_type, Some(ActivityActortype::Api));
 }
 
 #[test]
-fn default_struct_has_defaults() {
+fn default_response_struct_has_no_values() {
+    // A response model's `Default` means "nothing was returned", not a set of
+    // fabricated zero values.
     let svc = Service::default();
-    assert_eq!(svc.id, uuid::Uuid::default());
-    assert_eq!(svc.name, "");
-    assert_eq!(svc.provider, ServiceProvider::default());
-    assert_eq!(svc.state, ServiceState::default());
+    assert_eq!(svc.id, None);
+    assert_eq!(svc.name, None);
+    assert_eq!(svc.provider, None);
+    assert_eq!(svc.state, None);
 }
 
 #[test]
@@ -521,7 +527,7 @@ fn unknown_enum_variant_deserializes() {
     let svc: Service = serde_json::from_str(json).unwrap();
     assert_eq!(
         svc.state,
-        ServiceState::Unknown("brand-new-state".to_string())
+        Some(ServiceState::Unknown("brand-new-state".to_string()))
     );
 }
 
@@ -584,7 +590,7 @@ fn api_response_extra_fields_ignored() {
     let resp: ApiResponse<Organization> = serde_json::from_str(json).unwrap();
     assert_eq!(resp.status, Some(200.0));
     let org = resp.result.unwrap();
-    assert_eq!(org.name, "Test");
+    assert_eq!(org.name.as_deref(), Some("Test"));
 }
 
 #[test]
@@ -975,20 +981,13 @@ fn deserialize_scaling_schedule_entry_fixed_scaling_fields() {
         "maxReplicaMemoryGb": 32
     }"#;
     let entry: ScalingScheduleEntry = serde_json::from_str(json).unwrap();
-    assert_eq!(entry.autoscaling_mode, AutoscalingMode::Vertical);
+    assert_eq!(entry.autoscaling_mode, Some(AutoscalingMode::Vertical));
     assert_eq!(entry.min_replica_memory_gb, Some(16.0));
     assert_eq!(entry.max_replica_memory_gb, Some(32.0));
 
-    let req = ScalingScheduleEntryRequest {
-        name: entry.name.clone(),
-        weekdays: entry.weekdays.clone(),
-        start_hour_utc: entry.start_hour_utc,
-        end_hour_utc: entry.end_hour_utc,
-        autoscaling_mode: Some(entry.autoscaling_mode.clone()),
-        min_replica_memory_gb: entry.min_replica_memory_gb,
-        max_replica_memory_gb: entry.max_replica_memory_gb,
-        ..Default::default()
-    };
+    // Writing a fetched entry back goes through the explicit conversion, which
+    // resolves the fields the request requires.
+    let req = ScalingScheduleEntryRequest::try_from(entry).unwrap();
     let json = serde_json::to_value(&req).unwrap();
     assert_eq!(json["autoscalingMode"], "vertical");
     assert_eq!(json["minReplicaMemoryGb"], 16.0);
@@ -1013,15 +1012,15 @@ fn serialize_postgres_instance_config_default_envelope() {
 fn organization_ignores_extra_fields() {
     let json = r#"{"name":"Test","brandNewField":"surprise","anotherNew":42}"#;
     let org: Organization = serde_json::from_str(json).unwrap();
-    assert_eq!(org.name, "Test");
+    assert_eq!(org.name.as_deref(), Some("Test"));
 }
 
 #[test]
 fn service_ignores_extra_fields() {
     let json = r#"{"name":"svc","state":"running","futureField":"v2","nested":{"a":1}}"#;
     let svc: Service = serde_json::from_str(json).unwrap();
-    assert_eq!(svc.name, "svc");
-    assert_eq!(svc.state, ServiceState::Running);
+    assert_eq!(svc.name.as_deref(), Some("svc"));
+    assert_eq!(svc.state, Some(ServiceState::Running));
 }
 
 #[test]
@@ -1036,31 +1035,31 @@ fn clickpipe_ignores_extra_fields() {
 fn backup_ignores_extra_fields() {
     let json = r#"{"status":"done","type":"full","compressionRatio":0.85}"#;
     let backup: Backup = serde_json::from_str(json).unwrap();
-    assert_eq!(backup.status, BackupStatus::Done);
+    assert_eq!(backup.status, Some(BackupStatus::Done));
 }
 
 #[test]
 fn api_key_ignores_extra_fields() {
     let json = r#"{"name":"key","state":"enabled","rotationPolicy":"weekly"}"#;
     let key: ApiKey = serde_json::from_str(json).unwrap();
-    assert_eq!(key.name, "key");
-    assert_eq!(key.state, ApiKeyState::Enabled);
+    assert_eq!(key.name.as_deref(), Some("key"));
+    assert_eq!(key.state, Some(ApiKeyState::Enabled));
 }
 
 #[test]
 fn member_ignores_extra_fields() {
     let json = r#"{"name":"Alice","role":"admin","department":"eng","mfa":true}"#;
     let m: Member = serde_json::from_str(json).unwrap();
-    assert_eq!(m.name, "Alice");
+    assert_eq!(m.name.as_deref(), Some("Alice"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(m.role, MemberRole::Admin);
+    assert_eq!(m.role, Some(MemberRole::Admin));
 }
 
 #[test]
 fn invitation_ignores_extra_fields() {
     let json = r#"{"email":"a@b.com","role":"developer","expiresIn":"7d"}"#;
     let inv: Invitation = serde_json::from_str(json).unwrap();
-    assert_eq!(inv.email, "a@b.com");
+    assert_eq!(inv.email.as_deref(), Some("a@b.com"));
 }
 
 #[test]
@@ -1074,14 +1073,14 @@ fn postgres_service_ignores_extra_fields() {
 fn activity_ignores_extra_fields() {
     let json = r#"{"actorType":"user","sourceIp":"1.2.3.4"}"#;
     let a: Activity = serde_json::from_str(json).unwrap();
-    assert_eq!(a.actor_type, ActivityActortype::User);
+    assert_eq!(a.actor_type, Some(ActivityActortype::User));
 }
 
 #[test]
 fn backup_configuration_ignores_extra_fields() {
     let json = r#"{"backupPeriodInHours":24,"backupRetentionPeriodInHours":168,"compressionEnabled":true}"#;
     let c: BackupConfiguration = serde_json::from_str(json).unwrap();
-    assert_eq!(c.backup_period_in_hours, 24.0);
+    assert_eq!(c.backup_period_in_hours, Some(24.0));
 }
 
 // ===========================================================================
@@ -1094,15 +1093,18 @@ fn service_minimal_response() {
     let svc: Service = serde_json::from_str(json).unwrap();
     assert_eq!(
         svc.id,
-        "11111111-2222-3333-4444-555555555555"
-            .parse::<uuid::Uuid>()
-            .unwrap()
+        Some(
+            "11111111-2222-3333-4444-555555555555"
+                .parse::<uuid::Uuid>()
+                .unwrap()
+        )
     );
-    // Missing fields get their default values
-    assert_eq!(svc.name, "");
-    assert_eq!(svc.provider, ServiceProvider::default());
-    assert_eq!(svc.state, ServiceState::default());
-    assert!(svc.endpoints.is_empty());
+    // Every response field is `Option<T>`: an omitted key is `None`, not a
+    // fabricated zero value.
+    assert_eq!(svc.name, None);
+    assert_eq!(svc.provider, None);
+    assert_eq!(svc.state, None);
+    assert_eq!(svc.endpoints, None);
 }
 
 #[cfg(feature = "deprecated-fields")]
@@ -1113,8 +1115,8 @@ fn service_deserializes_deprecated_fields() {
     // the struct entirely (see `deprecated_fields_absent_by_default`).
     let json = r#"{"tier":"production","minTotalMemoryGb":24,"maxTotalMemoryGb":48}"#;
     let svc: Service = serde_json::from_str(json).unwrap();
-    assert_eq!(svc.min_total_memory_gb, 24.0);
-    assert_eq!(svc.max_total_memory_gb, 48.0);
+    assert_eq!(svc.min_total_memory_gb, Some(24.0));
+    assert_eq!(svc.max_total_memory_gb, Some(48.0));
 }
 
 /// In the default build (no `deprecated-fields` feature) deprecated response
@@ -1171,16 +1173,17 @@ fn service_shows_deprecated_fields_with_feature() {
 #[test]
 fn service_empty_object() {
     let svc: Service = serde_json::from_str("{}").unwrap();
-    assert_eq!(svc.id, uuid::Uuid::default());
-    assert_eq!(svc.name, "");
+    assert_eq!(svc, Service::default());
+    assert_eq!(svc.id, None);
+    assert_eq!(svc.name, None);
 }
 
 #[test]
 fn organization_minimal_response() {
     let org: Organization = serde_json::from_str(r#"{"name":"X"}"#).unwrap();
-    assert_eq!(org.name, "X");
-    assert_eq!(org.id, uuid::Uuid::default());
-    assert_eq!(org.created_at, chrono::DateTime::<chrono::Utc>::default());
+    assert_eq!(org.name.as_deref(), Some("X"));
+    assert_eq!(org.id, None);
+    assert_eq!(org.created_at, None);
 }
 
 #[test]
@@ -1273,17 +1276,154 @@ fn postgres_instance_config_response_conversion_reports_missing_required_fields(
 #[test]
 fn backup_minimal_response() {
     let b: Backup = serde_json::from_str("{}").unwrap();
-    assert_eq!(b.id, uuid::Uuid::default());
-    assert_eq!(b.status, BackupStatus::default());
-    assert_eq!(b.size_in_bytes, 0.0);
+    assert_eq!(b.id, None);
+    assert_eq!(b.status, None);
+    assert_eq!(b.size_in_bytes, None);
 }
 
 #[test]
 fn api_key_minimal_response() {
     let k: ApiKey = serde_json::from_str(r#"{"name":"k"}"#).unwrap();
-    assert_eq!(k.name, "k");
-    assert_eq!(k.id, uuid::Uuid::default());
-    assert_eq!(k.state, ApiKeyState::default());
+    assert_eq!(k.name.as_deref(), Some("k"));
+    assert_eq!(k.id, None);
+    assert_eq!(k.state, None);
+}
+
+#[test]
+fn service_response_tolerates_dropped_and_null_fields() {
+    // A response field the API stops sending, and one it sends as an explicit
+    // `null`, must both land as `None` rather than failing the response. `null`
+    // is the case `#[serde(default)]` never covered: it only fills a missing
+    // key.
+    let dropped: Service = serde_json::from_str("{}").unwrap();
+    let nulled: Service = serde_json::from_str(
+        r#"{"id":null,"name":null,"state":null,"endpoints":null,"ipAccessList":null,
+            "tags":null,"currentScaling":null,"scalingSchedule":null,"numReplicas":null}"#,
+    )
+    .unwrap();
+    assert_eq!(dropped, Service::default());
+    assert_eq!(nulled, Service::default());
+    assert_eq!(nulled.endpoints, None);
+    assert_eq!(nulled.ip_access_list, None);
+    assert_eq!(nulled.tags, None);
+}
+
+#[test]
+fn service_response_omits_absent_fields_when_serialized() {
+    // Absent means absent, at every level of the response tree: a field that
+    // was not returned is omitted from `--json` output, never emitted as
+    // `null`.
+    let svc = Service {
+        name: Some("svc".to_string()),
+        ip_access_list: Some(vec![IpAccessListEntryResponse {
+            source: Some("0.0.0.0/0".to_string()),
+            description: None,
+        }]),
+        tags: Some(vec![ResourceTagsV1Response {
+            key: Some("env".to_string()),
+            value: None,
+        }]),
+        ..Default::default()
+    };
+    assert_eq!(
+        serde_json::to_value(&svc).unwrap(),
+        serde_json::json!({
+            "name": "svc",
+            "ipAccessList": [{ "source": "0.0.0.0/0" }],
+            "tags": [{ "key": "env" }],
+        })
+    );
+}
+
+#[test]
+fn shared_leaves_stay_strict_on_the_request_side() {
+    // `ipAccessListEntry` and `resourceTagsV1` are sent as well as returned, so
+    // each splits: the request variant keeps the schema's required fields as
+    // `T`, and only the response variant is all-`Option`.
+    let entry = IpAccessListEntry {
+        source: "0.0.0.0/0".to_string(),
+        description: None,
+    };
+    assert_eq!(
+        serde_json::to_value(&entry).unwrap(),
+        serde_json::json!({ "source": "0.0.0.0/0" })
+    );
+    // A request payload missing a required field is rejected, not defaulted.
+    assert!(serde_json::from_str::<IpAccessListEntry>("{}").is_err());
+    assert!(serde_json::from_str::<ResourceTagsV1>("{}").is_err());
+    // The response variants accept the same payload.
+    assert_eq!(
+        serde_json::from_str::<IpAccessListEntryResponse>("{}").unwrap(),
+        IpAccessListEntryResponse::default()
+    );
+    assert_eq!(
+        serde_json::from_str::<ResourceTagsV1Response>("{}").unwrap(),
+        ResourceTagsV1Response::default()
+    );
+}
+
+#[test]
+fn resource_tag_response_converts_back_into_a_request_tag() {
+    let tag = ResourceTagsV1::try_from(ResourceTagsV1Response {
+        key: Some("env".to_string()),
+        value: Some("dev".to_string()),
+    })
+    .unwrap();
+    assert_eq!(tag.key, "env");
+    assert_eq!(tag.value.as_deref(), Some("dev"));
+
+    // A tag is identified by its key, so a keyless response tag cannot be
+    // written back.
+    let missing = ResourceTagsV1::try_from(ResourceTagsV1Response {
+        key: None,
+        value: Some("dev".to_string()),
+    })
+    .unwrap_err();
+    assert_eq!(missing.fields(), ["key"]);
+}
+
+#[test]
+fn scaling_schedule_entry_response_converts_back_into_a_request_entry() {
+    let entry = ScalingScheduleEntry {
+        name: Some("weekday-peak".to_string()),
+        weekdays: Some(vec![1, 2, 3]),
+        start_hour_utc: Some(8),
+        end_hour_utc: Some(18),
+        autoscaling_mode: Some(AutoscalingMode::Vertical),
+        min_replica_memory_gb: Some(16.0),
+        ..Default::default()
+    };
+    let request = ScalingScheduleEntryRequest::try_from(entry).unwrap();
+    assert_eq!(request.name, "weekday-peak");
+    assert_eq!(request.weekdays, vec![1, 2, 3]);
+    assert_eq!(request.start_hour_utc, 8);
+    assert_eq!(request.end_hour_utc, 18);
+    assert_eq!(request.min_replica_memory_gb, Some(16.0));
+
+    // An upsert replaces the whole schedule, so an entry the API returned
+    // without its window bounds, weekdays or name cannot be re-sent.
+    let missing =
+        ScalingScheduleEntryRequest::try_from(ScalingScheduleEntry::default()).unwrap_err();
+    assert_eq!(
+        missing.fields(),
+        ["endHourUtc", "name", "startHourUtc", "weekdays"]
+    );
+}
+
+#[test]
+fn upgrade_window_response_converts_back_into_a_put_body() {
+    let request = UpgradeWindowPutRequest::try_from(UpgradeWindow {
+        // `duration` is response-only and does not cross over.
+        duration: Some(21600),
+        start_hour_utc: Some(6),
+        weekday: Some(2),
+    })
+    .unwrap();
+    assert_eq!(request.start_hour_utc, 6);
+    assert_eq!(request.weekday, 2);
+
+    let missing = UpgradeWindowPutRequest::try_from(UpgradeWindow::default()).unwrap_err();
+    assert_eq!(missing.fields(), ["startHourUtc", "weekday"]);
 }
 
 #[test]
@@ -1306,8 +1446,11 @@ fn deserialize_aws_backup_bucket() {
         "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
     }"#;
     let b: AwsBackupBucket = serde_json::from_str(json).unwrap();
-    assert_eq!(b.bucket_path, "s3://my-bucket/prefix");
-    assert_eq!(b.iam_role_arn, "arn:aws:iam::123:role/backup");
+    assert_eq!(b.bucket_path.as_deref(), Some("s3://my-bucket/prefix"));
+    assert_eq!(
+        b.iam_role_arn.as_deref(),
+        Some("arn:aws:iam::123:role/backup")
+    );
 }
 
 #[test]
@@ -1321,8 +1464,11 @@ fn deserialize_backup_bucket_dispatches_aws() {
     let b: BackupBucket = serde_json::from_str(json).unwrap();
     assert!(matches!(b, BackupBucket::AwsBackupBucket(_)));
     if let BackupBucket::AwsBackupBucket(aws) = b {
-        assert_eq!(aws.bucket_path, "s3://my-bucket/prefix");
-        assert_eq!(aws.iam_role_arn, "arn:aws:iam::123:role/backup");
+        assert_eq!(aws.bucket_path.as_deref(), Some("s3://my-bucket/prefix"));
+        assert_eq!(
+            aws.iam_role_arn.as_deref(),
+            Some("arn:aws:iam::123:role/backup")
+        );
     }
 }
 
@@ -1337,8 +1483,11 @@ fn deserialize_backup_bucket_dispatches_gcp() {
     let b: BackupBucket = serde_json::from_str(json).unwrap();
     assert!(matches!(b, BackupBucket::GcpBackupBucket(_)));
     if let BackupBucket::GcpBackupBucket(gcp) = b {
-        assert_eq!(gcp.access_key_id, "GOOG1234567890");
-        assert_eq!(gcp.bucket_path, "gs://my-gcp-bucket/prefix");
+        assert_eq!(gcp.access_key_id.as_deref(), Some("GOOG1234567890"));
+        assert_eq!(
+            gcp.bucket_path.as_deref(),
+            Some("gs://my-gcp-bucket/prefix")
+        );
     }
 }
 
@@ -1352,7 +1501,7 @@ fn deserialize_backup_bucket_dispatches_azure() {
     let b: BackupBucket = serde_json::from_str(json).unwrap();
     assert!(matches!(b, BackupBucket::AzureBackupBucket(_)));
     if let BackupBucket::AzureBackupBucket(azure) = b {
-        assert_eq!(azure.container_name, "my-container");
+        assert_eq!(azure.container_name.as_deref(), Some("my-container"));
     }
 }
 
@@ -1423,9 +1572,10 @@ fn deserialize_service_post_response() {
         "password": "gen-pw-123"
     }"#;
     let resp: ServicePostResponse = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.password, "gen-pw-123");
-    assert_eq!(resp.service.name, "new-svc");
-    assert_eq!(resp.service.state, ServiceState::Provisioning);
+    assert_eq!(resp.password.as_deref(), Some("gen-pw-123"));
+    let service = resp.service.unwrap();
+    assert_eq!(service.name.as_deref(), Some("new-svc"));
+    assert_eq!(service.state, Some(ServiceState::Provisioning));
 }
 
 #[test]
@@ -1444,8 +1594,8 @@ fn deserialize_usage_cost_with_records() {
         "grandTotalCHC": 35.5
     }"#;
     let cost: UsageCost = serde_json::from_str(json).unwrap();
-    assert_eq!(cost.grand_total_chc, 35.5);
-    assert_eq!(cost.costs.len(), 2);
+    assert_eq!(cost.grand_total_chc, Some(35.5));
+    assert_eq!(cost.costs.as_deref().map(<[_]>::len), Some(2));
 }
 
 #[test]
@@ -1564,9 +1714,9 @@ fn deserialize_upgrade_window() {
         "duration": 21600
     }"#;
     let w: UpgradeWindow = serde_json::from_str(json).unwrap();
-    assert_eq!(w.weekday, 2);
-    assert_eq!(w.start_hour_utc, 6);
-    assert_eq!(w.duration, 21600);
+    assert_eq!(w.weekday, Some(2));
+    assert_eq!(w.start_hour_utc, Some(6));
+    assert_eq!(w.duration, Some(21600));
 
     let round_tripped = serde_json::to_value(&w).unwrap();
     assert_eq!(round_tripped["startHourUtc"], 6);

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -1780,10 +1780,37 @@ fn clickstack_alert_channel_known_variants_deserialize() {
 }
 
 #[test]
+fn clickstack_alert_channel_known_type_sparse_payload_defaults() {
+    // A recognized `type` dispatches hard to its variant, and the variant's own
+    // fields are tolerant: a server that drops `emailRecipients` degrades to the
+    // default rather than failing the response.
+    let json = r#"{"type":"email"}"#;
+    let channel: ClickStackAlertChannel = serde_json::from_str(json).unwrap();
+    match channel {
+        ClickStackAlertChannel::ClickStackAlertChannelEmail(v) => {
+            assert_eq!(v.r#type, ClickStackAlertChannelEmailType::Email);
+            assert!(v.email_recipients.is_empty());
+        }
+        other => panic!("expected email variant, got {other}"),
+    }
+}
+
+#[test]
+fn clickstack_alert_channel_missing_type_key_is_unknown() {
+    // This union has no arm for an absent `type` key, in deliberate contrast to
+    // the chart-config unions where absence means the Builder variant, so a
+    // payload without the discriminator lands in the lossless Unknown catch-all.
+    let json = r#"{"webhookId":"wh-1"}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackAlertChannel| {
+        matches!(c, ClickStackAlertChannel::Unknown(_))
+    });
+}
+
+#[test]
 fn clickstack_alert_channel_unknown_shape_round_trips() {
-    // A payload matching neither the email nor webhook variant must land in the
-    // lossless Unknown catch-all and re-serialize to the same JSON object rather
-    // than erroring on deserialize.
+    // An unrecognized `type` value must land in the lossless Unknown catch-all
+    // and re-serialize to the same JSON object rather than erroring on
+    // deserialize.
     let json = r#"{
         "type": "future_channel",
         "foo": 1

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -2816,9 +2816,9 @@ fn clickstack_tile_config_markdown_variant() {
 
 #[test]
 fn clickstack_tile_config_heatmap_variant() {
-    // Untagged-enum dispatch must reach the new ClickStackHeatmapChartConfig
-    // arm. The discriminator is `displayType: "heatmap"` plus the heatmap-
-    // specific `select` shape with `valueExpression`.
+    // `displayType: "heatmap"` is the only discriminator that reaches the
+    // ClickStackHeatmapChartConfig arm; the heatmap-specific `select` shape with
+    // `valueExpression` is then parsed by that variant, not used to select it.
     let json = r#"{
         "displayType": "heatmap",
         "sourceId": "src-1",
@@ -2850,17 +2850,66 @@ fn clickstack_tile_config_unknown_display_type_round_trips() {
 }
 
 #[test]
-fn clickstack_tile_config_known_display_type_novel_shape_falls_to_sub_union_unknown() {
-    // A known `displayType` whose body matches neither the builder nor the raw
-    // SQL shape must land in the sub-union's Unknown(Value) rather than error.
+fn clickstack_tile_config_line_novel_shape_defaults_to_builder() {
+    // A known `displayType` carrying no `configType` dispatches to the builder
+    // variant: the novel member is ignored and the builder's strict fields fall
+    // back to their serde defaults instead of failing the response.
     let json = r#"{"displayType":"line","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
     match cfg {
-        ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(v)) => {
-            assert_eq!(v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+        ClickStackTileConfig::ClickStackLineChartConfig(
+            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected line sub-union Unknown(Value), got {other}"),
+        other => panic!("expected line builder variant, got {other}"),
     }
+}
+
+#[test]
+fn clickstack_tile_config_line_minimal_body_defaults_to_builder() {
+    // The bare discriminator with no `configType` key at all: key absence is the
+    // builder discriminator, and every builder field defaults.
+    let json = r#"{"displayType":"line"}"#;
+    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    match cfg {
+        ClickStackTileConfig::ClickStackLineChartConfig(
+            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b, ClickStackLineBuilderChartConfig::default());
+        }
+        other => panic!("expected line builder variant, got {other}"),
+    }
+}
+
+#[test]
+fn clickstack_tile_config_non_string_config_type_defaults_to_builder() {
+    // A non-string `configType` is deliberately conflated with an absent one:
+    // both dispatch to the builder variant rather than to Unknown.
+    let json = r#"{"displayType":"line","configType":123,"sourceId":"src-1"}"#;
+    let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
+    match cfg {
+        ClickStackTileConfig::ClickStackLineChartConfig(
+            ClickStackLineChartConfig::ClickStackLineBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b.source_id, "src-1");
+        }
+        other => panic!("expected line builder variant, got {other}"),
+    }
+}
+
+#[test]
+fn clickstack_tile_config_line_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // With the builder variant total, an unrecognized *string* `configType` is
+    // the only route into the line sub-union's Unknown(Value); it round-trips.
+    let json = r#"{"displayType":"line","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(_))
+        )
+    });
 }
 
 #[test]
@@ -3003,89 +3052,159 @@ fn clickstack_tile_config_pie_raw_sql_variant() {
 }
 
 #[test]
-fn clickstack_tile_config_categorical_bar_novel_shape_falls_to_sub_union_unknown() {
-    // A "bar" body matching neither the categorical bar builder nor raw SQL shape
-    // lands in the categorical bar sub-union's Unknown(Value) and round-trips.
+fn clickstack_tile_config_categorical_bar_novel_shape_defaults_to_builder() {
+    // A "bar" body with no `configType` dispatches to the categorical bar builder
+    // variant, whose strict fields default rather than failing the response.
     let json = r#"{"displayType":"bar","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
-    match &cfg {
+    match cfg {
         ClickStackTileConfig::ClickStackCategoricalBarChartConfig(
-            ClickStackCategoricalBarChartConfig::Unknown(v),
+            ClickStackCategoricalBarChartConfig::ClickStackCategoricalBarBuilderChartConfig(b),
         ) => {
-            assert_eq!(*v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected categorical bar sub-union Unknown(Value), got {other}"),
+        other => panic!("expected categorical bar builder variant, got {other}"),
     }
-    let expected: serde_json::Value = serde_json::from_str(json).unwrap();
-    assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
 }
 
 #[test]
-fn clickstack_tile_config_stacked_bar_novel_shape_falls_to_sub_union_unknown() {
-    // A "stacked_bar" body matching neither the bar builder nor raw SQL shape
-    // lands in the bar sub-union's Unknown(Value) and round-trips.
+fn clickstack_tile_config_categorical_bar_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // An unrecognized *string* `configType` is the only route into the
+    // categorical bar sub-union's Unknown(Value); it round-trips losslessly.
+    let json = r#"{"displayType":"bar","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackCategoricalBarChartConfig(
+                ClickStackCategoricalBarChartConfig::Unknown(_)
+            )
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_stacked_bar_novel_shape_defaults_to_builder() {
+    // A "stacked_bar" body with no `configType` dispatches to the bar builder
+    // variant, whose strict fields default rather than failing the response.
     let json = r#"{"displayType":"stacked_bar","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
-    match &cfg {
-        ClickStackTileConfig::ClickStackBarChartConfig(ClickStackBarChartConfig::Unknown(v)) => {
-            assert_eq!(*v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+    match cfg {
+        ClickStackTileConfig::ClickStackBarChartConfig(
+            ClickStackBarChartConfig::ClickStackBarBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected bar sub-union Unknown(Value), got {other}"),
+        other => panic!("expected bar builder variant, got {other}"),
     }
-    let expected: serde_json::Value = serde_json::from_str(json).unwrap();
-    assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
 }
 
 #[test]
-fn clickstack_tile_config_table_novel_shape_falls_to_sub_union_unknown() {
-    // A "table" body matching neither the table builder nor raw SQL shape lands
-    // in the table sub-union's Unknown(Value) and round-trips.
+fn clickstack_tile_config_stacked_bar_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // An unrecognized *string* `configType` is the only route into the bar
+    // sub-union's Unknown(Value); it round-trips losslessly.
+    let json = r#"{"displayType":"stacked_bar","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackBarChartConfig(ClickStackBarChartConfig::Unknown(_))
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_table_novel_shape_defaults_to_builder() {
+    // A "table" body with no `configType` dispatches to the table builder
+    // variant, whose strict fields default rather than failing the response.
     let json = r#"{"displayType":"table","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
-    match &cfg {
-        ClickStackTileConfig::ClickStackTableChartConfig(ClickStackTableChartConfig::Unknown(
-            v,
-        )) => {
-            assert_eq!(*v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+    match cfg {
+        ClickStackTileConfig::ClickStackTableChartConfig(
+            ClickStackTableChartConfig::ClickStackTableBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected table sub-union Unknown(Value), got {other}"),
+        other => panic!("expected table builder variant, got {other}"),
     }
-    let expected: serde_json::Value = serde_json::from_str(json).unwrap();
-    assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
 }
 
 #[test]
-fn clickstack_tile_config_number_novel_shape_falls_to_sub_union_unknown() {
-    // A "number" body matching neither the number builder nor raw SQL shape lands
-    // in the number sub-union's Unknown(Value) and round-trips.
+fn clickstack_tile_config_table_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // An unrecognized *string* `configType` is the only route into the table
+    // sub-union's Unknown(Value); it round-trips losslessly.
+    let json = r#"{"displayType":"table","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackTableChartConfig(ClickStackTableChartConfig::Unknown(
+                _
+            ))
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_number_novel_shape_defaults_to_builder() {
+    // A "number" body with no `configType` dispatches to the number builder
+    // variant, whose strict fields default rather than failing the response.
     let json = r#"{"displayType":"number","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
-    match &cfg {
+    match cfg {
         ClickStackTileConfig::ClickStackNumberChartConfig(
-            ClickStackNumberChartConfig::Unknown(v),
+            ClickStackNumberChartConfig::ClickStackNumberBuilderChartConfig(b),
         ) => {
-            assert_eq!(*v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected number sub-union Unknown(Value), got {other}"),
+        other => panic!("expected number builder variant, got {other}"),
     }
-    let expected: serde_json::Value = serde_json::from_str(json).unwrap();
-    assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
 }
 
 #[test]
-fn clickstack_tile_config_pie_novel_shape_falls_to_sub_union_unknown() {
-    // A "pie" body matching neither the pie builder nor raw SQL shape lands in
-    // the pie sub-union's Unknown(Value) and round-trips.
+fn clickstack_tile_config_number_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // An unrecognized *string* `configType` is the only route into the number
+    // sub-union's Unknown(Value); it round-trips losslessly.
+    let json = r#"{"displayType":"number","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackNumberChartConfig(
+                ClickStackNumberChartConfig::Unknown(_)
+            )
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_pie_novel_shape_defaults_to_builder() {
+    // A "pie" body with no `configType` dispatches to the pie builder variant,
+    // whose strict fields default rather than failing the response.
     let json = r#"{"displayType":"pie","somethingNew":true}"#;
     let cfg: ClickStackTileConfig = serde_json::from_str(json).unwrap();
-    match &cfg {
-        ClickStackTileConfig::ClickStackPieChartConfig(ClickStackPieChartConfig::Unknown(v)) => {
-            assert_eq!(*v, serde_json::from_str::<serde_json::Value>(json).unwrap());
+    match cfg {
+        ClickStackTileConfig::ClickStackPieChartConfig(
+            ClickStackPieChartConfig::ClickStackPieBuilderChartConfig(b),
+        ) => {
+            assert_eq!(b.source_id, "");
+            assert!(b.select.is_empty());
         }
-        other => panic!("expected pie sub-union Unknown(Value), got {other}"),
+        other => panic!("expected pie builder variant, got {other}"),
     }
-    let expected: serde_json::Value = serde_json::from_str(json).unwrap();
-    assert_eq!(serde_json::to_value(&cfg).unwrap(), expected);
+}
+
+#[test]
+fn clickstack_tile_config_pie_unrecognized_config_type_falls_to_sub_union_unknown() {
+    // An unrecognized *string* `configType` is the only route into the pie
+    // sub-union's Unknown(Value); it round-trips losslessly.
+    let json = r#"{"displayType":"pie","configType":"future"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackPieChartConfig(ClickStackPieChartConfig::Unknown(_))
+        )
+    });
 }
 
 #[test]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -4235,6 +4235,56 @@ fn organization_quota_usage_optional_omitted() {
 }
 
 #[test]
+fn organization_quota_tolerates_explicit_null_fields() {
+    // `OrganizationQuota` is response-only, so every field is `Option<T>` and an
+    // explicit `null` lands as `None` exactly like a dropped key — the case the
+    // superseded `#[serde(default)]` policy never covered.
+    let quota: OrganizationQuota = serde_json::from_str(
+        r#"{"quotaCode":null,"name":null,"description":null,"scope":null,
+            "value":null,"usage":null,"adjustable":null}"#,
+    )
+    .unwrap();
+    assert_eq!(quota, OrganizationQuota::default());
+
+    // Absence is omitted on the way out, never re-emitted as `null`.
+    assert_eq!(
+        serde_json::to_value(&quota).unwrap(),
+        serde_json::json!({}),
+        "absent response fields must be omitted from --json output"
+    );
+}
+
+#[test]
+fn scim_request_models_stay_strict() {
+    // The spec defines the SCIM schemas but no SCIM path, so the family is in
+    // neither direction's tree and stays strict (see the comment above
+    // `ScimEnterpriseManager` in models.rs and
+    // `scim_models_are_outside_the_response_tree` in spec_coverage_test.rs).
+    // Required fields are therefore `T` and a dropped one is a hard error.
+    let err = serde_json::from_str::<ScimGroupPostRequest>(r#"{"schemas":[]}"#).unwrap_err();
+    assert!(
+        err.to_string().contains("displayName"),
+        "unexpected error: {err}"
+    );
+
+    // Absent optional fields are still omitted rather than sent as `null`.
+    let group = ScimGroupPostRequest {
+        display_name: "Engineering".to_string(),
+        external_id: None,
+        members: None,
+        schemas: vec!["urn:ietf:params:scim:schemas:core:2.0:Group".to_string()],
+    };
+    let v = serde_json::to_value(&group).unwrap();
+    assert_eq!(v["displayName"], "Engineering");
+    assert_eq!(
+        v["schemas"][0],
+        "urn:ietf:params:scim:schemas:core:2.0:Group"
+    );
+    assert!(v.get("externalId").is_none());
+    assert!(v.get("members").is_none());
+}
+
+#[test]
 fn organization_quota_quota_code_unknown_catch_all() {
     let parsed: OrganizationQuotaQuotacode =
         serde_json::from_str("\"queries-per-second\"").unwrap();

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -19,6 +19,53 @@ where
     assert!(reserialized.is_object());
 }
 
+/// Every `discriminated_union!` enum with a `Default` is reachable from a
+/// response that drops a field carrying that union, so its default must be a
+/// fixed point of its own `Deserialize`: it has to come back as the same
+/// variant. It is not automatic — variants of one union can share the same
+/// inline `enum` values for the discriminating field (both alert channels
+/// declare `["webhook", "email"]`), so a variant defaulting its discriminator to
+/// another variant's value would silently retype the value on the next
+/// deserialize. Add new unions with a `Default` impl here.
+#[test]
+fn discriminated_union_defaults_round_trip_to_the_same_variant() {
+    macro_rules! assert_default_round_trips {
+        ($($union:ty),+ $(,)?) => {
+            $({
+                let default = <$union>::default();
+                let json = serde_json::to_string(&default).unwrap();
+                let parsed: $union = serde_json::from_str(&json).unwrap();
+                assert_eq!(
+                    parsed,
+                    default,
+                    "{} default deserialized as another variant from {json}",
+                    stringify!($union),
+                );
+            })+
+        };
+    }
+
+    assert_default_round_trips!(
+        BackupBucket,
+        BackupBucketPatchRequest,
+        BackupBucketPostRequest,
+        BackupBucketProperties,
+        ClickStackAlertChannel,
+        ClickStackBarChartConfig,
+        ClickStackCategoricalBarChartConfig,
+        ClickStackDashboardChartSeries,
+        ClickStackLineChartConfig,
+        ClickStackNumberChartConfig,
+        ClickStackOnClick,
+        ClickStackOnClickTarget,
+        ClickStackPieChartConfig,
+        ClickStackSource,
+        ClickStackTableChartConfig,
+        ClickStackTileConfig,
+        ClickStackWebhook,
+    );
+}
+
 #[test]
 fn deserialize_organization() {
     let json = r#"{
@@ -1821,6 +1868,40 @@ fn clickstack_alert_channel_unknown_shape_round_trips() {
 }
 
 #[test]
+fn clickstack_alert_channel_changed_field_shape_is_unknown() {
+    // A recognized `type` whose payload no longer fits the variant — here
+    // `emailRecipients` as a string instead of an array — must not fail the
+    // response. `list_alerts` returns a Vec, so one such element would otherwise
+    // take down the whole call; instead the element lands in Unknown intact.
+    let json = r#"{"type":"email","emailRecipients":"a@b.c"}"#;
+    assert_unknown_variant_round_trips(json, |c: &ClickStackAlertChannel| {
+        matches!(c, ClickStackAlertChannel::Unknown(_))
+    });
+}
+
+#[test]
+fn clickstack_alert_channel_default_round_trips_to_the_same_variant() {
+    // Both alert-channel variants declare the same `enum: ["webhook", "email"]`
+    // for their discriminating `type`, so the email variant's default must name
+    // `email`: `channel` is defaulted on the alert response, and a default that
+    // named `webhook` would come back from its own union as the webhook variant
+    // and could be PUT back as a webhook channel with no `webhookId`.
+    let default = ClickStackAlertChannel::default();
+    assert!(matches!(
+        default,
+        ClickStackAlertChannel::ClickStackAlertChannelEmail(_)
+    ));
+    let json = serde_json::to_string(&default).unwrap();
+    assert_eq!(json, r#"{"emailRecipients":[],"type":"email"}"#);
+    let round_tripped: ClickStackAlertChannel = serde_json::from_str(&json).unwrap();
+    assert_eq!(round_tripped, default);
+
+    // A response that drops `channel` entirely lands on that same default.
+    let response: ClickStackAlertResponse = serde_json::from_str(r#"{"name":"my-alert"}"#).unwrap();
+    assert_eq!(response.channel, default);
+}
+
+#[test]
 fn deserialize_clickstack_log_source_with_metadata_materialized_views() {
     let json = r#"{
         "id": "src-1",
@@ -2901,10 +2982,61 @@ fn clickstack_tile_config_non_string_config_type_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_line_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // With the builder variant total, an unrecognized *string* `configType` is
-    // the only route into the line sub-union's Unknown(Value); it round-trips.
+    // An unrecognized *string* `configType` reaches the line sub-union's
+    // Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"line","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(_))
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_raw_sql_body_without_config_type_falls_to_sub_union_unknown() {
+    // `configType` is spec-required on the Raw SQL configs, so a server that
+    // stops sending it must not silently retype the tile: the builder variant is
+    // total and would otherwise absorb the body and drop `connectionId` and
+    // `sqlTemplate`. The `unless` guard routes it to Unknown, which keeps the
+    // payload verbatim.
+    let json = r#"{"displayType":"line","connectionId":"conn-1","sqlTemplate":"SELECT 1"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(_))
+        )
+    });
+
+    // Either guard key on its own disqualifies the builder variant, and the
+    // guard is wired on every chart-config sub-union, not just the line one.
+    let json = r#"{"displayType":"number","connectionId":"conn-1"}"#;
+    assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackNumberChartConfig(
+                ClickStackNumberChartConfig::Unknown(_)
+            )
+        )
+    });
+}
+
+#[test]
+fn clickstack_tile_config_changed_field_shape_falls_to_sub_union_unknown() {
+    // Field-level tolerance only covers a field the API stops sending. A field
+    // whose *shape* changes cannot deserialize into the dispatched variant, so
+    // the union hands the payload to its lossless Unknown catch-all rather than
+    // failing the whole dashboard response.
+    let builder = r#"{"displayType":"line","sourceId":123}"#;
+    assert_unknown_variant_round_trips(builder, |cfg: &ClickStackTileConfig| {
+        matches!(
+            cfg,
+            ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(_))
+        )
+    });
+
+    let raw_sql = r#"{"displayType":"line","configType":"sql","sqlTemplate":123}"#;
+    assert_unknown_variant_round_trips(raw_sql, |cfg: &ClickStackTileConfig| {
         matches!(
             cfg,
             ClickStackTileConfig::ClickStackLineChartConfig(ClickStackLineChartConfig::Unknown(_))
@@ -3070,8 +3202,8 @@ fn clickstack_tile_config_categorical_bar_novel_shape_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_categorical_bar_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // An unrecognized *string* `configType` is the only route into the
-    // categorical bar sub-union's Unknown(Value); it round-trips losslessly.
+    // An unrecognized *string* `configType` reaches the categorical bar
+    // sub-union's Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"bar","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
         matches!(
@@ -3102,8 +3234,8 @@ fn clickstack_tile_config_stacked_bar_novel_shape_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_stacked_bar_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // An unrecognized *string* `configType` is the only route into the bar
-    // sub-union's Unknown(Value); it round-trips losslessly.
+    // An unrecognized *string* `configType` reaches the bar sub-union's
+    // Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"stacked_bar","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
         matches!(
@@ -3132,8 +3264,8 @@ fn clickstack_tile_config_table_novel_shape_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_table_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // An unrecognized *string* `configType` is the only route into the table
-    // sub-union's Unknown(Value); it round-trips losslessly.
+    // An unrecognized *string* `configType` reaches the table sub-union's
+    // Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"table","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
         matches!(
@@ -3164,8 +3296,8 @@ fn clickstack_tile_config_number_novel_shape_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_number_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // An unrecognized *string* `configType` is the only route into the number
-    // sub-union's Unknown(Value); it round-trips losslessly.
+    // An unrecognized *string* `configType` reaches the number sub-union's
+    // Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"number","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
         matches!(
@@ -3196,8 +3328,8 @@ fn clickstack_tile_config_pie_novel_shape_defaults_to_builder() {
 
 #[test]
 fn clickstack_tile_config_pie_unrecognized_config_type_falls_to_sub_union_unknown() {
-    // An unrecognized *string* `configType` is the only route into the pie
-    // sub-union's Unknown(Value); it round-trips losslessly.
+    // An unrecognized *string* `configType` reaches the pie sub-union's
+    // Unknown(Value); it round-trips losslessly.
     let json = r#"{"displayType":"pie","configType":"future"}"#;
     assert_unknown_variant_round_trips(json, |cfg: &ClickStackTileConfig| {
         matches!(

--- a/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
+++ b/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use clickhouse_openapi_analyzer::config::clickhouse_cloud_config;
-use clickhouse_openapi_analyzer::{AnalysisInput, analyze};
+use clickhouse_openapi_analyzer::{AnalysisInput, analyze, response_tree};
 
 const SPEC_JSON: &str = include_str!("../clickhouse_cloud_openapi.json");
 const CLIENT_RS: &str = include_str!("../src/client.rs");
@@ -29,6 +29,32 @@ fn vendored_openapi_snapshot_matches_rust_api() {
     assert_eq!(
         reported_pointers, config.acknowledged_unsupported_enum_pointers,
         "the snapshot's unsupported enum inventory must exactly match analyzer configuration"
+    );
+}
+
+/// The SCIM models stay strict because they are in neither direction's tree: the
+/// spec defines 40 `Scim*` schemas but no SCIM path, so no `Client` method sends
+/// or returns one. Operation-unreferenced schemas resolve in request position, so
+/// making a SCIM list/response envelope all-`Option` reports
+/// `FieldOptionalityMismatch` drift while protecting no actual response.
+///
+/// If this fails, SCIM operations were added to `client.rs`: split the envelopes
+/// they return into all-`Option` `{Name}Response` variants before wiring them up.
+#[test]
+fn scim_models_are_outside_the_response_tree() {
+    assert!(
+        MODELS_RS.matches("\npub struct Scim").count() >= 30,
+        "vacuous test: the SCIM model family is no longer named `Scim*`"
+    );
+    let tree = response_tree(CLIENT_RS, MODELS_RS).unwrap();
+    let scim_response_types = tree
+        .types
+        .iter()
+        .filter(|name| name.starts_with("Scim"))
+        .collect::<Vec<_>>();
+    assert!(
+        scim_response_types.is_empty(),
+        "SCIM types became response-reachable and must be split: {scim_response_types:?}"
     );
 }
 

--- a/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
+++ b/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeSet;
 
 use clickhouse_openapi_analyzer::config::clickhouse_cloud_config;
-use clickhouse_openapi_analyzer::{AnalysisInput, analyze, response_tree};
+use clickhouse_openapi_analyzer::{
+    AnalysisInput, analyze, model_fields_with_serde_default, response_tree,
+};
 
 const SPEC_JSON: &str = include_str!("../clickhouse_cloud_openapi.json");
 const CLIENT_RS: &str = include_str!("../src/client.rs");
@@ -29,6 +31,78 @@ fn vendored_openapi_snapshot_matches_rust_api() {
     assert_eq!(
         reported_pointers, config.acknowledged_unsupported_enum_pointers,
         "the snapshot's unsupported enum inventory must exactly match analyzer configuration"
+    );
+}
+
+/// Fields deliberately kept non-`Option` in response-tree types, as
+/// `(RustTypeName, specFieldName)` pairs. The tolerant-response policy admits
+/// no exceptions today: a strict response field is a latent outage point the
+/// moment the API stops sending it, so adding an entry here requires the same
+/// bar as an analyzer exemption — verified runtime behavior and a comment
+/// saying why absence genuinely cannot happen.
+const ALL_OPTION_EXCEPTIONS: &[(&str, &str)] = &[];
+
+/// Every type the library deserializes API responses into is tolerant by
+/// construction: a field the server drops or sends as `null` lands as `None`
+/// instead of failing the response. The response tree is computed by the
+/// analyzer from `client.rs` return types, so newly wired operations are
+/// covered automatically. Types outside the tree (request bodies, orphan
+/// schemas like `Scim*`) stay strict — scoping this to "every model type"
+/// would itself create `FieldOptionalityMismatch` drift.
+#[test]
+fn every_response_tree_field_is_option() {
+    let tree = response_tree(CLIENT_RS, MODELS_RS).unwrap();
+    assert!(
+        tree.types.len() >= 300,
+        "vacuous test: the response tree collapsed to {} types — did client.rs \
+         return types or the analyzer's reachability change shape?",
+        tree.types.len()
+    );
+    let strict_fields = tree
+        .non_option_fields
+        .iter()
+        .filter(|(type_name, field)| {
+            !ALL_OPTION_EXCEPTIONS.contains(&(type_name.as_str(), field.as_str()))
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        strict_fields.is_empty(),
+        "response-reachable fields must be Option<T> so a dropped or null field \
+         cannot fail deserialization: {strict_fields:?}"
+    );
+}
+
+/// Pins the serialization half of the policy: an absent response field is
+/// OMITTED from serialized output (`--json`, `print_human`), never emitted as
+/// `null` — so every `Option` field in the response tree must carry
+/// `#[serde(skip_serializing_if = "Option::is_none")]`.
+#[test]
+fn every_response_tree_option_field_omits_none_when_serialized() {
+    let tree = response_tree(CLIENT_RS, MODELS_RS).unwrap();
+    assert!(
+        !tree.types.is_empty(),
+        "vacuous test: the response tree is empty"
+    );
+    assert!(
+        tree.option_fields_missing_skip_serializing_if.is_empty(),
+        "response fields must omit None instead of serializing null; add \
+         skip_serializing_if to: {:?}",
+        tree.option_fields_missing_skip_serializing_if
+    );
+}
+
+/// `#[serde(default)]` is banned in `models.rs`. On a required request field it
+/// fabricates a value (`""`/`0`/`false`) indistinguishable from a genuine
+/// server-sent one — a consumer doing get → tweak → post would silently persist
+/// it (the write-back hazard that sank the superseded issue-312 policy). On
+/// response fields it is dead weight: every response-tree field is `Option<T>`
+/// (enforced above), where a missing key already deserializes to `None`.
+#[test]
+fn models_carry_no_serde_default() {
+    let offenders = model_fields_with_serde_default(MODELS_RS).unwrap();
+    assert!(
+        offenders.is_empty(),
+        "remove #[serde(default)] from: {offenders:?}"
     );
 }
 

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -103,6 +103,52 @@ fn compare_models_and_refs(
     }
 }
 
+/// The direction a schema usage was reached from. Requiredness/optionality is
+/// request-position-only semantics: response-position types are all-`Option`
+/// by policy, so optionality findings are suppressed there and field presence
+/// (plus enum values) is the retained drift signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Direction {
+    Request,
+    Response,
+}
+
+/// The Rust struct name a schema resolves to in response position: the split
+/// `{Name}Response` variant when such a Rust type exists (and is not itself
+/// the model of a spec schema literally named `{Name}Response`), otherwise
+/// the unsplit `{Name}` type.
+fn response_position_type(rust: &RustInventory, spec: &OpenApiInventory, base: &str) -> String {
+    let candidate = format!("{base}Response");
+    if rust.model_types.contains(&candidate) && !spec.rust_schema_names.contains(&candidate) {
+        candidate
+    } else {
+        base.to_string()
+    }
+}
+
+/// Rust struct targets for a schema's field checks, one per direction the
+/// schema is used in. A bidirectional schema maps to two Rust types once the
+/// split `{Name}Response` variant exists; until then both directions collapse
+/// onto `{Name}` and only the request-direction target is kept.
+fn field_check_targets(
+    rust: &RustInventory,
+    spec: &OpenApiInventory,
+    schema_name: &str,
+) -> Vec<(String, Direction)> {
+    let base = pascalize(schema_name);
+    let mut targets = Vec::new();
+    if spec.is_request_position(schema_name) {
+        targets.push((base.clone(), Direction::Request));
+    }
+    if spec.is_response_position(schema_name) {
+        let response_name = response_position_type(rust, spec, &base);
+        if targets.iter().all(|(name, _)| *name != response_name) {
+            targets.push((response_name, Direction::Response));
+        }
+    }
+    targets
+}
+
 fn compare_fields(
     rust: &RustInventory,
     spec: &OpenApiInventory,
@@ -111,51 +157,59 @@ fn compare_fields(
 ) {
     let mut optionality_hits = BTreeSet::new();
     for ((schema_name, property_name), property) in &spec.properties {
-        let rust_name = pascalize(schema_name);
-        let Some(struct_info) = rust.structs.get(&rust_name) else {
-            continue;
-        };
-        let Some(field) = struct_info.fields.get(property_name) else {
-            report.findings.push(
-                Finding::new(
-                    FindingKind::MissingStructField,
-                    format!("{rust_name}.{property_name} is missing from models.rs"),
-                )
-                .at_spec(&property.pointer)
-                .at_rust(format!("models.rs::{rust_name}::{property_name}"))
-                .detail("schema", &rust_name)
-                .detail("field", property_name),
-            );
-            continue;
-        };
-        let mismatch = property.required_non_nullable == field.rust_type.is_option();
-        if mismatch {
-            let key = (rust_name.clone(), property_name.clone());
-            if config.optionality_exemptions.contains(&key) {
-                optionality_hits.insert(key);
-            } else {
-                let expected = if property.required_non_nullable {
-                    "T"
-                } else {
-                    "Option<T>"
-                };
-                let actual = if field.rust_type.is_option() {
-                    "Option<T>"
-                } else {
-                    "T"
-                };
+        for (rust_name, direction) in field_check_targets(rust, spec, schema_name) {
+            let Some(struct_info) = rust.structs.get(&rust_name) else {
+                continue;
+            };
+            let Some(field) = struct_info.fields.get(property_name) else {
                 report.findings.push(
                     Finding::new(
-                        FindingKind::FieldOptionalityMismatch,
-                        format!("{rust_name}.{property_name} should be {expected}, found {actual}"),
+                        FindingKind::MissingStructField,
+                        format!("{rust_name}.{property_name} is missing from models.rs"),
                     )
                     .at_spec(&property.pointer)
-                    .at_rust(format!("models.rs::{rust_name}::{}", field.rust_name))
+                    .at_rust(format!("models.rs::{rust_name}::{property_name}"))
                     .detail("schema", &rust_name)
-                    .detail("field", property_name)
-                    .detail("expected", expected)
-                    .detail("actual", actual),
+                    .detail("field", property_name),
                 );
+                continue;
+            };
+            if direction == Direction::Response {
+                // Every response field is Option<T> by policy, so requiredness
+                // drift is invisible in response position by design.
+                continue;
+            }
+            let mismatch = property.required_non_nullable == field.rust_type.is_option();
+            if mismatch {
+                let key = (rust_name.clone(), property_name.clone());
+                if config.optionality_exemptions.contains(&key) {
+                    optionality_hits.insert(key);
+                } else {
+                    let expected = if property.required_non_nullable {
+                        "T"
+                    } else {
+                        "Option<T>"
+                    };
+                    let actual = if field.rust_type.is_option() {
+                        "Option<T>"
+                    } else {
+                        "T"
+                    };
+                    report.findings.push(
+                        Finding::new(
+                            FindingKind::FieldOptionalityMismatch,
+                            format!(
+                                "{rust_name}.{property_name} should be {expected}, found {actual}"
+                            ),
+                        )
+                        .at_spec(&property.pointer)
+                        .at_rust(format!("models.rs::{rust_name}::{}", field.rust_name))
+                        .detail("schema", &rust_name)
+                        .detail("field", property_name)
+                        .detail("expected", expected)
+                        .detail("actual", actual),
+                    );
+                }
             }
         }
     }
@@ -178,28 +232,29 @@ fn compare_fields(
         if property_names.is_empty() {
             continue;
         }
-        let rust_name = pascalize(schema_name);
-        let Some(struct_info) = rust.structs.get(&rust_name) else {
-            continue;
-        };
-        for (spec_name, field) in &struct_info.fields {
-            if property_names.contains(spec_name.as_str()) {
+        for (rust_name, _direction) in field_check_targets(rust, spec, schema_name) {
+            let Some(struct_info) = rust.structs.get(&rust_name) else {
                 continue;
-            }
-            let key = (rust_name.clone(), spec_name.clone());
-            if config.extra_field_exemptions.contains(&key) {
-                extra_hits.insert(key);
-            } else {
-                report.findings.push(
-                    Finding::new(
-                        FindingKind::ExtraStructField,
-                        format!("{rust_name}.{spec_name} has no matching OpenAPI property"),
-                    )
-                    .at_spec(&spec.schemas[schema_name])
-                    .at_rust(format!("models.rs::{rust_name}::{}", field.rust_name))
-                    .detail("schema", &rust_name)
-                    .detail("field", spec_name),
-                );
+            };
+            for (spec_name, field) in &struct_info.fields {
+                if property_names.contains(spec_name.as_str()) {
+                    continue;
+                }
+                let key = (rust_name.clone(), spec_name.clone());
+                if config.extra_field_exemptions.contains(&key) {
+                    extra_hits.insert(key);
+                } else {
+                    report.findings.push(
+                        Finding::new(
+                            FindingKind::ExtraStructField,
+                            format!("{rust_name}.{spec_name} has no matching OpenAPI property"),
+                        )
+                        .at_spec(&spec.schemas[schema_name])
+                        .at_rust(format!("models.rs::{rust_name}::{}", field.rust_name))
+                        .detail("schema", &rust_name)
+                        .detail("field", spec_name),
+                    );
+                }
             }
         }
     }
@@ -243,20 +298,22 @@ fn compare_beta_and_deprecation(
         }
     }
 
+    // A deprecated property is expected once per Rust type the schema maps to:
+    // just `{Name}` today, and additionally `{Name}Response` once a schema used
+    // in both directions is split, doubling the DEPRECATED_FIELDS bookkeeping.
     let mut deprecated_exemption_hits = BTreeSet::new();
-    let expected: BTreeSet<_> = spec
-        .deprecated_fields
-        .keys()
-        .filter(|key| {
-            if config.deprecated_field_exemptions.contains(*key) {
-                deprecated_exemption_hits.insert((*key).clone());
-                false
+    let mut expected_pointers: BTreeMap<(String, String), &String> = BTreeMap::new();
+    for ((schema_name, field), pointer) in &spec.deprecated_fields {
+        for (rust_name, _direction) in field_check_targets(rust, spec, schema_name) {
+            let key = (rust_name, field.clone());
+            if config.deprecated_field_exemptions.contains(&key) {
+                deprecated_exemption_hits.insert(key);
             } else {
-                true
+                expected_pointers.insert(key, pointer);
             }
-        })
-        .cloned()
-        .collect();
+        }
+    }
+    let expected: BTreeSet<(String, String)> = expected_pointers.keys().cloned().collect();
     stale_pairs(
         "deprecated_field",
         &config.deprecated_field_exemptions,
@@ -265,7 +322,7 @@ fn compare_beta_and_deprecation(
     );
 
     for (schema, field) in expected.difference(&rust.metadata.deprecated_fields) {
-        let pointer = &spec.deprecated_fields[&(schema.clone(), field.clone())];
+        let pointer = expected_pointers[&(schema.clone(), field.clone())];
         report.findings.push(
             Finding::new(
                 FindingKind::NewlyDeprecatedField,
@@ -786,6 +843,286 @@ mod tests {
         .unwrap();
         let openapi = OpenApiInventory::build(&spec, &config).unwrap();
         compare(&rust, &openapi, &openapi, &config)
+    }
+
+    /// A minimal spec with one operation that sends `Widget` as the request
+    /// body when `request` is set, and returns `Widget` when `response` is set,
+    /// so fixtures can place the schema in either or both positions.
+    fn directional_spec(
+        schema: serde_json::Value,
+        request: bool,
+        response: bool,
+    ) -> serde_json::Value {
+        let mut operation = serde_json::json!({"operationId": "mutateWidget"});
+        if request {
+            operation["requestBody"] = serde_json::json!({"content": {"application/json": {
+                "schema": {"$ref": "#/components/schemas/Widget"}
+            }}});
+        }
+        if response {
+            operation["responses"] = serde_json::json!({"200": {"content": {"application/json": {
+                "schema": {"$ref": "#/components/schemas/Widget"}
+            }}}});
+        }
+        serde_json::json!({
+            "paths": {
+                "/widgets": {"post": operation},
+                // Matches the fixture Client's second method so no-drift
+                // assertions are not polluted by ExtraClientMethod.
+                "/widgets/{id}": {"get": {"operationId": "getWidget"}}
+            },
+            "components": {"schemas": {"Widget": schema}}
+        })
+    }
+
+    fn analyze_directional(
+        models: &str,
+        spec: serde_json::Value,
+        config: AnalyzerConfig,
+    ) -> DriftReport {
+        let rust = RustInventory::parse(
+            r#"
+                pub struct Client;
+                impl Client {
+                    pub async fn mutate_widget(&self) {}
+                    pub async fn get_widget(&self) {}
+                }
+            "#,
+            models,
+            "pub const BETA_OPERATIONS: &[&str] = &[]; pub const DEPRECATED_FIELDS: &[(&str, &str)] = &[];",
+        )
+        .unwrap();
+        let openapi = OpenApiInventory::build(&spec, &config).unwrap();
+        compare(&rust, &openapi, &openapi, &config)
+    }
+
+    #[test]
+    fn suppresses_optionality_but_keeps_presence_checks_in_response_position() {
+        // Response-only schema: `name` is required in the spec but Option<T>
+        // in Rust (all-Option response policy) — no optionality finding.
+        // Presence drift (missing `gone`, extra `extraCode`) still fires.
+        let report = analyze_directional(
+            r#"
+                pub struct Widget {
+                    pub name: Option<String>,
+                    #[serde(rename = "extraCode")]
+                    pub extra_code: Option<String>,
+                }
+            "#,
+            directional_spec(
+                serde_json::json!({
+                    "required": ["name", "gone"],
+                    "properties": {"name": {"type": "string"}, "gone": {"type": "string"}}
+                }),
+                false,
+                true,
+            ),
+            AnalyzerConfig::default(),
+        );
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|finding| finding.kind == FindingKind::FieldOptionalityMismatch),
+            "{}",
+            report.render_text()
+        );
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::MissingStructField
+                && finding.details.get("field").map(String::as_str) == Some("gone")
+        }));
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::ExtraStructField
+                && finding.details.get("field").map(String::as_str) == Some("extraCode")
+        }));
+    }
+
+    #[test]
+    fn keeps_optionality_checks_in_request_position() {
+        let report = analyze_directional(
+            "pub struct Widget { pub name: Option<String> }",
+            directional_spec(
+                serde_json::json!({
+                    "required": ["name"],
+                    "properties": {"name": {"type": "string"}}
+                }),
+                true,
+                false,
+            ),
+            AnalyzerConfig::default(),
+        );
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::FieldOptionalityMismatch
+                && finding.rust_item.as_deref() == Some("models.rs::Widget::name")
+        }));
+    }
+
+    #[test]
+    fn bidirectional_schema_checks_both_split_variants() {
+        // `Widget` is used in both directions and the split `WidgetResponse`
+        // exists: the request variant is checked strictly, the response
+        // variant gets presence checks only.
+        let models = r#"
+            pub struct Widget {
+                pub name: String,
+                pub mode: Option<String>,
+            }
+            pub struct WidgetResponse {
+                pub name: Option<String>,
+                #[serde(rename = "extraCode")]
+                pub extra_code: Option<String>,
+            }
+        "#;
+        let schema = serde_json::json!({
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "mode": {"type": "string", "description": "Optional mode"}
+            }
+        });
+        let report = analyze_directional(
+            models,
+            directional_spec(schema, true, true),
+            AnalyzerConfig::default(),
+        );
+        // The strict request variant is compliant and the response variant is
+        // all-Option: no optionality findings anywhere.
+        assert!(
+            !report
+                .findings
+                .iter()
+                .any(|finding| finding.kind == FindingKind::FieldOptionalityMismatch),
+            "{}",
+            report.render_text()
+        );
+        // Presence drift is reported per variant: `mode` is missing from the
+        // response variant, `extraCode` exists only there.
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::MissingStructField
+                && finding.rust_item.as_deref() == Some("models.rs::WidgetResponse::mode")
+        }));
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::ExtraStructField
+                && finding.details.get("schema").map(String::as_str) == Some("WidgetResponse")
+                && finding.details.get("field").map(String::as_str) == Some("extraCode")
+        }));
+        assert!(!report.findings.iter().any(|finding| {
+            finding.details.get("schema").map(String::as_str) == Some("Widget")
+        }));
+    }
+
+    #[test]
+    fn bidirectional_schema_without_split_type_falls_back_to_the_shared_struct() {
+        // models.rs not yet split: both directions collapse onto `Widget`,
+        // which is checked once under request-position rules.
+        let report = analyze_directional(
+            "pub struct Widget { pub name: String }",
+            directional_spec(
+                serde_json::json!({
+                    "required": ["name"],
+                    "properties": {"name": {"type": "string"}}
+                }),
+                true,
+                true,
+            ),
+            AnalyzerConfig::default(),
+        );
+        assert!(!report.has_drift(), "{}", report.render_text());
+    }
+
+    #[test]
+    fn response_mapping_does_not_hijack_a_type_modeling_a_response_named_schema() {
+        // The spec defines both `Widget` (response-only) and `WidgetResponse`.
+        // Rust `WidgetResponse` models the latter, so schema `Widget` must
+        // keep resolving to Rust `Widget` — `mode` missing from Rust
+        // `WidgetResponse` must be attributed to schema `WidgetResponse`,
+        // and Rust `Widget` must satisfy schema `Widget`.
+        let spec = serde_json::json!({
+            "paths": {"/widgets": {"get": {
+                "operationId": "getWidget",
+                "responses": {"200": {"content": {"application/json": {"schema": {
+                    "properties": {
+                        "plain": {"$ref": "#/components/schemas/Widget"},
+                        "named": {"$ref": "#/components/schemas/WidgetResponse"}
+                    }
+                }}}}}
+            }}},
+            "components": {"schemas": {
+                "Widget": {"required": ["name"], "properties": {"name": {"type": "string"}}},
+                "WidgetResponse": {
+                    "required": ["name", "mode"],
+                    "properties": {"name": {"type": "string"}, "mode": {"type": "string"}}
+                }
+            }}
+        });
+        let report = analyze_directional(
+            r#"
+                pub struct Widget { pub name: Option<String> }
+                pub struct WidgetResponse { pub name: Option<String> }
+            "#,
+            spec,
+            AnalyzerConfig::default(),
+        );
+        let missing: Vec<_> = report
+            .findings
+            .iter()
+            .filter(|finding| finding.kind == FindingKind::MissingStructField)
+            .collect();
+        assert_eq!(missing.len(), 1, "{}", report.render_text());
+        assert_eq!(
+            missing[0].rust_item.as_deref(),
+            Some("models.rs::WidgetResponse::mode")
+        );
+        assert_eq!(
+            missing[0].spec_pointer.as_deref(),
+            Some("/components/schemas/WidgetResponse/properties/mode")
+        );
+    }
+
+    #[test]
+    fn deprecated_fields_are_expected_on_both_split_variants() {
+        let schema = serde_json::json!({
+            "required": ["name"],
+            "properties": {
+                "name": {"type": "string"},
+                "old": {"type": "string", "description": "Optional legacy", "deprecated": true}
+            }
+        });
+        let models = r#"
+            pub struct Widget {
+                pub name: String,
+                #[cfg(feature = "deprecated-fields")]
+                pub old: Option<String>,
+            }
+            pub struct WidgetResponse {
+                pub name: Option<String>,
+                #[cfg(feature = "deprecated-fields")]
+                pub old: Option<String>,
+            }
+        "#;
+        let rust = RustInventory::parse(
+            "pub struct Client; impl Client {}",
+            models,
+            r#"
+                pub const BETA_OPERATIONS: &[&str] = &[];
+                pub const DEPRECATED_FIELDS: &[(&str, &str)] = &[("Widget", "old")];
+            "#,
+        )
+        .unwrap();
+        let config = AnalyzerConfig::default();
+        let openapi =
+            OpenApiInventory::build(&directional_spec(schema, true, true), &config).unwrap();
+        let report = compare(&rust, &openapi, &openapi, &config);
+        // The split response variant carries the marker but is missing from
+        // DEPRECATED_FIELDS: the doubled bookkeeping is enforced.
+        assert!(report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::NewlyDeprecatedField
+                && finding.details.get("schema").map(String::as_str) == Some("WidgetResponse")
+        }));
+        assert!(!report.findings.iter().any(|finding| {
+            finding.kind == FindingKind::NewlyDeprecatedField
+                && finding.details.get("schema").map(String::as_str) == Some("Widget")
+        }));
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/config.rs
+++ b/crates/clickhouse-openapi-analyzer/src/config.rs
@@ -3,10 +3,19 @@ use std::collections::BTreeSet;
 #[derive(Debug, Clone, Default)]
 pub struct AnalyzerConfig {
     pub non_openapi_client_methods: BTreeSet<String>,
+    /// Fields deliberately kept optional despite the resolved spec. Only
+    /// meaningful for request-position usage: optionality findings are
+    /// suppressed entirely in response position, so a response-only entry can
+    /// never be hit and would surface as a stale exemption.
     pub optionality_exemptions: BTreeSet<(String, String)>,
     pub extra_field_exemptions: BTreeSet<(String, String)>,
     pub deprecated_field_exemptions: BTreeSet<(String, String)>,
     pub extra_enum_value_exemptions: BTreeSet<(String, String)>,
+    /// Schemas whose upstream `required[]` is non-exhaustive; requiredness
+    /// resolution unions the array with the description heuristic. This is
+    /// request-position-only semantics: response-position fields are all
+    /// `Option<T>` by policy, so an entry for a response-only schema does not
+    /// change any finding.
     pub partial_required_schemas: BTreeSet<String>,
     pub acknowledged_unsupported_enum_pointers: BTreeSet<String>,
 }
@@ -30,6 +39,11 @@ pub fn clickhouse_cloud_config() -> AnalyzerConfig {
         extra_field_exemptions: BTreeSet::new(),
         deprecated_field_exemptions: BTreeSet::new(),
         extra_enum_value_exemptions: BTreeSet::new(),
+        // Request-position-only semantics. Both entries currently sit in
+        // response position (their required[] arrays are non-exhaustive
+        // upstream); they are retained so the resolved requiredness inventory
+        // stays faithful to runtime behaviour, but under direction-aware
+        // checking they no longer influence any finding.
         partial_required_schemas: strings(&["Service", "ServiceScalingPatchResponse"]),
         acknowledged_unsupported_enum_pointers: strings(ACKNOWLEDGED_UNSUPPORTED_ENUM_POINTERS),
     }

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -85,6 +85,12 @@ pub struct ResponseTree {
     /// response tree whose Rust type is not `Option<T>` — the pairs a policy
     /// enforcement test must require to be empty (modulo its exception list).
     pub non_option_fields: BTreeSet<(String, String)>,
+    /// `(type name, spec/wire field name)` pairs for `Option<T>` struct fields
+    /// in the response tree lacking `#[serde(skip_serializing_if = "...")]`.
+    /// The policy pins the serialization decision: an absent response field is
+    /// OMITTED from serialized output (`--json`, `print_human`), never emitted
+    /// as `null`, so this set must also be empty.
+    pub option_fields_missing_skip_serializing_if: BTreeSet<(String, String)>,
 }
 
 /// Computes response-tree membership from the library's `client.rs` and
@@ -93,6 +99,7 @@ pub fn response_tree(client_rs: &str, models_rs: &str) -> Result<ResponseTree, A
     let rust = RustInventory::parse(client_rs, models_rs, "").map_err(AnalyzeError::RustSource)?;
     let types = rust.response_reachable_types();
     let mut non_option_fields = BTreeSet::new();
+    let mut option_fields_missing_skip_serializing_if = BTreeSet::new();
     for type_name in &types {
         let Some(struct_info) = rust.structs.get(type_name) else {
             continue;
@@ -100,13 +107,35 @@ pub fn response_tree(client_rs: &str, models_rs: &str) -> Result<ResponseTree, A
         for (spec_name, field) in &struct_info.fields {
             if !field.rust_type.is_option() {
                 non_option_fields.insert((type_name.clone(), spec_name.clone()));
+            } else if !field.skip_serializing_if {
+                option_fields_missing_skip_serializing_if
+                    .insert((type_name.clone(), spec_name.clone()));
             }
         }
     }
     Ok(ResponseTree {
         types,
         non_option_fields,
+        option_fields_missing_skip_serializing_if,
     })
+}
+
+/// Lists every public model struct field in `models_rs` that carries a
+/// field-level `#[serde(default)]` (a container-level one reports every field
+/// of its struct), as `StructName.rust_field_name`.
+///
+/// `#[serde(default)]` is banned repository-wide: on a required request field
+/// it fabricates a value (`""`/`0`/`false`) indistinguishable from a genuine
+/// server-sent one — the write-back hazard that sank the superseded
+/// tolerant-deserialization policy — and on all-`Option` response fields it is
+/// meaningless, because a missing key or explicit `null` already deserializes
+/// to `None`. This backs the policy test in `clickhouse-cloud-api`'s
+/// `spec_coverage_test.rs`; it is intentionally not a drift `FindingKind`,
+/// because it compares Rust source against a repository policy rather than
+/// against the OpenAPI spec. The parsing stays behind this narrow function so
+/// `syn` never enters the `clickhouse-cloud-api` dependency graph.
+pub fn model_fields_with_serde_default(models_rs: &str) -> Result<Vec<String>, AnalyzeError> {
+    rust_inventory::model_fields_with_serde_default(models_rs).map_err(AnalyzeError::RustSource)
 }
 
 #[cfg(test)]
@@ -124,12 +153,13 @@ mod tests {
         "#;
         let models = r#"
             pub struct Widget {
+                #[serde(skip_serializing_if = "Option::is_none")]
                 pub name: Option<String>,
                 #[serde(rename = "strictLeaf")]
                 pub strict_leaf: WidgetLeaf,
             }
             pub struct WidgetLeaf { pub value: Option<String> }
-            pub struct WidgetPostRequest { pub name: String }
+            pub struct WidgetPostRequest { pub name: String, pub note: Option<String> }
         "#;
         let tree = response_tree(client, models).unwrap();
         assert_eq!(
@@ -140,6 +170,12 @@ mod tests {
             tree.non_option_fields,
             BTreeSet::from([("Widget".to_string(), "strictLeaf".to_string())]),
             "request-only strictness (WidgetPostRequest.name) must not be reported"
+        );
+        assert_eq!(
+            tree.option_fields_missing_skip_serializing_if,
+            BTreeSet::from([("WidgetLeaf".to_string(), "value".to_string())]),
+            "request-only fields (WidgetPostRequest.note) must not be reported, \
+             and Option fields with skip_serializing_if (Widget.name) are compliant"
         );
     }
 }

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -138,6 +138,24 @@ pub fn model_fields_with_serde_default(models_rs: &str) -> Result<Vec<String>, A
     rust_inventory::model_fields_with_serde_default(models_rs).map_err(AnalyzeError::RustSource)
 }
 
+/// Lists every model type in `models_rs` with a hand-written `impl Default
+/// for` block, sorted by name.
+///
+/// Backs the completeness half of
+/// `discriminated_union_defaults_round_trip_to_the_same_variant` in
+/// `clickhouse-cloud-api`'s `models_test.rs`: a `discriminated_union!` enum's
+/// `Default` must round-trip to the same variant, and every union with a
+/// `Default` uses a manual impl (derived `Default` cannot pick a payload
+/// variant), so requiring the test's covered-type list to equal this set means
+/// a new manual `Default` impl cannot silently escape the invariant. Like
+/// [`model_fields_with_serde_default`], this is a repository-policy check
+/// rather than a drift `FindingKind`, and it keeps `syn` out of the published
+/// crate's dependency graph.
+pub fn model_types_with_manual_default_impl(models_rs: &str) -> Result<Vec<String>, AnalyzeError> {
+    rust_inventory::model_types_with_manual_default_impl(models_rs)
+        .map_err(AnalyzeError::RustSource)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -1,4 +1,22 @@
 //! Internal OpenAPI drift analyzer used by tests and repository automation.
+//!
+//! # Direction-aware checking
+//!
+//! Every spec schema is classified by the position(s) it is used in: request
+//! position (reachable from a request body or operation parameter) and/or
+//! response position (reachable from an operation response). Requiredness and
+//! optionality rules (`required[]`, PATCH-all-optional, the description
+//! heuristic, `partial_required_schemas`) apply only in request position. In
+//! response position every field is `Option<T>` by policy — a server-dropped
+//! or `null` field must never fail deserialization — so response-side
+//! optionality drift is invisible by design; field *presence* (missing/extra
+//! fields) and enum-value drift are the retained signals and are checked in
+//! both directions.
+//!
+//! A schema used in both directions maps to two Rust types: the request
+//! variant keeps the schema's name, and the response variant is
+//! `{Name}Response` when that type exists (falling back to `{Name}` while the
+//! split has not happened yet).
 
 mod compare;
 mod openapi;
@@ -6,6 +24,8 @@ mod rust_inventory;
 
 pub mod config;
 pub mod report;
+
+use std::collections::BTreeSet;
 
 use config::AnalyzerConfig;
 use openapi::OpenApiInventory;
@@ -51,4 +71,75 @@ pub fn analyze(
     let snapshot =
         OpenApiInventory::build(&snapshot, config).map_err(AnalyzeError::SnapshotInventory)?;
     Ok(compare::compare(&rust, &spec, &snapshot, config))
+}
+
+/// The Rust response tree: model types reachable from `Client` method return
+/// types, for policy enforcement tests ("every field of every
+/// response-reachable type is `Option<T>`").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResponseTree {
+    /// Model type names transitively reachable from `Client` method return
+    /// types via struct fields, enum variant payloads, and type aliases.
+    pub types: BTreeSet<String>,
+    /// `(type name, spec/wire field name)` pairs for struct fields in the
+    /// response tree whose Rust type is not `Option<T>` — the pairs a policy
+    /// enforcement test must require to be empty (modulo its exception list).
+    pub non_option_fields: BTreeSet<(String, String)>,
+}
+
+/// Computes response-tree membership from the library's `client.rs` and
+/// `models.rs` sources.
+pub fn response_tree(client_rs: &str, models_rs: &str) -> Result<ResponseTree, AnalyzeError> {
+    let rust = RustInventory::parse(client_rs, models_rs, "").map_err(AnalyzeError::RustSource)?;
+    let types = rust.response_reachable_types();
+    let mut non_option_fields = BTreeSet::new();
+    for type_name in &types {
+        let Some(struct_info) = rust.structs.get(type_name) else {
+            continue;
+        };
+        for (spec_name, field) in &struct_info.fields {
+            if !field.rust_type.is_option() {
+                non_option_fields.insert((type_name.clone(), spec_name.clone()));
+            }
+        }
+    }
+    Ok(ResponseTree {
+        types,
+        non_option_fields,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_tree_reports_membership_and_non_option_fields() {
+        let client = r#"
+            pub struct Client;
+            impl Client {
+                pub async fn get_widget(&self) -> Result<Widget, Error> { unimplemented!() }
+                pub async fn create_widget(&self, body: WidgetPostRequest) {}
+            }
+        "#;
+        let models = r#"
+            pub struct Widget {
+                pub name: Option<String>,
+                #[serde(rename = "strictLeaf")]
+                pub strict_leaf: WidgetLeaf,
+            }
+            pub struct WidgetLeaf { pub value: Option<String> }
+            pub struct WidgetPostRequest { pub name: String }
+        "#;
+        let tree = response_tree(client, models).unwrap();
+        assert_eq!(
+            tree.types,
+            BTreeSet::from(["Widget".to_string(), "WidgetLeaf".to_string()])
+        );
+        assert_eq!(
+            tree.non_option_fields,
+            BTreeSet::from([("Widget".to_string(), "strictLeaf".to_string())]),
+            "request-only strictness (WidgetPostRequest.name) must not be reported"
+        );
+    }
 }

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -208,7 +208,10 @@ impl OpenApiInventory {
     /// response-position by walking `$ref`s from each operation's parameters
     /// and request body (request roots) and responses (response roots), then
     /// taking the transitive closure through the schema reference graph. A
-    /// schema can be in both positions.
+    /// schema can be in both positions. Reusable component objects
+    /// (`#/components/responses/...` and friends) used in those positions are
+    /// resolved as part of the walk, so a schema reachable only through one is
+    /// still classified by direction.
     fn collect_schema_positions(&mut self, spec: &Value) {
         let mut request_roots = BTreeSet::new();
         let mut response_roots = BTreeSet::new();
@@ -221,20 +224,20 @@ impl OpenApiInventory {
                     continue;
                 };
                 if let Some(parameters) = path_object.get("parameters") {
-                    referenced_schema_names(parameters, &mut request_roots);
+                    referenced_schema_names(spec, parameters, &mut request_roots);
                 }
                 for (method, operation) in path_object {
                     if !HTTP_METHODS.contains(&method.as_str()) {
                         continue;
                     }
                     if let Some(parameters) = operation.get("parameters") {
-                        referenced_schema_names(parameters, &mut request_roots);
+                        referenced_schema_names(spec, parameters, &mut request_roots);
                     }
                     if let Some(request_body) = operation.get("requestBody") {
-                        referenced_schema_names(request_body, &mut request_roots);
+                        referenced_schema_names(spec, request_body, &mut request_roots);
                     }
                     if let Some(responses) = operation.get("responses") {
-                        referenced_schema_names(responses, &mut response_roots);
+                        referenced_schema_names(spec, responses, &mut response_roots);
                     }
                 }
             }
@@ -247,7 +250,7 @@ impl OpenApiInventory {
         {
             for (schema_name, schema) in schemas {
                 let mut refs = BTreeSet::new();
-                referenced_schema_names(schema, &mut refs);
+                referenced_schema_names(spec, schema, &mut refs);
                 schema_refs.insert(schema_name.clone(), refs);
             }
         }
@@ -256,25 +259,59 @@ impl OpenApiInventory {
     }
 }
 
-fn referenced_schema_names(value: &Value, output: &mut BTreeSet<String>) {
+/// Collects the names of every `#/components/schemas/...` schema referenced
+/// from `value`, resolving `$ref`s to reusable non-schema components against
+/// `spec` and continuing the walk through them.
+///
+/// An operation may name a component object instead of inlining it —
+/// `responses: {"200": {"$ref": "#/components/responses/Widget"}}`, or the
+/// `#/components/requestBodies/...` and `#/components/parameters/...`
+/// equivalents — and those components may in turn reference further
+/// components. Without following them the schemas behind such an operation
+/// would be classified in neither direction.
+fn referenced_schema_names(spec: &Value, value: &Value, output: &mut BTreeSet<String>) {
+    walk_schema_references(spec, value, output, &mut BTreeSet::new());
+}
+
+/// `visited` holds the component references already entered, so a reference
+/// cycle between components terminates instead of recursing forever.
+fn walk_schema_references(
+    spec: &Value,
+    value: &Value,
+    output: &mut BTreeSet<String>,
+    visited: &mut BTreeSet<String>,
+) {
     match value {
         Value::Object(object) => {
-            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
-                && let Some(name) = reference.strip_prefix("#/components/schemas/")
-            {
-                output.insert(name.to_string());
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+                if let Some(name) = reference.strip_prefix("#/components/schemas/") {
+                    output.insert(name.to_string());
+                } else if is_component_reference(reference)
+                    && visited.insert(reference.to_string())
+                    && let Some(component) = spec.pointer(&reference[1..])
+                {
+                    walk_schema_references(spec, component, output, visited);
+                }
             }
             for child in object.values() {
-                referenced_schema_names(child, output);
+                walk_schema_references(spec, child, output, visited);
             }
         }
         Value::Array(items) => {
             for child in items {
-                referenced_schema_names(child, output);
+                walk_schema_references(spec, child, output, visited);
             }
         }
         _ => {}
     }
+}
+
+/// True for a local reference to a reusable component other than a schema —
+/// a response, request body, parameter, header, and so on. Schema references
+/// are recorded by name instead, because the transitive closure runs over the
+/// schema reference graph.
+fn is_component_reference(reference: &str) -> bool {
+    reference.starts_with("#/components/") && !reference.starts_with("#/components/schemas/")
 }
 
 fn transitive_schema_closure(
@@ -1199,6 +1236,108 @@ mod tests {
         assert!(inventory.is_request_position("Unreferenced"));
         assert!(!inventory.is_response_position("Unreferenced"));
         assert!(!inventory.is_request_position("ResponseOnlyDetail"));
+    }
+
+    #[test]
+    fn classifies_schemas_reached_through_reusable_components() {
+        // An operation may name a reusable component object instead of
+        // inlining it, and that component may reference another component. The
+        // schemas behind either hop must still be classified by direction.
+        let spec = serde_json::json!({
+            "paths": {
+                "/widgets": {
+                    "post": {
+                        "operationId": "createWidget",
+                        "parameters": [{"$ref": "#/components/parameters/SortOrder"}],
+                        "requestBody": {"$ref": "#/components/requestBodies/WidgetPost"},
+                        "responses": {"200": {"$ref": "#/components/responses/Widget"}}
+                    }
+                }
+            },
+            "components": {
+                "parameters": {"SortOrder": {
+                    "name": "sort",
+                    "schema": {"$ref": "#/components/schemas/SortOrder"}
+                }},
+                "requestBodies": {"WidgetPost": {"content": {"application/json": {
+                    "schema": {"$ref": "#/components/schemas/WidgetPostRequest"}
+                }}}},
+                "responses": {"Widget": {
+                    "headers": {"X-Widget-Mode": {"$ref": "#/components/headers/WidgetMode"}},
+                    "content": {"application/json": {
+                        "schema": {"$ref": "#/components/schemas/WidgetPostResponse"}
+                    }}
+                }},
+                "headers": {"WidgetMode": {
+                    "schema": {"$ref": "#/components/schemas/WidgetMode"}
+                }},
+                "schemas": {
+                    "SortOrder": {"type": "string"},
+                    "WidgetPostRequest": {"properties": {
+                        "nested": {"$ref": "#/components/schemas/RequestNested"}
+                    }},
+                    "RequestNested": {"type": "string"},
+                    "WidgetPostResponse": {"properties": {
+                        "nested": {"$ref": "#/components/schemas/ResponseNested"}
+                    }},
+                    "ResponseNested": {"type": "string"},
+                    "WidgetMode": {"type": "string"}
+                }
+            }
+        });
+        let inventory = OpenApiInventory::build(&spec, &AnalyzerConfig::default()).unwrap();
+        assert_eq!(
+            inventory.request_position_schemas,
+            BTreeSet::from([
+                "SortOrder".to_string(),
+                "WidgetPostRequest".to_string(),
+                "RequestNested".to_string(),
+            ])
+        );
+        assert_eq!(
+            inventory.response_position_schemas,
+            BTreeSet::from([
+                "WidgetPostResponse".to_string(),
+                "ResponseNested".to_string(),
+                "WidgetMode".to_string(),
+            ])
+        );
+        assert!(!inventory.is_request_position("WidgetPostResponse"));
+    }
+
+    #[test]
+    fn terminates_on_a_component_reference_cycle() {
+        // Cyclic component references are malformed, but the walk must not
+        // recurse forever on them, and schemas seen on the way still classify.
+        let spec = serde_json::json!({
+            "paths": {
+                "/widgets": {
+                    "get": {
+                        "operationId": "getWidget",
+                        "responses": {"200": {"$ref": "#/components/responses/First"}}
+                    }
+                }
+            },
+            "components": {
+                "responses": {
+                    "First": {
+                        "content": {"application/json": {
+                            "schema": {"$ref": "#/components/schemas/Widget"}
+                        }},
+                        "x-next": {"$ref": "#/components/responses/Second"},
+                        "x-self": {"$ref": "#/components/responses/SelfReferential"}
+                    },
+                    "Second": {"x-next": {"$ref": "#/components/responses/First"}},
+                    "SelfReferential": {"x-next": {"$ref": "#/components/responses/SelfReferential"}}
+                },
+                "schemas": {"Widget": {"type": "string"}}
+            }
+        });
+        let inventory = OpenApiInventory::build(&spec, &AnalyzerConfig::default()).unwrap();
+        assert_eq!(
+            inventory.response_position_schemas,
+            BTreeSet::from(["Widget".to_string()])
+        );
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -69,9 +69,21 @@ pub(crate) struct EnumConstraint {
 pub(crate) struct OpenApiInventory {
     pub(crate) operations: BTreeMap<String, OperationInfo>,
     pub(crate) schemas: BTreeMap<String, String>,
+    /// Pascalized Rust type names of every named spec schema. Used to
+    /// distinguish a split `{Name}Response` Rust variant from a Rust type that
+    /// models a spec schema literally named `{Name}Response`.
+    pub(crate) rust_schema_names: BTreeSet<String>,
     pub(crate) properties: BTreeMap<(String, String), PropertyInfo>,
     pub(crate) referenced_schemas: BTreeMap<String, String>,
+    /// Schemas transitively reachable from a request body or an operation
+    /// parameter. Requiredness/optionality drift is checked only here.
+    pub(crate) request_position_schemas: BTreeSet<String>,
+    /// Schemas transitively reachable from an operation response. Optionality
+    /// findings are suppressed here by policy (every response field is
+    /// `Option<T>`); presence and enum-value checks still apply.
+    pub(crate) response_position_schemas: BTreeSet<String>,
     pub(crate) beta_operations: BTreeMap<String, String>,
+    /// Deprecated spec properties keyed by (spec schema name, property name).
     pub(crate) deprecated_fields: BTreeMap<(String, String), String>,
     pub(crate) enum_constraints: Vec<EnumConstraint>,
 }
@@ -81,12 +93,26 @@ impl OpenApiInventory {
         let mut inventory = Self::default();
         inventory.collect_operations(spec)?;
         inventory.collect_schemas(spec, config)?;
+        inventory.collect_schema_positions(spec);
         collect_refs(spec, &mut Vec::new(), &mut inventory.referenced_schemas);
         collect_enums(spec, &mut inventory.enum_constraints);
         inventory
             .enum_constraints
             .sort_by(|left, right| left.pointer.cmp(&right.pointer));
         Ok(inventory)
+    }
+
+    /// Request-position semantics apply when the schema is reachable from a
+    /// request body or parameter, and also when it is reachable from neither
+    /// direction (e.g. defined but unused schemas), so unclassified schemas
+    /// keep the historical strict checks.
+    pub(crate) fn is_request_position(&self, schema_name: &str) -> bool {
+        self.request_position_schemas.contains(schema_name)
+            || !self.response_position_schemas.contains(schema_name)
+    }
+
+    pub(crate) fn is_response_position(&self, schema_name: &str) -> bool {
+        self.response_position_schemas.contains(schema_name)
     }
 
     fn collect_operations(&mut self, spec: &Value) -> Result<(), String> {
@@ -145,7 +171,7 @@ impl OpenApiInventory {
             .and_then(Value::as_object)
             .ok_or_else(|| "OpenAPI document has no components.schemas object".to_string())?;
         for (schema_name, schema) in schemas {
-            let rust_name = pascalize(schema_name);
+            self.rust_schema_names.insert(pascalize(schema_name));
             let schema_pointer = json_pointer(&[
                 "components".to_string(),
                 "schemas".to_string(),
@@ -171,12 +197,105 @@ impl OpenApiInventory {
                 );
                 if property.get("deprecated").and_then(Value::as_bool) == Some(true) {
                     self.deprecated_fields
-                        .insert((rust_name.clone(), property_name.clone()), pointer);
+                        .insert((schema_name.clone(), property_name.clone()), pointer);
                 }
             }
         }
         Ok(())
     }
+
+    /// Classifies every named schema as request-position and/or
+    /// response-position by walking `$ref`s from each operation's parameters
+    /// and request body (request roots) and responses (response roots), then
+    /// taking the transitive closure through the schema reference graph. A
+    /// schema can be in both positions.
+    fn collect_schema_positions(&mut self, spec: &Value) {
+        let mut request_roots = BTreeSet::new();
+        let mut response_roots = BTreeSet::new();
+        if let Some(paths) = spec.get("paths").and_then(Value::as_object) {
+            for (path_name, path_item) in paths {
+                if path_name.starts_with("x-") {
+                    continue;
+                }
+                let Some(path_object) = path_item.as_object() else {
+                    continue;
+                };
+                if let Some(parameters) = path_object.get("parameters") {
+                    referenced_schema_names(parameters, &mut request_roots);
+                }
+                for (method, operation) in path_object {
+                    if !HTTP_METHODS.contains(&method.as_str()) {
+                        continue;
+                    }
+                    if let Some(parameters) = operation.get("parameters") {
+                        referenced_schema_names(parameters, &mut request_roots);
+                    }
+                    if let Some(request_body) = operation.get("requestBody") {
+                        referenced_schema_names(request_body, &mut request_roots);
+                    }
+                    if let Some(responses) = operation.get("responses") {
+                        referenced_schema_names(responses, &mut response_roots);
+                    }
+                }
+            }
+        }
+
+        let mut schema_refs: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        if let Some(schemas) = spec
+            .pointer("/components/schemas")
+            .and_then(Value::as_object)
+        {
+            for (schema_name, schema) in schemas {
+                let mut refs = BTreeSet::new();
+                referenced_schema_names(schema, &mut refs);
+                schema_refs.insert(schema_name.clone(), refs);
+            }
+        }
+        self.request_position_schemas = transitive_schema_closure(request_roots, &schema_refs);
+        self.response_position_schemas = transitive_schema_closure(response_roots, &schema_refs);
+    }
+}
+
+fn referenced_schema_names(value: &Value, output: &mut BTreeSet<String>) {
+    match value {
+        Value::Object(object) => {
+            if let Some(reference) = object.get("$ref").and_then(Value::as_str)
+                && let Some(name) = reference.strip_prefix("#/components/schemas/")
+            {
+                output.insert(name.to_string());
+            }
+            for child in object.values() {
+                referenced_schema_names(child, output);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                referenced_schema_names(child, output);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn transitive_schema_closure(
+    roots: BTreeSet<String>,
+    schema_refs: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    let mut seen = BTreeSet::new();
+    let mut stack: Vec<String> = roots.into_iter().collect();
+    while let Some(name) = stack.pop() {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        if let Some(references) = schema_refs.get(&name) {
+            for reference in references {
+                if !seen.contains(reference) {
+                    stack.push(reference.clone());
+                }
+            }
+        }
+    }
+    seen
 }
 
 fn required_fields(schema_name: &str, schema: &Value, config: &AnalyzerConfig) -> BTreeSet<String> {
@@ -1015,6 +1134,71 @@ mod tests {
             ),
             other => panic!("expected property context, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn classifies_schema_positions_transitively_per_direction() {
+        let spec = serde_json::json!({
+            "paths": {
+                "/widgets": {
+                    "parameters": [{"name": "f", "schema": {"$ref": "#/components/schemas/PathParamFilter"}}],
+                    "post": {
+                        "operationId": "createWidget",
+                        "parameters": [{"name": "sort", "schema": {"$ref": "#/components/schemas/SortOrder"}}],
+                        "requestBody": {"content": {"application/json": {
+                            "schema": {"$ref": "#/components/schemas/WidgetPostRequest"}
+                        }}},
+                        "responses": {"200": {"content": {"application/json": {
+                            "schema": {"$ref": "#/components/schemas/WidgetPostResponse"}
+                        }}}}
+                    }
+                }
+            },
+            "components": {"schemas": {
+                "PathParamFilter": {"type": "string"},
+                "SortOrder": {"type": "string"},
+                "WidgetPostRequest": {"properties": {
+                    "shared": {"$ref": "#/components/schemas/SharedNested"}
+                }},
+                "WidgetPostResponse": {"properties": {
+                    "shared": {"$ref": "#/components/schemas/SharedNested"},
+                    "detail": {"$ref": "#/components/schemas/ResponseOnlyDetail"}
+                }},
+                "SharedNested": {"properties": {
+                    "leaf": {"$ref": "#/components/schemas/SharedLeaf"}
+                }},
+                "SharedLeaf": {"type": "string"},
+                "ResponseOnlyDetail": {"type": "string"},
+                "Unreferenced": {"type": "string"}
+            }}
+        });
+        let inventory = OpenApiInventory::build(&spec, &AnalyzerConfig::default()).unwrap();
+        assert_eq!(
+            inventory.request_position_schemas,
+            BTreeSet::from([
+                "PathParamFilter".to_string(),
+                "SortOrder".to_string(),
+                "WidgetPostRequest".to_string(),
+                "SharedNested".to_string(),
+                "SharedLeaf".to_string(),
+            ])
+        );
+        assert_eq!(
+            inventory.response_position_schemas,
+            BTreeSet::from([
+                "WidgetPostResponse".to_string(),
+                "SharedNested".to_string(),
+                "SharedLeaf".to_string(),
+                "ResponseOnlyDetail".to_string(),
+            ])
+        );
+        // Shared schemas are in both positions; unclassified schemas keep
+        // request-position semantics.
+        assert!(inventory.is_request_position("SharedNested"));
+        assert!(inventory.is_response_position("SharedNested"));
+        assert!(inventory.is_request_position("Unreferenced"));
+        assert!(!inventory.is_response_position("Unreferenced"));
+        assert!(!inventory.is_request_position("ResponseOnlyDetail"));
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -88,6 +88,10 @@ impl TypeNode {
 pub(crate) struct FieldInfo {
     pub(crate) rust_name: String,
     pub(crate) rust_type: TypeNode,
+    /// Every named type mentioned anywhere in the field's type, including
+    /// inside generic arguments the [`TypeNode`] shape model does not follow
+    /// (e.g. map values). Used for response-tree reachability.
+    pub(crate) type_names: BTreeSet<String>,
     pub(crate) deprecated_marker: bool,
 }
 
@@ -101,11 +105,17 @@ pub(crate) struct EnumInfo {
     pub(crate) values: BTreeSet<String>,
     pub(crate) is_value_enum: bool,
     pub(crate) values_const: Option<BTreeSet<String>>,
+    /// Named types carried by any variant's payload (union arms), so
+    /// response-tree reachability can traverse data-carrying enums.
+    pub(crate) variant_type_names: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct MethodInfo {
     pub(crate) arguments: BTreeMap<String, TypeNode>,
+    /// Every named type mentioned anywhere in the method's return type
+    /// (e.g. `ApiResponse` and `Service` in `Result<ApiResponse<Vec<Service>>, Error>`).
+    pub(crate) return_type_names: BTreeSet<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -121,6 +131,9 @@ pub(crate) struct RustInventory {
     pub(crate) structs: BTreeMap<String, StructInfo>,
     pub(crate) enums: BTreeMap<String, EnumInfo>,
     pub(crate) aliases: BTreeMap<String, TypeNode>,
+    /// Named types mentioned anywhere in each alias's target type, for
+    /// response-tree reachability (parallel to `aliases`).
+    pub(crate) alias_type_names: BTreeMap<String, BTreeSet<String>>,
     pub(crate) metadata: MetadataInventory,
 }
 
@@ -177,9 +190,16 @@ impl RustInventory {
                         TypeNode::from_syn(&argument.ty),
                     );
                 }
+                let mut return_type_names = BTreeSet::new();
+                if let syn::ReturnType::Type(_, ty) = &function.sig.output {
+                    collect_type_names(ty, &mut return_type_names);
+                }
                 self.client_methods.insert(
                     function.sig.ident.unraw().to_string(),
-                    MethodInfo { arguments },
+                    MethodInfo {
+                        arguments,
+                        return_type_names,
+                    },
                 );
             }
         }
@@ -206,11 +226,14 @@ impl RustInventory {
                             let rust_name = ident.unraw().to_string();
                             let options = serde_options(&field.attrs)?;
                             let spec_name = options.rename.unwrap_or_else(|| rust_name.clone());
+                            let mut type_names = BTreeSet::new();
+                            collect_type_names(&field.ty, &mut type_names);
                             fields.insert(
                                 spec_name,
                                 FieldInfo {
                                     rust_name,
                                     rust_type: TypeNode::from_syn(&field.ty),
+                                    type_names,
                                     deprecated_marker: has_deprecated_cfg(&field.attrs)?,
                                 },
                             );
@@ -223,8 +246,12 @@ impl RustInventory {
                     self.model_types.insert(name.clone());
                     let container = serde_options(&item_enum.attrs)?;
                     let mut values = BTreeSet::new();
+                    let mut variant_type_names = BTreeSet::new();
                     let mut is_value_enum = !container.untagged;
                     for variant in &item_enum.variants {
+                        for field in variant.fields.iter() {
+                            collect_type_names(&field.ty, &mut variant_type_names);
+                        }
                         let options = serde_options(&variant.attrs)?;
                         if options.untagged || options.other {
                             continue;
@@ -242,12 +269,16 @@ impl RustInventory {
                             values,
                             is_value_enum,
                             values_const: None,
+                            variant_type_names,
                         },
                     );
                 }
                 Item::Type(item_type) if matches!(item_type.vis, Visibility::Public(_)) => {
                     let name = item_type.ident.unraw().to_string();
                     self.model_types.insert(name.clone());
+                    let mut type_names = BTreeSet::new();
+                    collect_type_names(&item_type.ty, &mut type_names);
+                    self.alias_type_names.insert(name.clone(), type_names);
                     self.aliases.insert(name, TypeNode::from_syn(&item_type.ty));
                 }
                 _ => {}
@@ -301,6 +332,44 @@ impl RustInventory {
         }
     }
 
+    /// The set of model types transitively reachable from `Client` method
+    /// return types, traversing struct fields, enum variant payloads, and
+    /// type aliases. This is the "response tree": the types the library
+    /// deserializes API responses into.
+    pub(crate) fn response_reachable_types(&self) -> BTreeSet<String> {
+        let mut seen = BTreeSet::new();
+        let mut stack: Vec<String> = self
+            .client_methods
+            .values()
+            .flat_map(|method| method.return_type_names.iter())
+            .filter(|name| self.model_types.contains(*name))
+            .cloned()
+            .collect();
+        while let Some(name) = stack.pop() {
+            if !seen.insert(name.clone()) {
+                continue;
+            }
+            let mut neighbours = BTreeSet::new();
+            if let Some(struct_info) = self.structs.get(&name) {
+                for field in struct_info.fields.values() {
+                    neighbours.extend(field.type_names.iter().cloned());
+                }
+            }
+            if let Some(enum_info) = self.enums.get(&name) {
+                neighbours.extend(enum_info.variant_type_names.iter().cloned());
+            }
+            if let Some(alias_names) = self.alias_type_names.get(&name) {
+                neighbours.extend(alias_names.iter().cloned());
+            }
+            for neighbour in neighbours {
+                if self.model_types.contains(&neighbour) && !seen.contains(&neighbour) {
+                    stack.push(neighbour);
+                }
+            }
+        }
+        seen
+    }
+
     pub(crate) fn terminal_type(&self, ty: &TypeNode) -> Option<String> {
         self.resolve_terminal(ty, &mut BTreeSet::new())
     }
@@ -341,6 +410,40 @@ impl RustInventory {
             }
             TypeNode::Other(_) => None,
         }
+    }
+}
+
+/// Collects every named type appearing anywhere in `ty`, including inside
+/// generic arguments of wrappers [`TypeNode`] does not model (`Result`, maps,
+/// tuples). Used for reachability, where dropping a nested name would silently
+/// shrink the response tree.
+fn collect_type_names(ty: &Type, output: &mut BTreeSet<String>) {
+    match ty {
+        Type::Path(type_path) => {
+            if let Some(segment) = type_path.path.segments.last() {
+                output.insert(segment.ident.unraw().to_string());
+            }
+            for segment in &type_path.path.segments {
+                if let PathArguments::AngleBracketed(arguments) = &segment.arguments {
+                    for argument in &arguments.args {
+                        if let GenericArgument::Type(inner) = argument {
+                            collect_type_names(inner, output);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Reference(reference) => collect_type_names(&reference.elem, output),
+        Type::Slice(slice) => collect_type_names(&slice.elem, output),
+        Type::Array(array) => collect_type_names(&array.elem, output),
+        Type::Tuple(tuple) => {
+            for element in &tuple.elems {
+                collect_type_names(element, output);
+            }
+        }
+        Type::Paren(paren) => collect_type_names(&paren.elem, output),
+        Type::Group(group) => collect_type_names(&group.elem, output),
+        _ => {}
     }
 }
 
@@ -521,6 +624,62 @@ mod tests {
             Some("WidgetType".to_string())
         );
         assert!(inventory.metadata.beta_operations.contains("list_widgets"));
+    }
+
+    #[test]
+    fn response_reachability_walks_returns_fields_variants_and_aliases() {
+        let client = r#"
+            pub struct Client;
+            impl Client {
+                pub async fn get_widget(&self) -> Result<ApiResponse<Vec<Widget>>, Error> {
+                    unimplemented!()
+                }
+                pub async fn mutate_widget(&self, body: WidgetPostRequest) {}
+            }
+        "#;
+        let models = r#"
+            pub struct ApiResponse<T> { pub result: Option<T> }
+            pub struct Widget {
+                pub union: Option<WidgetUnion>,
+                pub rows: WidgetRows,
+                pub map: std::collections::BTreeMap<String, MapValue>,
+            }
+            pub enum WidgetUnion {
+                Known(WidgetVariant),
+                #[serde(untagged)]
+                Unknown(serde_json::Value),
+            }
+            pub struct WidgetVariant { pub leaf: Option<String> }
+            pub type WidgetRows = Vec<WidgetRow>;
+            pub struct WidgetRow { pub cell: Option<String> }
+            pub struct MapValue { pub value: Option<String> }
+            pub struct WidgetPostRequest { pub name: String }
+            pub struct Unrelated { pub other: String }
+        "#;
+        let inventory = RustInventory::parse(client, models, "").unwrap();
+        assert_eq!(
+            inventory.client_methods["get_widget"].return_type_names,
+            BTreeSet::from([
+                "Result".to_string(),
+                "ApiResponse".to_string(),
+                "Vec".to_string(),
+                "Widget".to_string(),
+                "Error".to_string(),
+            ])
+        );
+        assert_eq!(
+            inventory.response_reachable_types(),
+            BTreeSet::from([
+                "ApiResponse".to_string(),
+                "Widget".to_string(),
+                "WidgetUnion".to_string(),
+                "WidgetVariant".to_string(),
+                "WidgetRows".to_string(),
+                "WidgetRow".to_string(),
+                "MapValue".to_string(),
+            ]),
+            "request-only and unrelated types must stay out of the response tree"
+        );
     }
 
     #[test]

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -450,6 +450,33 @@ pub(crate) fn model_fields_with_serde_default(models: &str) -> syn::Result<Vec<S
         .collect())
 }
 
+/// Lists every model type with a hand-written `impl Default for` block,
+/// sorted by name. Derived `Default`s are deliberately excluded: only the
+/// manual impls are the ones `discriminated_union!` enums use, and only those
+/// carry the pick-a-variant decision the round-trip invariant guards.
+pub(crate) fn model_types_with_manual_default_impl(models: &str) -> syn::Result<Vec<String>> {
+    let file: syn::File = syn::parse_str(models)?;
+    let mut names: Vec<String> = file
+        .items
+        .iter()
+        .filter_map(|item| {
+            let Item::Impl(item_impl) = item else {
+                return None;
+            };
+            let (_, trait_path, _) = item_impl.trait_.as_ref()?;
+            if trait_path.segments.last()?.ident != "Default" {
+                return None;
+            }
+            let Type::Path(type_path) = item_impl.self_ty.as_ref() else {
+                return None;
+            };
+            Some(type_path.path.segments.last()?.ident.unraw().to_string())
+        })
+        .collect();
+    names.sort();
+    Ok(names)
+}
+
 /// Collects every named type appearing anywhere in `ty`, including inside
 /// generic arguments of wrappers [`TypeNode`] does not model (`Result`, maps,
 /// tuples). Used for reachability, where dropping a nested name would silently
@@ -783,6 +810,30 @@ mod tests {
                 "Widget.legacy_name".to_string(),
                 "Widget.name".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn model_types_with_manual_default_impl_lists_only_hand_written_impls() {
+        let models = r#"
+            #[derive(Default)]
+            pub struct Derived { pub id: Option<String> }
+            pub enum Union { A(Widget), Unknown(serde_json::Value) }
+            impl Default for Union {
+                fn default() -> Self { Self::A(Widget::default()) }
+            }
+            pub struct Widget;
+            impl Default for Widget {
+                fn default() -> Self { Self }
+            }
+            impl std::fmt::Display for Union {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { Ok(()) }
+            }
+        "#;
+
+        assert_eq!(
+            model_types_with_manual_default_impl(models).unwrap(),
+            vec!["Union".to_string(), "Widget".to_string()]
         );
     }
 

--- a/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
+++ b/crates/clickhouse-openapi-analyzer/src/rust_inventory.rs
@@ -93,6 +93,16 @@ pub(crate) struct FieldInfo {
     /// (e.g. map values). Used for response-tree reachability.
     pub(crate) type_names: BTreeSet<String>,
     pub(crate) deprecated_marker: bool,
+    /// Whether the field carries a field-level `#[serde(default)]` (bare or
+    /// `default = "path"`). Banned repository-wide: on a required request
+    /// field it fabricates a value the server never sent, and on `Option`
+    /// response fields it is meaningless (see the policy test in
+    /// `clickhouse-cloud-api/tests/spec_coverage_test.rs`).
+    pub(crate) serde_default: bool,
+    /// Whether the field carries `#[serde(skip_serializing_if = "...")]`.
+    /// Response-tree `Option` fields must all carry it so an absent field is
+    /// omitted from serialized output rather than emitted as `null`.
+    pub(crate) skip_serializing_if: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -212,8 +222,8 @@ impl RustInventory {
                 Item::Struct(item_struct) if matches!(item_struct.vis, Visibility::Public(_)) => {
                     let name = item_struct.ident.unraw().to_string();
                     self.model_types.insert(name.clone());
-                    // Rejects a banned `rename_all` on the struct container.
-                    serde_options(&item_struct.attrs)?;
+                    // Also rejects a banned `rename_all` on the struct container.
+                    let container = serde_options(&item_struct.attrs)?;
                     let mut fields = BTreeMap::new();
                     if let Fields::Named(named) = &item_struct.fields {
                         for field in &named.named {
@@ -235,6 +245,12 @@ impl RustInventory {
                                     rust_type: TypeNode::from_syn(&field.ty),
                                     type_names,
                                     deprecated_marker: has_deprecated_cfg(&field.attrs)?,
+                                    // A container-level `#[serde(default)]` fills every
+                                    // missing field, so it marks each field individually —
+                                    // the serde(default) ban cannot be dodged by moving
+                                    // the attribute up to the struct.
+                                    serde_default: options.default || container.default,
+                                    skip_serializing_if: options.skip_serializing_if,
                                 },
                             );
                         }
@@ -413,6 +429,27 @@ impl RustInventory {
     }
 }
 
+/// Lists every public model struct field that carries a field-level
+/// `#[serde(default)]` (bare or `default = "path"`), as
+/// `StructName.rust_field_name`, sorted by struct name then wire field name.
+///
+/// `cfg`-gated deprecated-marker fields are included, and a container-level
+/// `#[serde(default)]` reports every field of its struct — the ban cannot be
+/// dodged by moving the attribute up to the container.
+pub(crate) fn model_fields_with_serde_default(models: &str) -> syn::Result<Vec<String>> {
+    let inventory = RustInventory::parse("", models, "")?;
+    Ok(inventory
+        .structs
+        .iter()
+        .flat_map(|(struct_name, info)| {
+            info.fields
+                .values()
+                .filter(|field| field.serde_default)
+                .map(move |field| format!("{struct_name}.{}", field.rust_name))
+        })
+        .collect())
+}
+
 /// Collects every named type appearing anywhere in `ty`, including inside
 /// generic arguments of wrappers [`TypeNode`] does not model (`Result`, maps,
 /// tuples). Used for reachability, where dropping a nested name would silently
@@ -452,6 +489,8 @@ struct SerdeOptions {
     rename: Option<String>,
     untagged: bool,
     other: bool,
+    default: bool,
+    skip_serializing_if: bool,
 }
 
 fn serde_options(attributes: &[Attribute]) -> syn::Result<SerdeOptions> {
@@ -484,6 +523,16 @@ fn serde_options(attributes: &[Attribute]) -> syn::Result<SerdeOptions> {
                 options.untagged = true;
             } else if meta.path.is_ident("other") {
                 options.other = true;
+            } else if meta.path.is_ident("default") {
+                // Both `default` and `default = "path"` opt the field into value
+                // fabrication, so this must precede the generic `key = value` arm below.
+                options.default = true;
+                if meta.input.peek(syn::Token![=]) {
+                    let _: Expr = meta.value()?.parse()?;
+                }
+            } else if meta.path.is_ident("skip_serializing_if") {
+                options.skip_serializing_if = true;
+                let _: Expr = meta.value()?.parse()?;
             } else if meta.input.peek(syn::Token![=]) {
                 let _: Expr = meta.value()?.parse()?;
             }
@@ -679,6 +728,77 @@ mod tests {
                 "MapValue".to_string(),
             ]),
             "request-only and unrelated types must stay out of the response tree"
+        );
+    }
+
+    #[test]
+    fn tracks_serde_default_and_skip_serializing_if_in_all_attribute_forms() {
+        let models = r#"
+            pub struct Widget {
+                #[serde(default)]
+                pub bare: String,
+                #[serde(rename = "renamedWithDefault", default)]
+                pub renamed: String,
+                #[serde(default = "some::path")]
+                pub with_path: String,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                pub skipped: Option<String>,
+                pub plain: String,
+            }
+        "#;
+
+        let inventory = RustInventory::parse("", models, "").unwrap();
+        let fields = &inventory.structs["Widget"].fields;
+        assert!(fields["bare"].serde_default);
+        assert!(fields["renamedWithDefault"].serde_default);
+        assert!(fields["with_path"].serde_default);
+        assert!(!fields["plain"].serde_default);
+        assert!(fields["skipped"].skip_serializing_if);
+        assert!(!fields["plain"].skip_serializing_if);
+    }
+
+    #[test]
+    fn model_fields_with_serde_default_lists_carriers_sorted() {
+        let models = r#"
+            pub struct Widget {
+                #[serde(default)]
+                pub name: String,
+                pub description: Option<String>,
+                #[serde(rename = "createdAt", default)]
+                pub created_at: String,
+                #[cfg(feature = "deprecated-fields")]
+                #[serde(rename = "legacyName", default)]
+                pub legacy_name: Option<String>,
+            }
+            pub struct Gadget {
+                pub id: Option<String>,
+            }
+            pub enum State { Ready }
+        "#;
+
+        assert_eq!(
+            model_fields_with_serde_default(models).unwrap(),
+            vec![
+                "Widget.created_at".to_string(),
+                "Widget.legacy_name".to_string(),
+                "Widget.name".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn container_level_serde_default_marks_every_field() {
+        let models = r#"
+            #[serde(default)]
+            pub struct Widget {
+                pub name: String,
+                pub description: Option<String>,
+            }
+        "#;
+
+        assert_eq!(
+            model_fields_with_serde_default(models).unwrap(),
+            vec!["Widget.description".to_string(), "Widget.name".to_string()]
         );
     }
 

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1042,7 +1042,7 @@ impl CloudClient {
         org_id: &str,
         service_id: &str,
         clickpipe_id: &str,
-    ) -> Result<clickhouse_cloud_api::models::ClickPipeSettings> {
+    ) -> Result<clickhouse_cloud_api::models::ClickPipeSettingsResponse> {
         let response = self
             .api()
             .click_pipe_settings_get(org_id, service_id, clickpipe_id)
@@ -1057,7 +1057,7 @@ impl CloudClient {
         service_id: &str,
         clickpipe_id: &str,
         request: &clickhouse_cloud_api::models::ClickPipeSettingsPutRequest,
-    ) -> Result<clickhouse_cloud_api::models::ClickPipeSettings> {
+    ) -> Result<clickhouse_cloud_api::models::ClickPipeSettingsResponse> {
         let response = self
             .api()
             .click_pipe_settings_update(org_id, service_id, clickpipe_id, request)

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -492,8 +492,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 
@@ -627,8 +627,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 
@@ -763,8 +763,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 
@@ -818,8 +818,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 
@@ -883,8 +883,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 
@@ -998,8 +998,8 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error(e))?;
         Ok(DeleteResponse {
-            status: response.status.unwrap_or(0.0),
-            request_id: response.request_id.unwrap_or_default(),
+            status: response.status,
+            request_id: response.request_id,
         })
     }
 

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1085,7 +1085,10 @@ impl CloudClient {
         let orgs = self.list_organizations().await?;
         match orgs.len() {
             0 => Err(CloudError::new("No organization found for this API key")),
-            1 => Ok(orgs[0].id.to_string()),
+            1 => orgs[0]
+                .id
+                .map(|id| id.to_string())
+                .ok_or_else(|| CloudError::new("Organization response is missing its id")),
             _ => Err(CloudError::new(
                 "Multiple organizations found. Specify --org-id to choose one. \
                  Use `clickhousectl cloud org list` to see your organizations.",

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -2218,18 +2218,60 @@ pub async fn service_reset_password(
     let request = build_service_password_patch_request(&opts);
     let resp = client.reset_password(&org_id, service_id, &request).await?;
 
+    // Resolve before either output branch, so --json cannot report success
+    // over a response that dropped the one-time generated password.
+    let outcome = resolve_reset_password_outcome(
+        request.new_password_hash.is_none() && request.new_double_sha1_hash.is_none(),
+        resp.password.as_deref(),
+    )?;
+
     if json {
         println!("{}", serde_json::to_string_pretty(&resp)?);
     } else {
         println!("Password reset for service {}", service_id);
-        match resp.password.as_deref() {
-            Some(password) if !password.is_empty() => {
+        match outcome {
+            ResetPasswordOutcome::Generated(password) => {
                 println!("  New password: {}", password)
             }
-            _ => println!("  Password hash updated; no plaintext password returned"),
+            ResetPasswordOutcome::HashUpdated => {
+                println!("  Password hash updated; no plaintext password returned")
+            }
         }
     }
     Ok(())
+}
+
+/// What a `service reset-password` response says about the new credential.
+#[derive(Debug)]
+enum ResetPasswordOutcome<'a> {
+    /// The API generated the password; it is returned once and never again.
+    Generated(&'a str),
+    /// The caller supplied a hash, so the API generates no plaintext password.
+    HashUpdated,
+}
+
+/// Resolves what to report from the request mode and the response.
+///
+/// A PATCH body without either hash asks the API to generate a password, so
+/// the mode is read from the request rather than inferred from what came
+/// back: only a hash request explains a response without a password, and an
+/// absent one on a generation request means the new credential is lost.
+fn resolve_reset_password_outcome(
+    generation_requested: bool,
+    password: Option<&str>,
+) -> Result<ResetPasswordOutcome<'_>, Box<dyn std::error::Error>> {
+    if !generation_requested {
+        return Ok(ResetPasswordOutcome::HashUpdated);
+    }
+    match password {
+        Some(password) => Ok(ResetPasswordOutcome::Generated(password)),
+        None => Err(
+            "the API response omitted the generated password, so it cannot be shown: the \
+                     service password may already have been rotated — run the reset again to get \
+                     a password you can use"
+                .into(),
+        ),
+    }
 }
 
 pub async fn query_endpoint_get(
@@ -3305,6 +3347,49 @@ mod tests {
             .to_string();
         assert!(
             err.contains("the key may still have been created"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_reset_password_outcome_returns_the_generated_password() {
+        match resolve_reset_password_outcome(true, Some("s3cret")).unwrap() {
+            ResetPasswordOutcome::Generated(password) => assert_eq!(password, "s3cret"),
+            ResetPasswordOutcome::HashUpdated => panic!("expected the generated password"),
+        }
+
+        // An empty string is a password the API did send, so it is not absent.
+        assert!(matches!(
+            resolve_reset_password_outcome(true, Some("")).unwrap(),
+            ResetPasswordOutcome::Generated("")
+        ));
+    }
+
+    #[test]
+    fn resolve_reset_password_outcome_reports_hash_updated_regardless_of_response() {
+        assert!(matches!(
+            resolve_reset_password_outcome(false, None).unwrap(),
+            ResetPasswordOutcome::HashUpdated
+        ));
+        // The mode comes from the request, so an echoed password does not
+        // turn a hash reset into a generated one.
+        assert!(matches!(
+            resolve_reset_password_outcome(false, Some("s3cret")).unwrap(),
+            ResetPasswordOutcome::HashUpdated
+        ));
+    }
+
+    #[test]
+    fn resolve_reset_password_outcome_fails_when_the_generated_password_is_absent() {
+        let err = resolve_reset_password_outcome(true, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("omitted the generated password"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("may already have been rotated") && err.contains("run the reset again"),
             "unexpected error: {err}"
         );
     }

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -2250,10 +2250,8 @@ pub async fn service_reset_password(
 
     // Resolve before either output branch, so --json cannot report success
     // over a response that dropped the one-time generated password.
-    let outcome = resolve_reset_password_outcome(
-        request.new_password_hash.is_none() && request.new_double_sha1_hash.is_none(),
-        resp.password.as_deref(),
-    )?;
+    let outcome =
+        resolve_reset_password_outcome(generation_requested(&request), resp.password.as_deref())?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -2280,12 +2278,23 @@ enum ResetPasswordOutcome<'a> {
     HashUpdated,
 }
 
+/// Whether the PATCH body asks the API to generate a password.
+///
+/// `newPasswordHash` alone decides it: the spec says `newDoubleSha1Hash` "will
+/// be ignored and the generated password will be used" when `newPasswordHash`
+/// is absent, and that the response carries a password "only if there was no
+/// 'newPasswordHash' in the request". So a double-SHA1-only body is still a
+/// generation request, and treating it as a hash update would discard the
+/// generated password the API rotated to.
+fn generation_requested(request: &ServicePasswordPatchRequest) -> bool {
+    request.new_password_hash.is_none()
+}
+
 /// Resolves what to report from the request mode and the response.
 ///
-/// A PATCH body without either hash asks the API to generate a password, so
-/// the mode is read from the request rather than inferred from what came
-/// back: only a hash request explains a response without a password, and an
-/// absent one on a generation request means the new credential is lost.
+/// The mode is read from the request rather than inferred from what came back:
+/// only a hash request explains a response without a password, and an absent
+/// one on a generation request means the new credential is lost.
 fn resolve_reset_password_outcome(
     generation_requested: bool,
     password: Option<&str>,
@@ -3426,6 +3435,26 @@ mod tests {
             err.contains("the key may still have been created"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn generation_is_requested_unless_a_password_hash_is_sent() {
+        let request = |new_password_hash: Option<&str>, new_double_sha1_hash: Option<&str>| {
+            ServicePasswordPatchRequest {
+                new_password_hash: new_password_hash.map(str::to_string),
+                new_double_sha1_hash: new_double_sha1_hash.map(str::to_string),
+            }
+        };
+        assert!(generation_requested(&request(None, None)));
+        // The API ignores `newDoubleSha1Hash` without `newPasswordHash` and
+        // generates a password anyway, so this is still a generation request:
+        // reporting "hash updated" would discard the new credential.
+        assert!(generation_requested(&request(None, Some("sha1"))));
+        assert!(!generation_requested(&request(Some("sha256"), None)));
+        assert!(!generation_requested(&request(
+            Some("sha256"),
+            Some("sha1")
+        )));
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -32,14 +32,16 @@ fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String 
 
 /// `host:port` of a service's first endpoint, for list tables.
 ///
-/// Renders [`ABSENT`] when the API returned no endpoints, or an endpoint
-/// without a host or port.
+/// Renders [`ABSENT`] when the API returned no endpoints, and keeps whichever
+/// half of a partial endpoint it did return (`host` alone, or `-:port`).
 fn first_endpoint(endpoints: Option<&[ServiceEndpoint]>) -> String {
     endpoints
         .and_then(|endpoints| endpoints.first())
-        .and_then(|endpoint| match (endpoint.host.as_deref(), endpoint.port) {
-            (Some(host), Some(port)) => Some(format!("{host}:{port}")),
-            _ => None,
+        .map(|endpoint| match (endpoint.host.as_deref(), endpoint.port) {
+            (Some(host), Some(port)) => format!("{host}:{port}"),
+            (Some(host), None) => host.to_string(),
+            (None, Some(port)) => format!("{ABSENT}:{port}"),
+            (None, None) => ABSENT.to_string(),
         })
         .unwrap_or_else(|| ABSENT.to_string())
 }
@@ -3101,6 +3103,31 @@ fn format_bytes(bytes: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn first_endpoint_keeps_the_present_half_of_a_partial_endpoint() {
+        let endpoint = |host: Option<&str>, port: Option<f64>| ServiceEndpoint {
+            host: host.map(str::to_string),
+            port,
+            ..Default::default()
+        };
+
+        assert_eq!(first_endpoint(None), ABSENT);
+        assert_eq!(first_endpoint(Some(&[])), ABSENT);
+        assert_eq!(
+            first_endpoint(Some(&[endpoint(Some("host"), Some(9440.0))])),
+            "host:9440"
+        );
+        assert_eq!(
+            first_endpoint(Some(&[endpoint(Some("host"), None)])),
+            "host"
+        );
+        assert_eq!(
+            first_endpoint(Some(&[endpoint(None, Some(9440.0))])),
+            format!("{ABSENT}:9440")
+        );
+        assert_eq!(first_endpoint(Some(&[endpoint(None, None)])), ABSENT);
+    }
 
     #[test]
     fn parse_tag_rejects_empty_keys() {

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -1,6 +1,6 @@
 use crate::cloud::client::CloudClient;
 use crate::cloud::credentials;
-use crate::cloud::output::print_human;
+use crate::cloud::output::{ABSENT, or_absent, print_human};
 use clickhouse_cloud_api::models::{
     ApiKeyPatchRequest, ApiKeyPatchRequestState, ApiKeyPostRequest, ApiKeyPostRequestState,
     AutoscalingMode, BackupConfigurationPatchRequest, InstancePrivateEndpointsPatch,
@@ -8,7 +8,7 @@ use clickhouse_cloud_api::models::{
     IpAccessListPatch, OrganizationPatchPrivateEndpoint,
     OrganizationPatchPrivateEndpointCloudprovider, OrganizationPatchPrivateEndpointRegion,
     OrganizationPatchRequest, OrganizationPrivateEndpointsPatch, ResourceTagsV1,
-    ServicPrivateEndpointePostRequest, Service, ServiceEndpointChange,
+    ServicPrivateEndpointePostRequest, Service, ServiceEndpoint, ServiceEndpointChange,
     ServiceEndpointChangeProtocol, ServicePasswordPatchRequest, ServicePatchRequest,
     ServicePatchRequestReleasechannel, ServicePostRequest, ServicePostRequestCompliancetype,
     ServicePostRequestProfile, ServicePostRequestProvider, ServicePostRequestRegion,
@@ -17,6 +17,32 @@ use clickhouse_cloud_api::models::{
 };
 use std::io::{IsTerminal, Write};
 use tabled::{Table, Tabled, settings::Style};
+
+/// Comma-joins the rendered items of a response list.
+///
+/// An absent list renders as [`ABSENT`]; an absent field of an individual item
+/// renders as [`ABSENT`] inside the join, so a partially-returned list stays
+/// readable.
+fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String {
+    match items {
+        Some(items) => items.iter().map(render).collect::<Vec<_>>().join(", "),
+        None => ABSENT.to_string(),
+    }
+}
+
+/// `host:port` of a service's first endpoint, for list tables.
+///
+/// Renders [`ABSENT`] when the API returned no endpoints, or an endpoint
+/// without a host or port.
+fn first_endpoint(endpoints: Option<&[ServiceEndpoint]>) -> String {
+    endpoints
+        .and_then(|endpoints| endpoints.first())
+        .and_then(|endpoint| match (endpoint.host.as_deref(), endpoint.port) {
+            (Some(host), Some(port)) => Some(format!("{host}:{port}")),
+            _ => None,
+        })
+        .unwrap_or_else(|| ABSENT.to_string())
+}
 
 /// Resolve org ID from explicit arg or auto-detect
 pub(super) async fn resolve_org_id(
@@ -40,7 +66,10 @@ async fn resolve_service(
     match (name, id) {
         (Some(name), None) => {
             let services = client.list_services(org_id).await?;
-            let matches: Vec<_> = services.into_iter().filter(|s| s.name == name).collect();
+            let matches: Vec<_> = services
+                .into_iter()
+                .filter(|s| s.name.as_deref() == Some(name))
+                .collect();
             match matches.len() {
                 0 => Err(format!("no service found with name '{}'", name).into()),
                 1 => Ok(matches.into_iter().next().unwrap()),
@@ -382,8 +411,8 @@ pub async fn org_list(client: &CloudClient, json: bool) -> Result<(), Box<dyn st
         let rows: Vec<Row> = orgs
             .into_iter()
             .map(|o| Row {
-                name: o.name.clone(),
-                id: o.id.to_string(),
+                name: or_absent(o.name.as_deref()),
+                id: or_absent(o.id),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -444,20 +473,13 @@ pub async fn service_list(
         }
         let rows: Vec<Row> = services
             .into_iter()
-            .map(|svc| {
-                let endpoint = svc
-                    .endpoints
-                    .first()
-                    .map(|e| format!("{}:{}", e.host, e.port))
-                    .unwrap_or_else(|| "-".to_string());
-                Row {
-                    name: svc.name.clone(),
-                    id: svc.id.to_string(),
-                    state: svc.state.to_string(),
-                    provider: svc.provider.to_string(),
-                    region: svc.region.to_string(),
-                    endpoint,
-                }
+            .map(|svc| Row {
+                name: or_absent(svc.name.as_deref()),
+                id: or_absent(svc.id),
+                state: or_absent(svc.state.as_ref()),
+                provider: or_absent(svc.provider.as_ref()),
+                region: or_absent(svc.region.as_ref()),
+                endpoint: first_endpoint(svc.endpoints.as_deref()),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -856,18 +878,20 @@ pub async fn service_create(
     let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
 
     let response = client.create_service(&org_id, &request).await?;
-    let svc_id = response.service.id.to_string();
+    let svc_id = or_absent(response.service.as_ref().and_then(|svc| svc.id));
 
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
         println!("Service created successfully!");
         println!();
-        print_human(&response.service)?;
+        if let Some(service) = &response.service {
+            print_human(service)?;
+        }
         println!();
         println!("Credentials (save these, password shown only once):");
         println!("  Username: default");
-        println!("  Password: {}", response.password);
+        println!("  Password: {}", or_absent(response.password.as_deref()));
         println!();
         println!(
             "Run SQL with: clickhousectl cloud service query --id {} --query \"SELECT 1\"",
@@ -889,7 +913,9 @@ pub async fn service_delete(
 
     if force {
         let svc = client.get_service(&org_id, service_id).await?;
-        let state = svc.state.to_string();
+        // An absent state matches nothing: skip the stop and let the delete
+        // call decide, rather than guessing the service is running.
+        let state = or_absent(svc.state.as_ref());
         if matches!(state.as_str(), "running" | "idle" | "starting") {
             eprintln!("Stopping service {} before deletion...", service_id);
             client
@@ -900,7 +926,7 @@ pub async fn service_delete(
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let svc = client.get_service(&org_id, service_id).await?;
-                let state = svc.state.to_string();
+                let state = or_absent(svc.state.as_ref());
                 eprintln!("  state: {}", state);
                 if matches!(state.as_str(), "stopped" | "idle") {
                     break;
@@ -941,7 +967,11 @@ pub async fn service_start(
     if json {
         println!("{}", serde_json::to_string_pretty(&svc)?);
     } else {
-        println!("Service {} starting (state: {})", svc.name, svc.state);
+        println!(
+            "Service {} starting (state: {})",
+            or_absent(svc.name.as_deref()),
+            or_absent(svc.state.as_ref())
+        );
     }
     Ok(())
 }
@@ -961,7 +991,11 @@ pub async fn service_stop(
     if json {
         println!("{}", serde_json::to_string_pretty(&svc)?);
     } else {
-        println!("Service {} stopping (state: {})", svc.name, svc.state);
+        println!(
+            "Service {} stopping (state: {})",
+            or_absent(svc.name.as_deref()),
+            or_absent(svc.state.as_ref())
+        );
     }
     Ok(())
 }
@@ -1964,10 +1998,10 @@ pub async fn backup_list(
         let rows: Vec<Row> = backups
             .into_iter()
             .map(|b| Row {
-                id: b.id.to_string(),
-                status: b.status.to_string(),
-                size: format_bytes(b.size_in_bytes),
-                created: b.started_at.to_rfc3339(),
+                id: or_absent(b.id),
+                status: or_absent(b.status.as_ref()),
+                size: or_absent(b.size_in_bytes.map(format_bytes)),
+                created: or_absent(b.started_at.map(|at| at.to_rfc3339())),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -2041,9 +2075,9 @@ pub async fn service_update(
     if json {
         println!("{}", serde_json::to_string_pretty(&svc)?);
     } else {
-        println!("Service {} updated", svc.name);
-        println!("  ID: {}", svc.id);
-        println!("  State: {}", svc.state);
+        println!("Service {} updated", or_absent(svc.name.as_deref()));
+        println!("  ID: {}", or_absent(svc.id));
+        println!("  State: {}", or_absent(svc.state.as_ref()));
     }
     Ok(())
 }
@@ -2098,20 +2132,30 @@ pub async fn service_scale(
     if json {
         println!("{}", serde_json::to_string_pretty(&svc)?);
     } else {
-        println!("Service {} scaling updated", svc.name);
-        println!("  Autoscaling Mode: {}", svc.autoscaling_mode);
+        println!("Service {} scaling updated", or_absent(svc.name.as_deref()));
+        println!(
+            "  Autoscaling Mode: {}",
+            or_absent(svc.autoscaling_mode.as_ref())
+        );
         match svc.autoscaling_mode {
-            AutoscalingMode::Horizontal => {
-                println!("  Min Replicas: {}", svc.min_replicas);
-                println!("  Max Replicas: {}", svc.max_replicas);
-                println!("  Memory/Replica: {} GB", svc.replica_memory_gb);
+            Some(AutoscalingMode::Horizontal) => {
+                println!("  Min Replicas: {}", or_absent(svc.min_replicas));
+                println!("  Max Replicas: {}", or_absent(svc.max_replicas));
+                println!("  Memory/Replica: {} GB", or_absent(svc.replica_memory_gb));
             }
-            AutoscalingMode::Vertical => {
-                println!("  Min Memory/Replica: {} GB", svc.min_replica_memory_gb);
-                println!("  Max Memory/Replica: {} GB", svc.max_replica_memory_gb);
-                println!("  Replicas: {}", svc.num_replicas);
+            Some(AutoscalingMode::Vertical) => {
+                println!(
+                    "  Min Memory/Replica: {} GB",
+                    or_absent(svc.min_replica_memory_gb)
+                );
+                println!(
+                    "  Max Memory/Replica: {} GB",
+                    or_absent(svc.max_replica_memory_gb)
+                );
+                println!("  Replicas: {}", or_absent(svc.num_replicas));
             }
-            // A mode this CLI version doesn't know; don't guess which fields apply.
+            // A mode this CLI version doesn't know, or one the API did not
+            // return; don't guess which fields apply.
             _ => {}
         }
     }
@@ -2132,10 +2176,11 @@ pub async fn service_reset_password(
         println!("{}", serde_json::to_string_pretty(&resp)?);
     } else {
         println!("Password reset for service {}", service_id);
-        if resp.password.is_empty() {
-            println!("  Password hash updated; no plaintext password returned");
-        } else {
-            println!("  New password: {}", resp.password);
+        match resp.password.as_deref() {
+            Some(password) if !password.is_empty() => {
+                println!("  New password: {}", password)
+            }
+            _ => println!("  Password hash updated; no plaintext password returned"),
         }
     }
     Ok(())
@@ -2176,8 +2221,11 @@ pub async fn query_endpoint_create(
         println!("{}", serde_json::to_string_pretty(&ep)?);
     } else {
         println!("Query endpoint created for service {}", service_id);
-        println!("  ID: {}", ep.id);
-        println!("  Roles: {}", ep.roles.join(", "));
+        println!("  ID: {}", or_absent(ep.id.as_deref()));
+        println!(
+            "  Roles: {}",
+            or_absent(ep.roles.as_ref().map(|roles| roles.join(", ")))
+        );
     }
     Ok(())
 }
@@ -2219,7 +2267,17 @@ pub async fn service_query(
     let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
     let service =
         resolve_service(client, &org_id, opts.name.as_deref(), opts.id.as_deref()).await?;
-    let service_id = service.id.to_string();
+    // The whole query path is keyed on the service id: prefer the one the API
+    // echoed, and fall back to the one the user passed if the response omitted
+    // it.
+    let service_id = match service.id {
+        Some(id) => id.to_string(),
+        None => opts
+            .id
+            .clone()
+            .ok_or("the API response is missing the service id")?,
+    };
+    let service_name = or_absent(service.name.as_deref());
 
     let format = opts.format.unwrap_or_else(default_query_format);
 
@@ -2241,12 +2299,12 @@ pub async fn service_query(
         };
         let result = match run(false).await {
             Err(clickhouse_cloud_api::Error::ServiceIdle) => {
-                eprint_waking_service(&service.name);
+                eprint_waking_service(&service_name);
                 run(true).await
             }
             other => other,
         };
-        result.map_err(|e| convert_query_error(client, e, &service.name))?
+        result.map_err(|e| convert_query_error(client, e, &service_name))?
     } else {
         let key = match credentials::get_service_query_key(&service_id) {
             Some(k) => k,
@@ -2259,13 +2317,13 @@ pub async fn service_query(
             None => {
                 eprintln!(
                     "Provisioning Query API endpoint + key for service '{}'...",
-                    service.name
+                    service_name
                 );
                 crate::cloud::service_query::ensure_service_query_setup(
                     client,
                     &org_id,
                     &service_id,
-                    &service.name,
+                    &service_name,
                 )
                 .await?
             }
@@ -2287,12 +2345,12 @@ pub async fn service_query(
         };
         let result = match run(false).await {
             Err(clickhouse_cloud_api::Error::ServiceIdle) => {
-                eprint_waking_service(&service.name);
+                eprint_waking_service(&service_name);
                 run(true).await
             }
             other => other,
         };
-        result.map_err(|e| convert_query_error(client, e, &service.name))?
+        result.map_err(|e| convert_query_error(client, e, &service_name))?
     };
 
     use futures_util::StreamExt;
@@ -2403,8 +2461,8 @@ pub async fn private_endpoint_create(
         println!("{}", serde_json::to_string_pretty(&ep)?);
     } else {
         println!("Private endpoint created for service {}", service_id);
-        println!("  Endpoint ID: {}", ep.id);
-        println!("  Description: {}", ep.description);
+        println!("  Endpoint ID: {}", or_absent(ep.id.as_deref()));
+        println!("  Description: {}", or_absent(ep.description.as_deref()));
     }
     Ok(())
 }
@@ -2445,7 +2503,11 @@ pub async fn org_update(
     if json {
         println!("{}", serde_json::to_string_pretty(&org)?);
     } else {
-        println!("Organization updated: {} ({})", org.name, org.id);
+        println!(
+            "Organization updated: {} ({})",
+            or_absent(org.name.as_deref()),
+            or_absent(org.id)
+        );
     }
     Ok(())
 }
@@ -2490,8 +2552,12 @@ pub async fn org_usage(
     if json {
         println!("{}", serde_json::to_string_pretty(&usage)?);
     } else {
-        println!("Grand Total: {:.2} CHC", usage.grand_total_chc);
-        if usage.costs.is_empty() {
+        println!(
+            "Grand Total: {} CHC",
+            or_absent(usage.grand_total_chc.map(|total| format!("{total:.2}")))
+        );
+        let costs = usage.costs.unwrap_or_default();
+        if costs.is_empty() {
             println!("No usage cost records found");
             return Ok(());
         }
@@ -2505,13 +2571,12 @@ pub async fn org_usage(
             #[tabled(rename = "Total (CHC)")]
             total: String,
         }
-        let rows: Vec<Row> = usage
-            .costs
+        let rows: Vec<Row> = costs
             .iter()
             .map(|cost| Row {
-                entity: cost.entity_name.clone(),
-                date: cost.date.clone(),
-                total: format!("{:.2}", cost.total_chc),
+                entity: or_absent(cost.entity_name.as_deref()),
+                date: or_absent(cost.date.as_deref()),
+                total: or_absent(cost.total_chc.map(|total| format!("{total:.2}"))),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -2553,15 +2618,12 @@ pub async fn member_list(
         let rows: Vec<Row> = members
             .into_iter()
             .map(|m| Row {
-                email: m.email.clone(),
-                user_id: m.user_id.clone(),
-                roles: m
-                    .assigned_roles
-                    .iter()
-                    .map(|r| r.role_name.clone())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                name: m.name.clone(),
+                email: or_absent(m.email.as_deref()),
+                user_id: or_absent(m.user_id.as_deref()),
+                roles: join_absent(m.assigned_roles.as_deref(), |r| {
+                    or_absent(r.role_name.as_deref())
+                }),
+                name: or_absent(m.name.as_deref()),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -2611,7 +2673,7 @@ pub async fn member_update(
     if json {
         println!("{}", serde_json::to_string_pretty(&member)?);
     } else {
-        println!("Member {} updated", member.email);
+        println!("Member {} updated", or_absent(member.email.as_deref()));
     }
     Ok(())
 }
@@ -2667,15 +2729,12 @@ pub async fn invitation_list(
         let rows: Vec<Row> = invitations
             .into_iter()
             .map(|inv| Row {
-                email: inv.email.clone(),
-                id: inv.id.to_string(),
-                roles: inv
-                    .assigned_roles
-                    .iter()
-                    .map(|r| r.role_name.clone())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-                expires: inv.expire_at.to_rfc3339(),
+                email: or_absent(inv.email.as_deref()),
+                id: or_absent(inv.id),
+                roles: join_absent(inv.assigned_roles.as_deref(), |r| {
+                    or_absent(r.role_name.as_deref())
+                }),
+                expires: or_absent(inv.expire_at.map(|at| at.to_rfc3339())),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -2704,7 +2763,11 @@ pub async fn invitation_create(
     if json {
         println!("{}", serde_json::to_string_pretty(&inv)?);
     } else {
-        println!("Invitation sent to {} ({})", inv.email, inv.id);
+        println!(
+            "Invitation sent to {} ({})",
+            or_absent(inv.email.as_deref()),
+            or_absent(inv.id)
+        );
     }
     Ok(())
 }
@@ -2778,9 +2841,9 @@ pub async fn key_list(
         let rows: Vec<Row> = keys
             .into_iter()
             .map(|k| Row {
-                name: k.name.clone(),
-                id: k.id.to_string(),
-                state: k.state.to_string(),
+                name: or_absent(k.name.as_deref()),
+                id: or_absent(k.id),
+                state: or_absent(k.state.as_ref()),
                 expires: k
                     .expire_at
                     .map(|t| t.to_rfc3339())
@@ -2808,14 +2871,21 @@ pub async fn key_create(
         println!("{}", serde_json::to_string_pretty(&resp)?);
     } else {
         println!("API key created!");
-        println!("  Name: {}", resp.key.name);
-        if !resp.key_id.is_empty() {
-            println!("  Key ID: {}", resp.key_id);
+        println!(
+            "  Name: {}",
+            or_absent(resp.key.as_ref().and_then(|key| key.name.as_deref()))
+        );
+        // The API omits the generated pair when the caller supplied pre-hashed
+        // credentials, so absent and empty mean the same thing here.
+        let key_id = resp.key_id.unwrap_or_default();
+        let key_secret = resp.key_secret.unwrap_or_default();
+        if !key_id.is_empty() {
+            println!("  Key ID: {}", key_id);
         }
-        if !resp.key_secret.is_empty() {
-            println!("  Key Secret: {}", resp.key_secret);
+        if !key_secret.is_empty() {
+            println!("  Key Secret: {}", key_secret);
         }
-        if !resp.key_id.is_empty() || !resp.key_secret.is_empty() {
+        if !key_id.is_empty() || !key_secret.is_empty() {
             println!();
             println!("Save the key secret now — it will not be shown again.");
         } else {
@@ -2859,9 +2929,9 @@ pub async fn key_update(
     if json {
         println!("{}", serde_json::to_string_pretty(&key)?);
     } else {
-        println!("API key {} updated", key.name);
-        println!("  ID: {}", key.id);
-        println!("  State: {}", key.state);
+        println!("API key {} updated", or_absent(key.name.as_deref()));
+        println!("  ID: {}", or_absent(key.id));
+        println!("  State: {}", or_absent(key.state.as_ref()));
     }
     Ok(())
 }
@@ -2917,9 +2987,9 @@ pub async fn activity_list(
         let rows: Vec<Row> = activities
             .into_iter()
             .map(|a| Row {
-                id: a.id.clone(),
-                activity_type: a.r#type.to_string(),
-                created: a.created_at.to_rfc3339(),
+                id: or_absent(a.id.as_deref()),
+                activity_type: or_absent(a.r#type.as_ref()),
+                created: or_absent(a.created_at.map(|at| at.to_rfc3339())),
             })
             .collect();
         println!("{}", Table::new(rows).with(Style::markdown()));
@@ -2984,12 +3054,18 @@ pub async fn backup_config_update(
         println!("{}", serde_json::to_string_pretty(&config)?);
     } else {
         println!("Backup configuration updated for service {}", service_id);
-        println!("  Backup period: {} hours", config.backup_period_in_hours);
+        println!(
+            "  Backup period: {} hours",
+            or_absent(config.backup_period_in_hours)
+        );
         println!(
             "  Retention: {} hours",
-            config.backup_retention_period_in_hours
+            or_absent(config.backup_retention_period_in_hours)
         );
-        println!("  Start time: {}", config.backup_start_time);
+        println!(
+            "  Start time: {}",
+            or_absent(config.backup_start_time.as_deref())
+        );
     }
     Ok(())
 }

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -3002,18 +3002,19 @@ pub async fn key_create(
 
     let resp = client.create_api_key(&org_id, &request).await?;
 
+    let name = resp.key.as_ref().and_then(|key| key.name.as_deref());
+    // Resolve before either output branch, so --json cannot report success
+    // over a response that dropped the one-time key material.
+    let material = resolve_key_create_material(
+        request.hash_data.is_some(),
+        resp.key_id.as_deref(),
+        resp.key_secret.as_deref(),
+        name,
+    )?;
+
     if json {
         println!("{}", serde_json::to_string_pretty(&resp)?);
     } else {
-        let name = resp.key.as_ref().and_then(|key| key.name.as_deref());
-        // Resolve the credentials before printing anything, so a response
-        // missing the one-time secret does not report success first.
-        let material = resolve_key_create_material(
-            request.hash_data.is_some(),
-            resp.key_id.as_deref(),
-            resp.key_secret.as_deref(),
-            name,
-        )?;
         println!("API key created!");
         println!("  Name: {}", or_absent(name));
         match material {

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -884,6 +884,34 @@ fn service_query_hint(service_id: Option<uuid::Uuid>) -> Option<String> {
     })
 }
 
+/// The post-create credentials block, or the warning that replaces it.
+///
+/// The generated password is returned once, so a placeholder in its place would
+/// be read as the credential itself. An absent password therefore gets the
+/// omission plus the command that mints a usable one; the create succeeded and
+/// the password is recoverable, so this is a warning rather than an error. An
+/// empty string is a password the API sent.
+fn service_credentials_block(password: Option<&str>, service_id: Option<uuid::Uuid>) -> String {
+    match (password, service_id) {
+        (Some(password), _) => format!(
+            "Credentials (save these, password shown only once):\n  Username: default\n  \
+             Password: {}",
+            password
+        ),
+        (None, Some(id)) => format!(
+            "WARNING: the API response omitted the one-time password, so it cannot be shown.\n\
+             The service was created; reset the password to get a usable credential:\n  \
+             clickhousectl cloud service reset-password {}",
+            id
+        ),
+        (None, None) => "WARNING: the API response omitted the one-time password, so it cannot be \
+                         shown.\nThe service was created; once you have its id, reset the password \
+                         with `clickhousectl cloud service reset-password <service-id>` to get a \
+                         usable credential."
+            .to_string(),
+    }
+}
+
 pub async fn service_create(
     client: &CloudClient,
     opts: CreateServiceOptions,
@@ -899,16 +927,18 @@ pub async fn service_create(
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
+        let service_id = response.service.as_ref().and_then(|svc| svc.id);
         println!("Service created successfully!");
         println!();
         if let Some(service) = &response.service {
             print_human(service)?;
         }
         println!();
-        println!("Credentials (save these, password shown only once):");
-        println!("  Username: default");
-        println!("  Password: {}", or_absent(response.password.as_deref()));
-        if let Some(hint) = service_query_hint(response.service.as_ref().and_then(|svc| svc.id)) {
+        println!(
+            "{}",
+            service_credentials_block(response.password.as_deref(), service_id)
+        );
+        if let Some(hint) = service_query_hint(service_id) {
             println!();
             println!("{}", hint);
         }
@@ -3263,6 +3293,52 @@ mod tests {
             "hint should name the service: {hint}"
         );
         assert!(hint.contains("provisioned automatically on first use"));
+    }
+
+    #[test]
+    fn service_credentials_block_shows_the_password_the_api_sent() {
+        let id = uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap();
+        assert_eq!(
+            service_credentials_block(Some("s3cret"), Some(id)),
+            "Credentials (save these, password shown only once):\n  Username: default\n  \
+             Password: s3cret"
+        );
+    }
+
+    #[test]
+    fn service_credentials_block_treats_an_empty_password_as_sent() {
+        assert_eq!(
+            service_credentials_block(Some(""), None),
+            "Credentials (save these, password shown only once):\n  Username: default\n  \
+             Password: "
+        );
+    }
+
+    #[test]
+    fn service_credentials_block_warns_with_the_reset_command_when_the_password_is_absent() {
+        let id = uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap();
+        let block = service_credentials_block(None, Some(id));
+        assert!(
+            !block.contains(&format!("Password: {ABSENT}")),
+            "an absent password must not render a placeholder credential: {block}"
+        );
+        assert!(block.starts_with("WARNING: the API response omitted the one-time password"));
+        assert!(
+            block.contains(
+                "clickhousectl cloud service reset-password a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6"
+            ),
+            "the warning should name the exact recovery command: {block}"
+        );
+    }
+
+    #[test]
+    fn service_credentials_block_warns_generically_when_the_service_id_is_absent() {
+        let block = service_credentials_block(None, None);
+        assert!(block.starts_with("WARNING: the API response omitted the one-time password"));
+        assert!(
+            block.contains("clickhousectl cloud service reset-password <service-id>"),
+            "without an id the warning should stay generic: {block}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -12,7 +12,7 @@ use clickhouse_cloud_api::models::{
     ServiceEndpointChangeProtocol, ServicePasswordPatchRequest, ServicePatchRequest,
     ServicePatchRequestReleasechannel, ServicePostRequest, ServicePostRequestCompliancetype,
     ServicePostRequestProfile, ServicePostRequestProvider, ServicePostRequestRegion,
-    ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest,
+    ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest, ServiceState,
     ServiceStatePatchRequestCommand,
 };
 use std::io::{IsTerminal, Write};
@@ -869,6 +869,21 @@ fn build_backup_config_update_request(
     }
 }
 
+/// The post-create hint showing how to query the new service.
+///
+/// The hint is only useful with a real service id: an absent id would render a
+/// command line the user cannot run, so the hint is dropped rather than printed
+/// with a placeholder id in it.
+fn service_query_hint(service_id: Option<uuid::Uuid>) -> Option<String> {
+    service_id.map(|id| {
+        format!(
+            "Run SQL with: clickhousectl cloud service query --id {} --query \"SELECT 1\"\n\
+             (the Query API endpoint is provisioned automatically on first use)",
+            id
+        )
+    })
+}
+
 pub async fn service_create(
     client: &CloudClient,
     opts: CreateServiceOptions,
@@ -880,7 +895,6 @@ pub async fn service_create(
     let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
 
     let response = client.create_service(&org_id, &request).await?;
-    let svc_id = or_absent(response.service.as_ref().and_then(|svc| svc.id));
 
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
@@ -894,14 +908,40 @@ pub async fn service_create(
         println!("Credentials (save these, password shown only once):");
         println!("  Username: default");
         println!("  Password: {}", or_absent(response.password.as_deref()));
-        println!();
-        println!(
-            "Run SQL with: clickhousectl cloud service query --id {} --query \"SELECT 1\"",
-            svc_id
-        );
-        println!("(the Query API endpoint is provisioned automatically on first use)");
+        if let Some(hint) = service_query_hint(response.service.as_ref().and_then(|svc| svc.id)) {
+            println!();
+            println!("{}", hint);
+        }
     }
     Ok(())
+}
+
+/// Classifies one poll of a service's state while waiting for a stop to land.
+///
+/// Returns `true` once the service has stopped. An absent state cannot be
+/// classified and the loop has no other exit, so treating it as "not stopped
+/// yet" would poll forever: fail instead of waiting on a state the API is not
+/// reporting.
+fn classify_stop_poll_state(
+    state: Option<&ServiceState>,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let state = state
+        .ok_or(
+            "the API response omitted the service state while waiting for the service to stop, \
+             so the stop cannot be confirmed",
+        )?
+        .to_string();
+    if matches!(state.as_str(), "stopped" | "idle") {
+        return Ok(true);
+    }
+    if matches!(state.as_str(), "terminated" | "failed" | "deleted") {
+        return Err(format!(
+            "service entered unexpected state '{}' while waiting for stop",
+            state
+        )
+        .into());
+    }
+    Ok(false)
 }
 
 pub async fn service_delete(
@@ -928,17 +968,9 @@ pub async fn service_delete(
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let svc = client.get_service(&org_id, service_id).await?;
-                let state = or_absent(svc.state.as_ref());
-                eprintln!("  state: {}", state);
-                if matches!(state.as_str(), "stopped" | "idle") {
+                eprintln!("  state: {}", or_absent(svc.state.as_ref()));
+                if classify_stop_poll_state(svc.state.as_ref())? {
                     break;
-                }
-                if matches!(state.as_str(), "terminated" | "failed" | "deleted") {
-                    return Err(format!(
-                        "service entered unexpected state '{}' while waiting for stop",
-                        state
-                    )
-                    .into());
                 }
             }
         }
@@ -2869,6 +2901,53 @@ pub async fn key_list(
     Ok(())
 }
 
+/// What a `key create` response says about the key's credentials.
+#[derive(Debug)]
+enum KeyCreateMaterial<'a> {
+    /// The API returned the generated pair; it is shown once and never again.
+    Generated {
+        key_id: &'a str,
+        key_secret: &'a str,
+    },
+    /// The caller supplied pre-hashed credentials, so no pair is generated.
+    PreHashed,
+}
+
+/// Resolves the credentials to print from the request mode and the response.
+///
+/// Only a pre-hashed request explains a response without key material, so the
+/// mode is read from the request rather than inferred from what came back: an
+/// absent `keyId`/`keySecret` on a generated-key request means the one-time
+/// secret is lost, which is an error, not a "no key material returned" notice.
+fn resolve_key_create_material<'a>(
+    pre_hashed: bool,
+    key_id: Option<&'a str>,
+    key_secret: Option<&'a str>,
+    key_name: Option<&str>,
+) -> Result<KeyCreateMaterial<'a>, Box<dyn std::error::Error>> {
+    if pre_hashed {
+        return Ok(KeyCreateMaterial::PreHashed);
+    }
+    match (key_id, key_secret) {
+        (Some(key_id), Some(key_secret)) => Ok(KeyCreateMaterial::Generated { key_id, key_secret }),
+        _ => {
+            // Name the key when the response did return it, so the user knows
+            // which one to look for.
+            let named = match key_name {
+                Some(name) => format!(" '{}'", name),
+                None => String::new(),
+            };
+            Err(format!(
+                "the API response omitted the generated key material, so the one-time key secret \
+                 cannot be shown: the key{} may still have been created — list the organization's \
+                 keys and delete it if so",
+                named
+            )
+            .into())
+        }
+    }
+}
+
 pub async fn key_create(
     client: &CloudClient,
     opts: KeyCreateOptions,
@@ -2884,26 +2963,27 @@ pub async fn key_create(
     if json {
         println!("{}", serde_json::to_string_pretty(&resp)?);
     } else {
+        let name = resp.key.as_ref().and_then(|key| key.name.as_deref());
+        // Resolve the credentials before printing anything, so a response
+        // missing the one-time secret does not report success first.
+        let material = resolve_key_create_material(
+            request.hash_data.is_some(),
+            resp.key_id.as_deref(),
+            resp.key_secret.as_deref(),
+            name,
+        )?;
         println!("API key created!");
-        println!(
-            "  Name: {}",
-            or_absent(resp.key.as_ref().and_then(|key| key.name.as_deref()))
-        );
-        // The API omits the generated pair when the caller supplied pre-hashed
-        // credentials, so absent and empty mean the same thing here.
-        let key_id = resp.key_id.unwrap_or_default();
-        let key_secret = resp.key_secret.unwrap_or_default();
-        if !key_id.is_empty() {
-            println!("  Key ID: {}", key_id);
-        }
-        if !key_secret.is_empty() {
-            println!("  Key Secret: {}", key_secret);
-        }
-        if !key_id.is_empty() || !key_secret.is_empty() {
-            println!();
-            println!("Save the key secret now — it will not be shown again.");
-        } else {
-            println!("  Pre-hashed credentials accepted; no generated key material returned");
+        println!("  Name: {}", or_absent(name));
+        match material {
+            KeyCreateMaterial::Generated { key_id, key_secret } => {
+                println!("  Key ID: {}", key_id);
+                println!("  Key Secret: {}", key_secret);
+                println!();
+                println!("Save the key secret now — it will not be shown again.");
+            }
+            KeyCreateMaterial::PreHashed => {
+                println!("  Pre-hashed credentials accepted; no generated key material returned");
+            }
         }
     }
     Ok(())
@@ -3127,6 +3207,106 @@ mod tests {
             format!("{ABSENT}:9440")
         );
         assert_eq!(first_endpoint(Some(&[endpoint(None, None)])), ABSENT);
+    }
+
+    #[test]
+    fn service_query_hint_is_dropped_when_the_id_is_absent() {
+        assert_eq!(service_query_hint(None), None);
+
+        let id = uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap();
+        let hint = service_query_hint(Some(id)).unwrap();
+        assert!(
+            hint.contains("--id a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6"),
+            "hint should name the service: {hint}"
+        );
+        assert!(hint.contains("provisioned automatically on first use"));
+    }
+
+    #[test]
+    fn classify_stop_poll_state_fails_on_an_absent_state() {
+        let err = classify_stop_poll_state(None).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "the API response omitted the service state while waiting for the service to stop, \
+             so the stop cannot be confirmed"
+        );
+    }
+
+    #[test]
+    fn classify_stop_poll_state_separates_stopped_waiting_and_failed() {
+        assert!(classify_stop_poll_state(Some(&ServiceState::Stopped)).unwrap());
+        assert!(classify_stop_poll_state(Some(&ServiceState::Idle)).unwrap());
+        assert!(!classify_stop_poll_state(Some(&ServiceState::Stopping)).unwrap());
+        assert!(!classify_stop_poll_state(Some(&ServiceState::Running)).unwrap());
+        // An unrecognized state keeps the loop polling rather than failing.
+        assert!(
+            !classify_stop_poll_state(Some(&ServiceState::Unknown("hibernating".into()))).unwrap()
+        );
+
+        let err = classify_stop_poll_state(Some(&ServiceState::Failed)).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "service entered unexpected state 'failed' while waiting for stop"
+        );
+        // "deleted" is not a typed variant, so it arrives through the catch-all.
+        let err =
+            classify_stop_poll_state(Some(&ServiceState::Unknown("deleted".into()))).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "service entered unexpected state 'deleted' while waiting for stop"
+        );
+    }
+
+    #[test]
+    fn resolve_key_create_material_returns_the_generated_pair() {
+        let material =
+            resolve_key_create_material(false, Some("key-id"), Some("key-secret"), Some("ci"))
+                .unwrap();
+        match material {
+            KeyCreateMaterial::Generated { key_id, key_secret } => {
+                assert_eq!(key_id, "key-id");
+                assert_eq!(key_secret, "key-secret");
+            }
+            KeyCreateMaterial::PreHashed => panic!("expected the generated pair"),
+        }
+    }
+
+    #[test]
+    fn resolve_key_create_material_reports_pre_hashed_regardless_of_response() {
+        assert!(matches!(
+            resolve_key_create_material(true, None, None, Some("ci")).unwrap(),
+            KeyCreateMaterial::PreHashed
+        ));
+        // The mode comes from the request, so echoed material does not change it.
+        assert!(matches!(
+            resolve_key_create_material(true, Some("key-id"), None, None).unwrap(),
+            KeyCreateMaterial::PreHashed
+        ));
+    }
+
+    #[test]
+    fn resolve_key_create_material_fails_when_generated_material_is_absent() {
+        let err = resolve_key_create_material(false, None, Some("key-secret"), Some("ci"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("omitted the generated key material"),
+            "unexpected error: {err}"
+        );
+        assert!(err.contains("the key 'ci' may still have been created"));
+
+        // An empty string is material the API did send, so it is not absent.
+        let material = resolve_key_create_material(false, Some(""), Some(""), Some("ci")).unwrap();
+        assert!(matches!(material, KeyCreateMaterial::Generated { .. }));
+
+        // Without a name the message stays grammatical.
+        let err = resolve_key_create_material(false, Some("key-id"), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("the key may still have been created"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -1016,7 +1016,12 @@ pub async fn clickpipe_list(
     } else {
         println!("ClickPipes:");
         for cp in &clickpipes {
-            println!("  {} ({}) - {}", cp.name, cp.id, cp.state);
+            println!(
+                "  {} ({}) - {}",
+                or_absent(cp.name.as_deref()),
+                or_absent(cp.id.as_ref()),
+                or_absent(cp.state.as_ref())
+            );
         }
     }
     Ok(())
@@ -1387,10 +1392,11 @@ pub async fn clickpipe_schema_discover(
         }
         let rows: Vec<Row> = response
             .fields
+            .unwrap_or_default()
             .into_iter()
             .map(|f| Row {
-                name: f.name,
-                r#type: f.r#type,
+                name: or_absent(f.name),
+                r#type: or_absent(f.r#type),
                 optional: match f.optional {
                     Some(true) => "true".to_string(),
                     Some(false) => "false".to_string(),
@@ -1472,7 +1478,9 @@ pub async fn clickpipe_state(
     } else {
         println!(
             "ClickPipe {} {} (state: {})",
-            clickpipe.name, command, clickpipe.state
+            or_absent(clickpipe.name.as_deref()),
+            command,
+            or_absent(clickpipe.state.as_ref())
         );
     }
     Ok(())
@@ -1504,10 +1512,14 @@ pub async fn clickpipe_scale(
     if json {
         println!("{}", serde_json::to_string_pretty(&clickpipe)?);
     } else {
-        println!("ClickPipe {} scaling updated", clickpipe.name);
-        println!("  Replicas: {}", clickpipe.scaling.replicas);
-        println!("  CPU: {}m", clickpipe.scaling.replica_cpu_millicores);
-        println!("  Memory: {} GB", clickpipe.scaling.replica_memory_gb);
+        let scaling = clickpipe.scaling.unwrap_or_default();
+        println!(
+            "ClickPipe {} scaling updated",
+            or_absent(clickpipe.name.as_deref())
+        );
+        println!("  Replicas: {}", or_absent(scaling.replicas));
+        println!("  CPU: {}m", or_absent(scaling.replica_cpu_millicores));
+        println!("  Memory: {} GB", or_absent(scaling.replica_memory_gb));
     }
     Ok(())
 }
@@ -1659,9 +1671,9 @@ fn print_created(
         println!("{}", serde_json::to_string_pretty(clickpipe)?);
     } else {
         println!("ClickPipe created successfully!");
-        println!("  Name: {}", clickpipe.name);
-        println!("  ID: {}", clickpipe.id);
-        println!("  State: {}", clickpipe.state);
+        println!("  Name: {}", or_absent(clickpipe.name.as_deref()));
+        println!("  ID: {}", or_absent(clickpipe.id.as_ref()));
+        println!("  State: {}", or_absent(clickpipe.state.as_ref()));
     }
     Ok(())
 }

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -18,7 +18,11 @@ pub struct Credentials {
 pub struct ServiceQueryKey {
     pub key_id: String,
     pub key_secret: String,
-    pub endpoint_id: String,
+    /// The query endpoint the key is bound to, when the upsert echoed it.
+    /// Recorded for diagnostics only — authentication uses the key pair — so
+    /// an endpoint response that omits `id` still yields a usable record.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endpoint_id: Option<String>,
     pub service_name: String,
     pub created_at: DateTime<Utc>,
 }
@@ -108,7 +112,7 @@ mod tests {
             ServiceQueryKey {
                 key_id: "kid".into(),
                 key_secret: "sec".into(),
-                endpoint_id: "ep".into(),
+                endpoint_id: Some("ep".into()),
                 service_name: "demo".into(),
                 created_at: chrono::DateTime::parse_from_rfc3339("2026-05-11T12:00:00Z")
                     .unwrap()
@@ -121,7 +125,44 @@ mod tests {
         let key = back.service_query_keys.get("svc-1").unwrap();
         assert_eq!(key.key_id, "kid");
         assert_eq!(key.key_secret, "sec");
-        assert_eq!(key.endpoint_id, "ep");
+        assert_eq!(key.endpoint_id.as_deref(), Some("ep"));
         assert_eq!(key.service_name, "demo");
+    }
+
+    #[test]
+    fn stored_key_without_an_endpoint_id_round_trips_with_the_field_omitted() {
+        let mut creds = Credentials::default();
+        creds.service_query_keys.insert(
+            "svc-1".into(),
+            ServiceQueryKey {
+                key_id: "kid".into(),
+                key_secret: "sec".into(),
+                endpoint_id: None,
+                service_name: "demo".into(),
+                created_at: chrono::DateTime::parse_from_rfc3339("2026-05-11T12:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            },
+        );
+
+        let s = serde_json::to_string(&creds).unwrap();
+        assert!(!s.contains("endpoint_id"), "absent means omitted: {s}");
+        let back: Credentials = serde_json::from_str(&s).unwrap();
+        let key = back.service_query_keys.get("svc-1").unwrap();
+        assert_eq!(key.key_id, "kid");
+        assert_eq!(key.key_secret, "sec");
+        assert_eq!(key.endpoint_id, None);
+    }
+
+    #[test]
+    fn existing_credentials_files_with_an_endpoint_id_still_deserialize() {
+        // Files written before `endpoint_id` became optional carry it as a
+        // bare string and must keep loading.
+        let raw = r#"{"service_query_keys":{"svc-1":{"key_id":"kid","key_secret":"sec",
+            "endpoint_id":"ep","service_name":"demo","created_at":"2026-05-11T12:00:00Z"}}}"#;
+        let creds: Credentials = serde_json::from_str(raw).unwrap();
+        let key = creds.service_query_keys.get("svc-1").unwrap();
+        assert_eq!(key.endpoint_id.as_deref(), Some("ep"));
+        assert_eq!(key.key_id, "kid");
     }
 }

--- a/crates/clickhousectl/src/cloud/output.rs
+++ b/crates/clickhousectl/src/cloud/output.rs
@@ -16,6 +16,20 @@ use serde_json::{Map, Value};
 
 const INDENT: &str = "  ";
 
+/// Placeholder for a field the API did not return.
+///
+/// Every field of a response model is `Option<T>`, so absence is a normal
+/// outcome rather than an error: list tables and plain output render it as this
+/// placeholder instead of unwrapping or fabricating a value.
+pub(crate) const ABSENT: &str = "-";
+
+/// Renders an absent (`None`) response field as [`ABSENT`].
+pub(crate) fn or_absent<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| ABSENT.to_string())
+}
+
 /// Serialize `value` and print it as an indented, human-readable tree.
 ///
 /// - Object keys are printed verbatim (camelCase, as the API returns them).

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,6 +1,7 @@
 use crate::cloud::cli::parse_datetime;
 use crate::cloud::client::CloudClient;
 use crate::cloud::commands::{parse_serde_enum, parse_tags, resolve_org_id};
+use crate::cloud::output::{ABSENT, or_absent};
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
     ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgProvider, PgVersion,
@@ -378,16 +379,6 @@ fn apply_filter(item: &PostgresServiceListItem, filters: &[String]) -> bool {
     true
 }
 
-/// Placeholder for a field the API did not return.
-const ABSENT: &str = "-";
-
-/// Renders an absent (`None`) response field as [`ABSENT`].
-fn or_absent<T: std::fmt::Display>(value: Option<T>) -> String {
-    value
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| ABSENT.to_string())
-}
-
 fn state_label(s: Option<&clickhouse_cloud_api::models::PgStateProperty>) -> String {
     match s {
         Some(s) => serde_json::to_value(s)
@@ -431,9 +422,9 @@ fn render_postgres_service(svc: &PostgresService) {
     if let Some(svc_tags) = svc.tags.as_ref().filter(|t| !t.is_empty()) {
         let tags: Vec<String> = svc_tags
             .iter()
-            .map(|t| match &t.value {
-                Some(v) => format!("{}={}", t.key, v),
-                None => t.key.clone(),
+            .map(|t| match (t.key.as_deref(), t.value.as_deref()) {
+                (key, Some(value)) => format!("{}={}", or_absent(key), value),
+                (key, None) => or_absent(key).to_string(),
             })
             .collect();
         println!("  Tags: {}", tags.join(", "));
@@ -688,12 +679,16 @@ pub async fn postgres_update(
             .map_err(|e| client.convert_error(e))?;
         let current = unwrap_api(current)?;
         let add = parse_tags(opts.add_tag)?.unwrap_or_default();
-        // An omitted `tags` in the response means "no tags to merge with".
-        Some(merge_tags(
-            &current.tags.unwrap_or_default(),
-            &add,
-            opts.remove_tag,
-        ))
+        // An omitted `tags` in the response means "no tags to merge with"; a
+        // returned tag without a key cannot be sent back, so say so rather
+        // than dropping it from the merged set.
+        let existing = current
+            .tags
+            .unwrap_or_default()
+            .into_iter()
+            .map(ResourceTagsV1::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Some(merge_tags(&existing, &add, opts.remove_tag))
     } else {
         None
     };

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -4,7 +4,7 @@ use crate::cloud::commands::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::output::{ABSENT, or_absent};
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
-    ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgProvider, PgVersion,
+    ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgIdProperty, PgProvider, PgVersion,
     PostgresInstanceConfig, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
     PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
     PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
@@ -620,6 +620,38 @@ pub async fn postgres_get(
     Ok(())
 }
 
+/// The post-create credentials block, or the warning that replaces it.
+///
+/// The password is returned once, so a placeholder in its place would be read
+/// as the credential itself. An absent password therefore gets the omission
+/// plus the command that mints a usable one; the create succeeded and the
+/// password is recoverable, so this is a warning rather than an error. An empty
+/// string is a password the API sent.
+fn postgres_credentials_block(
+    username: Option<&str>,
+    password: Option<&str>,
+    postgres_id: Option<&PgIdProperty>,
+) -> String {
+    match (password, postgres_id) {
+        (Some(password), _) => format!(
+            "Credentials (save these — password shown only once):\n  Username: {}\n  Password: {}",
+            or_absent(username),
+            password
+        ),
+        (None, Some(id)) => format!(
+            "WARNING: the API response omitted the one-time password, so it cannot be shown.\n\
+             The service was created; reset the password to get a usable credential:\n  \
+             clickhousectl cloud postgres reset-password {} --generate",
+            id
+        ),
+        (None, None) => "WARNING: the API response omitted the one-time password, so it cannot be \
+                         shown.\nThe service was created; once you have its id, reset the password \
+                         with `clickhousectl cloud postgres reset-password <postgres-id> \
+                         --generate` to get a usable credential."
+            .to_string(),
+    }
+}
+
 pub async fn postgres_create(
     client: &CloudClient,
     opts: PostgresCreateOptions<'_>,
@@ -673,9 +705,14 @@ pub async fn postgres_create(
         println!();
         render_postgres_service(&svc);
         println!();
-        println!("Credentials (save these — password shown only once):");
-        println!("  Username: {}", or_absent(svc.username.as_deref()));
-        println!("  Password: {}", or_absent(svc.password.as_deref()));
+        println!(
+            "{}",
+            postgres_credentials_block(
+                svc.username.as_deref(),
+                svc.password.as_deref(),
+                svc.id.as_ref()
+            )
+        );
         if let Some(conn) = svc
             .connection_string
             .as_deref()
@@ -1692,6 +1729,57 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("key"), "unexpected error: {err}");
+    }
+
+    fn pg_test_id() -> PgIdProperty {
+        PgIdProperty::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6").unwrap()
+    }
+
+    #[test]
+    fn postgres_credentials_block_shows_the_password_the_api_sent() {
+        assert_eq!(
+            postgres_credentials_block(Some("pg_user"), Some("s3cret"), Some(&pg_test_id())),
+            "Credentials (save these — password shown only once):\n  Username: pg_user\n  \
+             Password: s3cret"
+        );
+    }
+
+    #[test]
+    fn postgres_credentials_block_treats_an_empty_password_as_sent() {
+        assert_eq!(
+            postgres_credentials_block(None, Some(""), None),
+            format!(
+                "Credentials (save these — password shown only once):\n  Username: {ABSENT}\n  \
+                 Password: "
+            )
+        );
+    }
+
+    #[test]
+    fn postgres_credentials_block_warns_with_the_reset_command_when_the_password_is_absent() {
+        let block = postgres_credentials_block(Some("pg_user"), None, Some(&pg_test_id()));
+        assert!(
+            !block.contains(&format!("Password: {ABSENT}")),
+            "an absent password must not render a placeholder credential: {block}"
+        );
+        assert!(block.starts_with("WARNING: the API response omitted the one-time password"));
+        assert!(
+            block.contains(
+                "clickhousectl cloud postgres reset-password \
+                 a1a2a3a4-b1b2-c1c2-d1d2-e1e2e3e4e5e6 --generate"
+            ),
+            "the warning should name the exact recovery command: {block}"
+        );
+    }
+
+    #[test]
+    fn postgres_credentials_block_warns_generically_when_the_service_id_is_absent() {
+        let block = postgres_credentials_block(Some("pg_user"), None, None);
+        assert!(block.starts_with("WARNING: the API response omitted the one-time password"));
+        assert!(
+            block.contains("clickhousectl cloud postgres reset-password <postgres-id> --generate"),
+            "without an id the warning should stay generic: {block}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -267,14 +267,21 @@ fn load_json_file<T: DeserializeOwned>(path: &Path) -> Result<T, Box<dyn std::er
 
 /// Builds the `postgres config` write body from a user-supplied JSON document.
 ///
+/// The document root must be a JSON object; anything else (a scalar, an array,
+/// `null`) is rejected rather than read as "no sections", which would send an
+/// empty body and reset the configuration.
+///
 /// The API rejects a body that omits either `pgConfig` or `pgBouncerConfig`, and
-/// the request model is strict (no serde defaults), so an omitted key resolves
-/// to an empty object here — explicitly, at the point of use.
+/// the request model is strict (no serde defaults), so an omitted key of an
+/// object root resolves to an empty object here — explicitly, at the point of use.
 fn instance_config_from_json(
     doc: &serde_json::Value,
 ) -> Result<PostgresInstanceConfig, Box<dyn std::error::Error>> {
+    let root = doc
+        .as_object()
+        .ok_or("configuration document must be a JSON object")?;
     let section = |key: &str| {
-        doc.get(key)
+        root.get(key)
             .cloned()
             .unwrap_or_else(|| serde_json::json!({}))
     };
@@ -1707,6 +1714,34 @@ mod tests {
             serde_json::to_value(&empty).unwrap(),
             serde_json::json!({ "pgConfig": {}, "pgBouncerConfig": {} })
         );
+    }
+
+    #[test]
+    fn instance_config_from_json_accepts_both_sections() {
+        let cfg = instance_config_from_json(&serde_json::json!({
+            "pgConfig": { "max_connections": 500, "work_mem": "64MB" },
+            "pgBouncerConfig": {},
+        }))
+        .unwrap();
+        assert_eq!(cfg.pg_config.max_connections, Some(serde_json::json!(500)));
+        assert_eq!(cfg.pg_config.work_mem, Some(serde_json::json!("64MB")));
+        assert_eq!(cfg.pg_bouncer_config, PgBouncerConfig::default());
+    }
+
+    #[test]
+    fn instance_config_from_json_refuses_a_non_object_root() {
+        // A non-object root must not read as "no sections": that would send
+        // `{"pgConfig": {}, "pgBouncerConfig": {}}` and reset the config.
+        for root in [
+            serde_json::Value::Null,
+            serde_json::json!([{ "pgConfig": {} }]),
+            serde_json::json!("pgConfig"),
+            serde_json::json!(7),
+            serde_json::json!(true),
+        ] {
+            let err = instance_config_from_json(&root).unwrap_err().to_string();
+            assert_eq!(err, "configuration document must be a JSON object");
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -3,8 +3,8 @@ use crate::cloud::client::CloudClient;
 use crate::cloud::commands::{parse_serde_enum, parse_tags, resolve_org_id};
 use clap::Subcommand;
 use clickhouse_cloud_api::models::{
-    ApiResponse, PgConfig, PgHaType, PgProvider, PgVersion, PostgresInstanceConfig,
-    PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
+    ApiResponse, PgBouncerConfig, PgConfig, PgHaType, PgProvider, PgVersion,
+    PostgresInstanceConfig, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
     PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
     PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
     ResourceTagsV1,
@@ -264,6 +264,27 @@ fn load_json_file<T: DeserializeOwned>(path: &Path) -> Result<T, Box<dyn std::er
         .map_err(|e| format!("failed to parse {} as JSON: {}", path.display(), e).into())
 }
 
+/// Builds the `postgres config` write body from a user-supplied JSON document.
+///
+/// The API rejects a body that omits either `pgConfig` or `pgBouncerConfig`, and
+/// the request model is strict (no serde defaults), so an omitted key resolves
+/// to an empty object here — explicitly, at the point of use.
+fn instance_config_from_json(
+    doc: &serde_json::Value,
+) -> Result<PostgresInstanceConfig, Box<dyn std::error::Error>> {
+    let section = |key: &str| {
+        doc.get(key)
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}))
+    };
+    Ok(PostgresInstanceConfig {
+        pg_config: serde_json::from_value(section("pgConfig"))
+            .map_err(|e| format!("invalid pgConfig: {}", e))?,
+        pg_bouncer_config: serde_json::from_value(section("pgBouncerConfig"))
+            .map_err(|e| format!("invalid pgBouncerConfig: {}", e))?,
+    })
+}
+
 /// Parse `--set key=value` overrides into a JSON object.
 ///
 /// Each value is parsed as JSON first (so `max_connections=500` becomes a number),
@@ -336,11 +357,18 @@ fn apply_filter(item: &PostgresServiceListItem, filters: &[String]) -> bool {
         let Some((key, val)) = filter.split_once('=') else {
             continue;
         };
+        // A response field the API omitted matches no filter value.
         let matches = match key.trim() {
-            "state" => format!("{:?}", item.state).eq_ignore_ascii_case(val),
-            "region" => item.region == val,
-            "name" => item.name == val,
-            "provider" => format!("{:?}", item.provider).eq_ignore_ascii_case(val),
+            "state" => item
+                .state
+                .as_ref()
+                .is_some_and(|s| format!("{:?}", s).eq_ignore_ascii_case(val)),
+            "region" => item.region.as_deref() == Some(val),
+            "name" => item.name.as_deref() == Some(val),
+            "provider" => item
+                .provider
+                .as_ref()
+                .is_some_and(|p| format!("{:?}", p).eq_ignore_ascii_case(val)),
             _ => true,
         };
         if !matches {
@@ -350,37 +378,58 @@ fn apply_filter(item: &PostgresServiceListItem, filters: &[String]) -> bool {
     true
 }
 
-fn state_label(s: &clickhouse_cloud_api::models::PgStateProperty) -> String {
-    serde_json::to_value(s)
-        .ok()
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .unwrap_or_else(|| format!("{:?}", s))
+/// Placeholder for a field the API did not return.
+const ABSENT: &str = "-";
+
+/// Renders an absent (`None`) response field as [`ABSENT`].
+fn or_absent<T: std::fmt::Display>(value: Option<T>) -> String {
+    value
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| ABSENT.to_string())
 }
 
-fn enum_label<T: serde::Serialize>(v: &T) -> String {
-    serde_json::to_value(v)
-        .ok()
-        .and_then(|v| v.as_str().map(|s| s.to_string()))
-        .unwrap_or_default()
+fn state_label(s: Option<&clickhouse_cloud_api::models::PgStateProperty>) -> String {
+    match s {
+        Some(s) => serde_json::to_value(s)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_else(|| format!("{:?}", s)),
+        None => ABSENT.to_string(),
+    }
+}
+
+fn enum_label<T: serde::Serialize>(v: Option<&T>) -> String {
+    match v {
+        Some(v) => serde_json::to_value(v)
+            .ok()
+            .and_then(|v| v.as_str().map(|s| s.to_string()))
+            .unwrap_or_default(),
+        None => ABSENT.to_string(),
+    }
 }
 
 fn render_postgres_service(svc: &PostgresService) {
-    println!("  ID: {}", svc.id);
-    println!("  Name: {}", svc.name);
-    println!("  State: {}", state_label(&svc.state));
-    println!("  Provider: {}", enum_label(&svc.provider));
-    println!("  Region: {}", svc.region);
-    println!("  Size: {}", enum_label(&svc.size));
-    println!("  Storage (GB): {}", svc.storage_size);
-    println!("  PG version: {}", enum_label(&svc.postgres_version));
-    println!("  HA type: {}", enum_label(&svc.ha_type));
-    println!("  Primary: {}", svc.is_primary);
-    println!("  Host: {}", svc.hostname);
-    println!("  Username: {}", svc.username);
-    println!("  Created: {}", svc.created_at.to_rfc3339());
-    if !svc.tags.is_empty() {
-        let tags: Vec<String> = svc
-            .tags
+    println!("  ID: {}", or_absent(svc.id.as_ref()));
+    println!("  Name: {}", or_absent(svc.name.as_deref()));
+    println!("  State: {}", state_label(svc.state.as_ref()));
+    println!("  Provider: {}", enum_label(svc.provider.as_ref()));
+    println!("  Region: {}", or_absent(svc.region.as_deref()));
+    println!("  Size: {}", enum_label(svc.size.as_ref()));
+    println!("  Storage (GB): {}", or_absent(svc.storage_size));
+    println!(
+        "  PG version: {}",
+        enum_label(svc.postgres_version.as_ref())
+    );
+    println!("  HA type: {}", enum_label(svc.ha_type.as_ref()));
+    println!("  Primary: {}", or_absent(svc.is_primary));
+    println!("  Host: {}", or_absent(svc.hostname.as_deref()));
+    println!("  Username: {}", or_absent(svc.username.as_deref()));
+    println!(
+        "  Created: {}",
+        or_absent(svc.created_at.map(|c| c.to_rfc3339()))
+    );
+    if let Some(svc_tags) = svc.tags.as_ref().filter(|t| !t.is_empty()) {
+        let tags: Vec<String> = svc_tags
             .iter()
             .map(|t| match &t.value {
                 Some(v) => format!("{}={}", t.key, v),
@@ -505,14 +554,18 @@ pub async fn postgres_list(
     let rows: Vec<Row> = filtered
         .into_iter()
         .map(|i| Row {
-            name: i.name.clone(),
-            id: i.id.to_string(),
-            state: state_label(&i.state),
-            region: i.region.clone(),
-            size: enum_label(&i.size),
-            pg: enum_label(&i.postgres_version),
-            ha: enum_label(&i.ha_type),
-            primary: if i.is_primary { "yes" } else { "no" }.to_string(),
+            name: or_absent(i.name.as_deref()),
+            id: or_absent(i.id.as_ref()),
+            state: state_label(i.state.as_ref()),
+            region: or_absent(i.region.as_deref()),
+            size: enum_label(i.size.as_ref()),
+            pg: enum_label(i.postgres_version.as_ref()),
+            ha: enum_label(i.ha_type.as_ref()),
+            primary: match i.is_primary {
+                Some(true) => "yes".to_string(),
+                Some(false) => "no".to_string(),
+                None => ABSENT.to_string(),
+            },
         })
         .collect();
 
@@ -569,7 +622,7 @@ pub async fn postgres_create(
         .transpose()?;
     let pg_bouncer_config = opts
         .pg_bouncer_config_file
-        .map(load_json_file::<clickhouse_cloud_api::models::PgBouncerConfig>)
+        .map(load_json_file::<PgBouncerConfig>)
         .transpose()?;
 
     let req = PostgresServicePostRequest {
@@ -599,10 +652,14 @@ pub async fn postgres_create(
         render_postgres_service(&svc);
         println!();
         println!("Credentials (save these — password shown only once):");
-        println!("  Username: {}", svc.username);
-        println!("  Password: {}", svc.password);
-        if !svc.connection_string.is_empty() {
-            println!("  Connection string: {}", svc.connection_string);
+        println!("  Username: {}", or_absent(svc.username.as_deref()));
+        println!("  Password: {}", or_absent(svc.password.as_deref()));
+        if let Some(conn) = svc
+            .connection_string
+            .as_deref()
+            .filter(|conn| !conn.is_empty())
+        {
+            println!("  Connection string: {}", conn);
         }
     }
     Ok(())
@@ -631,7 +688,12 @@ pub async fn postgres_update(
             .map_err(|e| client.convert_error(e))?;
         let current = unwrap_api(current)?;
         let add = parse_tags(opts.add_tag)?.unwrap_or_default();
-        Some(merge_tags(&current.tags, &add, opts.remove_tag))
+        // An omitted `tags` in the response means "no tags to merge with".
+        Some(merge_tags(
+            &current.tags.unwrap_or_default(),
+            &add,
+            opts.remove_tag,
+        ))
     } else {
         None
     };
@@ -750,7 +812,7 @@ pub async fn postgres_config_replace(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let cfg: PostgresInstanceConfig = load_json_file(file)?;
+    let cfg = instance_config_from_json(&load_json_file::<serde_json::Value>(file)?)?;
     let resp = client
         .api()
         .postgres_instance_config_post(&org_id, postgres_id, &cfg)
@@ -783,19 +845,16 @@ pub async fn postgres_config_patch(
         return Err("provide --set key=value... or --file PATH".into());
     }
 
-    let cfg: PostgresInstanceConfig = if let Some(path) = file {
-        load_json_file(path)?
+    let cfg = if let Some(path) = file {
+        instance_config_from_json(&load_json_file::<serde_json::Value>(path)?)?
     } else {
-        // Build a PostgresInstanceConfig from --set entries by constructing
-        // a JSON object { "pgConfig": { ... overrides ... }, "pgBouncerConfig": {} }
-        // and deserializing, which merges with #[serde(default)] field defaults.
+        // Build the request body from --set entries: the overrides become the
+        // pgConfig object, and pgBouncerConfig resolves to `{}`.
         let overrides = parse_pg_config_overrides(sets)?;
-        let wrapper = serde_json::json!({
+        instance_config_from_json(&serde_json::json!({
             "pgConfig": serde_json::Value::Object(overrides),
-            "pgBouncerConfig": {},
-        });
-        serde_json::from_value(wrapper)
-            .map_err(|e| format!("failed to build config from --set entries: {}", e))?
+        }))
+        .map_err(|e| format!("failed to build config from --set entries: {}", e))?
     };
 
     let resp = client
@@ -845,14 +904,15 @@ pub async fn postgres_reset_password(
         .await
         .map_err(|e| client.convert_error(e))?;
     let out = unwrap_api(resp)?;
+    // Emit what the user now needs to use: the API echoes the password back, but
+    // fall back to the one we sent if the response omits it.
+    let password = out.password.unwrap_or(pw);
 
     if json {
-        // Return the password that was set (the API also echoes it back, but always
-        // emit what the user now needs to use).
         println!(
             "{}",
             serde_json::to_string_pretty(&serde_json::json!({
-                "password": out.password,
+                "password": password,
             }))?
         );
     } else {
@@ -860,7 +920,7 @@ pub async fn postgres_reset_password(
         if generate {
             println!();
             println!("Generated password (save this — not recoverable):");
-            println!("  {}", out.password);
+            println!("  {}", password);
         }
     }
     Ok(())
@@ -880,7 +940,7 @@ pub async fn postgres_read_replica_create(
         .transpose()?;
     let pg_bouncer_config = opts
         .pg_bouncer_config_file
-        .map(load_json_file::<clickhouse_cloud_api::models::PgBouncerConfig>)
+        .map(load_json_file::<PgBouncerConfig>)
         .transpose()?;
 
     let req = PostgresServiceReadReplicaRequest {
@@ -921,7 +981,7 @@ pub async fn postgres_restore(
         .transpose()?;
     let pg_bouncer_config = opts
         .pg_bouncer_config_file
-        .map(load_json_file::<clickhouse_cloud_api::models::PgBouncerConfig>)
+        .map(load_json_file::<PgBouncerConfig>)
         .transpose()?;
     let restore_target = chrono::DateTime::parse_from_rfc3339(opts.restore_target)
         .map_err(|e| format!("invalid restore-target: {}", e))?
@@ -1557,5 +1617,60 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].key, "env");
         assert_eq!(out[0].value.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn instance_config_from_json_fills_omitted_sections() {
+        // The request model is strict, so the handler resolves an omitted
+        // section to `{}` — the minimal body the API accepts.
+        let cfg = instance_config_from_json(&serde_json::json!({
+            "pgConfig": { "max_connections": 500 },
+        }))
+        .unwrap();
+        assert_eq!(cfg.pg_config.max_connections, Some(serde_json::json!(500)));
+        assert_eq!(cfg.pg_bouncer_config, PgBouncerConfig::default());
+        assert_eq!(
+            serde_json::to_value(&cfg).unwrap(),
+            serde_json::json!({ "pgConfig": { "max_connections": 500 }, "pgBouncerConfig": {} })
+        );
+
+        let empty = instance_config_from_json(&serde_json::json!({})).unwrap();
+        assert_eq!(
+            serde_json::to_value(&empty).unwrap(),
+            serde_json::json!({ "pgConfig": {}, "pgBouncerConfig": {} })
+        );
+    }
+
+    #[test]
+    fn instance_config_from_json_reports_an_invalid_section() {
+        let err = instance_config_from_json(&serde_json::json!({ "pgConfig": 7 }))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid pgConfig"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn absent_response_fields_render_as_a_dash() {
+        let item = PostgresServiceListItem::default();
+        assert_eq!(or_absent(item.name.as_deref()), ABSENT);
+        assert_eq!(state_label(item.state.as_ref()), ABSENT);
+        assert_eq!(enum_label(item.size.as_ref()), ABSENT);
+    }
+
+    #[test]
+    fn apply_filter_does_not_match_absent_response_fields() {
+        let absent = PostgresServiceListItem::default();
+        assert!(!apply_filter(&absent, &["region=us-east-1".to_string()]));
+        assert!(!apply_filter(&absent, &["state=running".to_string()]));
+        // An unknown filter key stays permissive, as before.
+        assert!(apply_filter(&absent, &["bogus=1".to_string()]));
+
+        let present = PostgresServiceListItem {
+            region: Some("us-east-1".to_string()),
+            state: Some(clickhouse_cloud_api::models::PgStateProperty::Running),
+            ..Default::default()
+        };
+        assert!(apply_filter(&present, &["region=us-east-1".to_string()]));
+        assert!(apply_filter(&present, &["state=running".to_string()]));
     }
 }

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -627,27 +627,37 @@ pub async fn postgres_get(
 /// plus the command that mints a usable one; the create succeeded and the
 /// password is recoverable, so this is a warning rather than an error. An empty
 /// string is a password the API sent.
+///
+/// `connection_string` is the non-empty connection string the same response
+/// carried, if any: the spec says it embeds the service password, so when it is
+/// present the credential is not actually lost and telling the user to reset
+/// would rotate a working password for nothing.
 fn postgres_credentials_block(
     username: Option<&str>,
     password: Option<&str>,
+    connection_string: Option<&str>,
     postgres_id: Option<&PgIdProperty>,
 ) -> String {
-    match (password, postgres_id) {
-        (Some(password), _) => format!(
+    match (password, connection_string, postgres_id) {
+        (Some(password), _, _) => format!(
             "Credentials (save these — password shown only once):\n  Username: {}\n  Password: {}",
             or_absent(username),
             password
         ),
-        (None, Some(id)) => format!(
+        (None, Some(_), _) => "WARNING: the API response omitted the `password` field, so the \
+                               password cannot be shown on its own.\nThe connection string below \
+                               embeds it, so no password reset is needed."
+            .to_string(),
+        (None, None, Some(id)) => format!(
             "WARNING: the API response omitted the one-time password, so it cannot be shown.\n\
              The service was created; reset the password to get a usable credential:\n  \
              clickhousectl cloud postgres reset-password {} --generate",
             id
         ),
-        (None, None) => "WARNING: the API response omitted the one-time password, so it cannot be \
-                         shown.\nThe service was created; once you have its id, reset the password \
-                         with `clickhousectl cloud postgres reset-password <postgres-id> \
-                         --generate` to get a usable credential."
+        (None, None, None) => "WARNING: the API response omitted the one-time password, so it \
+                               cannot be shown.\nThe service was created; once you have its id, \
+                               reset the password with `clickhousectl cloud postgres \
+                               reset-password <postgres-id> --generate` to get a usable credential."
             .to_string(),
     }
 }
@@ -705,19 +715,20 @@ pub async fn postgres_create(
         println!();
         render_postgres_service(&svc);
         println!();
+        let connection_string = svc
+            .connection_string
+            .as_deref()
+            .filter(|conn| !conn.is_empty());
         println!(
             "{}",
             postgres_credentials_block(
                 svc.username.as_deref(),
                 svc.password.as_deref(),
+                connection_string,
                 svc.id.as_ref()
             )
         );
-        if let Some(conn) = svc
-            .connection_string
-            .as_deref()
-            .filter(|conn| !conn.is_empty())
-        {
+        if let Some(conn) = connection_string {
             println!("  Connection string: {}", conn);
         }
     }
@@ -1738,7 +1749,7 @@ mod tests {
     #[test]
     fn postgres_credentials_block_shows_the_password_the_api_sent() {
         assert_eq!(
-            postgres_credentials_block(Some("pg_user"), Some("s3cret"), Some(&pg_test_id())),
+            postgres_credentials_block(Some("pg_user"), Some("s3cret"), None, Some(&pg_test_id())),
             "Credentials (save these — password shown only once):\n  Username: pg_user\n  \
              Password: s3cret"
         );
@@ -1747,7 +1758,7 @@ mod tests {
     #[test]
     fn postgres_credentials_block_treats_an_empty_password_as_sent() {
         assert_eq!(
-            postgres_credentials_block(None, Some(""), None),
+            postgres_credentials_block(None, Some(""), None, None),
             format!(
                 "Credentials (save these — password shown only once):\n  Username: {ABSENT}\n  \
                  Password: "
@@ -1756,8 +1767,28 @@ mod tests {
     }
 
     #[test]
+    fn postgres_credentials_block_points_at_the_connection_string_instead_of_a_reset() {
+        // The connection string embeds the password, so the credential isn't
+        // lost and a reset would rotate a working password for nothing.
+        let block = postgres_credentials_block(
+            Some("pg_user"),
+            None,
+            Some("postgresql://pg_user:s3cret@host:5432/postgres"),
+            Some(&pg_test_id()),
+        );
+        assert!(
+            !block.contains("reset-password"),
+            "a recoverable password must not be reset: {block}"
+        );
+        assert!(
+            block.contains("connection string below embeds it"),
+            "the warning should point at the connection string: {block}"
+        );
+    }
+
+    #[test]
     fn postgres_credentials_block_warns_with_the_reset_command_when_the_password_is_absent() {
-        let block = postgres_credentials_block(Some("pg_user"), None, Some(&pg_test_id()));
+        let block = postgres_credentials_block(Some("pg_user"), None, None, Some(&pg_test_id()));
         assert!(
             !block.contains(&format!("Password: {ABSENT}")),
             "an absent password must not render a placeholder credential: {block}"
@@ -1774,7 +1805,7 @@ mod tests {
 
     #[test]
     fn postgres_credentials_block_warns_generically_when_the_service_id_is_absent() {
-        let block = postgres_credentials_block(Some("pg_user"), None, None);
+        let block = postgres_credentials_block(Some("pg_user"), None, None, None);
         assert!(block.starts_with("WARNING: the API response omitted the one-time password"));
         assert!(
             block.contains("clickhousectl cloud postgres reset-password <postgres-id> --generate"),

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -8,7 +8,7 @@ use clickhouse_cloud_api::models::{
     PostgresInstanceConfig, PostgresService, PostgresServiceListItem, PostgresServicePatchRequest,
     PostgresServicePostRequest, PostgresServiceReadReplicaRequest, PostgresServiceRestoreRequest,
     PostgresServiceSetPassword, PostgresServiceSetState, PostgresServiceSetStateCommand,
-    ResourceTagsV1,
+    ResourceTagsV1, ResourceTagsV1Response,
 };
 use serde::de::DeserializeOwned;
 use std::path::{Path, PathBuf};
@@ -448,6 +448,30 @@ fn merge_tags(
     merged
 }
 
+/// Merges `--add-tag`/`--remove-tag` against the tag list a GET returned.
+///
+/// An omitted `tags` in the response is indistinguishable from a field the API
+/// dropped, so a read-modify-write must not proceed on it: `tags` is replaced
+/// wholesale by the PATCH, so merging against an assumed empty set would delete
+/// every tag the service still has. A returned tag without a key cannot be sent
+/// back either, so say so rather than dropping it from the merged set.
+fn merge_response_tags(
+    current: Option<Vec<ResourceTagsV1Response>>,
+    add: &[ResourceTagsV1],
+    remove_keys: &[String],
+) -> Result<Vec<ResourceTagsV1>, Box<dyn std::error::Error>> {
+    let current = current.ok_or(
+        "the API response omitted the tags field, so --add-tag/--remove-tag cannot be merged \
+         safely: an update replaces the tag set wholesale, and merging against an assumed empty \
+         set would delete any tags the service already has",
+    )?;
+    let existing = current
+        .into_iter()
+        .map(ResourceTagsV1::try_from)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(merge_tags(&existing, add, remove_keys))
+}
+
 // ---------------------------------------------------------------------------
 // Option structs (for commands with many args)
 // ---------------------------------------------------------------------------
@@ -679,16 +703,7 @@ pub async fn postgres_update(
             .map_err(|e| client.convert_error(e))?;
         let current = unwrap_api(current)?;
         let add = parse_tags(opts.add_tag)?.unwrap_or_default();
-        // An omitted `tags` in the response means "no tags to merge with"; a
-        // returned tag without a key cannot be sent back, so say so rather
-        // than dropping it from the merged set.
-        let existing = current
-            .tags
-            .unwrap_or_default()
-            .into_iter()
-            .map(ResourceTagsV1::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
-        Some(merge_tags(&existing, &add, opts.remove_tag))
+        Some(merge_response_tags(current.tags, &add, opts.remove_tag)?)
     } else {
         None
     };
@@ -1612,6 +1627,64 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].key, "env");
         assert_eq!(out[0].value.as_deref(), Some("prod"));
+    }
+
+    #[test]
+    fn merge_response_tags_refuses_absent_tags() {
+        let add = vec![ResourceTagsV1 {
+            key: "env".into(),
+            value: Some("prod".into()),
+        }];
+        let err = merge_response_tags(None, &add, &[])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("omitted the tags field"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn merge_response_tags_merges_an_empty_tag_list() {
+        // `Some(vec![])` is the API saying "no tags", which is safe to merge on.
+        let add = vec![ResourceTagsV1 {
+            key: "env".into(),
+            value: Some("prod".into()),
+        }];
+        let out = merge_response_tags(Some(vec![]), &add, &[]).unwrap();
+        assert_eq!(out, add);
+    }
+
+    #[test]
+    fn merge_response_tags_merges_returned_tags() {
+        let current = vec![
+            ResourceTagsV1Response {
+                key: Some("env".into()),
+                value: Some("dev".into()),
+            },
+            ResourceTagsV1Response {
+                key: Some("team".into()),
+                value: Some("data".into()),
+            },
+        ];
+        let add = vec![ResourceTagsV1 {
+            key: "env".into(),
+            value: Some("prod".into()),
+        }];
+        let out = merge_response_tags(Some(current), &add, &["team".to_string()]).unwrap();
+        assert_eq!(out, add);
+    }
+
+    #[test]
+    fn merge_response_tags_refuses_a_returned_tag_without_a_key() {
+        let current = vec![ResourceTagsV1Response {
+            key: None,
+            value: Some("dev".into()),
+        }];
+        let err = merge_response_tags(Some(current), &[], &[])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("key"), "unexpected error: {err}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -25,6 +25,11 @@ const QUERY_ENDPOINT_ROLE: &str = "sql_console_admin";
 /// caller so CORS doesn't apply, but the API still requires a value.
 const ALLOWED_ORIGINS: &str = "*";
 
+/// Requires a response field the provisioning flow cannot proceed without.
+fn require_field<T>(value: Option<T>, field: &str) -> Result<T, Box<dyn std::error::Error>> {
+    value.ok_or_else(|| format!("the API response is missing required field '{field}'").into())
+}
+
 /// Ensure a query endpoint is provisioned for `service_id` and return the
 /// persisted key. If a key is already cached locally, returns it unchanged;
 /// otherwise creates the API key, binds it to the query endpoint (merging
@@ -57,13 +62,17 @@ pub async fn ensure_service_query_setup(
     };
 
     let key_response = client.create_api_key(org_id, &key_request).await?;
-    let key_id = key_response.key_id.clone();
-    let key_secret = key_response.key_secret.clone();
+    // Every response field is `Option<T>`, and an absent credential cannot be
+    // substituted with a placeholder: fail loudly instead of persisting an
+    // empty key pair that every later query would reject.
+    let key_id = require_field(key_response.key_id.clone(), "keyId")?;
+    let key_secret = require_field(key_response.key_secret.clone(), "keySecret")?;
     // `key_id`/`key_secret` are the credential pair used for query auth.
     // The endpoint binding's `openApiKeys` array, by contrast, references
     // API keys by their resource UUID — the same value the management
     // endpoints (GET/DELETE /v1/.../keys/{keyId}) accept.
-    let api_key_uuid = key_response.key.id.to_string();
+    let api_key_uuid =
+        require_field(key_response.key.and_then(|key| key.id), "key.id")?.to_string();
 
     let endpoint = match bind_query_endpoint(client, org_id, service_id, &api_key_uuid).await {
         Ok(endpoint) => endpoint,
@@ -79,7 +88,7 @@ pub async fn ensure_service_query_setup(
     let stored = ServiceQueryKey {
         key_id,
         key_secret,
-        endpoint_id: endpoint.id,
+        endpoint_id: require_field(endpoint.id, "id")?,
         service_name: service_name.to_string(),
         created_at: Utc::now(),
     };
@@ -102,7 +111,10 @@ async fn bind_query_endpoint(
         .instance_query_endpoint_get(org_id, service_id)
         .await
     {
-        Ok(resp) => resp.result.map(|ep| ep.open_api_keys).unwrap_or_default(),
+        Ok(resp) => resp
+            .result
+            .and_then(|ep| ep.open_api_keys)
+            .unwrap_or_default(),
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Vec::new(),
         Err(e) => return Err(client.convert_error(e).into()),
     };

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -114,22 +114,14 @@ pub async fn ensure_service_query_setup(
         }
     };
 
-    let endpoint_id = match require_field(endpoint.id, "id") {
-        Ok(id) => id,
-        Err(e) => {
-            // The binding took effect but we can't persist it, so the key
-            // is again unusable. Discarding it leaves a dangling UUID in the
-            // endpoint's `openApiKeys`, which is harmless — a retry merges a
-            // fresh key into the same endpoint (see `bind_query_endpoint`).
-            discard_api_key(client, org_id, &api_key_uuid).await;
-            return Err(e);
-        }
-    };
-
+    // The upsert succeeded, so the key is bound and fully usable. The echoed
+    // `id` is diagnostic only, never an auth input: persist the record
+    // without it rather than deleting a working credential and leaving a
+    // dangling UUID in the endpoint's `openApiKeys`.
     let stored = ServiceQueryKey {
         key_id,
         key_secret,
-        endpoint_id,
+        endpoint_id: endpoint.id,
         service_name: service_name.to_string(),
         created_at: Utc::now(),
     };

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -151,9 +151,10 @@ fn existing_open_api_keys(
         .ok_or_else(|| incomplete("openApiKeys"))
 }
 
-/// Bind `api_key_uuid` to the service's query endpoint, merging into any
-/// existing endpoint configuration so we don't silently revoke other
-/// bindings the user set up.
+/// Bind `api_key_uuid` to the service's query endpoint, merging into the
+/// endpoint's existing `openApiKeys` so we don't silently revoke other
+/// key bindings the user set up. Only the key list is merged: the upsert
+/// still replaces `roles` and `allowedOrigins` with this module's values.
 async fn bind_query_endpoint(
     client: &CloudClient,
     org_id: &str,

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -138,6 +138,27 @@ pub async fn ensure_service_query_setup(
     Ok(stored)
 }
 
+/// The keys already bound to an existing query endpoint, taken from a
+/// successful GET. The upsert replaces `openApiKeys` wholesale, so an absent
+/// `result` or absent `openApiKeys` cannot be read as "no keys bound": merging
+/// into an empty list would revoke every binding the response failed to
+/// report. An explicitly empty list is a real answer and merges normally.
+fn existing_open_api_keys(
+    endpoint: Option<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint>,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let incomplete = |field: &str| -> Box<dyn std::error::Error> {
+        format!(
+            "the query endpoint response is missing field '{field}', so the keys currently bound \
+             to the endpoint are unknown; binding a new key would revoke them"
+        )
+        .into()
+    };
+    endpoint
+        .ok_or_else(|| incomplete("result"))?
+        .open_api_keys
+        .ok_or_else(|| incomplete("openApiKeys"))
+}
+
 /// Bind `api_key_uuid` to the service's query endpoint, merging into any
 /// existing endpoint configuration so we don't silently revoke other
 /// bindings the user set up.
@@ -152,10 +173,9 @@ async fn bind_query_endpoint(
         .instance_query_endpoint_get(org_id, service_id)
         .await
     {
-        Ok(resp) => resp
-            .result
-            .and_then(|ep| ep.open_api_keys)
-            .unwrap_or_default(),
+        Ok(resp) => existing_open_api_keys(resp.result)?,
+        // Only a 404 means there is no endpoint yet, so this binding is the
+        // first one and starts from an empty list.
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Vec::new(),
         Err(e) => return Err(client.convert_error(e).into()),
     };
@@ -209,6 +229,52 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "the API response is missing required field 'keySecret'"
+        );
+    }
+
+    fn endpoint(
+        open_api_keys: Option<Vec<&str>>,
+    ) -> clickhouse_cloud_api::models::ServiceQueryAPIEndpoint {
+        clickhouse_cloud_api::models::ServiceQueryAPIEndpoint {
+            allowed_origins: None,
+            id: Some("ep-1".to_string()),
+            open_api_keys: open_api_keys.map(|keys| keys.into_iter().map(str::to_string).collect()),
+            roles: None,
+        }
+    }
+
+    #[test]
+    fn existing_keys_are_returned_when_the_endpoint_reports_them() {
+        assert_eq!(
+            existing_open_api_keys(Some(endpoint(Some(vec!["uuid-a", "uuid-b"])))).unwrap(),
+            vec!["uuid-a".to_string(), "uuid-b".to_string()],
+        );
+    }
+
+    #[test]
+    fn an_explicitly_empty_key_list_is_a_real_answer() {
+        assert!(
+            existing_open_api_keys(Some(endpoint(Some(vec![]))))
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn absent_open_api_keys_is_refused_rather_than_treated_as_empty() {
+        let err = existing_open_api_keys(Some(endpoint(None))).unwrap_err();
+        assert!(
+            err.to_string().contains("'openApiKeys'") && err.to_string().contains("revoke"),
+            "error should name the field and the consequence: {err}",
+        );
+    }
+
+    #[test]
+    fn absent_result_is_refused_rather_than_treated_as_empty() {
+        let err = existing_open_api_keys(None).unwrap_err();
+        assert!(
+            err.to_string().contains("'result'"),
+            "error should name the field: {err}",
         );
     }
 }

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -10,8 +10,8 @@ use crate::cloud::client::CloudClient;
 use crate::cloud::credentials::{self, ServiceQueryKey};
 use chrono::Utc;
 use clickhouse_cloud_api::models::{
-    ApiKeyPostRequest, ApiKeyPostRequestState, InstanceServiceQueryApiEndpointsPostRequest,
-    IpAccessListEntry,
+    ApiKeyPostRequest, ApiKeyPostRequestState, ApiKeyPostResponse,
+    InstanceServiceQueryApiEndpointsPostRequest, IpAccessListEntry,
 };
 
 /// The role attached to the query endpoint binding. Grants the key read +
@@ -28,6 +28,25 @@ const ALLOWED_ORIGINS: &str = "*";
 /// Requires a response field the provisioning flow cannot proceed without.
 fn require_field<T>(value: Option<T>, field: &str) -> Result<T, Box<dyn std::error::Error>> {
     value.ok_or_else(|| format!("the API response is missing required field '{field}'").into())
+}
+
+/// The `key_id`/`key_secret` pair the query host authenticates with, taken
+/// from the key-creation response. Both halves are required together: a key
+/// id without its secret is as unusable as neither.
+fn require_credential_pair(
+    key_response: &ApiKeyPostResponse,
+) -> Result<(String, String), Box<dyn std::error::Error>> {
+    let key_id = require_field(key_response.key_id.clone(), "keyId")?;
+    let key_secret = require_field(key_response.key_secret.clone(), "keySecret")?;
+    Ok((key_id, key_secret))
+}
+
+/// Discard the API key created for a provisioning attempt that then failed,
+/// so a later retry doesn't leave an orphaned key behind per attempt. Best
+/// effort: the caller is already returning an error, and a key we couldn't
+/// delete is no worse than the one we'd otherwise leave behind.
+async fn discard_api_key(client: &CloudClient, org_id: &str, api_key_uuid: &str) {
+    let _ = client.delete_api_key(org_id, api_key_uuid).await;
 }
 
 /// Ensure a query endpoint is provisioned for `service_id` and return the
@@ -62,25 +81,47 @@ pub async fn ensure_service_query_setup(
     };
 
     let key_response = client.create_api_key(org_id, &key_request).await?;
-    // Every response field is `Option<T>`, and an absent credential cannot be
-    // substituted with a placeholder: fail loudly instead of persisting an
-    // empty key pair that every later query would reject.
-    let key_id = require_field(key_response.key_id.clone(), "keyId")?;
-    let key_secret = require_field(key_response.key_secret.clone(), "keySecret")?;
     // `key_id`/`key_secret` are the credential pair used for query auth.
     // The endpoint binding's `openApiKeys` array, by contrast, references
     // API keys by their resource UUID — the same value the management
-    // endpoints (GET/DELETE /v1/.../keys/{keyId}) accept.
+    // endpoints (GET/DELETE /v1/.../keys/{keyId}) accept. Resolve the UUID
+    // first: every failure past this point deletes the key it identifies, so
+    // an absent `key.id` is the only one with no cleanup available — we
+    // cannot name the key we just created.
     let api_key_uuid =
-        require_field(key_response.key.and_then(|key| key.id), "key.id")?.to_string();
+        require_field(key_response.key.as_ref().and_then(|key| key.id), "key.id")?.to_string();
+
+    // Every response field is `Option<T>`, and an absent credential cannot be
+    // substituted with a placeholder: fail loudly instead of persisting an
+    // empty key pair that every later query would reject.
+    let (key_id, key_secret) = match require_credential_pair(&key_response) {
+        Ok(pair) => pair,
+        Err(e) => {
+            // The key exists but we can't authenticate with it, so it is
+            // dead weight in the org: discard it before failing.
+            discard_api_key(client, org_id, &api_key_uuid).await;
+            return Err(e);
+        }
+    };
 
     let endpoint = match bind_query_endpoint(client, org_id, service_id, &api_key_uuid).await {
         Ok(endpoint) => endpoint,
         Err(e) => {
             // The key was created but never bound or persisted, so nothing
-            // can use it. Delete it (best-effort) so a later retry doesn't
-            // leave an orphaned key behind per attempt.
-            let _ = client.delete_api_key(org_id, &api_key_uuid).await;
+            // can use it.
+            discard_api_key(client, org_id, &api_key_uuid).await;
+            return Err(e);
+        }
+    };
+
+    let endpoint_id = match require_field(endpoint.id, "id") {
+        Ok(id) => id,
+        Err(e) => {
+            // The binding took effect but we can't persist it, so the key
+            // is again unusable. Discarding it leaves a dangling UUID in the
+            // endpoint's `openApiKeys`, which is harmless — a retry merges a
+            // fresh key into the same endpoint (see `bind_query_endpoint`).
+            discard_api_key(client, org_id, &api_key_uuid).await;
             return Err(e);
         }
     };
@@ -88,7 +129,7 @@ pub async fn ensure_service_query_setup(
     let stored = ServiceQueryKey {
         key_id,
         key_secret,
-        endpoint_id: require_field(endpoint.id, "id")?,
+        endpoint_id,
         service_name: service_name.to_string(),
         created_at: Utc::now(),
     };
@@ -131,4 +172,43 @@ async fn bind_query_endpoint(
     Ok(client
         .create_query_endpoint(org_id, service_id, &endpoint_request)
         .await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_response(key_id: Option<&str>, key_secret: Option<&str>) -> ApiKeyPostResponse {
+        ApiKeyPostResponse {
+            key: None,
+            key_id: key_id.map(str::to_string),
+            key_secret: key_secret.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn credential_pair_is_returned_when_both_halves_are_present() {
+        let (key_id, key_secret) =
+            require_credential_pair(&key_response(Some("k-1"), Some("s-1"))).unwrap();
+        assert_eq!(key_id, "k-1");
+        assert_eq!(key_secret, "s-1");
+    }
+
+    #[test]
+    fn credential_pair_fails_naming_the_absent_key_id() {
+        let err = require_credential_pair(&key_response(None, Some("s-1"))).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "the API response is missing required field 'keyId'"
+        );
+    }
+
+    #[test]
+    fn credential_pair_fails_naming_the_absent_key_secret() {
+        let err = require_credential_pair(&key_response(Some("k-1"), None)).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "the API response is missing required field 'keySecret'"
+        );
+    }
 }

--- a/crates/clickhousectl/src/cloud/types.rs
+++ b/crates/clickhousectl/src/cloud/types.rs
@@ -1,9 +1,15 @@
 use serde::{Deserialize, Serialize};
 
 /// Delete service success payload returned directly by the API without a result wrapper.
+///
+/// Fields the API omitted stay `None` and are omitted from `--json` output,
+/// matching the library-wide all-`Option` response policy — never fabricate a
+/// `0.0` status or empty request ID the server did not send.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteResponse {
-    pub status: f64,
-    pub request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
 }

--- a/crates/clickhousectl/src/cloud/types_test.rs
+++ b/crates/clickhousectl/src/cloud/types_test.rs
@@ -15,20 +15,34 @@ fn test_delete_response_deserialize() {
         "requestId": "0182edf5-8c5b-4586-a6f8-78452320e4b1"
     });
     let response: DeleteResponse = serde_json::from_value(json).unwrap();
-    assert_eq!(response.status, 200.0);
-    assert_eq!(response.request_id, "0182edf5-8c5b-4586-a6f8-78452320e4b1");
+    assert_eq!(response.status, Some(200.0));
+    assert_eq!(
+        response.request_id.as_deref(),
+        Some("0182edf5-8c5b-4586-a6f8-78452320e4b1")
+    );
 }
 
 #[test]
 fn test_delete_response_serialize() {
     let response = DeleteResponse {
-        status: 200.0,
-        request_id: "0182edf5-8c5b-4586-a6f8-78452320e4b1".to_string(),
+        status: Some(200.0),
+        request_id: Some("0182edf5-8c5b-4586-a6f8-78452320e4b1".to_string()),
     };
     let json = serde_json::to_value(&response).unwrap();
     assert_eq!(json["status"], 200.0);
     assert_eq!(json["requestId"], "0182edf5-8c5b-4586-a6f8-78452320e4b1");
     assert!(json.get("request_id").is_none());
+}
+
+#[test]
+fn test_delete_response_omits_absent_fields_instead_of_fabricating() {
+    let response: DeleteResponse = serde_json::from_value(serde_json::json!({})).unwrap();
+    assert_eq!(response.status, None);
+    assert_eq!(response.request_id, None);
+    // `--json` output must reflect the key set the API actually sent — no
+    // fabricated `"status": 0.0` or `"requestId": ""`.
+    let json = serde_json::to_value(&response).unwrap();
+    assert_eq!(json, serde_json::json!({}));
 }
 
 // ── Activity tests (library types) ─────────────────────────────────

--- a/crates/clickhousectl/src/cloud/types_test.rs
+++ b/crates/clickhousectl/src/cloud/types_test.rs
@@ -33,6 +33,12 @@ fn test_delete_response_serialize() {
 
 // ── Activity tests (library types) ─────────────────────────────────
 
+/// The wire value of a response enum field, or an empty string when the API
+/// omitted it (which matches no real value).
+fn enum_wire_value<T: std::fmt::Display>(value: Option<T>) -> String {
+    value.map(|value| value.to_string()).unwrap_or_default()
+}
+
 #[test]
 fn test_activity_deserialize() {
     use clickhouse_cloud_api::models::Activity;
@@ -49,15 +55,15 @@ fn test_activity_deserialize() {
         "userAgent": "clickhousectl/0.1.0"
     });
     let act: Activity = serde_json::from_value(json).unwrap();
-    assert_eq!(act.id, "act-1");
-    assert_eq!(act.r#type.to_string(), "service_create");
-    assert_eq!(act.actor_type.to_string(), "user");
-    assert_eq!(act.actor_id, "user-5");
-    assert_eq!(act.actor_details, "Alice Smith");
-    assert_eq!(act.actor_ip_address, "1.2.3.4");
-    assert_eq!(act.organization_id, "org-1");
-    assert_eq!(act.service_id, "svc-1");
-    assert_eq!(act.user_agent, "clickhousectl/0.1.0");
+    assert_eq!(act.id.as_deref(), Some("act-1"));
+    assert_eq!(enum_wire_value(act.r#type), "service_create");
+    assert_eq!(enum_wire_value(act.actor_type), "user");
+    assert_eq!(act.actor_id.as_deref(), Some("user-5"));
+    assert_eq!(act.actor_details.as_deref(), Some("Alice Smith"));
+    assert_eq!(act.actor_ip_address.as_deref(), Some("1.2.3.4"));
+    assert_eq!(act.organization_id.as_deref(), Some("org-1"));
+    assert_eq!(act.service_id.as_deref(), Some("svc-1"));
+    assert_eq!(act.user_agent.as_deref(), Some("clickhousectl/0.1.0"));
 }
 
 #[test]
@@ -71,9 +77,9 @@ fn test_activity_key_update() {
         "keyUpdateType": "state-changed"
     });
     let act: Activity = serde_json::from_value(json).unwrap();
-    assert_eq!(act.r#type.to_string(), "openapi_key_update");
-    assert_eq!(act.target_key_id, "key-1");
-    assert_eq!(act.key_update_type.to_string(), "state-changed");
+    assert_eq!(enum_wire_value(act.r#type), "openapi_key_update");
+    assert_eq!(act.target_key_id.as_deref(), Some("key-1"));
+    assert_eq!(enum_wire_value(act.key_update_type), "state-changed");
 }
 
 #[test]
@@ -84,11 +90,12 @@ fn test_activity_minimal() {
         "type": "user_login"
     });
     let act: Activity = serde_json::from_value(json).unwrap();
-    assert_eq!(act.id, "act-3");
-    assert_eq!(act.r#type.to_string(), "user_login");
-    // Fields not present in JSON get their default values
-    assert_eq!(act.actor_details, "");
-    assert_eq!(act.service_id, "");
+    assert_eq!(act.id.as_deref(), Some("act-3"));
+    assert_eq!(enum_wire_value(act.r#type), "user_login");
+    // Every response field is `Option<T>`: a key the API did not send is
+    // `None`, not an empty string.
+    assert_eq!(act.actor_details, None);
+    assert_eq!(act.service_id, None);
 }
 
 // ── Comprehensive enum value tests (from OpenAPI spec) ──────────────
@@ -150,7 +157,7 @@ fn test_activity_type_values() {
     for t in &types {
         let json = serde_json::json!({"id": "act-1", "type": t});
         let act: Activity = serde_json::from_value(json).unwrap();
-        assert_eq!(act.r#type.to_string(), *t);
+        assert_eq!(enum_wire_value(act.r#type), *t);
     }
 }
 
@@ -161,7 +168,7 @@ fn test_activity_actor_type_values() {
         let json =
             serde_json::json!({"id": "act-1", "type": "user_login", "actorType": actor_type});
         let act: Activity = serde_json::from_value(json).unwrap();
-        assert_eq!(act.actor_type.to_string(), *actor_type);
+        assert_eq!(enum_wire_value(act.actor_type), *actor_type);
     }
 }
 
@@ -188,6 +195,6 @@ fn test_activity_key_update_type_values() {
             "keyUpdateType": t
         });
         let act: Activity = serde_json::from_value(json).unwrap();
-        assert_eq!(act.key_update_type.to_string(), *t);
+        assert_eq!(enum_wire_value(act.key_update_type), *t);
     }
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1595,8 +1595,9 @@ async fn service_query_deletes_the_key_when_the_create_response_omits_the_secret
 }
 
 #[tokio::test]
-async fn service_query_deletes_the_key_when_the_endpoint_response_omits_the_id() {
+async fn service_query_keeps_the_key_when_the_endpoint_response_omits_the_id() {
     let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
     mount_key_create_and_delete(
         &control,
         serde_json::json!({
@@ -1606,8 +1607,9 @@ async fn service_query_deletes_the_key_when_the_endpoint_response_omits_the_id()
         }),
     )
     .await;
-    // No endpoint configured yet (404), and the upsert answers without `id`,
-    // so the binding took effect but can't be persisted.
+    // No endpoint configured yet (404), and the upsert succeeds but answers
+    // without `id`. The key is bound and usable: the echoed id is diagnostic
+    // only, so provisioning completes rather than discarding the credential.
     let endpoint_path =
         format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
     Mock::given(method("GET"))
@@ -1629,20 +1631,49 @@ async fn service_query_deletes_the_key_when_the_endpoint_response_omits_the_id()
         .mount(&control)
         .await;
 
-    let (dir, stderr) = invoke_service_query_provisioning(&control);
+    let dir = tempfile::tempdir().unwrap();
+    let url = control.uri();
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .current_dir(dir.path())
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_success(&output);
+
     assert!(
-        stderr.contains("'id'"),
-        "stderr should name the missing field:\n{stderr}",
+        recorded_key_deletes(&control).await.is_empty(),
+        "a bound, usable key must not be discarded over an unused echoed id",
     );
 
-    assert_eq!(
-        recorded_key_deletes(&control).await,
-        vec![format!(
-            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
-        )],
-        "a bound-but-unpersistable key must be deleted",
+    // The credential is persisted, with `endpoint_id` omitted rather than
+    // written as a placeholder.
+    let stored: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join(".clickhouse/credentials.json")).unwrap(),
+    )
+    .unwrap();
+    let key = &stored["service_query_keys"][QUERY_TEST_SERVICE_ID];
+    assert_eq!(key["key_id"], "provisioned-key-id");
+    assert_eq!(key["key_secret"], "provisioned-key-secret");
+    assert!(
+        key.get("endpoint_id").is_none(),
+        "an absent endpoint id must not be stored: {stored}",
     );
-    assert!(!dir.path().join(".clickhouse/credentials.json").exists());
 }
 
 #[tokio::test]
@@ -1788,7 +1819,14 @@ async fn service_query_binds_the_new_key_when_the_endpoint_reports_no_keys() {
     // An explicitly empty `openApiKeys` is a real answer, not an omission.
     let (dir, sent_keys) = provision_against_endpoint_with_keys(serde_json::json!([])).await;
     assert_eq!(sent_keys, serde_json::json!([QUERY_TEST_KEY_UUID]));
-    assert!(dir.path().join(".clickhouse/credentials.json").exists());
+    let stored: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join(".clickhouse/credentials.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        stored["service_query_keys"][QUERY_TEST_SERVICE_ID]["endpoint_id"], "ep-1",
+        "an echoed endpoint id is recorded",
+    );
 }
 
 #[tokio::test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1528,6 +1528,9 @@ fn invoke_service_query_provisioning(control: &MockServer) -> (tempfile::TempDir
         .current_dir(dir.path())
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        // Provisioning must fail before the query runs; pin the query host to
+        // a closed port so a regression cannot reach the production host.
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", "http://127.0.0.1:1")
         .output()
         .expect("failed to spawn clickhousectl");
 
@@ -1640,6 +1643,164 @@ async fn service_query_deletes_the_key_when_the_endpoint_response_omits_the_id()
         "a bound-but-unpersistable key must be deleted",
     );
     assert!(!dir.path().join(".clickhouse/credentials.json").exists());
+}
+
+#[tokio::test]
+async fn service_query_deletes_the_key_when_the_endpoint_get_omits_open_api_keys() {
+    let control = start_mock_control_plane_with_service().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+    // A 200 endpoint GET whose `openApiKeys` is absent leaves the currently
+    // bound keys unknown. The upsert replaces the list wholesale, so binding
+    // on top of an assumed-empty list would revoke them.
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1", "roles": ["sql_console_admin"] },
+            "status": 200,
+            "requestId": "stub-endpoint-get",
+        })))
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1" },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert",
+        })))
+        .mount(&control)
+        .await;
+
+    let (dir, stderr) = invoke_service_query_provisioning(&control);
+
+    let upserts = control
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::POST && r.url.path() == endpoint_path)
+        .count();
+    assert_eq!(
+        upserts, 0,
+        "the endpoint must not be rebound from an unknown key list",
+    );
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+        "the unbindable key must be deleted exactly once",
+    );
+    assert!(!dir.path().join(".clickhouse/credentials.json").exists());
+    assert!(
+        stderr.contains("'openApiKeys'"),
+        "stderr should name the omitted field:\n{stderr}",
+    );
+}
+
+/// Provision against an endpoint GET that reports `existing_keys`, and return
+/// the `openApiKeys` the upsert was sent, plus the project dir.
+async fn provision_against_endpoint_with_keys(existing_keys: Value) -> (tempfile::TempDir, Value) {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1", "openApiKeys": existing_keys },
+            "status": 200,
+            "requestId": "stub-endpoint-get",
+        })))
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1" },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert",
+        })))
+        .mount(&control)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let url = control.uri();
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .current_dir(dir.path())
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_success(&output);
+
+    assert!(
+        recorded_key_deletes(&control).await.is_empty(),
+        "a successfully bound key must not be discarded",
+    );
+    let upsert = control
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.method == wiremock::http::Method::POST && r.url.path() == endpoint_path)
+        .expect("the endpoint upsert must be sent");
+    let body: Value = serde_json::from_slice(&upsert.body).unwrap();
+    (dir, body["openApiKeys"].clone())
+}
+
+#[tokio::test]
+async fn service_query_binds_the_new_key_when_the_endpoint_reports_no_keys() {
+    // An explicitly empty `openApiKeys` is a real answer, not an omission.
+    let (dir, sent_keys) = provision_against_endpoint_with_keys(serde_json::json!([])).await;
+    assert_eq!(sent_keys, serde_json::json!([QUERY_TEST_KEY_UUID]));
+    assert!(dir.path().join(".clickhouse/credentials.json").exists());
+}
+
+#[tokio::test]
+async fn service_query_merges_the_new_key_into_the_reported_keys() {
+    let existing = "99999999-8888-7777-6666-555555555555";
+    let (_dir, sent_keys) =
+        provision_against_endpoint_with_keys(serde_json::json!([existing])).await;
+    assert_eq!(
+        sent_keys,
+        serde_json::json!([existing, QUERY_TEST_KEY_UUID]),
+        "an existing binding must survive the upsert",
+    );
 }
 
 // ── Idled / stopped services (query host 206 protocol) ─────────────────────

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2490,3 +2490,109 @@ async fn service_reset_password_json_prints_the_generated_password() {
         serde_json::from_slice(&output.stdout).expect("--json output wasn't valid JSON");
     assert_eq!(body["password"], "s3cret");
 }
+
+// ── Generated API key material is never silently dropped ───────────────────
+//
+// `key create` without the pre-hash flags asks the API to generate a key pair
+// returned exactly once. A response missing `keyId`/`keySecret` loses that
+// credential, so validation runs before either output branch — `--json` (which
+// agent detection also turns on by itself) must not print the incomplete
+// response and exit zero.
+
+async fn run_key_create(result: Value, extra_args: &[&str]) -> std::process::Output {
+    let mock = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-key-create",
+        })))
+        .mount(&mock)
+        .await;
+
+    let url = mock.uri();
+    let mut args: Vec<&str> = vec![
+        "cloud", "--url", &url, "key", "create", "--name", "ci", "--org-id", "org-1",
+    ];
+    args.extend(extra_args);
+
+    Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args(&args)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn key_create_fails_when_the_generated_material_is_absent() {
+    for extra_args in [&[][..], &["--json"][..]] {
+        let output = run_key_create(
+            serde_json::json!({
+                "key": { "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "name": "ci" },
+                "keyId": "generated-key-id",
+            }),
+            extra_args,
+        )
+        .await;
+        assert!(
+            !output.status.success(),
+            "a generated key create with no secret must fail for args {extra_args:?}\nstdout:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("omitted the generated key material"),
+            "stderr should name the omitted material for args {extra_args:?}:\n{stderr}",
+        );
+        // Neither the human confirmation nor the incomplete response body may
+        // reach stdout ahead of the failure.
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("API key created!") && !stdout.contains("generated-key-id"),
+            "no success output may precede the failure for args {extra_args:?}:\n{stdout}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn key_create_json_prints_the_raw_response() {
+    let result = serde_json::json!({
+        "key": { "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "name": "ci" },
+        "keyId": "generated-key-id",
+        "keySecret": "generated-key-secret",
+    });
+    let output = run_key_create(result.clone(), &["--json"]).await;
+    assert_success(&output);
+    let body: Value =
+        serde_json::from_slice(&output.stdout).expect("--json output wasn't valid JSON");
+    // --json reflects the key set the API sent; nothing is synthesized from
+    // the resolved material.
+    assert_eq!(body, result);
+}
+
+#[tokio::test]
+async fn key_create_succeeds_for_a_pre_hashed_key_without_generated_material() {
+    let output = run_key_create(
+        serde_json::json!({ "key": { "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "name": "ci" } }),
+        &[
+            "--hash-key-id",
+            "0f1e2d3c",
+            "--hash-key-id-suffix",
+            "3c",
+            "--hash-key-secret",
+            "4b5a6978",
+        ],
+    )
+    .await;
+    assert_success(&output);
+    // Agent detection can force --json here, so assert only what holds in
+    // both output modes: no key material is reported.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Key Secret"),
+        "a pre-hashed create must not report key material:\n{stdout}",
+    );
+}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2482,6 +2482,28 @@ async fn service_reset_password_succeeds_for_a_hash_reset_without_a_password() {
 }
 
 #[tokio::test]
+async fn service_reset_password_treats_a_double_sha1_only_reset_as_generation() {
+    // The API ignores `newDoubleSha1Hash` unless `newPasswordHash` is also
+    // sent, and generates a password instead — so the mode is generation and a
+    // response without a password loses the new credential.
+    let output = run_service_reset_password(
+        serde_json::json!({}),
+        &["--new-double-sha1-hash", "aabbccdd"],
+    )
+    .await;
+    assert!(
+        !output.status.success(),
+        "a double-SHA1-only reset with no password must fail\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("omitted the generated password"),
+        "stderr should name the omitted password:\n{stderr}",
+    );
+}
+
+#[tokio::test]
 async fn service_reset_password_json_prints_the_generated_password() {
     let output =
         run_service_reset_password(serde_json::json!({ "password": "s3cret" }), &["--json"]).await;

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -1472,6 +1472,176 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
     );
 }
 
+// ── Provisioning cleanup (issue #314) ──────────────────────────────────────
+//
+// Every field of a key-creation or endpoint-upsert response is `Option<T>`,
+// so provisioning can fail *after* the key exists. Each of those failures
+// must delete the key it created, otherwise every retry leaves another
+// orphaned key in the org.
+
+const QUERY_TEST_KEY_UUID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+/// Mount a key-creation POST returning `result`, plus a key DELETE, on the
+/// control plane. `result` lets each test omit exactly the field under test.
+async fn mount_key_create_and_delete(control: &MockServer, result: Value) {
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": result,
+            "status": 200,
+            "requestId": "stub-key-create",
+        })))
+        .mount(control)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "stub-key-delete",
+        })))
+        .mount(control)
+        .await;
+}
+
+/// Run `cloud service query` in an empty project dir (no stored key, so the
+/// provisioning path runs) against `control`, with API key env creds.
+fn invoke_service_query_provisioning(control: &MockServer) -> (tempfile::TempDir, String) {
+    let dir = tempfile::tempdir().unwrap();
+    let url = control.uri();
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .current_dir(dir.path())
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert!(
+        !output.status.success(),
+        "provisioning with an incomplete response must fail\nstdout:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+    );
+    (dir, String::from_utf8_lossy(&output.stderr).to_string())
+}
+
+/// The key UUIDs the control plane was asked to delete.
+async fn recorded_key_deletes(control: &MockServer) -> Vec<String> {
+    control
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.method == wiremock::http::Method::DELETE)
+        .map(|r| r.url.path().to_string())
+        .collect()
+}
+
+#[tokio::test]
+async fn service_query_deletes_the_key_when_the_create_response_omits_the_secret() {
+    let control = start_mock_control_plane_with_service().await;
+    // `keySecret` absent: the key exists but cannot authenticate anything.
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+        }),
+    )
+    .await;
+
+    let (dir, stderr) = invoke_service_query_provisioning(&control);
+    assert!(
+        stderr.contains("keySecret"),
+        "stderr should name the missing field:\n{stderr}",
+    );
+
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+        "the unusable key must be deleted exactly once",
+    );
+
+    // The key was never bound, so no endpoint upsert was attempted, and
+    // nothing was persisted locally.
+    let upserts = control
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .filter(|r| r.url.path().ends_with("/serviceQueryEndpoint"))
+        .count();
+    assert_eq!(upserts, 0, "a keyless credential must not be bound");
+    assert!(!dir.path().join(".clickhouse/credentials.json").exists());
+}
+
+#[tokio::test]
+async fn service_query_deletes_the_key_when_the_endpoint_response_omits_the_id() {
+    let control = start_mock_control_plane_with_service().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+    // No endpoint configured yet (404), and the upsert answers without `id`,
+    // so the binding took effect but can't be persisted.
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get",
+        })))
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "roles": ["sql_console_admin"] },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert",
+        })))
+        .mount(&control)
+        .await;
+
+    let (dir, stderr) = invoke_service_query_provisioning(&control);
+    assert!(
+        stderr.contains("'id'"),
+        "stderr should name the missing field:\n{stderr}",
+    );
+
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+        "a bound-but-unpersistable key must be deleted",
+    );
+    assert!(!dir.path().join(".clickhouse/credentials.json").exists());
+}
+
 // ── Idled / stopped services (query host 206 protocol) ─────────────────────
 //
 // An idled or stopped service answers the run request with 206 and

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2396,3 +2396,97 @@ async fn schema_discover_kinesis_posts_source_body() {
         body["source"],
     );
 }
+
+// ── Generated service passwords are never silently dropped ─────────────────
+//
+// `service reset-password` without either hash flag sends an empty PATCH
+// body, which asks the API to generate a password returned exactly once. A
+// response without one loses that credential, so both output modes must fail
+// instead of reporting a successful reset.
+
+async fn run_service_reset_password(
+    password_response: Value,
+    extra_args: &[&str],
+) -> std::process::Output {
+    let mock = MockServer::start().await;
+    Mock::given(method("PATCH"))
+        .and(path_regex(
+            r"^/v1/organizations/[^/]+/services/[^/]+/password$",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": password_response,
+            "status": 200,
+            "requestId": "stub-reset-password",
+        })))
+        .mount(&mock)
+        .await;
+
+    let url = mock.uri();
+    let mut args: Vec<&str> = vec![
+        "cloud",
+        "--url",
+        &url,
+        "service",
+        "reset-password",
+        "svc-id",
+        "--org-id",
+        "org-1",
+    ];
+    args.extend(extra_args);
+
+    Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args(&args)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn service_reset_password_fails_when_the_generated_password_is_absent() {
+    for extra_args in [&[][..], &["--json"][..]] {
+        let output = run_service_reset_password(serde_json::json!({}), extra_args).await;
+        assert!(
+            !output.status.success(),
+            "a generation reset with no password must fail for args {extra_args:?}\nstdout:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains("omitted the generated password"),
+            "stderr should name the omitted password for args {extra_args:?}:\n{stderr}",
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("Password reset for service")
+                && !stdout.contains("no plaintext password returned"),
+            "no success output may precede the failure for args {extra_args:?}:\n{stdout}",
+        );
+    }
+}
+
+#[tokio::test]
+async fn service_reset_password_succeeds_for_a_hash_reset_without_a_password() {
+    let output =
+        run_service_reset_password(serde_json::json!({}), &["--new-password-hash", "e3b0c442"])
+            .await;
+    assert_success(&output);
+    // Agent detection can force --json here, so assert only what holds in
+    // both output modes: the reset succeeds and shows no password.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("New password"),
+        "a hash reset must not report a password:\n{stdout}",
+    );
+}
+
+#[tokio::test]
+async fn service_reset_password_json_prints_the_generated_password() {
+    let output =
+        run_service_reset_password(serde_json::json!({ "password": "s3cret" }), &["--json"]).await;
+    assert_success(&output);
+    let body: Value =
+        serde_json::from_slice(&output.stdout).expect("--json output wasn't valid JSON");
+    assert_eq!(body["password"], "s3cret");
+}

--- a/scripts/regenerate-deprecated-fields.py
+++ b/scripts/regenerate-deprecated-fields.py
@@ -14,6 +14,12 @@ The shared OpenAPI analyzer reports drift until the constant matches and each
 field also carries the `#[cfg(feature = "deprecated-fields")]` marker in
 models.rs.
 
+Struct names come from spec schema names alone. A schema modeled as both a
+request and a response type is split into `{Name}` and `{Name}Response` in
+models.rs, and the analyzer expects one entry per Rust type, so re-add the
+`{Name}Response` entries by hand after pasting (see meta.rs). Deriving them
+here would mean parsing models.rs, which belongs to the analyzer, not Python.
+
 Usage:
     python3 scripts/regenerate-deprecated-fields.py
 """


### PR DESCRIPTION
Closes #314

**Stacked on #311** — base is `issue-308-clickstack-drift`; retarget to `main` after #311 merges. Replaces #313 (closed), whose `serde(default)` sweep fabricated values indistinguishable from server-sent ones.

## What and why

A server-dropped or `null` response field must never fail deserialization — each strict response field is a latent outage point. Tolerance now lives in the type system instead of serde attributes:

- **Request types: strict.** Required fields are `T`, optional are `Option<T>` + `skip_serializing_if`. The compiler enforces "strict in what we send".
- **Response types: all-`Option`.** Every field of every type reachable from a `Client` return type (339 types) is `Option<T>`. Missing key *and* explicit `null` both land as `None` — nothing is fabricated, so "server sent `0`" and "server dropped the field" stay distinguishable.
- **Enums/unions unchanged**: `Unknown` catch-alls absorb unrecognized values and (new in this PR) malformed payloads under a recognized discriminator.

## How

- **Naming:** a schema used in both directions splits into `{Name}` (request) + `{Name}Response` — 88 pairs, more than the 75+2 the issue measured (agents verified reachability from `client.rs` rather than trusting the list). Unions whose variant structs split are duplicated (`discriminated_union!` invocation per direction).
- **Serialization pinned:** absent response fields are **omitted** from `--json`/`print_human` output, never emitted as `null` (`skip_serializing_if` on every response field, test-enforced).
- **Write-back is explicit:** new `convert.rs` with `TryFrom<{Name}Response>`/`From` conversions (top-level: `PostgresInstanceConfig`, `ClickStackSource`); a fallible conversion returns `MissingRequiredFields` naming the missing wire fields. This closes #313's GET→write-back caveat instead of documenting it.
- **`serde(default)` is banned** in `models.rs`, enforced by test via the analyzer.
- **Analyzer is direction-aware:** requiredness rules apply in request position only; response-side optionality findings are suppressed by design (presence and enum-value drift remain checked in both directions); response-position schemas resolve to `{Name}Response` when it exists. New `response_tree()` API backs the enforcement tests.
- **Union hardening (carried from #313 + extended):** `none unless "connectionId" | "sqlTemplate"` guards on the chart-config unions (mandatory now — all-`Option` variants are total, so a dropped discriminator would otherwise silently retype a RawSql payload); known-discriminator malformed payloads degrade to lossless `Unknown(Value)`; every union `Default` round-trips to the same variant, with the covered list structurally required to equal the manual `impl Default` blocks.
- **CLI:** no `unwrap`/`expect` on response fields; absence renders as `-` (`or_absent`); `postgres config set` builds the request variant; delete `--json` no longer fabricates `status`/`requestId`.

## Residual (documented, intentional)

A key that is *present* with a changed type still fails a plain struct field — `Option<T>` absorbs absence and `null`, not shape changes. Enums/unions absorb those via catch-alls. Spec conformance stays the drift job's responsibility.

## Breaking changes (library consumers, pre-1.0)

- All response-tree fields are now `Option<T>`; response-position types returned by `Client` methods are the `{Name}Response` variants where split.
- `discriminated_union!` grammar: bare `none =>` arms no longer parse; absence-discriminated unions must name disqualifying keys.
- CLI `DeleteResponse` fields are `Option`.

## Verification

Every commit is independently green (per-commit verifier agents re-ran all gates): `cargo test --workspace`, clippy `-D warnings` workspace-wide, `cargo fmt --all --check`, `cargo check --workspace --all-features`, `python3 -m unittest discover -s scripts/tests`, and `python3 scripts/check-openapi-drift.py --dry-run` → 0 actionable findings against the live spec. A fresh-context adversarial review of the full stack found no high/medium defects; its three low-severity findings are fixed in the final commit. Enforcement tests were mutation-tested (strictening a response field / removing a covered union fails the corresponding test with the exact offender named).

🤖 Generated with [Claude Code](https://claude.com/claude-code)