### PR TITLE
Surface overridden environment credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,12 +331,17 @@ clickhousectl cloud auth status    # Show current auth state (including read-onl
 clickhousectl cloud auth logout    # Clear all saved credentials (credentials.json & tokens.json)
 ```
 
-Credential resolution order: 
+Credential resolution order:
 1. CLI flags
 2. `.clickhouse/credentials.json`
 3. Environment variables exported in your session
 4. Environment variables from `.env`
 5. OAuth tokens.
+
+When environment credentials are configured but a credentials file or explicit
+CLI flags take precedence, clickhousectl prints a one-line note to stderr.
+`cloud auth status` also marks the environment credentials as configured but
+inactive and identifies the source that outranked them.
 
 ### Debugging which credential source was used
 

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -50,6 +50,15 @@ CONTEXT FOR AGENTS:
 
     /// Work with serverless ClickHouse in ClickHouse Cloud
     #[command(after_help = "\
+CREDENTIAL PRECEDENCE:
+  1. --api-key / --api-secret command-line flags
+  2. Project credentials in .clickhouse/credentials.json
+  3. CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET (shell, then .env)
+  4. OAuth tokens from `cloud auth login`
+
+Higher-precedence credentials override lower-precedence credentials. Use
+`clickhousectl cloud auth status` to see which configured source is active.
+
 CONTEXT FOR AGENTS:
   Used for managing ClickHouse Cloud infrastructure. You need to have a ClickHouse Cloud account and be authenticated.
   OAuth login (`cloud auth login`) is read-only — it can list and inspect resources but cannot create, modify, or delete.
@@ -153,6 +162,27 @@ pub struct UpdateArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn cloud_help_documents_credential_precedence() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("cloud")
+            .expect("cloud subcommand")
+            .render_long_help()
+            .to_string();
+
+        let precedence = help.split_once("CREDENTIAL PRECEDENCE:").unwrap().1;
+        let flags = precedence.find("1. --api-key / --api-secret").unwrap();
+        let file = precedence
+            .find("2. Project credentials in .clickhouse/credentials.json")
+            .unwrap();
+        let env = precedence.find("3. CLICKHOUSE_CLOUD_API_KEY").unwrap();
+        let oauth = precedence.find("4. OAuth tokens").unwrap();
+        assert!(flags < file && file < env && env < oauth, "{help}");
+        assert!(help.contains("Higher-precedence credentials override lower-precedence"));
+    }
 
     #[test]
     fn parses_skills_all_and_agent_flags() {

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -148,11 +148,11 @@ CONTEXT FOR AGENTS:
 
 #[derive(Args)]
 pub struct CloudArgs {
-    /// API key (or set CLICKHOUSE_CLOUD_API_KEY)
+    /// API key override (highest precedence; see `cloud --help` for all sources)
     #[arg(long, global = true)]
     pub api_key: Option<String>,
 
-    /// API secret (or set CLICKHOUSE_CLOUD_API_SECRET)
+    /// API secret override (highest precedence; see `cloud --help` for all sources)
     #[arg(long, global = true)]
     pub api_secret: Option<String>,
 

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -252,6 +252,7 @@ fn dotenv_env_provenance_with_sources(
 /// computed through the same `env_or_dotenv` merge the resolver uses so the
 /// `cloud auth status` table can never disagree with which source actually
 /// wins precedence. Empty values count as absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EnvCredPresence {
     pub key: bool,
     pub secret: bool,

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -12,6 +12,6 @@ pub mod types;
 mod types_test;
 
 pub use client::{
-    AuthSource, CloudClient, CloudError, CloudErrorKind, dotenv_env_provenance, env_cred_presence,
-    resolve_active_auth_source,
+    AuthSource, CloudClient, CloudError, CloudErrorKind, EnvCredPresence, dotenv_env_provenance,
+    env_cred_presence, resolve_active_auth_source,
 };

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -209,6 +209,30 @@ fn json_output(flag: bool) -> bool {
     flag || is_ai_agent::detect().is_some()
 }
 
+/// Explain when a configured environment credential cannot participate in
+/// authentication because a higher-precedence source won. Keep this notice on
+/// stderr so it does not contaminate `--json` output.
+fn ignored_env_credentials_notice(
+    active: cloud::AuthSource,
+    env_creds: cloud::EnvCredPresence,
+) -> Option<String> {
+    let configured = match (env_creds.key, env_creds.secret) {
+        (true, true) => {
+            "CLICKHOUSE_CLOUD_API_KEY and CLICKHOUSE_CLOUD_API_SECRET are set but ignored"
+        }
+        (true, false) => "CLICKHOUSE_CLOUD_API_KEY is set but ignored",
+        (false, true) => "CLICKHOUSE_CLOUD_API_SECRET is set but ignored",
+        (false, false) => return None,
+    };
+    let winner = match active {
+        cloud::AuthSource::CliFlags => "CLI flags",
+        cloud::AuthSource::CredentialsFile => "credentials file",
+        cloud::AuthSource::EnvVars | cloud::AuthSource::OAuthTokens => return None,
+    };
+
+    Some(format!("note: {configured}; using {winner} — see --debug"))
+}
+
 async fn run(cmd: Commands) -> Result<()> {
     match cmd {
         Commands::Local(args) => local::run(args.command, json_output(args.json)).await,
@@ -418,9 +442,15 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                         // one value is actually exported in the shell. Use
                         // the same rule as `dotenv_env_provenance()` so the
                         // table and `--debug describe()` stay consistent.
-                        let status = match cloud::dotenv_env_provenance() {
-                            Some(path) => format!("Active (from {})", path.display()),
-                            None => "Active".into(),
+                        let provenance = cloud::dotenv_env_provenance()
+                            .map(|path| format!(" (from {})", path.display()))
+                            .unwrap_or_default();
+                        let status = match active {
+                            Some(cloud::AuthSource::EnvVars) => format!("Active{provenance}"),
+                            Some(cloud::AuthSource::CredentialsFile) => format!(
+                                "Configured{provenance} (inactive, outranked by credentials file)"
+                            ),
+                            _ => format!("Configured{provenance} (inactive)"),
                         };
                         rows.push(AuthRow {
                             auth_type: "Env vars".into(),
@@ -487,6 +517,12 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
         args.url.as_deref(),
     )
     .map_err(cloud_error_to_top_level)?;
+
+    if let Some(notice) =
+        ignored_env_credentials_notice(client.auth_source(), cloud::env_cred_presence())
+    {
+        eprintln!("{notice}");
+    }
 
     if args.debug {
         eprintln!("[debug] auth source: {}", client.auth_source().describe());
@@ -1400,6 +1436,61 @@ mod tests {
     #[test]
     fn json_output_true_when_flag_set() {
         assert!(json_output(true));
+    }
+
+    #[test]
+    fn ignored_env_notice_names_the_overridden_variables_and_winner() {
+        assert_eq!(
+            ignored_env_credentials_notice(
+                cloud::AuthSource::CredentialsFile,
+                cloud::EnvCredPresence {
+                    key: true,
+                    secret: true,
+                },
+            )
+            .as_deref(),
+            Some(
+                "note: CLICKHOUSE_CLOUD_API_KEY and CLICKHOUSE_CLOUD_API_SECRET are set but \
+                 ignored; using credentials file — see --debug"
+            )
+        );
+        assert_eq!(
+            ignored_env_credentials_notice(
+                cloud::AuthSource::CliFlags,
+                cloud::EnvCredPresence {
+                    key: true,
+                    secret: false,
+                },
+            )
+            .as_deref(),
+            Some(
+                "note: CLICKHOUSE_CLOUD_API_KEY is set but ignored; using CLI flags — see --debug"
+            )
+        );
+    }
+
+    #[test]
+    fn ignored_env_notice_is_absent_when_env_wins_or_is_unset() {
+        assert!(
+            ignored_env_credentials_notice(
+                cloud::AuthSource::EnvVars,
+                cloud::EnvCredPresence {
+                    key: true,
+                    secret: true,
+                },
+            )
+            .is_none()
+        );
+        assert!(
+            ignored_env_credentials_notice(
+                cloud::AuthSource::CredentialsFile,
+                cloud::EnvCredPresence {
+                    key: false,
+                    secret: false,
+                },
+            )
+            .is_none()
+        );
     }
 
     fn parse(args: &[&str]) -> Commands {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -14,7 +14,7 @@
 //! Tests run as cargo integration tests:
 //!     cargo test -p clickhousectl --test cli_request_shape_test
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::Value;
@@ -160,6 +160,7 @@ async fn start_mock_org_auto_detection_api() -> MockServer {
 }
 
 fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
     let url = mock.uri();
     let mut args = vec!["cloud", "--url", &url, "--json"];
     args.extend(cli_args);
@@ -167,9 +168,106 @@ fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> st
         .env("DO_NOT_TRACK", "1")
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
         .args(args)
         .output()
         .expect("failed to spawn clickhousectl")
+}
+
+fn write_project_api_credentials(root: &Path, key: &str, secret: &str) {
+    let credentials_dir = root.join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(
+        credentials_dir.join("credentials.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "api_key": key,
+            "api_secret": secret,
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+// ── Credential precedence visibility (issue #336) ─────────────────────────
+
+#[tokio::test]
+async fn credentials_file_reports_that_environment_credentials_are_ignored() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": [],
+            "status": 200,
+            "requestId": "stub-org-list",
+        })))
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_project_api_credentials(dir.path(), "file-key", "file-secret");
+    let url = mock.uri();
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "env-key")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "env-secret")
+        .current_dir(dir.path())
+        .args(["cloud", "--url", &url, "--json", "org", "list"])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "note: CLICKHOUSE_CLOUD_API_KEY and CLICKHOUSE_CLOUD_API_SECRET are set but ignored; \
+         using credentials file — see --debug\n"
+    );
+
+    let requests = mock.received_requests().await.unwrap();
+    let authorization = requests[0]
+        .headers
+        .get("Authorization")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    let expected = format!(
+        "Basic {}",
+        base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            "file-key:file-secret",
+        )
+    );
+    assert_eq!(authorization, expected);
+}
+
+#[test]
+fn auth_status_marks_outranked_environment_credentials_inactive() {
+    let dir = tempfile::tempdir().unwrap();
+    write_project_api_credentials(dir.path(), "file-key", "file-secret");
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "env-key")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "env-secret")
+        .current_dir(dir.path())
+        .args(["cloud", "--json", "auth", "status"])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_success(&output);
+    assert!(output.stderr.is_empty());
+    let rows: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let env = rows
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|row| row["type"] == "Env vars")
+        .unwrap();
+    assert_eq!(
+        env["status"],
+        "Configured (inactive, outranked by credentials file)"
+    );
+    assert_eq!(env["active"], "-");
 }
 
 // ── Service deletion errors (issue #335) ──────────────────────────────────

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -161,11 +161,14 @@ async fn start_mock_org_auto_detection_api() -> MockServer {
 
 fn invoke_cli_with_cloud_credentials(mock: &MockServer, cli_args: &[&str]) -> std::process::Output {
     let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
     let url = mock.uri();
     let mut args = vec!["cloud", "--url", &url, "--json"];
     args.extend(cli_args);
     Command::new(clickhousectl_binary())
         .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .current_dir(dir.path())


### PR DESCRIPTION
## Summary

- print a one-line stderr note when environment API credentials are ignored in favor of CLI flags or the project credentials file
- show complete but outranked environment credentials as configured and inactive in `cloud auth status`
- document the credential precedence order in `cloud --help` and clarify the global credential flags
- add unit and subprocess regression coverage for the notice, status output, help text, and credential actually sent on the wire

## Why

Credential resolution deliberately prefers CLI flags, then `.clickhouse/credentials.json`, then environment credentials, then OAuth. When a credentials file existed, a user could set environment credentials for another organization and unknowingly continue operating with the file credentials. The resolved source was visible only with `--debug`, while normal commands gave no indication that the environment pair had been ignored.

## Impact

Commands now warn on stderr without contaminating JSON stdout, and `cloud auth status` distinguishes an inactive environment pair from an unconfigured one. The precedence itself is unchanged.

## Stack

This PR is stacked on #351 and should be reviewed as the delta from `codex/issue-335-delete-force-hint`.

Closes #336.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
