### PR TITLE
Telemetry: first-run notice and events cover every invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,14 +889,17 @@ The CLI checks for updates in the background (at most once per 24 hours) and cac
 
 Each event contains exactly:
 
-- the command path (e.g. `local start`)
+- the command path (e.g. `local start`) — for an invocation that fails to parse, the longest *valid* prefix of what was typed; a mistyped or unrecognized token is never recorded
 - the **names** of the flags passed (e.g. `json`, `org-id`) — never flag values, never positional arguments
-- the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required)
+- how the invocation ended: `ok`, `help`, `version`, or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
+- the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required; parse errors keep clap's exit 2)
 - the CLI version, OS, and architecture
 - whether it ran in CI (`CI` env var)
 - whether it ran under a detected coding agent, and if so which one (e.g. `claude-code`)
 
-There is no install ID, no device ID, and no fingerprinting of any kind. The payload is built from the clap command definitions rather than the raw command line, so leaking an argument value is structurally impossible — the code that builds the event has no access to values at all.
+Every invocation counts, including `--help`, `--version`, a bare `clickhousectl`, and mistyped commands — failed invocations are recorded as such (that is how we find the confusing corners of the CLI), subject to the same consent flow as everything else.
+
+There is no install ID, no device ID, and no fingerprinting of any kind. The payload is built from the clap command definitions rather than the raw command line, so leaking an argument value is structurally impossible — the code that builds the event has no access to values at all. That holds for failed parses too: they are reconstructed by matching argv tokens against the defined command tree, so every recorded string is one the CLI itself defines.
 
 Nothing is ever sent before you have seen the notice or explicitly enabled telemetry with `clickhousectl telemetry enable`: the first run prints a one-time notice to stderr, records that it was shown in `~/.clickhouse/telemetry.json`, and sends nothing. Sending starts from the following run — or immediately if you opt in by running `telemetry enable`, which is explicit consent and skips the notice. The send happens in a short-lived detached process, so command latency is unaffected even when the endpoint is unreachable.
 

--- a/README.md
+++ b/README.md
@@ -889,17 +889,14 @@ The CLI checks for updates in the background (at most once per 24 hours) and cac
 
 Each event contains exactly:
 
-- the command path (e.g. `local start`) — for an invocation that fails to parse, the longest *valid* prefix of what was typed; a mistyped or unrecognized token is never recorded
+- the command path (e.g. `local start`)
 - the **names** of the flags passed (e.g. `json`, `org-id`) — never flag values, never positional arguments
-- how the invocation ended: for dispatched invocations `ok`, `error`, `cancelled`, `auth_required`, or `exec` (the CLI handed the process over to another program, e.g. `local client`; its exit status is unknown); for invocations that fail to parse, `help`, `version`, or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
-- the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required; parse errors keep clap's exit 2; a fixed 0 for `exec`, where the real exit code is not knowable)
+- how the invocation ended and its exit code
 - the CLI version, OS, and architecture
 - whether it ran in CI (`CI` env var)
 - whether it ran under a detected coding agent, and if so which one (e.g. `claude-code`)
 
