### PR TITLE
Keep stopped ClickHouse servers discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ clickhousectl local server dotenv --user default --password secret --database my
 
 **Idempotent stop:** `server stop [name]` is idempotent — stopping a server that exists but is already stopped exits 0 (it reports "is already stopped" rather than erroring), so scripts don't need to guard against it. The name defaults to "default". An unknown server name still errors, so typos are caught. `server stop-all` likewise exits 0 when nothing is running.
 
+Stopping a server preserves both its data and metadata, so it remains visible in `server list` with a `stopped` status. The displayed version and ports are from its last run; starting the same name again resumes the existing data directory.
+
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
 
 **Ports:** Defaults are HTTP 8123 and TCP 9000. If these are already in use, free ports are automatically assigned and shown in the output. Use `--http-port` and `--tcp-port` to set explicit ports.
@@ -272,8 +274,10 @@ All server data lives inside `.clickhouse/` in your project directory:
 ├── .gitignore              # auto-created, ignores everything
 ├── credentials.json        # cloud API credentials (if configured)
 └── servers/
+    ├── default.json         # ClickHouse metadata and last known state
     ├── default/
     │   └── data/           # ClickHouse data files for "default" server
+    ├── dev.json             # ClickHouse metadata and last known state
     └── dev/
         └── data/           # ClickHouse data files for "dev" server
 ```

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ clickhousectl local server dotenv --user default --password secret --database my
 
 **Idempotent stop:** `server stop [name]` is idempotent — stopping a server that exists but is already stopped exits 0 (it reports "is already stopped" rather than erroring), so scripts don't need to guard against it. The name defaults to "default". An unknown server name still errors, so typos are caught. `server stop-all` likewise exits 0 when nothing is running.
 
-Stopping a server preserves both its data and metadata, so it remains visible in `server list` with a `stopped` status. The displayed version and ports are from its last run; starting the same name again resumes the existing data directory.
+Stopping a server preserves its data and identity metadata, so it remains visible in `server list` with a `stopped` status. Version and ports are shown only while running because they are resolved again on each start. Starting the same name resumes the existing data directory.
 
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
 
@@ -274,10 +274,10 @@ All server data lives inside `.clickhouse/` in your project directory:
 ├── .gitignore              # auto-created, ignores everything
 ├── credentials.json        # cloud API credentials (if configured)
 └── servers/
-    ├── default.json         # ClickHouse metadata and last known state
+    ├── default.json         # ClickHouse identity and runtime state
     ├── default/
     │   └── data/           # ClickHouse data files for "default" server
-    ├── dev.json             # ClickHouse metadata and last known state
+    ├── dev.json             # ClickHouse identity and runtime state
     └── dev/
         └── data/           # ClickHouse data files for "dev" server
 ```

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -227,7 +227,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Processes that exited unexpectedly are retained and shown as stopped.
-  Shows name, status (running/stopped), PID, version, and ports.
+  Running entries also show their PID, version, and ports.
   Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
     List {
         /// System-wide maintenance only: list servers across all projects. You almost certainly want the default project-scoped list instead.

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -227,7 +227,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
   Processes that exited unexpectedly are retained and shown as stopped.
-  Running entries also show their PID, version, and ports.
+  Running ClickHouse entries also show their PID, version, and ports.
   Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
     List {
         /// System-wide maintenance only: list servers across all projects. You almost certainly want the default project-scoped list instead.

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -226,7 +226,7 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Shows all named ClickHouse server instances and their status.
-  Automatically cleans up stale entries for processes that are no longer running.
+  Processes that exited unexpectedly are retained and shown as stopped.
   Shows name, status (running/stopped), PID, version, and ports.
   Related: `clickhousectl local server start` to start a server, `clickhousectl local server stop <name>` to stop one.")]
     List {
@@ -241,7 +241,8 @@ CONTEXT FOR AGENTS:
   Stops a ClickHouse server. The name defaults to \"default\"; use `clickhousectl local server list`
   to find other server names.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
-  The server's data directory is preserved — restart with `clickhousectl local server start --name <name>`.
+  The server's data and metadata are preserved so it remains visible in `server list`.
+  Restart with `clickhousectl local server start --name <name>`.
   Idempotent: a server that exists but is already stopped exits 0 (no error).
   An unknown server name still errors so typos are caught.
   Related: `clickhousectl local server list` to see servers.")]
@@ -264,7 +265,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Stops all running ClickHouse server instances.
   Sends SIGTERM first, then SIGKILL if processes don't exit.
-  Data directories are preserved.
+  Data and metadata are preserved, and stopped servers remain visible in `server list`.
   Related: `clickhousectl local server list` to see servers.")]
     StopAll {
         /// System-wide maintenance only: stop all servers across all projects. You almost certainly want the default project-scoped stop-all instead.

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -274,6 +274,9 @@ fn run_client(
             .iter()
             .find(|e| e.name == server_name)
             .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+        if !entry.running {
+            return Err(Error::ServerNotRunning(server_name.to_string()));
+        }
         let info = entry
             .info
             .as_ref()
@@ -492,7 +495,7 @@ async fn start_server(
         );
 
         let status = child.wait().map_err(|e| Error::Exec(e.to_string()))?;
-        server::remove_server_info(&server_name);
+        server::mark_server_stopped(&server_name, pid)?;
 
         if !status.success()
             && let Some(code) = status.code()
@@ -527,6 +530,9 @@ fn dotenv_server(
         .iter()
         .find(|e| e.name == server_name)
         .ok_or_else(|| Error::ServerNotFound(server_name.to_string()))?;
+    if !entry.running {
+        return Err(Error::ServerNotRunning(server_name.to_string()));
+    }
     let info = entry
         .info
         .as_ref()

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -816,7 +816,23 @@ fn list_servers_local(json: bool) -> Result<()> {
                             } else {
                                 None
                             };
-                            let http_port = if is_ch { Some(info.http_port) } else { None };
+                            // ClickHouse resolves its version and ports on each
+                            // start, so stopped entries expose identity only.
+                            let version = if !is_ch || running {
+                                Some(info.version)
+                            } else {
+                                None
+                            };
+                            let http_port = if is_ch && running {
+                                Some(info.http_port)
+                            } else {
+                                None
+                            };
+                            let tcp_port = if !is_ch || running {
+                                Some(info.tcp_port)
+                            } else {
+                                None
+                            };
                             // For Postgres the disk key is `<name>-pg<major>`;
                             // show users the friendly name without the suffix.
                             let display = if is_ch {
@@ -827,9 +843,9 @@ fn list_servers_local(json: bool) -> Result<()> {
                             (
                                 display,
                                 pid,
-                                Some(info.version),
+                                version,
                                 http_port,
-                                Some(info.tcp_port),
+                                tcp_port,
                                 info.engine.as_str().to_string(),
                                 info.container_id,
                             )

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -48,7 +48,7 @@ fn default_engine() -> Engine {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerInfo {
     pub name: String,
-    /// Process PID for ClickHouse; 0 for Postgres (use `container_id` instead).
+    /// Active ClickHouse process PID; 0 when stopped or for Postgres.
     pub pid: u32,
     /// ClickHouse version like "25.12.5.44", or "postgres:<tag>" for Postgres.
     pub version: String,
@@ -170,6 +170,21 @@ pub fn remove_server_info(name: &str) {
     let _ = std::fs::remove_file(server_meta_path(name));
 }
 
+/// Mark a ClickHouse server as stopped without discarding its metadata.
+///
+/// The PID match avoids overwriting metadata when a newer process was already
+/// recorded before this transition began.
+pub fn mark_server_stopped(name: &str, pid: u32) -> Result<()> {
+    let Some(mut info) = load_info(name) else {
+        return Ok(());
+    };
+    if info.engine == Engine::Clickhouse && info.pid == pid {
+        info.pid = 0;
+        save_server_info(&info)?;
+    }
+    Ok(())
+}
+
 /// Engine-aware liveness check.
 fn is_alive(info: &ServerInfo) -> bool {
     match info.engine {
@@ -227,10 +242,9 @@ pub fn find_pg_instances(name: &str) -> Vec<ServerInfo> {
 }
 
 /// Load server metadata only if the underlying process/container is alive.
-/// Does **not** auto-delete stale metadata — `list_all_servers` is the single
-/// place that GCs ClickHouse entries whose PID is gone, so callers like
-/// `is_server_running` and `resolve_name` can read the metadata without side
-/// effects.
+/// Does not update stale metadata. `list_all_servers` is the single place that
+/// marks ClickHouse entries stopped when their PID is gone, so callers like
+/// `is_server_running` and `resolve_name` can read metadata without side effects.
 fn load_running_info(name: &str) -> Option<ServerInfo> {
     let info = load_info(name)?;
     if is_alive(&info) { Some(info) } else { None }
@@ -267,25 +281,26 @@ pub fn list_all_servers() -> Vec<ServerEntry> {
             continue;
         }
 
-        let info = load_info(stem);
-        let running = match &info {
+        let mut info = load_info(stem);
+        let mut running = match &info {
             Some(i) => is_alive(i),
             None => false,
         };
 
-        // GC stale ClickHouse metadata: process is gone for good. Postgres
-        // entries stay so `start` can resume the existing container.
+        // A dead ClickHouse PID can result from a crash or a global stop. Keep
+        // the metadata and normalize it to the same stopped sentinel Postgres
+        // uses so the instance remains discoverable.
         if let Some(i) = &info
             && !running
             && i.engine == Engine::Clickhouse
+            && i.pid != 0
         {
-            let _ = std::fs::remove_file(server_meta_path(stem));
-            entries.push(ServerEntry {
-                name: stem.to_string(),
-                running: false,
-                info: None,
-            });
-            continue;
+            let stale_pid = i.pid;
+            let _ = mark_server_stopped(stem, stale_pid);
+            // Reload because a concurrent restart may have replaced the stale
+            // PID before `mark_server_stopped` acquired the latest metadata.
+            info = load_info(stem);
+            running = info.as_ref().is_some_and(is_alive);
         }
 
         entries.push(ServerEntry {
@@ -319,7 +334,7 @@ pub fn running_server_count() -> usize {
 }
 
 fn is_process_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as i32, 0) == 0 }
+    pid != 0 && i32::try_from(pid).is_ok_and(|pid| unsafe { libc::kill(pid, 0) == 0 })
 }
 
 /// Send a signal to a process and return an error if the signal could not be delivered
@@ -365,8 +380,8 @@ fn kill_process(pid: u32) -> Result<()> {
 
 /// Stop a running server by name.
 ///
-/// * ClickHouse: SIGTERM (then SIGKILL on timeout); metadata is removed
-///   because the process is gone for good.
+/// * ClickHouse: SIGTERM (then SIGKILL on timeout); metadata is retained with
+///   PID 0 so the stopped instance remains discoverable.
 /// * Postgres: stops the container only — does **not** remove it, and keeps
 ///   the metadata file so a subsequent `start` resumes the same container
 ///   (preserving the password and any other PGDATA-encoded settings).
@@ -376,7 +391,7 @@ pub fn kill_server(name: &str) -> Result<()> {
     match info.engine {
         Engine::Clickhouse => {
             kill_process(info.pid)?;
-            remove_server_info(name);
+            mark_server_stopped(name, info.pid)?;
         }
         Engine::Postgres => {
             let id = info.container_id.as_deref().ok_or_else(|| {
@@ -439,7 +454,7 @@ pub fn check_spawn_health(pid: u32, name: &str) -> Result<()> {
     std::thread::sleep(std::time::Duration::from_millis(300));
 
     if !is_process_alive(pid) {
-        remove_server_info(name);
+        let _ = mark_server_stopped(name, pid);
         return Err(Error::Exec(format!(
             "Server '{}' exited immediately after starting. \
              Check if another server is using the same ports, \
@@ -652,5 +667,11 @@ mod tests {
         assert_eq!(parsed.engine, Engine::Postgres);
         assert_eq!(parsed.container_id.as_deref(), Some("abc123"));
         assert!(json.contains("\"engine\":\"postgres\""));
+    }
+
+    #[test]
+    fn stopped_and_out_of_range_pids_are_never_alive() {
+        assert!(!is_process_alive(0));
+        assert!(!is_process_alive(u32::MAX));
     }
 }

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -50,11 +50,12 @@ pub struct ServerInfo {
     pub name: String,
     /// Active ClickHouse process PID; 0 when stopped or for Postgres.
     pub pid: u32,
-    /// ClickHouse version like "25.12.5.44", or "postgres:<tag>" for Postgres.
+    /// Running ClickHouse version like "25.12.5.44", empty when stopped, or
+    /// "postgres:<tag>" for Postgres.
     pub version: String,
-    /// Unused for Postgres (set to 0).
+    /// Running ClickHouse HTTP port; 0 when stopped or for Postgres.
     pub http_port: u16,
-    /// TCP port for ClickHouse; mapped host port for Postgres.
+    /// Running ClickHouse TCP port, 0 when stopped, or mapped host port for Postgres.
     pub tcp_port: u16,
     pub started_at: String,
     pub cwd: String,
@@ -180,6 +181,9 @@ pub fn mark_server_stopped(name: &str, pid: u32) -> Result<()> {
     };
     if info.engine == Engine::Clickhouse && info.pid == pid {
         info.pid = 0;
+        info.version.clear();
+        info.http_port = 0;
+        info.tcp_port = 0;
         save_server_info(&info)?;
     }
     Ok(())

--- a/crates/clickhousectl/tests/local_server_stopped_test.rs
+++ b/crates/clickhousectl/tests/local_server_stopped_test.rs
@@ -66,10 +66,10 @@ fn assert_stopped_list(output: &Output) {
     let server = &body["servers"][0];
     assert_eq!(server["name"], "default");
     assert_eq!(server["running"], false);
-    assert_eq!(server["version"], "25.12.9.61");
-    assert_eq!(server["http_port"], 8123);
-    assert_eq!(server["tcp_port"], 9000);
     assert!(server.get("pid").is_none());
+    assert!(server.get("version").is_none());
+    assert!(server.get("http_port").is_none());
+    assert!(server.get("tcp_port").is_none());
 }
 
 struct ProcessGuard {
@@ -142,6 +142,9 @@ fn stopping_clickhouse_retains_metadata_and_lists_it_as_stopped() {
 
     let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
     assert_eq!(saved["pid"], 0);
+    assert_eq!(saved["version"], "");
+    assert_eq!(saved["http_port"], 0);
+    assert_eq!(saved["tcp_port"], 0);
     assert_stopped_list(&run(
         project.path(),
         home.path(),
@@ -164,6 +167,9 @@ fn stale_clickhouse_metadata_is_retained_as_stopped() {
 
     let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
     assert_eq!(saved["pid"], 0);
+    assert_eq!(saved["version"], "");
+    assert_eq!(saved["http_port"], 0);
+    assert_eq!(saved["tcp_port"], 0);
 
     let second = run(
         project.path(),

--- a/crates/clickhousectl/tests/local_server_stopped_test.rs
+++ b/crates/clickhousectl/tests/local_server_stopped_test.rs
@@ -1,0 +1,199 @@
+//! Regression coverage for stopped ClickHouse server metadata (issue #324).
+
+use serde_json::{Value, json};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn write_server_metadata(project: &Path, pid: u32) -> PathBuf {
+    let servers = project.join(".clickhouse/servers");
+    std::fs::create_dir_all(servers.join("default/data")).expect("create server data dir");
+    let metadata = servers.join("default.json");
+    std::fs::write(
+        &metadata,
+        serde_json::to_vec_pretty(&json!({
+            "name": "default",
+            "pid": pid,
+            "version": "25.12.9.61",
+            "http_port": 8123,
+            "tcp_port": 9000,
+            "started_at": "1700000000",
+            "cwd": project.display().to_string(),
+            "engine": "clickhouse"
+        }))
+        .unwrap(),
+    )
+    .expect("write server metadata");
+    metadata
+}
+
+fn run(project: &Path, home: &Path, args: &[&str]) -> Output {
+    Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(project)
+        .args(args)
+        .output()
+        .expect("run clickhousectl")
+}
+
+fn install_fake_clickhouse(home: &Path) {
+    let binary = home.join(".clickhouse/versions/25.12.9.61/clickhouse");
+    std::fs::create_dir_all(binary.parent().unwrap()).expect("create fake version dir");
+    std::fs::write(
+        &binary,
+        b"#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+    )
+    .expect("write fake ClickHouse");
+    let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(binary, permissions).expect("make fake ClickHouse executable");
+}
+
+fn assert_stopped_list(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: Value = serde_json::from_slice(&output.stdout).expect("parse list JSON");
+    assert_eq!(body["total_servers"], 1);
+    assert_eq!(body["total_running_servers"], 0);
+    let server = &body["servers"][0];
+    assert_eq!(server["name"], "default");
+    assert_eq!(server["running"], false);
+    assert_eq!(server["version"], "25.12.9.61");
+    assert_eq!(server["http_port"], 8123);
+    assert_eq!(server["tcp_port"], 9000);
+    assert!(server.get("pid").is_none());
+}
+
+struct ProcessGuard {
+    pid: u32,
+    active: bool,
+}
+
+impl ProcessGuard {
+    fn new(pid: u32) -> Self {
+        Self { pid, active: true }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe {
+                libc::kill(self.pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[test]
+fn stopping_clickhouse_retains_metadata_and_lists_it_as_stopped() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path());
+
+    let start = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            "25.12.9.61",
+        ],
+    );
+    assert!(
+        start.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&start.stderr)
+    );
+    let start_body: Value = serde_json::from_slice(&start.stdout).expect("parse start JSON");
+    let pid = start_body["pid"].as_u64().expect("start PID") as u32;
+    let mut process = ProcessGuard::new(pid);
+    let metadata = project.path().join(".clickhouse/servers/default.json");
+
+    let stop = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert!(
+        stop.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    process.disarm();
+    let body: Value = serde_json::from_slice(&stop.stdout).expect("parse stop JSON");
+    assert_eq!(body["name"], "default");
+    assert_eq!(body["already_stopped"], false);
+
+    let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
+    assert_eq!(saved["pid"], 0);
+    assert_stopped_list(&run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "list"],
+    ));
+}
+
+#[test]
+fn stale_clickhouse_metadata_is_retained_as_stopped() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let metadata = write_server_metadata(project.path(), u32::MAX);
+
+    let first = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "list"],
+    );
+    assert_stopped_list(&first);
+
+    let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
+    assert_eq!(saved["pid"], 0);
+
+    let second = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "list"],
+    );
+    assert_stopped_list(&second);
+    assert!(metadata.exists());
+}
+
+#[test]
+fn stopped_server_connection_commands_fail_without_using_saved_ports() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    write_server_metadata(project.path(), 0);
+
+    let client = run(
+        project.path(),
+        home.path(),
+        &["local", "client", "--name", "default"],
+    );
+    assert_eq!(client.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&client.stderr).contains("Server 'default' is not running"));
+
+    let dotenv = run(
+        project.path(),
+        home.path(),
+        &["local", "server", "dotenv", "--name", "default"],
+    );
+    assert_eq!(dotenv.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&dotenv.stderr).contains("Server 'default' is not running"));
+    assert!(!project.path().join(".env").exists());
+}


### PR DESCRIPTION
## Summary

- retain ClickHouse server identity metadata with `pid: 0` after clean stops, foreground exits, failed starts, and stale-process detection
- clear and omit transient ClickHouse version and port details while stopped because each start resolves them again
- reject client and dotenv connections to stopped entries
- add subprocess coverage for start/stop/list, stale metadata normalization, and stopped connection commands
- document retained identity metadata and stopped-server listing

## Stack

This PR is stacked on #355 and should be reviewed as the delta from `codex/issue-326-default-local-instance`.

Closes #324.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`