### PR TITLE
Wait for local server readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ clickhousectl local server start                          # Named "default" (ins
 clickhousectl local server start --name dev               # Named "dev"
 clickhousectl local server start --version latest         # Use a specific version (installs if needed, doesn't change default)
 clickhousectl local server start --foreground             # Run in foreground (-F / --fg)
+clickhousectl local server start --no-wait                # Return after spawning without waiting for readiness
 clickhousectl local server start --http-port 8124 --tcp-port 9001  # Explicit ports
 clickhousectl local server start --config analytics       # Apply a custom config (see "Custom config files" below)
 
@@ -201,6 +202,8 @@ Stopping a server preserves its data and identity metadata, so it remains visibl
 **Server naming:** Without `--name`, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Use `--name` for stable identities you can start/stop repeatedly.
 
 **Ports:** Defaults are HTTP 8123 and TCP 9000. If these are already in use, free ports are automatically assigned and shown in the output. Use `--http-port` and `--tcp-port` to set explicit ports.
+
+**Readiness:** Background starts wait up to 30 seconds for the HTTP health check and TCP port before reporting success, so a following `local client` command can connect immediately. Startup failures point to `.clickhouse/servers/<name>/server.log`. Use `--no-wait` for fire-and-forget startup.
 
 **Orphaned server recovery:** If server metadata files are lost while the ClickHouse process is still running, the CLI automatically recovers them via process discovery. Running `server list`, `server start`, or any server command will detect orphaned processes belonging to the current project and bring them back under management.
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -172,6 +172,7 @@ CONTEXT FOR AGENTS:
   Ports default to 8123 (HTTP) and 9000 (TCP). If they're in use, free ports are auto-assigned.
   Use --http-port and --tcp-port to set explicit ports.
   Runs in background by default. Use --foreground (-F / --fg) to run in foreground.
+  Background starts wait for HTTP health and TCP connections. Use --no-wait to return after spawning.
   If --name is given and that server is already running, the command will error.
   Shows count of already-running servers before starting.
   Use --config <NAME> to apply a custom ClickHouse config file from ~/.clickhouse/configs/
@@ -200,6 +201,10 @@ CONTEXT FOR AGENTS:
         /// Run server in foreground (default: background)
         #[arg(long, alias = "fg", short = 'F')]
         foreground: bool,
+
+        /// Return after spawning without waiting for HTTP and TCP readiness
+        #[arg(long, conflicts_with = "foreground")]
+        no_wait: bool,
 
         /// Overlay a named config file from ~/.clickhouse/configs/ on top of the defaults (see `server configs`)
         #[arg(long = "config", alias = "config-file", value_name = "NAME")]