-Every invocation counts, including `--help`, `--version`, a bare `clickhousectl`, and mistyped commands — failed invocations are recorded as such (that is how we find the confusing corners of the CLI), subject to the same consent flow as everything else. (One known gap: a few local commands that mirror a child process's exit code directly skip the event when the child exits non-zero; tracked in [#321](https://github.com/ClickHouse/clickhousectl/issues/321).)
-
-There is no install ID, no device ID, and no fingerprinting of any kind. The payload is built from the clap command definitions rather than the raw command line, so leaking an argument value is structurally impossible — the code that builds the event has no access to values at all. That holds for failed parses too: they are reconstructed by matching argv tokens against the defined command tree, so every recorded string is one the CLI itself defines.
+There is no install ID, no device ID, and no fingerprinting of any kind. The payload is built from the clap command definitions rather than the raw command line, so leaking an argument value is structurally impossible — the code that builds the event has no access to values at all.
 
 Nothing is ever sent before you have seen the notice or explicitly enabled telemetry with `clickhousectl telemetry enable`: the first run prints a one-time notice to stderr, records that it was shown in `~/.clickhouse/telemetry.json`, and sends nothing. Sending starts from the following run — or immediately if you opt in by running `telemetry enable`, which is explicit consent and skips the notice. The send happens in a short-lived detached process, so command latency is unaffected even when the endpoint is unreachable.
 

--- a/README.md
+++ b/README.md
@@ -885,7 +885,7 @@ The CLI checks for updates in the background (at most once per 24 hours) and cac
 
 ## Telemetry
 
-`clickhousectl` collects anonymous usage data to help us understand which commands matter and improve the CLI. Full details: <https://clickhouse.com/docs/interfaces/cli#telemetry>.
+`clickhousectl` collects anonymous usage data to help us understand which commands matter and improve the CLI. Full details: <https://clickhouse.com/docs/concepts/features/interfaces/cli#telemetry>.
 
 Each event contains exactly:
 
@@ -897,7 +897,7 @@ Each event contains exactly:
 - whether it ran in CI (`CI` env var)
 - whether it ran under a detected coding agent, and if so which one (e.g. `claude-code`)
 
-Every invocation counts, including `--help`, `--version`, a bare `clickhousectl`, and mistyped commands — failed invocations are recorded as such (that is how we find the confusing corners of the CLI), subject to the same consent flow as everything else.
+Every invocation counts, including `--help`, `--version`, a bare `clickhousectl`, and mistyped commands — failed invocations are recorded as such (that is how we find the confusing corners of the CLI), subject to the same consent flow as everything else. (One known gap: a few local commands that mirror a child process's exit code directly skip the event when the child exits non-zero; tracked in [#321](https://github.com/ClickHouse/clickhousectl/issues/321).)
 
 There is no install ID, no device ID, and no fingerprinting of any kind. The payload is built from the clap command definitions rather than the raw command line, so leaking an argument value is structurally impossible — the code that builds the event has no access to values at all. That holds for failed parses too: they are reconstructed by matching argv tokens against the defined command tree, so every recorded string is one the CLI itself defines.
 

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ Each event contains exactly:
 
 - the command path (e.g. `local start`) — for an invocation that fails to parse, the longest *valid* prefix of what was typed; a mistyped or unrecognized token is never recorded
 - the **names** of the flags passed (e.g. `json`, `org-id`) — never flag values, never positional arguments
-- how the invocation ended: `ok`, `help`, `version`, `exec` (the CLI handed the process over to another program, e.g. `local client`; its exit status is unknown), or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
+- how the invocation ended: for dispatched invocations `ok`, `error`, `cancelled`, `auth_required`, or `exec` (the CLI handed the process over to another program, e.g. `local client`; its exit status is unknown); for invocations that fail to parse, `help`, `version`, or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
 - the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required; parse errors keep clap's exit 2; a fixed 0 for `exec`, where the real exit code is not knowable)
 - the CLI version, OS, and architecture
 - whether it ran in CI (`CI` env var)

--- a/README.md
+++ b/README.md
@@ -891,8 +891,8 @@ Each event contains exactly:
 
 - the command path (e.g. `local start`) — for an invocation that fails to parse, the longest *valid* prefix of what was typed; a mistyped or unrecognized token is never recorded
 - the **names** of the flags passed (e.g. `json`, `org-id`) — never flag values, never positional arguments
-- how the invocation ended: `ok`, `help`, `version`, or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
-- the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required; parse errors keep clap's exit 2)
+- how the invocation ended: `ok`, `help`, `version`, `exec` (the CLI handed the process over to another program, e.g. `local client`; its exit status is unknown), or a parse-error kind such as `invalid_subcommand` — plus, for typos, clap's "did you mean" suggestion (always the name of a real command or flag, never your input)
+- the exit code (`gh`-style: 0 success, 1 error, 2 cancelled, 4 auth required; parse errors keep clap's exit 2; a fixed 0 for `exec`, where the real exit code is not knowable)
 - the CLI version, OS, and architecture
 - whether it ran in CI (`CI` env var)
 - whether it ran under a detected coding agent, and if so which one (e.g. `claude-code`)

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -84,7 +84,7 @@ CONTEXT FOR AGENTS:
   clickhousectl collects anonymous usage data: command name, flag names (never values or
   arguments), success/failure, version, OS/arch, and CI/agent detection. No user or machine IDs.
   Opt out with `clickhousectl telemetry disable` or DO_NOT_TRACK=1.
-  Details: https://clickhouse.com/docs/interfaces/cli#telemetry")]
+  Details: https://clickhouse.com/docs/concepts/features/interfaces/cli#telemetry")]
     Telemetry(TelemetryArgs),
 }
 

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -109,6 +109,12 @@ pub enum TelemetryCommands {
     /// the marker file and prints the notice).
     Status,
     /// (internal) Fire one telemetry POST from CHCTL_TELEMETRY_PAYLOAD and exit
+    //
+    // Stable cross-version interface — never remove or rename. After a
+    // self-update the parent (old version) spawns the freshly installed
+    // binary (new version) as `telemetry send` with the payload in
+    // CHCTL_TELEMETRY_PAYLOAD, so this subcommand and that env var must keep
+    // working across releases.
     #[command(hide = true)]
     Send,
 }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -296,6 +296,10 @@ fn run_client(
     }
 
     cmd.args(&args);
+    // `exec()` replaces the process image on success, so `main`'s telemetry
+    // tail never runs for this invocation; record the event now (#320).
+    #[cfg(feature = "telemetry")]
+    crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
 }

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -623,6 +623,10 @@ fn exec_host_psql(
         cmd.arg("-f").arg(f);
     }
     cmd.args(&extra_args);
+    // `exec()` replaces the process image on success, so `main`'s telemetry
+    // tail never runs for this invocation; record the event now (#320).
+    #[cfg(feature = "telemetry")]
+    crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
 }

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -51,8 +51,9 @@ async fn main() {
     // Single-exit invariant (#320): every invocation — bare, help, version,
     // typo, dispatched command — falls through to the common tail below, so
     // the first-run telemetry notice and subsequent events cover all of them.
-    // The sole exemption is the hidden `telemetry send` child inside
-    // `run_parsed`. Do not add exit paths that bypass this tail.
+    // The sole intended exemption is the hidden `telemetry send` child inside
+    // `run_parsed`; three pre-existing child-exit-code passthroughs in the
+    // local handlers still bypass the tail (#321). Do not add exit paths.
     let (exit_code, telemetry_invocation) = match cmd.try_get_matches_from_mut(argv.iter()) {
         Ok(matches) => {
             #[cfg(feature = "telemetry")]
@@ -67,8 +68,11 @@ async fn main() {
         }
         Err(e) => {
             // clap keeps its own formatting and colors; help/version print to
-            // stdout, usage errors to stderr.
-            e.print().expect("failed to print output");
+            // stdout, usage errors to stderr. Print failures are swallowed
+            // like clap's own `Error::exit` swallows them: a broken pipe must
+            // not turn exit 2 into a panic (which would also bypass the
+            // telemetry tail below).
+            let _ = e.print();
             match e.kind() {
                 // --version always hits the network to refresh the cache + timer,
                 // then prints the notice from the freshly-updated cache.

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -159,7 +159,10 @@ async fn run_parsed(cli: Cli) -> i32 {
     let exit_code = match result {
         Ok(()) => 0,
         Err(e) => {
-            eprintln!("Error: {}", e);
+            use std::io::Write;
+            // Not `eprintln!`, which panics on a closed stderr — see
+            // `telemetry::print_first_run_notice`.
+            let _ = writeln!(std::io::stderr(), "Error: {}", e);
             e.exit_code()
         }
     };

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -43,41 +43,74 @@ async fn main() {
 
     // Parse via ArgMatches (rather than `Cli::try_parse()`) so the telemetry
     // capture below can read the command path and passed-flag *names* from the
-    // clap definitions — argument values are never consulted.
+    // clap definitions — argument values are never consulted. Argv is
+    // collected once so a failed parse can be re-walked by `capture_lossy`.
+    let argv: Vec<std::ffi::OsString> = std::env::args_os().collect();
     let mut cmd = Cli::command();
-    let matches = match cmd.try_get_matches_from_mut(std::env::args_os()) {
-        Ok(matches) => matches,
+
+    // Single-exit invariant (#320): every invocation — bare, help, version,
+    // typo, dispatched command — falls through to the common tail below, so
+    // the first-run telemetry notice and subsequent events cover all of them.
+    // The sole exemption is the hidden `telemetry send` child inside
+    // `run_parsed`. Do not add exit paths that bypass this tail.
+    let (exit_code, telemetry_invocation) = match cmd.try_get_matches_from_mut(argv.iter()) {
+        Ok(matches) => {
+            #[cfg(feature = "telemetry")]
+            let invocation = telemetry::capture(&cmd, &matches);
+            #[cfg(not(feature = "telemetry"))]
+            let invocation = ();
+            // The matches were produced by this very `cmd`, so a mismatch is
+            // a clap derive bug, not a user error.
+            let cli = Cli::from_arg_matches(&matches)
+                .expect("Cli::from_arg_matches must accept matches from Cli::command()");
+            (run_parsed(cli).await, invocation)
+        }
         Err(e) => {
+            // clap keeps its own formatting and colors; help/version print to
+            // stdout, usage errors to stderr.
+            e.print().expect("failed to print output");
             match e.kind() {
                 // --version always hits the network to refresh the cache + timer,
                 // then prints the notice from the freshly-updated cache.
                 ErrorKind::DisplayVersion => {
-                    e.print().expect("failed to print output");
                     update::force_refresh_update_cache().await;
                     update::print_cached_update_notice();
-                    std::process::exit(0);
                 }
                 // --help shows the notice from cache (no blocking network call).
-                ErrorKind::DisplayHelp => {
-                    e.print().expect("failed to print output");
-                    update::print_cached_update_notice();
-                    std::process::exit(0);
-                }
-                // Parse errors exit here, before telemetry capture: a mistyped
-                // invocation never produces an event.
-                _ => e.exit(),
+                ErrorKind::DisplayHelp => update::print_cached_update_notice(),
+                // Usage errors do no update-cache work: a mistyped invocation
+                // must not cause network activity beyond the consented
+                // telemetry send.
+                _ => {}
             }
+            #[cfg(feature = "telemetry")]
+            let invocation = telemetry::capture_lossy(&mut cmd, &argv, &e);
+            #[cfg(not(feature = "telemetry"))]
+            let invocation = ();
+            // clap's own exit codes: 0 for help/version, 2 for usage errors.
+            // The 2 numerically collides with the documented "cancelled" exit
+            // code; the telemetry `outcome` field disambiguates, and the
+            // shell-visible clash is #319's to fix.
+            (e.exit_code(), invocation)
         }
     };
 
+    // Consent is evaluated here, after the command ran, so `telemetry disable`
+    // silences its own event and `telemetry enable` sends one.
     #[cfg(feature = "telemetry")]
-    let telemetry_invocation = telemetry::capture(&cmd, &matches);
+    telemetry::finalize(telemetry_invocation, exit_code);
+    #[cfg(not(feature = "telemetry"))]
+    let () = telemetry_invocation;
 
-    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
+    std::process::exit(exit_code);
+}
 
-    // The hidden send child does exactly one POST and exits: no update-cache
-    // refresh, no dispatch, and no telemetry hook of its own (a send can never
-    // trigger another send).
+/// Run a successfully parsed invocation to completion and report the exit
+/// code for `main`'s single exit. The hidden `telemetry send` child is the
+/// one deliberate early exit in the binary: it does exactly one POST — no
+/// update-cache refresh, no dispatch, and no telemetry hook of its own, so a
+/// send can never trigger another send.
+async fn run_parsed(cli: Cli) -> i32 {
     #[cfg(feature = "telemetry")]
     if matches!(
         cli.command,
@@ -126,12 +159,7 @@ async fn main() {
         update::print_cached_update_notice();
     }
 
-    // Consent is evaluated here, after the command ran, so `telemetry disable`
-    // silences its own event and `telemetry enable` sends one.
-    #[cfg(feature = "telemetry")]
-    telemetry::finalize(telemetry_invocation, exit_code);
-
-    std::process::exit(exit_code);
+    exit_code
 }
 
 /// The explicit `--json` flag for a command, or `None` for commands that never

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -52,12 +52,19 @@ async fn main() {
     // typo, dispatched command — falls through to the common tail below, so
     // the first-run telemetry notice and subsequent events cover all of them.
     // The sole intended exemption is the hidden `telemetry send` child inside
-    // `run_parsed`; three pre-existing child-exit-code passthroughs in the
-    // local handlers still bypass the tail (#321). Do not add exit paths.
+    // `run_parsed`; the `exec()` handoffs (`local client`, host psql) record
+    // their event via `telemetry::finalize_before_exec` just before the
+    // process image is replaced; three pre-existing child-exit-code
+    // passthroughs in the local handlers still bypass the tail (#321). Do not
+    // add exit paths.
     let (exit_code, telemetry_invocation) = match cmd.try_get_matches_from_mut(argv.iter()) {
         Ok(matches) => {
             #[cfg(feature = "telemetry")]
             let invocation = telemetry::capture(&cmd, &matches);
+            // Stashed so the pre-exec hook can reach it from inside a
+            // handler when `exec()` makes the tail below unreachable.
+            #[cfg(feature = "telemetry")]
+            telemetry::stash_invocation(invocation.clone());
             #[cfg(not(feature = "telemetry"))]
             let invocation = ();
             // The matches were produced by this very `cmd`, so a mismatch is

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -34,6 +34,13 @@ async fn main() {
     // libc's environ.
     dotenv::init();
 
+    // Snapshot the executable path before the command runs: a successful
+    // `clickhousectl update` replaces the binary on disk, after which a lazy
+    // `current_exe()` lookup fails on Linux and the update's own telemetry
+    // event would be dropped.
+    #[cfg(feature = "telemetry")]
+    telemetry::init();
+
     // Parse via ArgMatches (rather than `Cli::try_parse()`) so the telemetry
     // capture below can read the command path and passed-flag *names* from the
     // clap definitions — argument values are never consulted.

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -16,6 +16,16 @@
 //! ([`capture`] walks `ArgMatches` ids and `Arg` metadata, never touching
 //! `get_one`/`get_raw`), so leaking a value is structurally impossible.
 //!
+//! Every invocation of the binary counts (#320): bare, `--help`,
+//! `--version`, and mistyped commands all show the first-run notice and
+//! produce events under the same consent state machine — failed invocations
+//! are exactly the signal that shows where the CLI confuses people and
+//! agents. A successful parse is captured exactly from `ArgMatches`; a
+//! failed parse has none, so [`capture_lossy`] re-walks argv against the
+//! clap definitions and records the longest *valid* prefix, the error kind,
+//! and clap's own suggestion — the unmatched token itself never leaves the
+//! machine.
+//!
 //! Transport is a detached child process (`clickhousectl telemetry send`,
 //! hidden): the parent spawns it with all stdio nulled and never waits, so
 //! command latency is unaffected even when the endpoint is unreachable. The

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -26,6 +26,14 @@
 //! and clap's own suggestion — the unmatched token itself never leaves the
 //! machine.
 //!
+//! Two commands hand the process over to another program via `exec()`
+//! (`local client`, host `psql`), replacing the process image so `main`'s
+//! tail never runs on success. Those call sites invoke
+//! [`finalize_before_exec`] immediately before `exec()`; it records the
+//! stashed invocation with outcome `"exec"` and shares an exactly-once
+//! guard with [`finalize`] so a *failed* `exec()` — where the error
+//! propagates back to `main` — never produces a second event.
+//!
 //! Transport is a detached child process (`clickhousectl telemetry send`,
 //! hidden): the parent spawns it with all stdio nulled and never waits, so
 //! command latency is unaffected even when the endpoint is unreachable. The
@@ -33,6 +41,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -176,9 +185,12 @@ struct Payload {
     /// `outcome` (see #319 for the shell-visible fix).
     exit_code: i32,
     /// How the invocation ended, from the closed vocabulary `"ok"` (parsed
-    /// and dispatched) or a direct mapping of clap's `ErrorKind` (`"help"`,
-    /// `"version"`, `"invalid_subcommand"`, …). Literal strings only — this
-    /// field can never carry user data.
+    /// and dispatched), `"exec"` (parsed, dispatched, and the process image
+    /// was replaced by `exec()` — the handed-over program's exit status is
+    /// unknowable, so `exit_code` is a fixed 0 and not meaningful), or a
+    /// direct mapping of clap's `ErrorKind` (`"help"`, `"version"`,
+    /// `"invalid_subcommand"`, …). Literal strings only — this field can
+    /// never carry user data.
     outcome: &'static str,
     /// Clap's "did you mean" for failed parses. Computed by clap from the
     /// definition set, so it names a defined subcommand or flag — never the
@@ -219,6 +231,7 @@ fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) ->
 
 /// What the user invoked: the subcommand path (e.g. `"local start"`) and the
 /// long names of the flags they passed. No values, no positionals.
+#[derive(Clone)]
 pub struct Invocation {
     command: String,
     flags: Vec<String>,
@@ -454,13 +467,69 @@ fn decide(path: &Path, invocation: &Invocation, exit_code: i32, env: EnvLookup<'
     }
 }
 
+/// The successfully-parsed invocation, stashed by `main` before dispatch so
+/// [`finalize_before_exec`] can build an event from deep inside a handler
+/// without threading the capture through every signature. Never set on the
+/// parse-failure path — `exec()` is only reachable after a successful parse.
+static STASHED_INVOCATION: OnceLock<Invocation> = OnceLock::new();
+
+pub fn stash_invocation(invocation: Invocation) {
+    let _ = STASHED_INVOCATION.set(invocation);
+}
+
+/// Exactly-once guard shared by [`finalize`] and [`finalize_before_exec`]:
+/// whichever runs first claims it, the other is a no-op. When `exec()` fails,
+/// the pre-exec hook has already recorded the invocation as `"exec"` and the
+/// error propagating back to `main`'s tail is not recorded — losing the
+/// exec-failure detail is the accepted price for never emitting two events
+/// for one invocation.
+static FINALIZED: AtomicBool = AtomicBool::new(false);
+
+/// `true` for exactly one caller per guard: swap semantics, first wins.
+fn claim(guard: &AtomicBool) -> bool {
+    !guard.swap(true, Ordering::SeqCst)
+}
+
+/// The event recorded when the process image is about to be replaced: the
+/// stashed parse result with its outcome rewritten to the `"exec"` literal
+/// (see [`Payload::outcome`]).
+fn exec_invocation(stashed: &Invocation) -> Invocation {
+    Invocation {
+        outcome: "exec",
+        ..stashed.clone()
+    }
+}
+
 /// The telemetry hook, called once at the very end of `main` (after the
 /// command has run, so `telemetry disable` silences its own event), with the
 /// gh-style exit code the process is about to exit with. Never errors, never
 /// blocks beyond spawning a detached child.
 pub fn finalize(invocation: Invocation, exit_code: i32) {
+    if !claim(&FINALIZED) {
+        return;
+    }
+    finalize_inner(&invocation, exit_code);
+}
+
+/// The pre-exec hook, called by the `exec()` handoffs (`local client`, host
+/// `psql`) immediately before the process image is replaced and `main`'s tail
+/// becomes unreachable. On a first run this prints the notice to stderr just
+/// before the handed-over program starts — acceptable and intended. The
+/// detached send child survives the `exec()` because it is a separate
+/// process.
+pub fn finalize_before_exec() {
+    let Some(stashed) = STASHED_INVOCATION.get() else {
+        return;
+    };
+    if !claim(&FINALIZED) {
+        return;
+    }
+    finalize_inner(&exec_invocation(stashed), 0);
+}
+
+fn finalize_inner(invocation: &Invocation, exit_code: i32) {
     let Some(path) = state_path() else { return };
-    match decide(&path, &invocation, exit_code, &real_env_lookup) {
+    match decide(&path, invocation, exit_code, &real_env_lookup) {
         Action::Silent => {}
         Action::Notice => print_first_run_notice(),
         Action::Debug(json) => {
@@ -786,6 +855,56 @@ mod tests {
         };
         let payload = build_payload(&inv, 0, &env_of(&[]));
         assert_eq!(payload.flags.len(), MAX_FLAGS);
+    }
+
+    // -- exec handoffs: pre-exec hook building blocks -------------------------
+
+    #[test]
+    fn claim_yields_true_exactly_once() {
+        // Tested on a local guard, not the shared static, so this cannot
+        // race other tests or depend on execution order.
+        let guard = AtomicBool::new(false);
+        assert!(claim(&guard));
+        assert!(!claim(&guard));
+        assert!(!claim(&guard));
+    }
+
+    #[test]
+    fn exec_invocation_rewrites_only_the_outcome() {
+        let stashed = Invocation {
+            command: "local client".into(),
+            flags: vec!["port".into()],
+            outcome: "ok",
+            suggestion: None,
+        };
+        let inv = exec_invocation(&stashed);
+        assert_eq!(inv.outcome, "exec");
+        assert_eq!(inv.command, "local client");
+        assert_eq!(inv.flags, ["port"]);
+        assert_eq!(inv.suggestion, None);
+    }
+
+    #[test]
+    fn exec_outcome_sends_the_expected_payload() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("telemetry.json");
+        save_state_to(&path, false).unwrap();
+        let inv = exec_invocation(&Invocation {
+            command: "local client".into(),
+            flags: vec!["query".into()],
+            outcome: "ok",
+            suggestion: None,
+        });
+        // The hook always passes 0: the handed-over program's exit status is
+        // unknowable, and `outcome` marks the code as not meaningful.
+        let Action::Send(json) = decide(&path, &inv, 0, &env_of(&[])) else {
+            panic!("expected Send");
+        };
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["command"], "local client");
+        assert_eq!(value["flags"], serde_json::json!(["query"]));
+        assert_eq!(value["outcome"], "exec");
+        assert_eq!(value["exit_code"], 0);
     }
 
     // -- capture: values are structurally unreachable ------------------------

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -159,9 +159,21 @@ fn env_truthy(value: Option<String>) -> bool {
 struct Payload {
     command: String,
     flags: Vec<String>,
-    /// gh-style exit code (`Error::exit_code`): 0 success, 1 error,
-    /// 2 cancelled, 4 auth required.
+    /// Exit code: gh-style (`Error::exit_code`) for dispatched commands —
+    /// 0 success, 1 error, 2 cancelled, 4 auth required — and clap's own
+    /// code for parse outcomes (0 help/version, 2 usage error). The numeric
+    /// clash between "cancelled" and "usage error" is disambiguated by
+    /// `outcome` (see #319 for the shell-visible fix).
     exit_code: i32,
+    /// How the invocation ended, from the closed vocabulary `"ok"` (parsed
+    /// and dispatched) or a direct mapping of clap's `ErrorKind` (`"help"`,
+    /// `"version"`, `"invalid_subcommand"`, …). Literal strings only — this
+    /// field can never carry user data.
+    outcome: &'static str,
+    /// Clap's "did you mean" for failed parses. Computed by clap from the
+    /// definition set, so it names a defined subcommand or flag — never the
+    /// user's input. `null` when clap made no suggestion.
+    suggestion: Option<String>,
     is_agent: bool,
     /// Canonical id of the detected coding agent (e.g. "claude-code");
     /// `null` for human invocations.
@@ -180,6 +192,8 @@ fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) ->
         command: invocation.command.clone(),
         flags,
         exit_code,
+        outcome: invocation.outcome,
+        suggestion: invocation.suggestion.clone(),
         is_agent: detected.is_some(),
         agent: detected.map(|a| a.id.as_str().to_string()),
         ci: env_truthy(env(CI_ENV)),
@@ -198,6 +212,45 @@ fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) ->
 pub struct Invocation {
     command: String,
     flags: Vec<String>,
+    /// See [`Payload::outcome`]: `"ok"` from [`capture`], an error-kind
+    /// mapping from [`capture_lossy`].
+    outcome: &'static str,
+    /// See [`Payload::suggestion`]: always `None` from [`capture`].
+    suggestion: Option<String>,
+}
+
+/// Map clap's parse-error kind to the closed outcome vocabulary. Every value
+/// is a literal owned by this match; the wildcard covers the remaining (and
+/// future — `ErrorKind` is non-exhaustive) kinds.
+fn outcome_for_error(kind: clap::error::ErrorKind) -> &'static str {
+    use clap::error::ErrorKind as K;
+    match kind {
+        K::DisplayHelp => "help",
+        K::DisplayVersion => "version",
+        K::InvalidSubcommand => "invalid_subcommand",
+        K::UnknownArgument => "unknown_argument",
+        // Derive commands with a required subcommand report a bare
+        // invocation as the "display help" flavor; for telemetry both kinds
+        // are the same fact — no subcommand was given.
+        K::MissingSubcommand | K::DisplayHelpOnMissingArgumentOrSubcommand => "missing_subcommand",
+        K::MissingRequiredArgument => "missing_required",
+        K::InvalidValue | K::ValueValidation => "invalid_value",
+        _ => "other_parse_error",
+    }
+}
+
+/// Clap's "did you mean" for a failed parse, when present. The suggestion is
+/// computed by clap from the definition set, so it is definition-derived and
+/// safe to record.
+fn suggestion_for_error(error: &clap::Error) -> Option<String> {
+    use clap::error::{ContextKind, ContextValue};
+    [ContextKind::SuggestedSubcommand, ContextKind::SuggestedArg]
+        .iter()
+        .find_map(|kind| match error.get(*kind) {
+            Some(ContextValue::String(s)) => Some(s.clone()),
+            Some(ContextValue::Strings(s)) => s.first().cloned(),
+            _ => None,
+        })
 }
 
 /// Derive the command path and passed-flag names from the parsed matches.
@@ -260,6 +313,88 @@ pub fn capture(root: &clap::Command, matches: &clap::ArgMatches) -> Invocation {
     Invocation {
         command: path.join(" "),
         flags: flags.into_iter().collect(),
+        outcome: "ok",
+        suggestion: None,
+    }
+}
+
+/// Derive a lossy invocation from raw argv when parsing failed and no
+/// `ArgMatches` exists (help, version, and every usage error).
+///
+/// Walks the argv tokens against the clap `Command` tree and records only
+/// strings owned by the definitions, matched by equality — argv slices never
+/// enter the result, the same "structurally impossible to leak a value"
+/// guarantee as [`capture`]. The walk stops at the first token that matches
+/// nothing, so `command` is the longest *valid* prefix; the unmatched token
+/// itself is never recorded (a typo is indistinguishable from a secret
+/// pasted into the wrong window — see #320).
+pub fn capture_lossy(
+    root: &mut clap::Command,
+    argv: &[std::ffi::OsString],
+    error: &clap::Error,
+) -> Invocation {
+    // Idempotent; materializes the implicit help/version args so `--help`
+    // and `-h` resolve to real definitions below.
+    root.build();
+
+    // Ancestor commands, innermost last, like `capture`: flags are resolved
+    // against the current command first, then outward (global flags are
+    // defined on an ancestor but valid at deeper levels).
+    let mut stack: Vec<&clap::Command> = vec![root];
+    let mut path: Vec<&str> = Vec::new();
+    let mut flags = std::collections::BTreeSet::new();
+    let mut tokens = argv.iter().skip(1);
+    while let Some(token) = tokens.next() {
+        // A non-UTF-8 token cannot match any definition.
+        let Some(token) = token.to_str() else { break };
+        // Everything after `--` is positional by definition.
+        if token == "--" {
+            break;
+        }
+        if let Some(rest) = token.strip_prefix("--") {
+            let (name, has_inline_value) = match rest.split_once('=') {
+                Some((name, _value)) => (name, true),
+                None => (rest, false),
+            };
+            let Some(arg) = stack
+                .iter()
+                .rev()
+                .find_map(|cmd| cmd.get_arguments().find(|a| a.get_long() == Some(name)))
+            else {
+                break;
+            };
+            // `get_long` is `Some` — that is what the token just matched.
+            flags.extend(arg.get_long().map(str::to_string));
+            // The definition says this flag consumes the next token as its
+            // value: skip it, so a value that happens to equal a sibling
+            // subcommand name is never misrecorded as command path.
+            if !has_inline_value && arg.get_action().takes_values() {
+                tokens.next();
+            }
+        } else if token == "-h" {
+            // The short forms of the two implicit flags, recorded under
+            // their definitions' long names like everything else.
+            flags.insert("help".to_string());
+        } else if token == "-V" {
+            flags.insert("version".to_string());
+        } else if let Some(sub) = stack
+            .last()
+            .expect("stack starts non-empty and only grows")
+            .find_subcommand(token)
+        {
+            // Recorded name is the definition's, even when the token
+            // matched an alias.
+            path.push(sub.get_name());
+            stack.push(sub);
+        } else {
+            break;
+        }
+    }
+    Invocation {
+        command: path.join(" "),
+        flags: flags.into_iter().collect(),
+        outcome: outcome_for_error(error.kind()),
+        suggestion: suggestion_for_error(error),
     }
 }
 
@@ -477,6 +612,8 @@ mod tests {
         Invocation {
             command: "local list".into(),
             flags: vec!["json".into()],
+            outcome: "ok",
+            suggestion: None,
         }
     }
 
@@ -565,6 +702,8 @@ mod tests {
         assert_eq!(value["command"], "local list");
         assert_eq!(value["flags"], serde_json::json!(["json"]));
         assert_eq!(value["exit_code"], 4);
+        assert_eq!(value["outcome"], "ok");
+        assert_eq!(value["suggestion"], serde_json::Value::Null);
         assert_eq!(value["ci"], true);
         assert_eq!(value["version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(value["os"], std::env::consts::OS);
@@ -599,6 +738,8 @@ mod tests {
                 "command",
                 "flags",
                 "exit_code",
+                "outcome",
+                "suggestion",
                 "is_agent",
                 "agent",
                 "ci",
@@ -620,6 +761,8 @@ mod tests {
         let inv = Invocation {
             command: "x".into(),
             flags: (0..100).map(|i| format!("flag-{i}")).collect(),
+            outcome: "ok",
+            suggestion: None,
         };
         let payload = build_payload(&inv, 0, &env_of(&[]));
         assert_eq!(payload.flags.len(), MAX_FLAGS);
@@ -686,6 +829,145 @@ mod tests {
         let inv = capture_from(&["clickhousectl", "local", "list"]);
         assert_eq!(inv.command, "local list");
         assert!(inv.flags.is_empty());
+    }
+
+    // -- capture_lossy: failed parses, longest valid prefix only -------------
+
+    fn capture_lossy_from(args: &[&str]) -> Invocation {
+        let mut cmd = crate::cli::Cli::command();
+        let argv: Vec<std::ffi::OsString> = args.iter().map(Into::into).collect();
+        let error = cmd
+            .try_get_matches_from_mut(&argv)
+            .expect_err("argv must fail to parse for capture_lossy tests");
+        capture_lossy(&mut cmd, &argv, &error)
+    }
+
+    #[test]
+    fn lossy_bare_invocation_is_missing_subcommand() {
+        let inv = capture_lossy_from(&["clickhousectl"]);
+        assert_eq!(inv.command, "");
+        assert!(inv.flags.is_empty());
+        assert_eq!(inv.outcome, "missing_subcommand");
+        assert_eq!(inv.suggestion, None);
+    }
+
+    #[test]
+    fn lossy_root_help_records_the_help_flag() {
+        let inv = capture_lossy_from(&["clickhousectl", "--help"]);
+        assert_eq!(inv.command, "");
+        assert_eq!(inv.flags, ["help"]);
+        assert_eq!(inv.outcome, "help");
+    }
+
+    #[test]
+    fn lossy_nested_help_keeps_the_command_path() {
+        let inv = capture_lossy_from(&["clickhousectl", "cloud", "service", "--help"]);
+        assert_eq!(inv.command, "cloud service");
+        assert_eq!(inv.flags, ["help"]);
+        assert_eq!(inv.outcome, "help");
+    }
+
+    #[test]
+    fn lossy_short_help_and_version_record_long_names() {
+        let inv = capture_lossy_from(&["clickhousectl", "local", "-h"]);
+        assert_eq!(inv.command, "local");
+        assert_eq!(inv.flags, ["help"]);
+        assert_eq!(inv.outcome, "help");
+
+        let inv = capture_lossy_from(&["clickhousectl", "-V"]);
+        assert_eq!(inv.command, "");
+        assert_eq!(inv.flags, ["version"]);
+        assert_eq!(inv.outcome, "version");
+    }
+
+    #[test]
+    fn lossy_typoed_subcommand_stops_and_carries_the_suggestion() {
+        let inv = capture_lossy_from(&["clickhousectl", "cloud", "servce", "list"]);
+        // The typo'd token is never recorded; the path is the valid prefix.
+        assert_eq!(inv.command, "cloud");
+        assert!(inv.flags.is_empty());
+        assert_eq!(inv.outcome, "invalid_subcommand");
+        // Clap's did-you-mean names a *defined* subcommand.
+        assert_eq!(inv.suggestion.as_deref(), Some("service"));
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("servce"), "typo leaked into payload: {json}");
+    }
+
+    #[test]
+    fn lossy_unknown_flag_stops_the_walk() {
+        let inv = capture_lossy_from(&["clickhousectl", "local", "--frobnicate", "list"]);
+        assert_eq!(inv.command, "local");
+        assert!(inv.flags.is_empty());
+        assert_eq!(inv.outcome, "unknown_argument");
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("frobnicate"), "unknown flag leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_flag_value_equal_to_a_subcommand_name_is_skipped() {
+        // `get` is missing its required positional, so the parse fails; the
+        // `--org-id` *value* happens to be the name of a sibling subcommand
+        // and must not be misrecorded as command path.
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "get",
+            "--org-id",
+            "list",
+        ]);
+        assert_eq!(inv.command, "cloud service get");
+        assert_eq!(inv.flags, ["org-id"]);
+        assert_eq!(inv.outcome, "missing_required");
+    }
+
+    #[test]
+    fn lossy_inline_flag_value_is_discarded() {
+        // `--org-id=SECRET` fails only because of the trailing junk token;
+        // the name part is matched, the inline value never recorded.
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "list",
+            "--org-id=SECRET-ORG",
+            "junk-token",
+        ]);
+        assert_eq!(inv.command, "cloud service list");
+        assert_eq!(inv.flags, ["org-id"]);
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "inline value leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_double_dash_stops_the_walk() {
+        let inv = capture_lossy_from(&["clickhousectl", "local", "--", "SECRET-POSITIONAL"]);
+        assert_eq!(inv.command, "local");
+        assert!(inv.flags.is_empty());
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "post-`--` token leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_hostile_argv_never_reaches_the_payload() {
+        // Mirrors capture_reports_names_only_never_values_or_positionals:
+        // positionals, flag values, and unmatched tokens must all be absent.
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "cloud",
+            "--json",
+            "service",
+            "get",
+            "SECRET-SERVICE-ID",
+            "--org-id",
+            "SECRET-ORG",
+            "--wat",
+            "SECRET-TRAILING",
+        ]);
+        assert_eq!(inv.command, "cloud service get");
+        assert_eq!(inv.outcome, "unknown_argument");
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "payload leaked a value: {json}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -630,7 +630,11 @@ pub fn run_command(cmd: crate::cli::TelemetryCommands) -> Result<()> {
             // (see `decide`): without this note the user would see success
             // while telemetry stays fully silent.
             if env_truthy(real_env_lookup(DNT_ENV)) {
-                eprintln!(
+                use std::io::Write;
+                // Not `eprintln!`, which panics on a closed stderr — see
+                // `print_first_run_notice`.
+                let _ = writeln!(
+                    std::io::stderr(),
                     "Note: the DO_NOT_TRACK environment variable is set; telemetry will remain silent while it is set."
                 );
             }

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -463,15 +463,25 @@ pub fn finalize(invocation: Invocation, exit_code: i32) {
     match decide(&path, &invocation, exit_code, &real_env_lookup) {
         Action::Silent => {}
         Action::Notice => print_first_run_notice(),
-        Action::Debug(json) => eprintln!("{json}"),
+        Action::Debug(json) => {
+            use std::io::Write;
+            // Not `eprintln!`, which panics on a closed stderr — see
+            // `print_first_run_notice`.
+            let _ = writeln!(std::io::stderr(), "{json}");
+        }
         Action::Send(json) => spawn_send_child(&json),
     }
 }
 
 /// Printed to stderr regardless of TTY so agent/non-interactive usage still
-/// sees it exactly once (stdout stays machine-parseable).
+/// sees it exactly once (stdout stays machine-parseable). Write failures are
+/// ignored, not `eprintln!`-panicked: this hook runs on every invocation —
+/// including ones whose stderr is a closed pipe — and must never turn an
+/// exit code into a panic.
 fn print_first_run_notice() {
-    eprintln!(
+    use std::io::Write;
+    let _ = writeln!(
+        std::io::stderr(),
         "\nNote: clickhousectl collects anonymous usage data to help improve the CLI:\n\
          command name, flag names (never values or arguments), success/failure, version,\n\
          OS/arch, and CI/agent detection. No user or machine IDs. Nothing was sent this run.\n\

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -181,16 +181,20 @@ struct Payload {
     /// Exit code: gh-style (`Error::exit_code`) for dispatched commands —
     /// 0 success, 1 error, 2 cancelled, 4 auth required — and clap's own
     /// code for parse outcomes (0 help/version, 2 usage error). The numeric
-    /// clash between "cancelled" and "usage error" is disambiguated by
-    /// `outcome` (see #319 for the shell-visible fix).
+    /// clash between "cancelled" and "usage error" is fully disambiguated by
+    /// `outcome` in the payload: a dispatched 2 becomes `"cancelled"`, a
+    /// parse-failure 2 keeps its parse kind (see #319 for the shell-visible
+    /// fix).
     exit_code: i32,
-    /// How the invocation ended, from the closed vocabulary `"ok"` (parsed
-    /// and dispatched), `"exec"` (parsed, dispatched, and the process image
-    /// was replaced by `exec()` — the handed-over program's exit status is
-    /// unknowable, so `exit_code` is a fixed 0 and not meaningful), or a
-    /// direct mapping of clap's `ErrorKind` (`"help"`, `"version"`,
-    /// `"invalid_subcommand"`, …). Literal strings only — this field can
-    /// never carry user data.
+    /// How the invocation ended, from a closed vocabulary. Dispatched
+    /// invocations carry `"ok"`, `"error"`, `"cancelled"`, or
+    /// `"auth_required"` — derived from the gh-style exit code by
+    /// [`dispatched_outcome`] — or `"exec"` (parsed, dispatched, and the
+    /// process image was replaced by `exec()` — the handed-over program's
+    /// exit status is unknowable, so `exit_code` is a fixed 0 and not
+    /// meaningful). Failed parses carry a direct mapping of clap's
+    /// `ErrorKind` (`"help"`, `"version"`, `"invalid_subcommand"`, …).
+    /// Literal strings only — this field can never carry user data.
     outcome: &'static str,
     /// Clap's "did you mean" for failed parses, anchored locally: recorded
     /// only when it equality-matches a subcommand name or arg long name in
@@ -210,6 +214,26 @@ struct Payload {
     arch: &'static str,
 }
 
+/// Derive the dispatched outcome from the gh-style exit code. [`capture`]
+/// marks a successful parse `"ok"` before the command has run; by finalize
+/// time the exit code says how dispatch actually ended, so only that
+/// placeholder is rewritten — the parse kinds from [`capture_lossy`] and
+/// `"exec"` from [`finalize_before_exec`] pass through untouched. The mapping
+/// mirrors `Error::exit_code()`; issue #319 will move "cancelled" off exit
+/// code 2 (to stop the shell-level clash with clap's usage-error 2), and this
+/// mapping must follow when it lands.
+fn dispatched_outcome(outcome: &'static str, exit_code: i32) -> &'static str {
+    if outcome != "ok" {
+        return outcome;
+    }
+    match exit_code {
+        0 => "ok",
+        2 => "cancelled",
+        4 => "auth_required",
+        _ => "error",
+    }
+}
+
 fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) -> Payload {
     let mut flags = invocation.flags.clone();
     flags.truncate(MAX_FLAGS);
@@ -218,7 +242,7 @@ fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) ->
         command: invocation.command.clone(),
         flags,
         exit_code,
-        outcome: invocation.outcome,
+        outcome: dispatched_outcome(invocation.outcome, exit_code),
         suggestion: invocation.suggestion.clone(),
         is_agent: detected.is_some(),
         agent: detected.map(|a| a.id.as_str().to_string()),
@@ -239,8 +263,10 @@ fn build_payload(invocation: &Invocation, exit_code: i32, env: EnvLookup<'_>) ->
 pub struct Invocation {
     command: String,
     flags: Vec<String>,
-    /// See [`Payload::outcome`]: `"ok"` from [`capture`], an error-kind
-    /// mapping from [`capture_lossy`].
+    /// See [`Payload::outcome`]: `"ok"` from [`capture`] means *parsed* —
+    /// the dispatched outcome is not knowable until the exit code exists, so
+    /// [`dispatched_outcome`] derives it at finalize time. From
+    /// [`capture_lossy`] this is the error-kind mapping, never rewritten.
     outcome: &'static str,
     /// See [`Payload::suggestion`]: always `None` from [`capture`]; from
     /// [`capture_lossy`] it is a clone of a definition-owned string, never
@@ -864,12 +890,60 @@ mod tests {
         assert_eq!(value["command"], "local list");
         assert_eq!(value["flags"], serde_json::json!(["json"]));
         assert_eq!(value["exit_code"], 4);
-        assert_eq!(value["outcome"], "ok");
+        // The parse-time "ok" placeholder is rewritten from the exit code.
+        assert_eq!(value["outcome"], "auth_required");
         assert_eq!(value["suggestion"], serde_json::Value::Null);
         assert_eq!(value["ci"], true);
         assert_eq!(value["version"], env!("CARGO_PKG_VERSION"));
         assert_eq!(value["os"], std::env::consts::OS);
         assert_eq!(value["arch"], std::env::consts::ARCH);
+    }
+
+    #[test]
+    fn dispatched_outcome_derives_from_the_gh_style_exit_code() {
+        assert_eq!(dispatched_outcome("ok", 0), "ok");
+        assert_eq!(dispatched_outcome("ok", 1), "error");
+        assert_eq!(dispatched_outcome("ok", 2), "cancelled");
+        assert_eq!(dispatched_outcome("ok", 4), "auth_required");
+        // Any exit code outside the gh-style vocabulary is still a failure.
+        assert_eq!(dispatched_outcome("ok", 3), "error");
+        // Non-"ok" outcomes are never rewritten, whatever the exit code.
+        assert_eq!(
+            dispatched_outcome("unknown_argument", 2),
+            "unknown_argument"
+        );
+        assert_eq!(dispatched_outcome("exec", 0), "exec");
+    }
+
+    /// The `outcome` field of the payload `decide` builds for the given
+    /// invocation and exit code, with an enabled state file.
+    fn decided_outcome(invocation: &Invocation, exit_code: i32) -> String {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("telemetry.json");
+        save_state_to(&path, false).unwrap();
+        let Action::Send(json) = decide(&path, invocation, exit_code, &env_of(&[])) else {
+            panic!("expected Send");
+        };
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value["outcome"].as_str().unwrap().to_string()
+    }
+
+    #[test]
+    fn dispatched_payload_outcomes_track_the_exit_code() {
+        assert_eq!(decided_outcome(&invocation(), 0), "ok");
+        assert_eq!(decided_outcome(&invocation(), 1), "error");
+        assert_eq!(decided_outcome(&invocation(), 2), "cancelled");
+    }
+
+    #[test]
+    fn lossy_payload_outcome_is_not_rewritten_by_the_exit_code() {
+        let inv = Invocation {
+            command: "local".into(),
+            flags: vec![],
+            outcome: "unknown_argument",
+            suggestion: None,
+        };
+        assert_eq!(decided_outcome(&inv, 2), "unknown_argument");
     }
 
     #[test]

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -367,7 +367,7 @@ pub fn capture_lossy(
     let mut path: Vec<&str> = Vec::new();
     let mut flags = std::collections::BTreeSet::new();
     let mut tokens = argv.iter().skip(1);
-    while let Some(token) = tokens.next() {
+    'walk: while let Some(token) = tokens.next() {
         // A non-UTF-8 token cannot match any definition.
         let Some(token) = token.to_str() else { break };
         // Everything after `--` is positional by definition.
@@ -379,14 +379,17 @@ pub fn capture_lossy(
                 Some((name, _value)) => (name, true),
                 None => (rest, false),
             };
-            let Some(arg) = stack
-                .iter()
-                .rev()
-                .find_map(|cmd| cmd.get_arguments().find(|a| a.get_long() == Some(name)))
-            else {
+            let Some(arg) = stack.iter().rev().find_map(|cmd| {
+                cmd.get_arguments().find(|a| {
+                    a.get_long() == Some(name)
+                        || a.get_all_aliases()
+                            .is_some_and(|aliases| aliases.contains(&name))
+                })
+            }) else {
                 break;
             };
-            // `get_long` is `Some` — that is what the token just matched.
+            // Recorded name is the canonical long, even when the token
+            // matched a hidden alias (e.g. `--fg` records `foreground`).
             flags.extend(arg.get_long().map(str::to_string));
             // The definition says this flag consumes the next token as its
             // value: skip it, so a value that happens to equal a sibling
@@ -394,12 +397,38 @@ pub fn capture_lossy(
             if !has_inline_value && arg.get_action().takes_values() {
                 tokens.next();
             }
-        } else if token == "-h" {
-            // The short forms of the two implicit flags, recorded under
-            // their definitions' long names like everything else.
-            flags.insert("help".to_string());
-        } else if token == "-V" {
-            flags.insert("version".to_string());
+        } else if let Some(cluster) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
+            // A short cluster (`-F`, `-Fv`, `-p9000`): resolve each char the
+            // way clap does, innermost-outward like the long path. This also
+            // covers the implicit `-h`/`-V`, which `root.build()` above
+            // materialized as real definitions. A bare `-` never gets here
+            // (empty cluster) and falls through to the subcommand branch,
+            // where it breaks the walk like any unknown token.
+            for (i, ch) in cluster.char_indices() {
+                let Some(arg) = stack.iter().rev().find_map(|cmd| {
+                    cmd.get_arguments().find(|a| {
+                        a.get_short() == Some(ch)
+                            || a.get_all_short_aliases().is_some_and(|s| s.contains(&ch))
+                    })
+                }) else {
+                    // An unresolvable char stops the whole walk; flags already
+                    // recorded stay — they are definition strings.
+                    break 'walk;
+                };
+                // Canonical long name, falling back to the definition's id
+                // for short-only args — the same fallback `capture` uses.
+                flags.insert(arg.get_long().unwrap_or(arg.get_id().as_str()).to_string());
+                if arg.get_action().takes_values() {
+                    // The rest of the token (optionally after `=`) is this
+                    // flag's attached value: discard it. When the cluster
+                    // ends with no attached value, the next argv token is
+                    // the value: skip it, as in the long path.
+                    if cluster[i + ch.len_utf8()..].is_empty() {
+                        tokens.next();
+                    }
+                    break;
+                }
+            }
         } else if let Some(sub) = stack
             .last()
             .expect("stack starts non-empty and only grows")
@@ -1080,6 +1109,118 @@ mod tests {
         assert_eq!(inv.flags, ["org-id"]);
         let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
         assert!(!json.contains("SECRET"), "inline value leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_long_aliases_record_the_canonical_names() {
+        // `--fg` and `--config-file` are hidden aliases (local/cli.rs); the
+        // recorded names are the definitions' canonical longs. The parse
+        // fails only on the `--http-port` value.
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "local",
+            "server",
+            "start",
+            "--fg",
+            "--config-file",
+            "SECRET-CONFIG",
+            "--http-port",
+            "SECRET-PORT",
+        ]);
+        assert_eq!(inv.command, "local server start");
+        assert_eq!(inv.flags, ["config", "foreground", "http-port"]);
+        assert_eq!(inv.outcome, "invalid_value");
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "flag value leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_short_flag_value_equal_to_a_subcommand_name_is_skipped() {
+        // Short spelling of lossy_flag_value_equal_to_a_subcommand_name_is_
+        // skipped: the `-q` *value* is a subcommand name elsewhere in the
+        // tree and must not be misrecorded as command path — and must not
+        // break the walk before `-p` (whose bad value fails the parse).
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "local",
+            "client",
+            "-q",
+            "list",
+            "-p",
+            "SECRET-NOT-A-PORT",
+        ]);
+        assert_eq!(inv.command, "local client");
+        assert_eq!(inv.flags, ["port", "query"]);
+        assert_eq!(inv.outcome, "invalid_value");
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "flag value leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_short_cluster_resolves_each_char_and_discards_attached_value() {
+        use clap::{Arg, ArgAction, Command};
+        let mut cmd = Command::new("root").subcommand(
+            Command::new("sub")
+                .arg(
+                    Arg::new("verbose")
+                        .long("verbose")
+                        .short('v')
+                        .action(ArgAction::SetTrue),
+                )
+                // Short-only: recorded under its id, like `capture`.
+                .arg(Arg::new("quiet").short('q').action(ArgAction::SetTrue))
+                // `-L` is a short alias; the canonical long is recorded.
+                .arg(Arg::new("level").long("level").short('l').short_alias('L')),
+        );
+        // One cluster: two unit flags, then a value-taking flag whose
+        // attached value is the remainder of the token.
+        let argv: Vec<std::ffi::OsString> = ["root", "sub", "-qvLSECRET-LEVEL", "junk-token"]
+            .iter()
+            .map(Into::into)
+            .collect();
+        let error = cmd.try_get_matches_from_mut(&argv).unwrap_err();
+        let inv = capture_lossy(&mut cmd, &argv, &error);
+        assert_eq!(inv.command, "sub");
+        assert_eq!(inv.flags, ["level", "quiet", "verbose"]);
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "attached value leaked: {json}");
+    }
+
+    #[test]
+    fn lossy_unknown_short_stops_the_walk() {
+        // Nothing after the unresolvable char is recorded, not even a flag
+        // clap would have accepted.
+        let inv = capture_lossy_from(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "list",
+            "-Z",
+            "--org-id",
+            "SECRET-ORG",
+        ]);
+        assert_eq!(inv.command, "cloud service list");
+        assert!(inv.flags.is_empty());
+        assert_eq!(inv.outcome, "unknown_argument");
+        let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
+        assert!(!json.contains("SECRET"), "post-break token leaked: {json}");
+
+        // Mid-cluster: chars resolved before the unknown one stay recorded —
+        // they are definition strings.
+        use clap::{Arg, ArgAction, Command};
+        let mut cmd = Command::new("root").subcommand(
+            Command::new("sub").arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .short('v')
+                    .action(ArgAction::SetTrue),
+            ),
+        );
+        let argv: Vec<std::ffi::OsString> = ["root", "sub", "-vZ"].iter().map(Into::into).collect();
+        let error = cmd.try_get_matches_from_mut(&argv).unwrap_err();
+        let inv = capture_lossy(&mut cmd, &argv, &error);
+        assert_eq!(inv.command, "sub");
+        assert_eq!(inv.flags, ["verbose"]);
     }
 
     #[test]

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -48,7 +48,7 @@ use crate::error::{Error, Result};
 use crate::paths;
 
 /// Public documentation for what is collected and how to opt out.
-const DOCS_URL: &str = "https://clickhouse.com/docs/interfaces/cli#telemetry";
+const DOCS_URL: &str = "https://clickhouse.com/docs/concepts/features/interfaces/cli#telemetry";
 
 /// Production ingest endpoint (Cloudflare worker in front of ClickHouse Cloud).
 const DEFAULT_ENDPOINT: &str = "https://chctl.clickhouse.com/v1/telemetry";

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -22,6 +22,7 @@
 //! child fires one POST with a short timeout and dies silently on any failure.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -45,6 +46,28 @@ const DNT_ENV: &str = "DO_NOT_TRACK";
 const CI_ENV: &str = "CI";
 
 const SEND_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The executable path, snapshotted at process startup by [`init`].
+///
+/// Resolved eagerly rather than inside `spawn_send_child` because a successful
+/// `clickhousectl update` atomically replaces the binary on disk before the
+/// send child is spawned. On Linux, `/proc/self/exe` then resolves to
+/// `.../clickhousectl (deleted)`, the spawn fails, and the event for the
+/// update itself is silently dropped. At startup the path is always clean;
+/// after an update it names the new binary, which is valid to spawn (the
+/// hidden `telemetry send` interface is stable across versions — see the pin
+/// on `TelemetryCommands::Send` in `cli.rs`).
+static EXE_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Snapshot process-wide facts needed at finalize time. Called once at the
+/// top of `main`, same eager pattern as `dotenv::init`. If `current_exe()`
+/// fails the lock stays empty and the send is skipped — the same failure mode
+/// as resolving lazily.
+pub fn init() {
+    if let Ok(exe) = std::env::current_exe() {
+        let _ = EXE_PATH.set(exe);
+    }
+}
 
 /// The ingest worker caps `flags` at 64 entries; truncate client-side too.
 const MAX_FLAGS: usize = 64;
@@ -318,11 +341,14 @@ fn print_first_run_notice() {
 
 /// Re-invoke this binary as `clickhousectl telemetry send` with the payload
 /// in the child's environment, all stdio nulled, and never wait: the parent
-/// exits immediately and the child dies silently on any failure.
+/// exits immediately and the child dies silently on any failure. The path
+/// comes from the startup snapshot, so after a self-update this spawns the
+/// *new* binary — which may be a newer version than the parent that built
+/// the payload.
 fn spawn_send_child(payload_json: &str) {
     use std::process::{Command, Stdio};
 
-    let Ok(exe) = std::env::current_exe() else {
+    let Some(exe) = EXE_PATH.get() else {
         return;
     };
     let _ = Command::new(exe)
@@ -660,6 +686,16 @@ mod tests {
         let inv = capture_from(&["clickhousectl", "local", "list"]);
         assert_eq!(inv.command, "local list");
         assert!(inv.flags.is_empty());
+    }
+
+    #[test]
+    fn init_snapshots_the_executable_path_once() {
+        // Under `cargo test` the test binary always has a resolvable path.
+        init();
+        let first = EXE_PATH.get().expect("init must snapshot the exe path");
+        // Idempotent: a second call keeps the first snapshot.
+        init();
+        assert_eq!(EXE_PATH.get(), Some(first));
     }
 
     #[test]

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -23,8 +23,8 @@
 //! agents. A successful parse is captured exactly from `ArgMatches`; a
 //! failed parse has none, so [`capture_lossy`] re-walks argv against the
 //! clap definitions and records the longest *valid* prefix, the error kind,
-//! and clap's own suggestion — the unmatched token itself never leaves the
-//! machine.
+//! and clap's suggestion re-anchored to a definition string — the unmatched
+//! token itself never leaves the machine.
 //!
 //! Two commands hand the process over to another program via `exec()`
 //! (`local client`, host `psql`), replacing the process image so `main`'s
@@ -192,9 +192,13 @@ struct Payload {
     /// `"invalid_subcommand"`, …). Literal strings only — this field can
     /// never carry user data.
     outcome: &'static str,
-    /// Clap's "did you mean" for failed parses. Computed by clap from the
-    /// definition set, so it names a defined subcommand or flag — never the
-    /// user's input. `null` when clap made no suggestion.
+    /// Clap's "did you mean" for failed parses, anchored locally: recorded
+    /// only when it equality-matches a subcommand name or arg long name in
+    /// the clap definitions, and the recorded string is cloned from the
+    /// definition itself — the "never the user's input" guarantee is
+    /// enforced here, not inherited from clap internals. Always the bare
+    /// canonical name (no `--`), for flags and subcommands alike. `null`
+    /// when clap made no suggestion or the suggestion matched no definition.
     suggestion: Option<String>,
     is_agent: bool,
     /// Canonical id of the detected coding agent (e.g. "claude-code");
@@ -238,7 +242,9 @@ pub struct Invocation {
     /// See [`Payload::outcome`]: `"ok"` from [`capture`], an error-kind
     /// mapping from [`capture_lossy`].
     outcome: &'static str,
-    /// See [`Payload::suggestion`]: always `None` from [`capture`].
+    /// See [`Payload::suggestion`]: always `None` from [`capture`]; from
+    /// [`capture_lossy`] it is a clone of a definition-owned string, never
+    /// of clap's error context.
     suggestion: Option<String>,
 }
 
@@ -262,17 +268,51 @@ fn outcome_for_error(kind: clap::error::ErrorKind) -> &'static str {
     }
 }
 
-/// Clap's "did you mean" for a failed parse, when present. The suggestion is
-/// computed by clap from the definition set, so it is definition-derived and
-/// safe to record.
-fn suggestion_for_error(error: &clap::Error) -> Option<String> {
+/// Clap's "did you mean" for a failed parse, when present. Candidates come
+/// out of clap's error context, but the recorded value does not: each one is
+/// re-anchored to the built definitions by [`resolve_suggestion`], so the
+/// privacy invariant holds locally rather than resting on clap internals.
+/// Clap sorts multi-candidate lists by *ascending* similarity (clap_builder
+/// `did_you_mean` contract), so the best candidate is the last one that
+/// resolves.
+fn suggestion_for_error(root: &clap::Command, error: &clap::Error) -> Option<String> {
     use clap::error::{ContextKind, ContextValue};
     [ContextKind::SuggestedSubcommand, ContextKind::SuggestedArg]
         .iter()
         .find_map(|kind| match error.get(*kind) {
-            Some(ContextValue::String(s)) => Some(s.clone()),
-            Some(ContextValue::Strings(s)) => s.first().cloned(),
+            Some(ContextValue::String(s)) => resolve_suggestion(root, s),
+            Some(ContextValue::Strings(s)) => {
+                s.iter().rev().find_map(|s| resolve_suggestion(root, s))
+            }
             _ => None,
+        })
+}
+
+/// Anchor a clap-suggested name to the definition that owns it: strip the
+/// `--` prefix clap puts on flag suggestions, then require an equality match
+/// against some subcommand name or arg long name in the tree. The returned
+/// string is cloned from the *definition*, never from clap's error context,
+/// so a recorded suggestion is structurally definition-owned; anything
+/// unmatched is dropped. Flags and subcommands are both recorded as the bare
+/// canonical name.
+fn resolve_suggestion(root: &clap::Command, suggested: &str) -> Option<String> {
+    let name = suggested.trim_start_matches('-');
+    find_defined_name(root, name).map(str::to_string)
+}
+
+/// Depth-first search of the whole command tree for a definition string
+/// equal to `name`: arg long names first, then subcommand names, recursing
+/// into every subcommand.
+fn find_defined_name<'a>(cmd: &'a clap::Command, name: &str) -> Option<&'a str> {
+    cmd.get_arguments()
+        .filter_map(|a| a.get_long())
+        .find(|&long| long == name)
+        .or_else(|| {
+            cmd.get_subcommands().find_map(|sub| {
+                Some(sub.get_name())
+                    .filter(|&sub_name| sub_name == name)
+                    .or_else(|| find_defined_name(sub, name))
+            })
         })
 }
 
@@ -446,7 +486,7 @@ pub fn capture_lossy(
         command: path.join(" "),
         flags: flags.into_iter().collect(),
         outcome: outcome_for_error(error.kind()),
-        suggestion: suggestion_for_error(error),
+        suggestion: suggestion_for_error(root, error),
     }
 }
 
@@ -1063,6 +1103,65 @@ mod tests {
         assert_eq!(inv.suggestion.as_deref(), Some("service"));
         let json = serde_json::to_string(&build_payload(&inv, 2, &env_of(&[]))).unwrap();
         assert!(!json.contains("servce"), "typo leaked into payload: {json}");
+    }
+
+    #[test]
+    fn lossy_suggestion_picks_the_most_similar_candidate() {
+        use clap::Command;
+        use clap::error::{ContextKind, ContextValue};
+        // Jaro similarity to the typo "starz" is unambiguously ordered:
+        // "start" 0.87 > "stash" 0.73, both above clap's 0.7 threshold, so
+        // clap suggests both — ascending, most similar last. Taking the
+        // first would record the weakest candidate.
+        let mut cmd = Command::new("root")
+            .subcommand(Command::new("stash"))
+            .subcommand(Command::new("start"));
+        let argv: Vec<std::ffi::OsString> = ["root", "starz"].iter().map(Into::into).collect();
+        let error = cmd.try_get_matches_from_mut(&argv).unwrap_err();
+        // Guard against the premise going stale: both candidates must be
+        // present, ascending, or the assertion below proves nothing.
+        assert_eq!(
+            error.get(ContextKind::SuggestedSubcommand),
+            Some(&ContextValue::Strings(vec!["stash".into(), "start".into()]))
+        );
+        let inv = capture_lossy(&mut cmd, &argv, &error);
+        assert_eq!(inv.suggestion.as_deref(), Some("start"));
+    }
+
+    #[test]
+    fn lossy_flag_suggestion_records_the_bare_definition_name() {
+        // Clap's SuggestedArg context carries `--json`; the recorded value is
+        // the bare canonical name, cloned from the definition.
+        let inv = capture_lossy_from(&["clickhousectl", "cloud", "service", "list", "--jsn"]);
+        assert_eq!(inv.outcome, "unknown_argument");
+        assert_eq!(inv.suggestion.as_deref(), Some("json"));
+    }
+
+    #[test]
+    fn suggestion_matching_no_definition_is_dropped() {
+        use clap::error::{ContextKind, ContextValue, ErrorKind};
+        let mut cmd = crate::cli::Cli::command();
+        cmd.build();
+        // Fabricate a suggestion clap could never produce: anchoring must
+        // reject anything that is not a definition string.
+        let mut error = clap::Error::new(ErrorKind::InvalidSubcommand);
+        error.insert(
+            ContextKind::SuggestedSubcommand,
+            ContextValue::Strings(vec!["not-a-defined-name".into()]),
+        );
+        assert_eq!(suggestion_for_error(&cmd, &error), None);
+
+        // A candidate list where only the weaker (earlier) entry resolves:
+        // the unresolvable one is skipped, not recorded.
+        let mut error = clap::Error::new(ErrorKind::InvalidSubcommand);
+        error.insert(
+            ContextKind::SuggestedSubcommand,
+            ContextValue::Strings(vec!["service".into(), "not-a-defined-name".into()]),
+        );
+        assert_eq!(
+            suggestion_for_error(&cmd, &error).as_deref(),
+            Some("service")
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/update.rs
+++ b/crates/clickhousectl/src/update.rs
@@ -278,7 +278,11 @@ pub fn print_cached_update_notice() {
     if let Some((_, cached_version)) = read_update_check() {
         let current = env!("CARGO_PKG_VERSION");
         if is_newer(current, &cached_version) {
-            eprintln!(
+            use std::io::Write;
+            // Not `eprintln!`, which panics on a closed stderr — see
+            // `telemetry::print_first_run_notice`.
+            let _ = writeln!(
+                std::io::stderr(),
                 "\nThere is a new version of clickhousectl. Update with `clickhousectl update`."
             );
         }

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -273,6 +273,101 @@ async fn flag_names_sent_but_values_never_leak() {
     assert_eq!(event["flags"], serde_json::json!(["json"]));
 }
 
+// -- any invocation counts (#320): bare, help, version, parse errors --------
+
+#[tokio::test]
+async fn first_run_of_help_prints_notice_and_writes_marker() {
+    let sandbox = Sandbox::new().await;
+
+    // A user whose first-ever touch is `--help` still starts their consent
+    // clock: notice shown, marker written, nothing sent.
+    let output = sandbox.run(&["--help"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(stdout_of(&output).contains("Usage:"));
+    assert!(
+        stderr_of(&output).contains("anonymous usage data"),
+        "first --help must print the notice, got stderr: {}",
+        stderr_of(&output)
+    );
+    assert_eq!(
+        std::fs::read_to_string(sandbox.state_path()).unwrap(),
+        r#"{"disabled":false}"#
+    );
+    sandbox.assert_no_requests().await;
+
+    // Second help run: no repeated notice, and (consent granted) an event
+    // with the help outcome and the flag recorded under its long name.
+    let output = sandbox.run(&["cloud", "--help"]);
+    assert_eq!(output.status.code(), Some(0));
+    assert!(!stderr_of(&output).contains("anonymous usage data"));
+    let payloads = sandbox.wait_for_requests(1).await;
+    let event = &payloads[0];
+    assert_eq!(event["command"], "cloud");
+    assert_eq!(event["flags"], serde_json::json!(["help"]));
+    assert_eq!(event["outcome"], "help");
+    assert_eq!(event["exit_code"], 0);
+}
+
+#[tokio::test]
+async fn bare_invocation_reports_missing_subcommand() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+
+    let output = sandbox.run(&[]);
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "clap usage errors keep exit 2"
+    );
+
+    let payloads = sandbox.wait_for_requests(1).await;
+    let event = &payloads[0];
+    assert_eq!(event["command"], "");
+    assert_eq!(event["outcome"], "missing_subcommand");
+    assert_eq!(event["exit_code"], 2);
+}
+
+#[tokio::test]
+async fn invalid_subcommand_reports_kind_but_never_the_token() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+
+    // An agent-hallucinated command: the event records that it happened and
+    // where the valid prefix ended — never the unmatched token itself, which
+    // is indistinguishable from a secret pasted into the wrong window.
+    let output = sandbox.run(&["hallucinated-subcommand-xyz"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let payloads = sandbox.wait_for_requests(1).await;
+    let event = &payloads[0];
+    assert_eq!(event["command"], "");
+    assert_eq!(event["outcome"], "invalid_subcommand");
+    let raw = serde_json::to_string(event).unwrap();
+    assert!(
+        !raw.contains("hallucinated-subcommand-xyz"),
+        "raw token leaked into the payload: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn typo_carries_definition_derived_suggestion() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+
+    let output = sandbox.run(&["cloud", "servce", "list"]);
+    assert_eq!(output.status.code(), Some(2));
+
+    let payloads = sandbox.wait_for_requests(1).await;
+    let event = &payloads[0];
+    assert_eq!(event["command"], "cloud");
+    assert_eq!(event["outcome"], "invalid_subcommand");
+    // Clap's did-you-mean names the *defined* subcommand, so recording it is
+    // safe; the typo'd token stays off the wire.
+    assert_eq!(event["suggestion"], "service");
+    let raw = serde_json::to_string(event).unwrap();
+    assert!(!raw.contains("servce"), "typo leaked: {raw}");
+}
+
 #[tokio::test]
 async fn do_not_track_is_fully_silent() {
     let sandbox = Sandbox::new().await;

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -258,9 +258,11 @@ async fn failure_reported_and_positional_value_never_leaks() {
     let payloads = sandbox.wait_for_requests(1).await;
     let event = &payloads[0];
     assert_eq!(event["command"], "local remove");
-    // The event carries the gh-style exit code the process exited with.
+    // The event carries the gh-style exit code the process exited with, and
+    // the outcome derived from it — a failed handler is "error", not "ok".
     assert_eq!(event["exit_code"], 1);
     assert_eq!(event["exit_code"], output.status.code().unwrap());
+    assert_eq!(event["outcome"], "error");
     let raw = serde_json::to_string(event).unwrap();
     assert!(
         !raw.contains("no-such-version-xyz"),

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -80,6 +80,18 @@ impl Sandbox {
         self.command(args).output().expect("failed to spawn binary")
     }
 
+    /// Run the binary with its stderr attached to a pipe whose read end is
+    /// already closed, so every stderr write in the child fails. A panic on
+    /// such a write would surface as exit code 101.
+    fn run_with_closed_stderr(&self, args: &[&str]) -> Output {
+        let (reader, writer) = std::io::pipe().expect("failed to create pipe");
+        drop(reader);
+        self.command(args)
+            .stderr(writer)
+            .output()
+            .expect("failed to spawn binary")
+    }
+
     /// Poll until the mock has seen `n` requests; panics after ~5s. The send
     /// child is detached, so arrival is asynchronous.
     async fn wait_for_requests(&self, n: usize) -> Vec<Value> {
@@ -584,4 +596,56 @@ async fn marker_lives_in_dot_clickhouse_telemetry_json() {
         entries.contains(&"telemetry.json".to_string()),
         "{entries:?}"
     );
+}
+
+// -- closed stderr must never turn an exit code into a panic (#320) ----------
+
+#[tokio::test]
+async fn closed_stderr_never_panics_or_bypasses_telemetry() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+
+    // Cache a newer version so `--help` and the failing command both try to
+    // write the update notice to the (closed) stderr.
+    let cache = sandbox
+        .home
+        .path()
+        .join(".clickhouse")
+        .join("last_update_check");
+    std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    std::fs::write(&cache, format!("{now}\n999.0.0")).unwrap();
+
+    // `--help`: the update notice write is swallowed, clap's exit code 0 is
+    // preserved, and the telemetry tail still runs.
+    let output = sandbox.run_with_closed_stderr(&["--help"]);
+    assert_eq!(output.status.code(), Some(0), "help must not panic");
+    let payloads = sandbox.wait_for_requests(1).await;
+    assert_eq!(payloads[0]["outcome"], "help");
+
+    // A failing command: the `Error: ...` line and the update notice both hit
+    // the closed stderr; the handler's exit code 1 survives (not panic's 101)
+    // and the failure event still goes out.
+    let output = sandbox.run_with_closed_stderr(&["local", "remove", "no-such-version-xyz"]);
+    assert_eq!(output.status.code(), Some(1), "failure must keep exit 1");
+    let payloads = sandbox.wait_for_requests(2).await;
+    assert_eq!(payloads[1]["exit_code"], 1);
+
+    // `telemetry enable` under DO_NOT_TRACK: the stderr note about DNT is
+    // swallowed and the command still succeeds.
+    let output = {
+        let (reader, writer) = std::io::pipe().expect("failed to create pipe");
+        drop(reader);
+        sandbox
+            .command(&["telemetry", "enable"])
+            .env("DO_NOT_TRACK", "1")
+            .stderr(writer)
+            .output()
+            .expect("failed to spawn binary")
+    };
+    assert_eq!(output.status.code(), Some(0), "enable must not panic");
+    assert!(stdout_of(&output).contains("Telemetry enabled."));
 }


### PR DESCRIPTION
Closes #320

Based on `main`, deliberately **not** stacked on #316: the two changesets are disjoint (#316 touches cloud models/commands and appends to `cli_request_shape_test.rs`; this PR touches `main.rs`, `telemetry.rs`, `src/cli.rs`, `tests/telemetry_test.rs`), so they merge cleanly in either order.

## What

Any invocation of the binary — bare, `--help`, `--version`, mistyped commands — now shows the first-run notice on first run and produces a telemetry event on subsequent runs, under the unchanged consent state machine.

- **Single-exit `main` (#320 §1):** exactly one `process::exit`, preceded by exactly one `finalize()`. Parse `Err` branches `e.print()` (clap keeps formatting), keep their existing help/version update-notice behavior, and fall through as `(invocation, exit_code)`. Usage errors keep clap's exit 2 and spawn no update-cache refresh. The hidden `telemetry send` child stays the sole intended early exit.
- **Definition-anchored lossy capture (§2):** `capture_lossy(root, argv, error)` walks argv against the built clap `Command` tree — subcommand tokens descend and record the *definition's* name, `--long` tokens resolve to defined flags (value-taking flags consume the next token, so a value equal to a sibling subcommand name is never misrecorded), and the walk stops at the first unmatched token. Every recorded string is owned by the clap definitions; argv slices never enter the payload.
- **Payload (§3):** new `outcome` (closed vocabulary: `ok | help | version | invalid_subcommand | unknown_argument | missing_subcommand | missing_required | invalid_value | other_parse_error`) and `suggestion` (clap's definition-derived did-you-mean). **The raw unmatched token is deliberately never recorded** — a typo is indistinguishable from a pasted secret.
- **Exit codes (§4):** untouched; the numeric 2-collision with "cancelled" is disambiguated by `outcome` in analytics and is #319's to fix shell-side.
- **Exe-path snapshot (§5):** `telemetry::init()` at the top of `main` snapshots `current_exe()` into a `OnceLock`, fixing the Linux post-self-update dropped event; the `telemetry send` child interface is pinned as stable cross-version in `cli.rs`.

## Verification

- Unit tests for `capture_lossy`: bare, root/nested help, `-h`/`-V`, typo + suggestion, unknown flag, flag-value-equals-subcommand-name, inline `=` values, `--` handling, hostile-argv `SECRET` never on the wire.
- Subprocess e2e (wiremock + temp `HOME`): first `--help` prints the notice and writes the marker; bare → `missing_subcommand`/exit 2; hallucinated subcommand → `invalid_subcommand` with no raw token; typo → `suggestion: "service"`.
- Gates green per commit: `cargo test -p clickhousectl` (429 unit + 18 e2e), clippy `-D warnings`, `cargo fmt --check`, `cargo check --workspace --all-features`, and the full suite with telemetry compiled out (`--no-default-features`).
- A fresh-context adversarial review probed hostile argv shapes (non-UTF-8 tokens, `--flag=SECRET`, closed pipes) and audited clap 4.6's suggestion contexts (`SuggestedSubcommand`/`SuggestedArg` are definition-derived; the input-embedding `Suggested*` kinds are not read). Its findings are fixed in the final commit: a closed stderr no longer turns exit 2 into a panic (writes are swallowed like clap's own `Error::exit`), and the pre-existing child-exit-code passthrough exits it spotted are acknowledged and tracked as #321.

## Rollout

The ingest worker must accept `outcome`/`suggestion` (backward compatible — deploy before the next CLI release). The docs page update ('help/version/failed invocations are recorded as such') is step 3; the notice text stays true and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)