### PR TITLE
Default local teardown to the default instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,16 @@ clickhousectl local server list
 clickhousectl local server list --global                  # List servers across all projects
 
 # Stop servers
-clickhousectl local server stop default                   # Stop by name
+clickhousectl local server stop                           # Stop "default"
+clickhousectl local server stop dev                       # Stop by name
 clickhousectl local server stop default --global          # Stop from any project
 clickhousectl local server stop default --global --project /path/to/project  # Disambiguate
 clickhousectl local server stop-all                       # Stop all running servers
 clickhousectl local server stop-all --global              # Stop all servers system-wide
 
 # Remove a stopped server and its data
-clickhousectl local server remove test
+clickhousectl local server remove                         # Remove "default"
+clickhousectl local server remove test                    # Remove by name
 
 # Write connection env vars to .env file
 clickhousectl local server dotenv                        # From "default" server → .env
@@ -192,7 +194,7 @@ clickhousectl local server dotenv --local                # Write to .env.local i
 clickhousectl local server dotenv --user default --password secret --database mydb  # Include credentials
 ```
 
-**Idempotent stop:** `server stop <name>` is idempotent — stopping a server that exists but is already stopped exits 0 (it reports "is already stopped" rather than erroring), so scripts don't need to guard against it. An unknown server name still errors, so typos are caught. `server stop-all` likewise exits 0 when nothing is running.
+**Idempotent stop:** `server stop [name]` is idempotent — stopping a server that exists but is already stopped exits 0 (it reports "is already stopped" rather than erroring), so scripts don't need to guard against it. The name defaults to "default". An unknown server name still errors, so typos are caught. `server stop-all` likewise exits 0 when nothing is running.
 
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
 
@@ -249,9 +251,11 @@ clickhousectl local postgres client --name dev --query "SELECT 1"
 clickhousectl local postgres dotenv --name dev
 
 # Stop / remove. Pass --version when more than one major shares a name.
+clickhousectl local postgres stop                         # Stop "default"
 clickhousectl local postgres stop dev
 clickhousectl local postgres stop dev --version 17        # disambiguate
 clickhousectl local postgres stop-all                     # Stop all Postgres instances in this project
+clickhousectl local postgres remove                       # Remove "default"
 clickhousectl local postgres remove dev
 ```
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -179,7 +179,7 @@ CONTEXT FOR AGENTS:
   ClickHouse's built-in defaults (via config.d), so it can contain just the settings you want
   to change (e.g. <query_log>). The data directory and ports stay managed regardless of the
   file's contents (they are forced as command-line overrides).
-  Related: `clickhousectl local server list` to see servers, `clickhousectl local server stop <name>` to stop one.")]
+  Related: `clickhousectl local server list` to see servers, `clickhousectl local server stop [name]` to stop one.")]
     Start {
         /// Server name (default: \"default\", or random if default is already running)
         #[arg(long)]
@@ -238,14 +238,16 @@ CONTEXT FOR AGENTS:
     /// Stop a running server by name
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Stops a named ClickHouse server. Use the name from `clickhousectl local server list`.
+  Stops a ClickHouse server. The name defaults to \"default\"; use `clickhousectl local server list`
+  to find other server names.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data directory is preserved — restart with `clickhousectl local server start --name <name>`.
   Idempotent: a server that exists but is already stopped exits 0 (no error).
   An unknown server name still errors so typos are caught.
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
-        /// Name of the server to stop
+        /// Name of the server to stop (default: "default")
+        #[arg(default_value = "default")]
         name: String,
 
         /// System-wide maintenance only: stop a server from any project. You almost certainly want the default project-scoped stop instead.
@@ -275,9 +277,11 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  Related: `clickhousectl local server stop <name>` to stop first, `clickhousectl local server list` to see servers.")]
+  The name defaults to \"default\".
+  Related: `clickhousectl local server stop [name]` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
-        /// Name of the server to remove
+        /// Name of the server to remove (default: "default")
+        #[arg(default_value = "default")]
         name: String,
     },
 
