### PR TITLE
Report invalid local versions directly

### DIFF
--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("No matching version found for: {0}")]
     NoMatchingVersion(String),
 
+    #[error("{0}")]
+    InvalidVersion(String),
+
     #[error("Failed to execute ClickHouse: {0}")]
     Exec(String),
 

--- a/crates/clickhousectl/src/version_manager/spec.rs
+++ b/crates/clickhousectl/src/version_manager/spec.rs
@@ -34,7 +34,7 @@ pub fn parse_version_spec(input: &str) -> Result<VersionSpec> {
     let input = input.trim();
 
     if input.is_empty() {
-        return Err(Error::NoMatchingVersion("empty version".to_string()));
+        return Err(Error::InvalidVersion("empty version".to_string()));
     }
 
     // Keywords
@@ -51,7 +51,7 @@ pub fn parse_version_spec(input: &str) -> Result<VersionSpec> {
     // Validate all parts are numeric
     for part in &parts {
         if part.parse::<u32>().is_err() {
-            return Err(Error::NoMatchingVersion(format!(
+            return Err(Error::InvalidVersion(format!(
                 "invalid version '{}': all parts must be numeric",
                 input
             )));
@@ -68,12 +68,12 @@ pub fn parse_version_spec(input: &str) -> Result<VersionSpec> {
             let minor: u32 = parts[1].parse().unwrap();
             Ok(VersionSpec::Minor(major, minor))
         }
-        3 => Err(Error::NoMatchingVersion(format!(
+        3 => Err(Error::InvalidVersion(format!(
             "3-part version '{}' is not supported. Use a full 4-part version (e.g., {}.1)",
             input, input
         ))),
         4 => Ok(VersionSpec::Exact(input.to_string())),
-        _ => Err(Error::NoMatchingVersion(format!(
+        _ => Err(Error::InvalidVersion(format!(
             "invalid version '{}': expected 1-2 or 4 parts",
             input
         ))),
@@ -129,26 +129,40 @@ mod tests {
     #[test]
     fn test_parse_3_part_rejected() {
         let err = parse_version_spec("25.12.9").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("3-part version"), "got: {}", msg);
-        assert!(msg.contains("25.12.9.1"), "should hint at 4-part: {}", msg);
+        assert!(matches!(&err, Error::InvalidVersion(_)));
+        assert_eq!(
+            err.to_string(),
+            "3-part version '25.12.9' is not supported. Use a full 4-part version (e.g., 25.12.9.1)"
+        );
     }
 
     #[test]
     fn test_parse_5_part_rejected() {
-        assert!(parse_version_spec("25.12.9.61.2").is_err());
+        let err = parse_version_spec("25.12.9.61.2").unwrap_err();
+        assert!(matches!(&err, Error::InvalidVersion(_)));
+        assert_eq!(
+            err.to_string(),
+            "invalid version '25.12.9.61.2': expected 1-2 or 4 parts"
+        );
     }
 
     #[test]
     fn test_parse_empty_rejected() {
-        assert!(parse_version_spec("").is_err());
+        let err = parse_version_spec("").unwrap_err();
+        assert!(matches!(&err, Error::InvalidVersion(_)));
+        assert_eq!(err.to_string(), "empty version");
     }
 
     #[test]
     fn test_parse_non_numeric_rejected() {
-        assert!(parse_version_spec("foo").is_err());
-        assert!(parse_version_spec("25.foo").is_err());
-        assert!(parse_version_spec("abc.12.9.61").is_err());
+        for input in ["foo", "25.foo", "abc.12.9.61"] {
+            let err = parse_version_spec(input).unwrap_err();
+            assert!(matches!(&err, Error::InvalidVersion(_)));
+            assert_eq!(
+                err.to_string(),
+                format!("invalid version '{input}': all parts must be numeric")
+            );
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/tests/local_version_error_test.rs
+++ b/crates/clickhousectl/tests/local_version_error_test.rs
@@ -1,0 +1,30 @@
+//! Regression coverage for local version-spec error reporting.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+#[test]
+fn local_use_reports_an_invalid_version_without_a_lookup_wrapper() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", tempdir.path())
+        .args(["local", "use", "not.a.version"])
+        .output()
+        .expect("run clickhousectl");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains("Error: invalid version 'not.a.version': all parts must be numeric"),
+        "unexpected stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("No matching version found"),
+        "parse error was wrapped as a lookup miss: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- distinguish invalid version syntax from version lookup misses
- render parser diagnostics directly instead of prefixing them with `No matching version found for:`
- add focused unit coverage for invalid spec shapes and a subprocess regression test for `local use`

## Why

`parse_version_spec` used `Error::NoMatchingVersion` for both parser failures and genuine resolution misses. That error variant adds a lookup-specific prefix, so an input such as `not.a.version` produced a double-wrapped, garbled message.

## Impact

`clickhousectl local use not.a.version` now reports:

```
Error: invalid version 'not.a.version': all parts must be numeric
```

Genuine lookup misses continue to use the existing `No matching version found for:` message.

## Stack

This PR is stacked on #343 and should be reviewed as the delta from `codex/issue-323-openapi-drift`.

Closes #340.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl --all-targets`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
