### PR TITLE
Support multi-statement cloud query files

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ clickhousectl cloud service stop <service-id>
 # Run SQL over HTTP via the Query API (no local clickhouse binary needed)
 clickhousectl cloud service query --name my-service --query "SELECT 1"
 clickhousectl cloud service query --id <service-id> --query "SELECT count() FROM system.tables" --format JSONEachRow
-clickhousectl cloud service query --name my-service --queries-file schema.sql   # "-" reads from stdin
+clickhousectl cloud service query --name my-service --queries-file schema.sql   # Runs statements sequentially; "-" reads from stdin
 clickhousectl cloud service query --name my-service --database mydb --query "SHOW TABLES"
 echo "SELECT 1+1" | clickhousectl cloud service query --name my-service
 
@@ -516,6 +516,8 @@ clickhousectl cloud service delete <service-id> --force
 
 - **API key auth** (read + write SQL): the first time `cloud service query` runs against a service without a stored key, it provisions a Query API endpoint for that service and creates a dedicated API key bound to it. The key (`keyId`, `keySecret`, and `endpointId`) is stored in `.clickhouse/credentials.json` under `service_query_keys.<service-id>`, alongside any user-level API key. Subsequent queries use that key. It is scoped to a single service, so it can read and write (SELECT, INSERT, DDL) against that service but cannot reach any other service in the org. Pass `--no-auto-enable` to fail instead of provisioning.
 - **OAuth** (`cloud auth login`): the query runs as your own identity — the CLI sends your bearer token straight to the Query API, which grants **read-only** SQL access (SELECT and other read statements only; no INSERT, DDL, or other writes). No Query API key is provisioned or stored, and no query endpoint needs to be configured on the service. Use API key auth if you need to write. `--no-auto-enable` has no effect in this mode.
+
+The Query API accepts one statement per request. For `--queries-file`, including `--queries-file -`, the CLI splits the input and sends its statements sequentially in file order. Execution stops on the first failure, so earlier statements may already have taken effect when the command exits with an error. Each statement is an independent request: persistent DDL/DML changes carry forward, but connection-local state such as `USE`, `SET`, temporary tables, or transactions does not. Result bodies are written to stdout back-to-back.
 
 Provisioning happens lazily (rather than at `service create` time) because the endpoint can only be bound once the service has finished provisioning, which can take several minutes — `service create` returns immediately instead of blocking on it.
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -833,6 +833,8 @@ CONTEXT FOR AGENTS:
   With OAuth (cloud auth login): sends your own bearer token — SQL runs as
   your cloud user with read-only access (SELECT only, no writes); no key
   provisioning and no query endpoint required on the service.