@@ -362,7 +366,8 @@ CONTEXT FOR AGENTS:
 
     /// Stop a running Postgres container by name
     Stop {
-        /// Name of the server to stop
+        /// Name of the server to stop (default: "default")
+        #[arg(default_value = "default")]
         name: String,
         /// Postgres version to disambiguate when multiple share a name
         #[arg(long, short = 'v')]
@@ -374,7 +379,8 @@ CONTEXT FOR AGENTS:
 
     /// Remove a stopped Postgres server and its data directory
     Remove {
-        /// Name of the server to remove
+        /// Name of the server to remove (default: "default")
+        #[arg(default_value = "default")]
         name: String,
         /// Postgres version to disambiguate when multiple share a name
         #[arg(long, short = 'v')]
@@ -525,5 +531,84 @@ mod tests {
         else {
             panic!("expected server configs");
         };
+    }
+
+    #[test]
+    fn server_stop_name_defaults_to_default() {
+        let LocalCommands::Server {
+            command: ServerCommands::Stop { name, .. },
+        } = local_command(&["server", "stop"])
+        else {
+            panic!("expected server stop");
+        };
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn server_remove_name_defaults_to_default() {
+        let LocalCommands::Server {
+            command: ServerCommands::Remove { name },
+        } = local_command(&["server", "remove"])
+        else {
+            panic!("expected server remove");
+        };
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn postgres_stop_name_defaults_to_default() {
+        let LocalCommands::Postgres {
+            command: PostgresCommands::Stop { name, .. },
+        } = local_command(&["postgres", "stop"])
+        else {
+            panic!("expected postgres stop");
+        };
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn postgres_remove_name_defaults_to_default() {
+        let LocalCommands::Postgres {
+            command: PostgresCommands::Remove { name, .. },
+        } = local_command(&["postgres", "remove"])
+        else {
+            panic!("expected postgres remove");
+        };
+        assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn teardown_commands_preserve_explicit_names() {
+        let LocalCommands::Server {
+            command: ServerCommands::Stop { name, .. },
+        } = local_command(&["server", "stop", "analytics"])
+        else {
+            panic!("expected server stop");
+        };
+        assert_eq!(name, "analytics");
+
+        let LocalCommands::Server {
+            command: ServerCommands::Remove { name },
+        } = local_command(&["server", "remove", "analytics"])
+        else {
+            panic!("expected server remove");
+        };
+        assert_eq!(name, "analytics");
+
+        let LocalCommands::Postgres {
+            command: PostgresCommands::Stop { name, .. },
+        } = local_command(&["postgres", "stop", "warehouse"])
+        else {
+            panic!("expected postgres stop");
+        };
+        assert_eq!(name, "warehouse");
+
+        let LocalCommands::Postgres {
+            command: PostgresCommands::Remove { name, .. },
+        } = local_command(&["postgres", "remove", "warehouse"])
+        else {
+            panic!("expected postgres remove");
+        };
+        assert_eq!(name, "warehouse");
     }
 }

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -228,7 +228,7 @@ CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Automatically cleans up stale entries for processes that are no longer running.
   Shows name, status (running/stopped), PID, version, and ports.
-  Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
+  Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop [name]` to stop one.")]
     List {
         /// System-wide maintenance only: list servers across all projects. You almost certainly want the default project-scoped list instead.
         #[arg(long)]


### PR DESCRIPTION
## Summary

- default omitted names to `default` for ClickHouse `server stop` and `server remove`
- apply the same default to Postgres `postgres stop` and `postgres remove`
- add Clap parse coverage for omitted and explicit names
- document the bare default-instance lifecycle commands

## Why

`start` creates or resumes the `default` instance when no name is supplied, but the matching teardown commands required a positional name. This made the natural default-instance lifecycle fail at argument parsing before the command could run.

## Impact

Users can now start, stop, and remove the default ClickHouse or Postgres instance without typing its name. Explicit names and existing disambiguation flags continue to work unchanged.

## Stack

This PR is stacked on #354 and should be reviewed as the delta from `codex/issue-328-install-output-polish`.

Closes #326.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
