### PR TITLE
Polish local install confirmations

### DIFF
--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -105,7 +105,14 @@ async fn install(version_spec: &str, force: bool, json: bool) -> Result<()> {
         version,
         set_as_default,
     };
-    output::print_output(&out, json);
+    // The version manager already emits outcome-aware human output: a real
+    // install is confirmed there, while a no-op says that the existing build
+    // is being reused. The generic display text always says "Installed", so
+    // reserve it for structured output to avoid a duplicate or misleading
+    // human confirmation.
+    if json {
+        output::print_output(&out, true);
+    }
 
     Ok(())
 }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -111,7 +111,7 @@ async fn install(version_spec: &str, force: bool, json: bool) -> Result<()> {
     // reserve it for structured output to avoid a duplicate or misleading
     // human confirmation.
     if json {
-        output::print_output(&out, true);
+        output::print_output(&out, json);
     }
 
     Ok(())

--- a/crates/clickhousectl/tests/local_install_local_first_test.rs
+++ b/crates/clickhousectl/tests/local_install_local_first_test.rs
@@ -4,9 +4,11 @@
 //! spellings of an installed version to both be successful no-ops.
 //!
 //! Strategy: spawn the binary with `HOME=<tempdir>`, pre-seed a fake installed
-//! version, run both partial and exact `local install` commands, and assert that:
+//! version, run both partial and exact `local install` commands in human-output
+//! mode, and assert that:
 //!   - the command exits 0,
 //!   - stderr says "already installed",
+//!   - stdout has no generic "Installed version" confirmation,
 //!   - stderr does NOT say "Resolving" (which only prints on the remote path).
 //!
 //! Network calls aren't mocked because the version-manager URLs aren't currently
@@ -36,10 +38,14 @@ fn install_with_existing_version(installed_version: &str, requested_spec: &str) 
     perms.set_mode(0o755);
     std::fs::set_permissions(&binary, perms).unwrap();
 
-    Command::new(clickhousectl_binary())
+    let mut command = Command::new(clickhousectl_binary());
+    command
+        // Prevent coding-agent detection from switching the subprocess to JSON
+        // so this exercises the human output reported in issue #328.
+        .env_clear()
         .env("DO_NOT_TRACK", "1")
         .env("HOME", tempdir.path())
-        .args(["local", "install", requested_spec, "--json"])
+        .args(["local", "install", requested_spec])
         .output()
         .expect("run clickhousectl")
 }
@@ -59,6 +65,11 @@ fn local_install_minor_with_existing_match_does_not_hit_network() {
         stderr.contains("already installed"),
         "expected 'already installed' in stderr, got: {}",
         stderr
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "expected no generic install confirmation, got: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
     assert!(
         !stderr.contains("Resolving"),
@@ -90,6 +101,11 @@ fn local_install_exact_with_existing_match_is_a_successful_no_op() {
         stderr.contains("Use --force to re-download the latest build"),
         "expected --force hint, got: {}",
         stderr
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "expected no generic install confirmation, got: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
     assert!(
         !stderr.contains("Resolving"),


### PR DESCRIPTION
## Summary

- stop the local ClickHouse install handler from appending a generic human confirmation after the version manager has already reported the outcome
- preserve the existing structured JSON install result for `--json` and coding-agent consumers
- run the local-first install regression tests in human-output mode and assert that no generic confirmation is printed for a no-op

## Why

The version manager already distinguishes real installs from reused builds, but the CLI layer always appended `Installed version X`. That produced duplicate confirmations after a real install and contradicted the no-op message when a matching version was already present.

## Impact

A no-op install now ends after the accurate “already installed” message and `--force` hint. A real install keeps the single `Installed ClickHouse X` confirmation emitted by the version manager. JSON output is unchanged.

## Stack

This PR is stacked on #352 and should be reviewed as the delta from `codex/issue-336-env-credential-precedence`.

Closes #328.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