+  --queries-file statements are sent sequentially in file order; execution
+  stops on the first failure. Use --queries-file - to read a file from stdin.
   SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
   on a TTY, TabSeparated when piped.")]
     Query {
@@ -848,7 +850,7 @@ CONTEXT FOR AGENTS:
         #[arg(long, short)]
         query: Option<String>,
 
-        /// Execute queries from a SQL file (use "-" for stdin)
+        /// Execute a SQL file sequentially; stops on the first failure (use "-" for stdin)
         #[arg(long)]
         queries_file: Option<String>,
 

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -2389,7 +2389,10 @@ pub async fn service_query(
     client: &CloudClient,
     opts: ServiceQueryOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let sql = read_query_sql(opts.query.as_deref(), opts.queries_file.as_deref())?;
+    let statements = crate::cloud::query_file::read_query_statements(
+        opts.query.as_deref(),
+        opts.queries_file.as_deref(),
+    )?;
 
     let org_id = resolve_org_id(client, opts.org_id.as_deref()).await?;
     let service =
@@ -2408,30 +2411,14 @@ pub async fn service_query(
 
     let format = opts.format.unwrap_or_else(default_query_format);
 
-    let response = if client.is_bearer_auth() {
+    let query_auth = if client.is_bearer_auth() {
         // OAuth: the Query API authenticates the user's bearer token
         // directly, SQL-console style — the query runs as the user's own
         // cloud identity, with no per-service Query API key and no
         // query-endpoint configuration needed on the service.
         // `--no-auto-enable` is a no-op here since nothing is ever
         // provisioned.
-        let run = |wake: bool| {
-            client.api().run_query_bearer(
-                &service_id,
-                &sql,
-                opts.database.as_deref(),
-                &format,
-                wake,
-            )
-        };
-        let result = match run(false).await {
-            Err(clickhouse_cloud_api::Error::ServiceIdle) => {
-                eprint_waking_service(&service_name);
-                run(true).await
-            }
-            other => other,
-        };
-        result.map_err(|e| convert_query_error(client, e, &service_name))?
+        ServiceQueryAuth::Bearer
     } else {
         let key = match credentials::get_service_query_key(&service_id) {
             Some(k) => k,
@@ -2455,44 +2442,100 @@ pub async fn service_query(
                 .await?
             }
         };
-
-        // The query host normally wakes an idled service on its own for
-        // Query API key auth, but handle the wake confirmation here too so
-        // both auth paths behave the same if it ever asks.
-        let run = |wake: bool| {
-            client.api().run_query(
-                &service_id,
-                &key.key_id,
-                &key.key_secret,
-                &sql,
-                opts.database.as_deref(),
-                &format,
-                wake,
-            )
-        };
-        let result = match run(false).await {
-            Err(clickhouse_cloud_api::Error::ServiceIdle) => {
-                eprint_waking_service(&service_name);
-                run(true).await
-            }
-            other => other,
-        };
-        result.map_err(|e| convert_query_error(client, e, &service_name))?
+        ServiceQueryAuth::Basic(key)
     };
 
     use futures_util::StreamExt;
     use std::io::Write as _;
-    let mut stream = response.bytes_stream();
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
-    while let Some(chunk) = stream.next().await {
-        let bytes = chunk.map_err(|e| -> Box<dyn std::error::Error> {
-            format!("Failed to read query response: {e}").into()
-        })?;
-        handle.write_all(&bytes)?;
+    for sql in statements {
+        let response = run_service_query_statement(
+            client,
+            &query_auth,
+            &service_id,
+            &sql,
+            opts.database.as_deref(),
+            &format,
+            &service_name,
+        )
+        .await?;
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk.map_err(|e| -> Box<dyn std::error::Error> {
+                format!("Failed to read query response: {e}").into()
+            })?;
+            handle.write_all(&bytes)?;
+        }
+        // Make successful earlier statements visible even if a later one
+        // fails, and surface a broken output pipe before executing more SQL.
+        handle.flush()?;
     }
-    handle.flush()?;
     Ok(())
+}
+
+enum ServiceQueryAuth {
+    Bearer,
+    Basic(credentials::ServiceQueryKey),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn send_service_query_statement(
+    client: &CloudClient,
+    auth: &ServiceQueryAuth,
+    service_id: &str,
+    sql: &str,
+    database: Option<&str>,
+    format: &str,
+    wake: bool,
+) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
+    match auth {
+        ServiceQueryAuth::Bearer => {
+            client
+                .api()
+                .run_query_bearer(service_id, sql, database, format, wake)
+                .await
+        }
+        ServiceQueryAuth::Basic(key) => {
+            client
+                .api()
+                .run_query(
+                    service_id,
+                    &key.key_id,
+                    &key.key_secret,
+                    sql,
+                    database,
+                    format,
+                    wake,
+                )
+                .await
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_service_query_statement(
+    client: &CloudClient,
+    auth: &ServiceQueryAuth,
+    service_id: &str,
+    sql: &str,
+    database: Option<&str>,
+    format: &str,
+    service_name: &str,
+) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
+    let result =
+        match send_service_query_statement(client, auth, service_id, sql, database, format, false)
+            .await
+        {
+            Err(clickhouse_cloud_api::Error::ServiceIdle) => {
+                eprint_waking_service(service_name);
+                send_service_query_statement(client, auth, service_id, sql, database, format, true)
+                    .await
+            }
+            other => other,
+        };
+
+    result.map_err(|e| convert_query_error(client, e, service_name))
 }
 
 /// Stderr notice shown when the query host reports the service is idled and
@@ -2516,45 +2559,6 @@ fn convert_query_error(
         .into(),
         other => client.convert_error(other).into(),
     }
-}
-
-fn read_query_sql(
-    inline: Option<&str>,
-    queries_file: Option<&str>,
-) -> Result<String, Box<dyn std::error::Error>> {
-    use std::io::Read as _;
-
-    if let Some(q) = inline {
-        let trimmed = q.trim();
-        if trimmed.is_empty() {
-            return Err("--query was empty".into());
-        }
-        return Ok(q.to_string());
-    }
-
-    if let Some(path) = queries_file {
-        let mut content = String::new();
-        if path == "-" {
-            std::io::stdin().read_to_string(&mut content)?;
-        } else {
-            content = std::fs::read_to_string(path)?;
-        }
-        if content.trim().is_empty() {
-            return Err("queries file was empty".into());
-        }
-        return Ok(content);
-    }
-
-    if std::io::stdin().is_terminal() {
-        return Err("no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.".into());
-    }
-
-    let mut content = String::new();
-    std::io::stdin().read_to_string(&mut content)?;
-    if content.trim().is_empty() {
-        return Err("no SQL received on stdin".into());
-    }
-    Ok(content)
 }
 
 fn default_query_format() -> String {

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod credentials;
 pub mod output;
 pub mod postgres;
+pub mod query_file;
 pub mod service_query;
 pub mod types;
 

--- a/crates/clickhousectl/src/cloud/query_file.rs
+++ b/crates/clickhousectl/src/cloud/query_file.rs
@@ -1,0 +1,494 @@
+//! Reading and splitting SQL passed to `cloud service query`.
+//!
+//! The Query API accepts one statement per request, while ClickHouse query
+//! files may contain several semicolon-delimited statements. This module does
+//! the minimum lexical work needed to find real statement delimiters without
+//! trying to parse or restrict ClickHouse SQL itself.
+
+use std::io::{IsTerminal as _, Read as _};
+
+/// Read the command's SQL input and return the Query API requests to run.
+///
+/// `--query` deliberately remains a single request. Only `--queries-file`
+/// (including `--queries-file -`) has query-file semantics and is split into
+/// statements. Bare piped stdin also retains its existing single-request
+/// behavior.
+pub fn read_query_statements(
+    inline: Option<&str>,
+    queries_file: Option<&str>,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    if let Some(query) = inline {
+        if query.trim().is_empty() {
+            return Err("--query was empty".into());
+        }
+        return Ok(vec![query.to_string()]);
+    }
+
+    if let Some(path) = queries_file {
+        let mut content = String::new();
+        if path == "-" {
+            std::io::stdin().read_to_string(&mut content)?;
+        } else {
+            content = std::fs::read_to_string(path)?;
+        }
+        if content.trim().is_empty() {
+            return Err("queries file was empty".into());
+        }
+
+        let statements = split_query_file(&content);
+        if statements.is_empty() {
+            return Err("queries file contained no SQL statements".into());
+        }
+        return Ok(statements);
+    }
+
+    if std::io::stdin().is_terminal() {
+        return Err("no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.".into());
+    }
+
+    let mut content = String::new();
+    std::io::stdin().read_to_string(&mut content)?;
+    if content.trim().is_empty() {
+        return Err("no SQL received on stdin".into());
+    }
+    Ok(vec![content])
+}
+
+/// Split a ClickHouse query file on semicolons that occur outside lexical
+/// constructs where semicolons are data. The returned statements omit the
+/// delimiter and surrounding whitespace, and empty/comment-only segments are
+/// ignored.
+fn split_query_file(sql: &str) -> Vec<String> {
+    let bytes = sql.as_bytes();
+    let mut statements = Vec::new();
+    let mut statement_start = 0;
+    let mut has_sql = false;
+    let mut pos = 0;
+    let mut nesting = 0_usize;
+    let mut is_insert = false;
+    let mut is_explain = false;
+    let mut insert_select = false;
+    let mut expects_insert_target = false;
+    let mut expects_insert_format = false;
+
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\xEF'
+                if pos == statement_start && bytes.get(pos..pos + 3) == Some(b"\xEF\xBB\xBF") =>
+            {
+                pos += 3;
+                statement_start = pos;
+            }
+            b'\xE2'
+                if matches!(
+                    bytes.get(pos..pos + 3),
+                    Some(b"\xE2\x80\x98" | b"\xE2\x80\x9C")
+                ) =>
+            {
+                has_sql = true;
+                let closing_byte = bytes[pos + 2] + 1;
+                pos = unicode_quoted_end(bytes, pos + 3, closing_byte);
+                expects_insert_format = false;
+            }
+            b'\'' | b'"' | b'`' => {
+                has_sql = true;
+                pos = quoted_end(bytes, pos, bytes[pos]);
+                if is_insert && nesting == 0 && expects_insert_target {
+                    expects_insert_target = next_non_whitespace_is_dot(bytes, pos);
+                }
+                expects_insert_format = false;
+            }
+            b'-' if bytes.get(pos + 1) == Some(&b'-') => {
+                pos = line_comment_end(bytes, pos + 2);
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'/') => {
+                pos = line_comment_end(bytes, pos + 2);
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'*') => {
+                pos = block_comment_end(bytes, pos + 2);
+            }
+            b'#' if matches!(bytes.get(pos + 1), Some(b' ' | b'!')) => {
+                pos = line_comment_end(bytes, pos + 2);
+            }
+            b'$' => {
+                has_sql = true;
+                pos = match heredoc_end(bytes, pos) {
+                    Some(Some(end)) => end,
+                    Some(None) | None => pos + 1,
+                };
+                expects_insert_format = false;
+            }
+            b'(' | b'[' | b'{' => {
+                has_sql = true;
+                expects_insert_format = false;
+                nesting += 1;
+                pos += 1;
+            }
+            b')' | b']' | b'}' => {
+                has_sql = true;
+                expects_insert_format = false;
+                nesting = nesting.saturating_sub(1);
+                pos += 1;
+            }
+            b';' => {
+                push_statement(sql, statement_start, pos, has_sql, &mut statements);
+                pos += 1;
+                statement_start = pos;
+                has_sql = false;
+                nesting = 0;
+                is_insert = false;
+                is_explain = false;
+                insert_select = false;
+                expects_insert_target = false;
+                expects_insert_format = false;
+            }
+            byte if byte.is_ascii_alphanumeric() || byte == b'_' => {
+                let word_start = pos;
+                pos += 1;
+                while matches!(bytes.get(pos), Some(b) if b.is_ascii_alphanumeric() || *b == b'_') {
+                    pos += 1;
+                }
+                let word = &sql[word_start..pos];
+                if !has_sql {
+                    is_insert = word.eq_ignore_ascii_case("INSERT");
+                    is_explain = word.eq_ignore_ascii_case("EXPLAIN");
+                } else if is_explain
+                    && !is_insert
+                    && nesting == 0
+                    && word.eq_ignore_ascii_case("INSERT")
+                {
+                    is_insert = true;
+                } else if is_insert && nesting == 0 {
+                    if expects_insert_target {
+                        if !word.eq_ignore_ascii_case("TABLE")
+                            && !word.eq_ignore_ascii_case("FUNCTION")
+                        {
+                            expects_insert_target = next_non_whitespace_is_dot(bytes, pos);
+                        }
+                    } else if expects_insert_format {
+                        expects_insert_format = false;
+                        if word.eq_ignore_ascii_case("SELECT") || word.eq_ignore_ascii_case("WITH")
+                        {
+                            insert_select = true;
+                        } else if !word.eq_ignore_ascii_case("Values") {
+                            let blank_line = find_blank_line(bytes, pos);
+                            let raw_end = blank_line
+                                .map(|(delimiter_start, _)| delimiter_start)
+                                .unwrap_or(bytes.len());
+                            push_raw_insert(sql, statement_start, raw_end, &mut statements);
+                            if raw_end == bytes.len() {
+                                return statements;
+                            }
+                            pos = raw_end + blank_line.unwrap().1;
+                            statement_start = pos;
+                            has_sql = false;
+                            nesting = 0;
+                            is_insert = false;
+                            is_explain = false;
+                            insert_select = false;
+                            expects_insert_target = false;
+                            continue;
+                        }
+                    } else if word.eq_ignore_ascii_case("INTO") {
+                        expects_insert_target = true;
+                    } else if word.eq_ignore_ascii_case("SELECT")
+                        || word.eq_ignore_ascii_case("WITH")
+                    {
+                        // An INSERT ... SELECT has no inline data payload.
+                        insert_select = true;
+                    } else if !insert_select && word.eq_ignore_ascii_case("FORMAT") {
+                        expects_insert_format = true;
+                    }
+                }
+                has_sql = true;
+            }
+            byte => {
+                if !byte.is_ascii_whitespace() {
+                    has_sql = true;
+                    expects_insert_format = false;
+                }
+                pos += 1;
+            }
+        }
+    }
+
+    push_statement(sql, statement_start, bytes.len(), has_sql, &mut statements);
+    statements
+}
+
+fn push_statement(
+    sql: &str,
+    start: usize,
+    end: usize,
+    has_sql: bool,
+    statements: &mut Vec<String>,
+) {
+    if has_sql {
+        statements.push(sql[start..end].trim().to_string());
+    }
+}
+
+/// Generic inline INSERT formats can contain arbitrary semicolons, so the
+/// native ClickHouse client ends their data at a blank line instead. Preserve
+/// their payload bytes apart from leading script whitespace.
+fn push_raw_insert(sql: &str, start: usize, end: usize, statements: &mut Vec<String>) {
+    statements.push(sql[start..end].trim_start().to_string());
+}
+
+fn quoted_end(bytes: &[u8], mut pos: usize, quote: u8) -> usize {
+    pos += 1;
+    while pos < bytes.len() {
+        if bytes[pos] == b'\\' {
+            pos = (pos + 2).min(bytes.len());
+        } else if bytes[pos] == quote {
+            pos += 1;
+            if bytes.get(pos) == Some(&quote) {
+                pos += 1;
+            } else {
+                break;
+            }
+        } else {
+            pos += 1;
+        }
+    }
+    pos
+}
+
+fn unicode_quoted_end(bytes: &[u8], mut pos: usize, closing_byte: u8) -> usize {
+    while pos + 2 < bytes.len() {
+        if bytes[pos..pos + 3] == [b'\xE2', b'\x80', closing_byte] {
+            return pos + 3;
+        }
+        pos += 1;
+    }
+    bytes.len()
+}
+
+fn line_comment_end(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && bytes[pos] != b'\n' {
+        pos += 1;
+    }
+    pos
+}
+
+fn block_comment_end(bytes: &[u8], mut pos: usize) -> usize {
+    let mut nesting = 1;
+    while pos < bytes.len() {
+        if bytes.get(pos..pos + 2) == Some(b"/*") {
+            nesting += 1;
+            pos += 2;
+        } else if bytes.get(pos..pos + 2) == Some(b"*/") {
+            nesting -= 1;
+            pos += 2;
+            if nesting == 0 {
+                break;
+            }
+        } else {
+            pos += 1;
+        }
+    }
+    pos
+}
+
+/// Find the byte immediately after a ClickHouse `$tag$...$tag$` heredoc.
+/// The tag follows ClickHouse's lexer rule: zero or more ASCII word
+/// characters between the dollar signs. The outer option distinguishes a
+/// dollar sign that is not an opening delimiter; the inner option is absent
+/// when the apparent opener is only a `$`-containing bare word because there
+/// is no later matching delimiter.
+fn heredoc_end(bytes: &[u8], start: usize) -> Option<Option<usize>> {
+    let relative_tag_end = bytes.get(start + 1..)?.iter().position(|b| *b == b'$')?;
+    let tag_end = start + 1 + relative_tag_end;
+    if !bytes[start + 1..tag_end]
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || *b == b'_')
+    {
+        return None;
+    }
+
+    let delimiter = &bytes[start..=tag_end];
+    Some(
+        find_bytes(&bytes[tag_end + 1..], delimiter)
+            .map(|relative_end| tag_end + 1 + relative_end + delimiter.len()),
+    )
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn find_blank_line(bytes: &[u8], mut pos: usize) -> Option<(usize, usize)> {
+    while pos < bytes.len() {
+        if bytes.get(pos..pos + 2) == Some(b"\n\n") {
+            return Some((pos, 2));
+        }
+        if bytes.get(pos..pos + 4) == Some(b"\r\n\r\n") {
+            return Some((pos, 4));
+        }
+        pos += 1;
+    }
+    None
+}
+
+fn next_non_whitespace_is_dot(bytes: &[u8], mut pos: usize) -> bool {
+    while matches!(bytes.get(pos), Some(byte) if byte.is_ascii_whitespace()) {
+        pos += 1;
+    }
+    bytes.get(pos) == Some(&b'.')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_semicolon_delimited_statements_and_ignores_empty_segments() {
+        assert_eq!(
+            split_query_file(" ; SELECT 1;\n\nSELECT 2;; \n"),
+            vec!["SELECT 1", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn does_not_split_semicolons_in_quotes_or_heredocs() {
+        let sql = r#"
+            SELECT 'one;two', 'it''s;safe', 'backslash\';safe';
+            SELECT "quoted;identifier", `backtick;identifier`;
+            SELECT $tag$embedded; SQL and 'quotes'$tag$;
+            SELECT $$an empty tag; works too$$;
+        "#;
+
+        assert_eq!(
+            split_query_file(sql),
+            vec![
+                r#"SELECT 'one;two', 'it''s;safe', 'backslash\';safe'"#,
+                r#"SELECT "quoted;identifier", `backtick;identifier`"#,
+                "SELECT $tag$embedded; SQL and 'quotes'$tag$",
+                "SELECT $$an empty tag; works too$$",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_dollar_wrapped_bare_word_without_heredoc_content_does_not_hide_delimiters() {
+        assert_eq!(
+            split_query_file("SELECT 1 AS $foo$; SELECT 2;"),
+            vec!["SELECT 1 AS $foo$", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn does_not_split_semicolons_in_unicode_quotes() {
+        assert_eq!(
+            split_query_file("SELECT ‘string; value’, “quoted; identifier”; SELECT 2;"),
+            vec!["SELECT ‘string; value’, “quoted; identifier”", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn strips_a_utf8_bom_before_splitting_the_first_statement() {
+        assert_eq!(
+            split_query_file("\u{feff}SELECT 'Здравствуйте; мир'; SELECT 2;"),
+            vec!["SELECT 'Здравствуйте; мир'", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn does_not_split_semicolons_in_clickhouse_comments() {
+        let sql = r#"
+            -- a SQL comment ;
+            SELECT 1; // a C++ comment ;
+            # a MySQL comment ;
+            SELECT 2; #! a shebang-style comment ;
+            /* outer ; /* nested ; */ still outer ; */ SELECT 3;
+        "#;
+
+        assert_eq!(
+            split_query_file(sql),
+            vec![
+                "-- a SQL comment ;\n            SELECT 1",
+                "// a C++ comment ;\n            # a MySQL comment ;\n            SELECT 2",
+                "#! a shebang-style comment ;\n            /* outer ; /* nested ; */ still outer ; */ SELECT 3",
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_a_file_containing_only_comments_and_delimiters() {
+        assert!(
+            split_query_file("-- comment;\n/* nested /* ; */ comment */ ; # final ;\n").is_empty()
+        );
+    }
+
+    #[test]
+    fn a_hash_without_comment_whitespace_does_not_hide_a_delimiter() {
+        assert_eq!(
+            split_query_file("SELECT #operator; SELECT 2;"),
+            vec!["SELECT #operator", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn generic_insert_format_data_ends_at_a_blank_line_not_a_semicolon() {
+        let sql = "INSERT INTO events FORMAT CSV\n1,'a;b'\n2,'c;d'\n\nSELECT count() FROM events;";
+        assert_eq!(
+            split_query_file(sql),
+            vec![
+                "INSERT INTO events FORMAT CSV\n1,'a;b'\n2,'c;d'",
+                "SELECT count() FROM events",
+            ]
+        );
+    }
+
+    #[test]
+    fn generic_insert_format_accepts_a_windows_blank_line_delimiter() {
+        let sql = "INSERT INTO events FORMAT CSV\r\n1,'a;b'\r\n\r\nSELECT 1;";
+        assert_eq!(
+            split_query_file(sql),
+            vec!["INSERT INTO events FORMAT CSV\r\n1,'a;b'", "SELECT 1"]
+        );
+    }
+
+    #[test]
+    fn insert_values_uses_the_normal_semicolon_delimiter() {
+        let sql = "INSERT INTO events FORMAT Values (1, 'a;b'); SELECT count() FROM events;";
+        assert_eq!(
+            split_query_file(sql),
+            vec![
+                "INSERT INTO events FORMAT Values (1, 'a;b')",
+                "SELECT count() FROM events",
+            ]
+        );
+    }
+
+    #[test]
+    fn format_used_as_an_insert_target_is_not_mistaken_for_a_format_clause() {
+        assert_eq!(
+            split_query_file("INSERT INTO db.format SELECT 1; SELECT 2;"),
+            vec!["INSERT INTO db.format SELECT 1", "SELECT 2"]
+        );
+        assert_eq!(
+            split_query_file("INSERT INTO TABLE format SELECT 1; SELECT 2;"),
+            vec!["INSERT INTO TABLE format SELECT 1", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn format_used_in_an_insert_select_cte_is_not_mistaken_for_inline_data() {
+        assert_eq!(
+            split_query_file("INSERT INTO dst WITH 1 AS format SELECT format; SELECT 2;"),
+            vec!["INSERT INTO dst WITH 1 AS format SELECT format", "SELECT 2"]
+        );
+    }
+
+    #[test]
+    fn explain_insert_format_data_uses_the_blank_line_boundary() {
+        let sql = "EXPLAIN INSERT INTO events FORMAT CSV\n1,'a;b'\n\nSELECT 2;";
+        assert_eq!(
+            split_query_file(sql),
+            vec!["EXPLAIN INSERT INTO events FORMAT CSV\n1,'a;b'", "SELECT 2",]
+        );
+    }
+}

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -14,11 +14,12 @@
 //! Tests run as cargo integration tests:
 //!     cargo test -p clickhousectl --test cli_request_shape_test
 
-use std::path::PathBuf;
-use std::process::Command;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
 use serde_json::Value;
-use wiremock::matchers::{header, method, path, path_regex};
+use wiremock::matchers::{body_string_contains, header, method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Locate the `clickhousectl` binary. cargo populates `CARGO_BIN_EXE_<name>`
@@ -1304,6 +1305,69 @@ async fn start_mock_query_host() -> MockServer {
     mock
 }
 
+fn write_stored_service_query_key(project_dir: &Path) {
+    let ch_dir = project_dir.join(".clickhouse");
+    std::fs::create_dir_all(&ch_dir).unwrap();
+    let creds = serde_json::json!({
+        "service_query_keys": {
+            QUERY_TEST_SERVICE_ID: {
+                "key_id": "stored-key-id",
+                "key_secret": "stored-key-secret",
+                "endpoint_id": "ep-1",
+                "service_name": "demo",
+                "created_at": "2026-05-11T12:00:00Z",
+            }
+        }
+    });
+    std::fs::write(
+        ch_dir.join("credentials.json"),
+        serde_json::to_vec(&creds).unwrap(),
+    )
+    .unwrap();
+}
+
+fn stored_key_service_query_command(
+    control: &MockServer,
+    query_host: &MockServer,
+    project_dir: &Path,
+) -> Command {
+    let mut command = Command::new(clickhousectl_binary());
+    command
+        .env("DO_NOT_TRACK", "1")
+        .args(["cloud", "--url"])
+        .arg(control.uri())
+        .args([
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+        ])
+        .current_dir(project_dir)
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri());
+    command
+}
+
+async fn received_query_sql(query_host: &MockServer) -> Vec<String> {
+    query_host
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|request| {
+            let body: Value = serde_json::from_slice(&request.body).unwrap();
+            body["sql"].as_str().unwrap().to_string()
+        })
+        .collect()
+}
+
+fn statement_text(sql: &str) -> &str {
+    sql.trim().trim_end_matches(';').trim_end()
+}
+
 #[tokio::test]
 async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
     let control = start_mock_control_plane_with_service().await;
@@ -1399,45 +1463,10 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
     // control-plane creds come from the env tier (the credentials file
     // carries only service_query_keys, no api_key/api_secret).
     let dir = tempfile::tempdir().unwrap();
-    let ch_dir = dir.path().join(".clickhouse");
-    std::fs::create_dir_all(&ch_dir).unwrap();
-    let creds = serde_json::json!({
-        "service_query_keys": {
-            QUERY_TEST_SERVICE_ID: {
-                "key_id": "stored-key-id",
-                "key_secret": "stored-key-secret",
-                "endpoint_id": "ep-1",
-                "service_name": "demo",
-                "created_at": "2026-05-11T12:00:00Z",
-            }
-        }
-    });
-    std::fs::write(
-        ch_dir.join("credentials.json"),
-        serde_json::to_vec(&creds).unwrap(),
-    )
-    .unwrap();
+    write_stored_service_query_key(dir.path());
 
-    let url = control.uri();
-    let output = Command::new(clickhousectl_binary())
-        .env("DO_NOT_TRACK", "1")
-        .args([
-            "cloud",
-            "--url",
-            &url,
-            "service",
-            "query",
-            "--id",
-            QUERY_TEST_SERVICE_ID,
-            "--org-id",
-            "org-1",
-            "--query",
-            "SELECT 1",
-        ])
-        .current_dir(dir.path())
-        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
-        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
-        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+    let output = stored_key_service_query_command(&control, &query_host, dir.path())
+        .args(["--query", "SELECT 1"])
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
@@ -1470,6 +1499,130 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
             .map(|r| format!("{} {}", r.method, r.url.path()))
             .collect::<Vec<_>>(),
     );
+}
+
+// ── Multi-statement query files (issue #333) ──────────────────────────────
+//
+// The Query API accepts only one statement per request, while the local
+// client accepts multi-statement `--queries-file` input. The cloud command
+// preserves that CLI contract by splitting files and sending their statements
+// serially, streaming each response before it moves to the next statement.
+
+#[tokio::test]
+async fn service_query_file_sends_statements_sequentially_and_concatenates_output() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
+    let dir = tempfile::tempdir().unwrap();
+    write_stored_service_query_key(dir.path());
+    std::fs::write(dir.path().join("queries.sql"), "SELECT 1;\nSELECT 2;\n").unwrap();
+
+    let output = stored_key_service_query_command(&control, &query_host, dir.path())
+        .args([
+            "--queries-file",
+            "queries.sql",
+            "--database",
+            "analytics",
+            "--format",
+            "TabSeparated",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_success(&output);
+
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n1\n");
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 2);
+    let sql: Vec<_> = requests
+        .iter()
+        .map(|request| {
+            let body: Value = serde_json::from_slice(&request.body).unwrap();
+            assert_eq!(body["database"], "analytics");
+            assert_eq!(
+                request
+                    .url
+                    .query_pairs()
+                    .find(|(key, _)| key == "format")
+                    .map(|(_, value)| value.to_string())
+                    .as_deref(),
+                Some("TabSeparated")
+            );
+            body["sql"].as_str().unwrap().to_string()
+        })
+        .collect();
+    assert_eq!(statement_text(&sql[0]), "SELECT 1");
+    assert_eq!(statement_text(&sql[1]), "SELECT 2");
+}
+
+#[tokio::test]
+async fn service_query_file_dash_splits_statements_read_from_stdin() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
+    let dir = tempfile::tempdir().unwrap();
+    write_stored_service_query_key(dir.path());
+
+    let mut child = stored_key_service_query_command(&control, &query_host, dir.path())
+        .args(["--queries-file", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"SELECT 10;\nSELECT 20;\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert_success(&output);
+
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n1\n");
+    let sql = received_query_sql(&query_host).await;
+    assert_eq!(sql.len(), 2);
+    assert_eq!(statement_text(&sql[0]), "SELECT 10");
+    assert_eq!(statement_text(&sql[1]), "SELECT 20");
+}
+
+#[tokio::test]
+async fn service_query_file_stops_before_later_statements_after_failure() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .and(body_string_contains("SELECT broken"))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_string(r#"{"error":{"code":"62","details":"test syntax error"}}"#),
+        )
+        .with_priority(1)
+        .mount(&query_host)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .respond_with(ResponseTemplate::new(200).set_body_string("1\n"))
+        .with_priority(5)
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_stored_service_query_key(dir.path());
+    std::fs::write(
+        dir.path().join("queries.sql"),
+        "SELECT 1;\nSELECT broken;\nSELECT 3;\n",
+    )
+    .unwrap();
+
+    let output = stored_key_service_query_command(&control, &query_host, dir.path())
+        .args(["--queries-file", "queries.sql"])
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n");
+
+    let sql = received_query_sql(&query_host).await;
+    assert_eq!(sql.len(), 2, "the third statement must not be submitted");
+    assert_eq!(statement_text(&sql[0]), "SELECT 1");
+    assert_eq!(statement_text(&sql[1]), "SELECT broken");
 }
 
 // ── Provisioning cleanup (issue #314) ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- split `cloud service query --queries-file` input into ClickHouse-aware statements
- send each statement to the Query API sequentially, stream responses in order, and stop on the first failure
- support quoted strings and identifiers, ClickHouse comment forms, heredocs, Unicode quotes, and inline `INSERT ... FORMAT` data boundaries
- document independent-request/session-state and partial-application behavior

## Root cause

The Query API accepts one SQL statement per request, but the CLI read a query file into one string and submitted the entire file in a single request. Local `client --queries-file` delegates to the native ClickHouse client, which already processes multi-statement files.

## Impact

Multi-statement files, including `--queries-file -`, now execute in file order. Authentication, service resolution, and any Query API provisioning happen once. Earlier statements and output remain visible if a later statement fails; statements after the failure are not submitted.

Each statement is an independent Query API request, so persistent DDL/DML changes carry forward but connection-local state such as `USE`, `SET`, temporary tables, and transactions does not.

## Stack

- Depends on #343
- Closes #333

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl --all-targets`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