@@ -513,15 +518,46 @@ mod tests {
     #[test]
     fn server_start_config_file_defaults_to_none() {
         let LocalCommands::Server {
-            command: ServerCommands::Start {
-                config_file, args, ..
-            },
+            command:
+                ServerCommands::Start {
+                    config_file,
+                    no_wait,
+                    args,
+                    ..
+                },
         } = local_command(&["server", "start"])
         else {
             panic!("expected server start");
         };
         assert_eq!(config_file, None);
+        assert!(!no_wait);
         assert!(args.is_empty());
+    }
+
+    #[test]
+    fn parses_server_start_no_wait() {
+        let LocalCommands::Server {
+            command: ServerCommands::Start { no_wait, .. },
+        } = local_command(&["server", "start", "--no-wait"])
+        else {
+            panic!("expected server start");
+        };
+        assert!(no_wait);
+    }
+
+    #[test]
+    fn server_start_no_wait_conflicts_with_foreground() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "local",
+            "server",
+            "start",
+            "--no-wait",
+            "--foreground",
+        ])
+        .err()
+        .expect("flags should conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -321,6 +321,7 @@ async fn start_server(
     http_port: Option<u16>,
     tcp_port: Option<u16>,
     foreground: bool,
+    no_wait: bool,
     config_file: Option<String>,
     args: Vec<String>,
     json: bool,
@@ -442,9 +443,15 @@ async fn start_server(
         .unwrap_or_default();
 
     if !foreground {
-        cmd.stdout(std::process::Stdio::null());
-        cmd.stderr(std::process::Stdio::null());
-        let child = cmd.spawn().map_err(|e| Error::Exec(e.to_string()))?;
+        let log_path = server::server_log_path(&server_name);
+        let log = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&log_path)?;
+        cmd.stdout(log.try_clone()?);
+        cmd.stderr(log);
+        let mut child = cmd.spawn().map_err(|e| Error::Exec(e.to_string()))?;
         let pid = child.id();
 
         let info = server::ServerInfo {
@@ -460,8 +467,19 @@ async fn start_server(
         };
         server::save_server_info(&info)?;
 
-        // Check that it actually started
-        server::check_spawn_health(pid, &server_name)?;
+        if no_wait {
+            server::check_spawn_health(&mut child, &server_name, &log_path).await?;
+        } else {
+            server::wait_for_server_ready(
+                &mut child,
+                &server_name,
+                http_port,
+                tcp_port,
+                &log_path,
+                server::STARTUP_TIMEOUT,
+            )
+            .await?;
+        }
 
         let out = output::ServerStartOutput {
             name: server_name,
@@ -669,6 +687,7 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             http_port,
             tcp_port,
             foreground,
+            no_wait,
             config_file,
             args,
         } => {
@@ -678,6 +697,7 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
                 http_port,
                 tcp_port,
                 foreground,
+                no_wait,
                 config_file,
                 args,
                 json,

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -3,10 +3,16 @@ use crate::init;
 use crate::local::discovery;
 use crate::local::docker;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 const DEFAULT_HTTP_PORT: u16 = 8123;
 const DEFAULT_TCP_PORT: u16 = 9000;
+pub const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+const SPAWN_HEALTH_DELAY: Duration = Duration::from_millis(300);
+const STARTUP_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(200);
+const STARTUP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(3);
 
 const ADJECTIVES: &[&str] = &[
     "bold", "calm", "dark", "fast", "gold", "keen", "loud", "neat", "pale", "red", "slim", "tall",
@@ -107,6 +113,11 @@ pub fn server_meta_path_for_recovery(name: &str) -> PathBuf {
 /// Data directory for a ClickHouse server: .clickhouse/servers/<name>/data/.
 pub fn server_data_dir(name: &str) -> PathBuf {
     servers_dir().join(name).join("data")
+}
+
+/// Combined stdout/stderr log for a background ClickHouse server.
+pub fn server_log_path(name: &str) -> PathBuf {
+    servers_dir().join(name).join("server.log")
 }
 
 /// Disk identifier for a Postgres instance: `<name>-pg<major>`. Used in the
@@ -451,22 +462,127 @@ fn generate_random_name() -> String {
     tag
 }
 
-/// Wait a moment after spawn and check if the process is still alive.
-/// Returns Ok if alive, Err with details if it died immediately.
-pub fn check_spawn_health(pid: u32, name: &str) -> Result<()> {
-    // Give it a moment to start (or fail)
-    std::thread::sleep(std::time::Duration::from_millis(300));
-
-    if !is_process_alive(pid) {
-        let _ = mark_server_stopped(name, pid);
+/// Wait a moment after spawn and check if the child exited immediately.
+pub async fn check_spawn_health(
+    child: &mut std::process::Child,
+    name: &str,
+    log_path: &Path,
+) -> Result<()> {
+    tokio::time::sleep(SPAWN_HEALTH_DELAY).await;
+    if let Some(status) = child.try_wait().map_err(|e| Error::Exec(e.to_string()))? {
+        let _ = mark_server_stopped(name, child.id());
         return Err(Error::Exec(format!(
-            "Server '{}' exited immediately after starting. \
-             Check if another server is using the same ports, \
-             or run in foreground to see the error output.",
-            name
+            "Server '{}' exited immediately after starting ({}). See server log: {}",
+            name,
+            status,
+            log_path.display()
         )));
     }
     Ok(())
+}
+
+async fn stop_starting_child(
+    child: &mut std::process::Child,
+    name: &str,
+) -> std::result::Result<(), String> {
+    let pid = child.id();
+    if child.try_wait().map_err(|e| e.to_string())?.is_none()
+        && let Err(signal_error) = send_signal(pid, libc::SIGTERM)
+        && child.try_wait().map_err(|e| e.to_string())?.is_none()
+    {
+        return Err(signal_error.to_string());
+    }
+
+    let deadline = tokio::time::Instant::now() + STARTUP_SHUTDOWN_TIMEOUT;
+    loop {
+        if child.try_wait().map_err(|e| e.to_string())?.is_some() {
+            return mark_server_stopped(name, pid).map_err(|e| e.to_string());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(STARTUP_POLL_INTERVAL).await;
+    }
+
+    child.kill().map_err(|e| e.to_string())?;
+    child.wait().map_err(|e| e.to_string())?;
+    mark_server_stopped(name, pid).map_err(|e| e.to_string())
+}
+
+/// Wait until ClickHouse responds to HTTP health checks and accepts TCP connections.
+pub async fn wait_for_server_ready(
+    child: &mut std::process::Child,
+    name: &str,
+    http_port: u16,
+    tcp_port: u16,
+    log_path: &Path,
+    timeout: Duration,
+) -> Result<()> {
+    let started = tokio::time::Instant::now();
+    check_spawn_health(child, name, log_path).await?;
+    let health_client = reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(CONNECT_TIMEOUT)
+        .timeout(CONNECT_TIMEOUT)
+        .build()?;
+    let health_url = format!("http://localhost:{http_port}/ping");
+
+    loop {
+        if let Some(status) = child.try_wait().map_err(|e| Error::Exec(e.to_string()))? {
+            let _ = mark_server_stopped(name, child.id());
+            return Err(Error::Exec(format!(
+                "Server '{}' exited before becoming ready on HTTP port {} and TCP port {} ({}). \
+                 See server log: {}",
+                name,
+                http_port,
+                tcp_port,
+                status,
+                log_path.display()
+            )));
+        }
+
+        let tcp_ready = matches!(
+            tokio::time::timeout(
+                CONNECT_TIMEOUT,
+                tokio::net::TcpStream::connect(("localhost", tcp_port))
+            )
+            .await,
+            Ok(Ok(_))
+        );
+        let http_ready = if tcp_ready {
+            match health_client.get(&health_url).send().await {
+                Ok(response) if response.status().is_success() => {
+                    response.text().await.is_ok_and(|body| body.trim() == "Ok.")
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        if tcp_ready && http_ready {
+            return Ok(());
+        }
+
+        if started.elapsed() >= timeout {
+            let pid = child.id();
+            let cleanup = match stop_starting_child(child, name).await {
+                Ok(()) => " and was stopped".to_string(),
+                Err(error) => format!("; failed to stop PID {}: {}", pid, error),
+            };
+            return Err(Error::Exec(format!(
+                "Server '{}' did not become ready on HTTP port {} and TCP port {} within {} seconds{}. \
+                 See server log: {}",
+                name,
+                http_port,
+                tcp_port,
+                timeout.as_secs(),
+                cleanup,
+                log_path.display()
+            )));
+        }
+
+        tokio::time::sleep(STARTUP_POLL_INTERVAL).await;
+    }
 }
 
 /// Check if a TCP port is available by attempting to bind to it.
@@ -486,7 +602,8 @@ fn find_free_port(start: u16) -> Option<u16> {
 /// we picked non-default ports.
 pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u16, u16, bool)> {
     let http = match http_port {
-        Some(p) => p,
+        Some(p) if is_port_available(p) => p,
+        Some(p) => return Err(Error::Exec(format!("HTTP port {} is already in use", p))),
         None => {
             if is_port_available(DEFAULT_HTTP_PORT) {
                 DEFAULT_HTTP_PORT
@@ -498,7 +615,8 @@ pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u
     };
 
     let tcp = match tcp_port {
-        Some(p) => p,
+        Some(p) if is_port_available(p) => p,
+        Some(p) => return Err(Error::Exec(format!("TCP port {} is already in use", p))),
         None => {
             if is_port_available(DEFAULT_TCP_PORT) {
                 DEFAULT_TCP_PORT
@@ -677,5 +795,42 @@ mod tests {
     fn stopped_and_out_of_range_pids_are_never_alive() {
         assert!(!is_process_alive(0));
         assert!(!is_process_alive(u32::MAX));
+    }
+
+    #[tokio::test]
+    async fn readiness_timeout_stops_child() {
+        let mut child = std::process::Command::new("sh")
+            .args(["-c", "exec sleep 10"])
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+
+        let error = wait_for_server_ready(
+            &mut child,
+            "readiness-timeout-test",
+            0,
+            0,
+            Path::new("server.log"),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("did not become ready"));
+        assert!(error.contains("server.log"));
+        assert!(!is_process_alive(pid));
+    }
+
+    #[test]
+    fn explicit_ports_must_be_available() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let http_error = resolve_ports(Some(port), None).unwrap_err();
+        assert!(http_error.to_string().contains("HTTP port"));
+
+        let tcp_error = resolve_ports(None, Some(port)).unwrap_err();
+        assert!(tcp_error.to_string().contains("TCP port"));
     }
 }

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -602,6 +602,11 @@ fn find_free_port(start: u16) -> Option<u16> {
 /// we picked non-default ports.
 pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u16, u16, bool)> {
     let http = match http_port {
+        Some(0) => {
+            return Err(Error::Exec(
+                "--http-port 0 is not allowed; pick a specific port or omit the flag".into(),
+            ));
+        }
         Some(p) if is_port_available(p) => p,
         Some(p) => return Err(Error::Exec(format!("HTTP port {} is already in use", p))),
         None => {
@@ -615,6 +620,11 @@ pub fn resolve_ports(http_port: Option<u16>, tcp_port: Option<u16>) -> Result<(u
     };
 
     let tcp = match tcp_port {
+        Some(0) => {
+            return Err(Error::Exec(
+                "--tcp-port 0 is not allowed; pick a specific port or omit the flag".into(),
+            ));
+        }
         Some(p) if is_port_available(p) => p,
         Some(p) => return Err(Error::Exec(format!("TCP port {} is already in use", p))),
         None => {
@@ -832,5 +842,14 @@ mod tests {
 
         let tcp_error = resolve_ports(None, Some(port)).unwrap_err();
         assert!(tcp_error.to_string().contains("TCP port"));
+    }
+
+    #[test]
+    fn explicit_ports_reject_zero() {
+        let http_error = resolve_ports(Some(0), None).unwrap_err();
+        assert!(matches!(http_error, Error::Exec(msg) if msg.contains("--http-port 0")));
+
+        let tcp_error = resolve_ports(None, Some(0)).unwrap_err();
+        assert!(matches!(tcp_error, Error::Exec(msg) if msg.contains("--tcp-port 0")));
     }
 }

--- a/crates/clickhousectl/tests/local_server_readiness_test.rs
+++ b/crates/clickhousectl/tests/local_server_readiness_test.rs
@@ -1,0 +1,154 @@
+//! Regression coverage for ClickHouse startup readiness (issue #330).
+
+use serde_json::Value;
+use std::io::{Read, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn install_fake_clickhouse(home: &Path, script: &str) {
+    let binary = home.join(".clickhouse/versions/25.12.9.61/clickhouse");
+    std::fs::create_dir_all(binary.parent().unwrap()).expect("create fake version dir");
+    std::fs::write(&binary, script).expect("write fake ClickHouse");
+    let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(binary, permissions).expect("make fake ClickHouse executable");
+}
+
+fn run_start(project: &Path, home: &Path, http_port: u16, tcp_port: u16) -> Output {
+    let http_port_arg = http_port.to_string();
+    let tcp_port_arg = tcp_port.to_string();
+    Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("FAKE_CLICKHOUSE_HTTP_PORT", &http_port_arg)
+        .env("FAKE_CLICKHOUSE_PORT", tcp_port.to_string())
+        .current_dir(project)
+        .args([
+            "local",
+            "--json",
+            "server",
+            "start",
+            "--version",
+            "25.12.9.61",
+            "--http-port",
+            &http_port_arg,
+            "--tcp-port",
+            &tcp_port_arg,
+        ])
+        .output()
+        .expect("run clickhousectl")
+}
+
+fn unused_port() -> u16 {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind temporary port");
+    listener.local_addr().unwrap().port()
+}
+
+struct ProcessGuard(u32);
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        unsafe {
+            libc::kill(self.0 as i32, libc::SIGKILL);
+        }
+    }
+}
+
+#[test]
+fn fake_clickhouse_process() {
+    let Ok(http_port) = std::env::var("FAKE_CLICKHOUSE_HTTP_PORT") else {
+        return;
+    };
+    let Ok(port) = std::env::var("FAKE_CLICKHOUSE_PORT") else {
+        return;
+    };
+    std::thread::sleep(Duration::from_millis(700));
+    let tcp_listener = std::net::TcpListener::bind(("127.0.0.1", port.parse::<u16>().unwrap()))
+        .expect("bind fake ClickHouse port");
+    std::thread::spawn(move || {
+        tcp_listener.accept().expect("accept readiness probe");
+        std::thread::sleep(Duration::from_secs(30));
+    });
+    let http_listener =
+        std::net::TcpListener::bind(("127.0.0.1", http_port.parse::<u16>().unwrap()))
+            .expect("bind fake ClickHouse HTTP port");
+    let (mut request, _) = http_listener.accept().expect("accept HTTP health check");
+    let mut buffer = [0; 1024];
+    let bytes_read = request.read(&mut buffer).expect("read HTTP health check");
+    assert!(bytes_read > 0, "HTTP health check should not be empty");
+    request
+        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\nOk.\n")
+        .expect("write HTTP health response");
+    std::thread::sleep(Duration::from_secs(30));
+}
+
+#[test]
+fn background_start_waits_for_http_and_tcp_readiness() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let test_binary = std::env::current_exe().expect("locate test binary");
+    install_fake_clickhouse(
+        home.path(),
+        &format!(
+            "#!/bin/sh\nexec '{}' --exact fake_clickhouse_process --nocapture\n",
+            test_binary.display()
+        ),
+    );
+    let http_port = unused_port();
+    let tcp_port = unused_port();
+
+    let started = Instant::now();
+    let output = run_start(project.path(), home.path(), http_port, tcp_port);
+    let elapsed = started.elapsed();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        elapsed >= Duration::from_millis(600),
+        "start returned before readiness after {elapsed:?}"
+    );
+
+    let body: Value = serde_json::from_slice(&output.stdout).expect("parse start JSON");
+    let pid = body["pid"].as_u64().expect("start PID") as u32;
+    let _process = ProcessGuard(pid);
+    std::net::TcpStream::connect(("127.0.0.1", tcp_port))
+        .expect("server should accept connections after start returns");
+}
+
+#[test]
+fn failed_start_points_to_captured_server_log() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(
+        home.path(),
+        "#!/bin/sh\nprintf 'synthetic startup failure\\n' >&2\nexit 7\n",
+    );
+
+    let output = run_start(project.path(), home.path(), unused_port(), unused_port());
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("exited"), "stderr: {stderr}");
+    assert!(stderr.contains("server.log"), "stderr: {stderr}");
+
+    let log = project
+        .path()
+        .join(".clickhouse/servers/default/server.log");
+    assert_eq!(
+        std::fs::read_to_string(log).expect("read server log"),
+        "synthetic startup failure\n"
+    );
+    let metadata: Value = serde_json::from_slice(
+        &std::fs::read(project.path().join(".clickhouse/servers/default.json"))
+            .expect("read metadata"),
+    )
+    .expect("parse metadata");
+    assert_eq!(metadata["pid"], 0);
+}

--- a/crates/clickhousectl/tests/local_server_stopped_test.rs
+++ b/crates/clickhousectl/tests/local_server_stopped_test.rs
@@ -113,6 +113,7 @@ fn stopping_clickhouse_retains_metadata_and_lists_it_as_stopped() {
             "start",
             "--version",
             "25.12.9.61",
+            "--no-wait",
         ],
     );
     assert!(


### PR DESCRIPTION
## Summary

- wait up to 30 seconds for ClickHouse HTTP `/ping` and TCP readiness before reporting a successful background start
- capture background startup output in `.clickhouse/servers/<name>/server.log` and point exit/timeout errors there
- stop timed-out startup processes gracefully, reject occupied explicit ports, and retain `--no-wait` for fire-and-forget startup
- add clap, timeout, failure-log, and delayed-readiness regression coverage

## Stack

This PR is stacked on #356 and should be reviewed as the delta from `codex/issue-324-list-stopped-servers`.

Closes #330.

## Validation

- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`