### PR TITLE
Move cancelled exit code from 2 to 3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The user-facing CLI surface. Contains all logic for local commands, wraps `click
 
 - Cloud handlers go through the `CloudClient` wrapper (`src/cloud/client.rs`), not `clickhouse_cloud_api::Client` directly. The wrapper handles credential precedence, error conversion, and response unwrapping.
 - Cloud handlers always support `--json` output unless there is good reason not to. JSON is emitted automatically when `--json` is passed or a coding agent is detected (`is_ai_agent::detect()` via the `json_output()` helper in `main.rs`).
-- `CloudError` carries a `kind: CloudErrorKind` (`Auth` for 401/403 and missing credentials, else `Generic`). It maps to `Error::AuthRequired` / `Error::Cloud` in `main.rs`, driving `gh`-style exit codes via `Error::exit_code()`: `0` success, `1` error, `2` cancelled, `4` auth required.
+- `CloudError` carries a `kind: CloudErrorKind` (`Auth` for 401/403 and missing credentials, else `Generic`). It maps to `Error::AuthRequired` / `Error::Cloud` in `main.rs`, driving exit codes via `Error::exit_code()`: `0` success, `1` error, `2` usage error (from clap), `3` cancelled, `4` auth required.
 
 Use `--help` to learn the current command surface.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ The user-facing CLI surface. Contains all logic for local commands, wraps `click
 
 - Cloud handlers go through the `CloudClient` wrapper (`src/cloud/client.rs`), not `clickhouse_cloud_api::Client` directly. The wrapper handles credential precedence, error conversion, and response unwrapping.
 - Cloud handlers always support `--json` output unless there is good reason not to. JSON is emitted automatically when `--json` is passed or a coding agent is detected (`is_ai_agent::detect()` via the `json_output()` helper in `main.rs`).
-- `CloudError` carries a `kind: CloudErrorKind` (`Auth` for 401/403 and missing credentials, else `Generic`). It maps to `Error::AuthRequired` / `Error::Cloud` in `main.rs`, driving exit codes via `Error::exit_code()`: `0` success, `1` error, `2` usage error (from clap), `3` cancelled, `4` auth required.
+- `CloudError` carries a `kind: CloudErrorKind` (`Auth` for 401/403 and missing credentials, else `Generic`). It maps to `Error::AuthRequired` / `Error::Cloud` in `main.rs`. Dispatched commands exit with `0` on success or use `Error::exit_code()` for failures: `1` error, `3` cancelled, `4` auth required. Clap uses `2` for usage errors.
 
 Use `--help` to learn the current command surface.
 

--- a/README.md
+++ b/README.md
@@ -823,13 +823,17 @@ Cloud commands never invent values for data the API did not return. A field the 
 
 ### Exit codes
 
-Follow `gh` conventions:
+Usage errors and cancelled actions use distinct exit codes.
+
+**Breaking change in v0.4.1:** cancelled actions now exit with `3`; `2` is
+reserved for command-line usage errors.
 
 | Code | Meaning                                                  |
 | ---- | -------------------------------------------------------- |
 | `0`  | Success                                                  |
 | `1`  | Error (anything not classified below)                    |
-| `2`  | Cancelled (user aborted)                                 |
+| `2`  | Usage error (invalid command line)                       |
+| `3`  | Cancelled (user aborted)                                 |
 | `4`  | Auth required (no credentials, 401/403, OAuth-only writes) |
 
 ## Skills

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -66,7 +66,7 @@ CONTEXT FOR AGENTS:
     clickhousectl cloud auth login --api-key YOUR_KEY --api-secret YOUR_SECRET
   If the user doesn't have an account, suggest `clickhousectl cloud auth signup` first.
   JSON emitted automatically for known agents.
-  Exit codes follow gh conventions: 0 success, 1 error, 2 cancelled, 4 auth required.
+  Exit codes: 0 success, 1 error, 2 usage error, 3 cancelled, 4 auth required.
   Typical workflow: `cloud auth login` → `cloud auth status` → `cloud org list` → `cloud service list`")]
     Cloud(Box<CloudArgs>),
 
@@ -182,6 +182,27 @@ mod tests {
         let oauth = precedence.find("4. OAuth tokens").unwrap();
         assert!(flags < file && file < env && env < oauth, "{help}");
         assert!(help.contains("Higher-precedence credentials override lower-precedence"));
+    }
+
+    #[test]
+    fn cloud_help_distinguishes_usage_errors_from_cancellation() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("cloud")
+            .expect("cloud subcommand")
+            .render_long_help()
+            .to_string();
+
+        assert!(help.contains(
+            "Exit codes: 0 success, 1 error, 2 usage error, 3 cancelled, 4 auth required."
+        ));
+        assert_eq!(
+            Cli::try_parse_from(["clickhousectl", "unknown-command"])
+                .err()
+                .expect("unknown command must be rejected")
+                .exit_code(),
+            2
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -94,12 +94,12 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl Error {
-    /// Process exit code following `gh` CLI conventions:
-    /// `0` success, `1` error, `2` cancelled, `4` auth required.
+    /// Process exit code: `0` success, `1` error, `3` cancelled,
+    /// `4` auth required. Clap reserves `2` for usage errors.
     pub fn exit_code(&self) -> i32 {
         match self {
             Error::AuthRequired(_) => 4,
-            Error::Cancelled => 2,
+            Error::Cancelled => 3,
             _ => 1,
         }
     }
@@ -115,8 +115,8 @@ mod tests {
     }
 
     #[test]
-    fn cancelled_maps_to_2() {
-        assert_eq!(Error::Cancelled.exit_code(), 2);
+    fn cancelled_maps_to_3() {
+        assert_eq!(Error::Cancelled.exit_code(), 3);
     }
 
     #[test]

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -99,9 +99,8 @@ async fn main() {
             #[cfg(not(feature = "telemetry"))]
             let invocation = ();
             // clap's own exit codes: 0 for help/version, 2 for usage errors.
-            // The 2 numerically collides with the documented "cancelled" exit
-            // code; the telemetry `outcome` field disambiguates, and the
-            // shell-visible clash is #319's to fix.
+            // Dispatched commands reserve 3 for cancellation, so 2 remains
+            // unambiguous to shell callers.
             (e.exit_code(), invocation)
         }
     };

--- a/crates/clickhousectl/src/telemetry.rs
+++ b/crates/clickhousectl/src/telemetry.rs
@@ -178,17 +178,13 @@ fn env_truthy(value: Option<String>) -> bool {
 struct Payload {
     command: String,
     flags: Vec<String>,
-    /// Exit code: gh-style (`Error::exit_code`) for dispatched commands —
-    /// 0 success, 1 error, 2 cancelled, 4 auth required — and clap's own
-    /// code for parse outcomes (0 help/version, 2 usage error). The numeric
-    /// clash between "cancelled" and "usage error" is fully disambiguated by
-    /// `outcome` in the payload: a dispatched 2 becomes `"cancelled"`, a
-    /// parse-failure 2 keeps its parse kind (see #319 for the shell-visible
-    /// fix).
+    /// Exit code: `Error::exit_code()` for dispatched commands — 0 success,
+    /// 1 error, 3 cancelled, 4 auth required — and clap's own code for parse
+    /// outcomes (0 help/version, 2 usage error).
     exit_code: i32,
     /// How the invocation ended, from a closed vocabulary. Dispatched
     /// invocations carry `"ok"`, `"error"`, `"cancelled"`, or
-    /// `"auth_required"` — derived from the gh-style exit code by
+    /// `"auth_required"` — derived from the dispatched exit code by
     /// [`dispatched_outcome`] — or `"exec"` (parsed, dispatched, and the
     /// process image was replaced by `exec()` — the handed-over program's
     /// exit status is unknowable, so `exit_code` is a fixed 0 and not
@@ -214,21 +210,19 @@ struct Payload {
     arch: &'static str,
 }
 
-/// Derive the dispatched outcome from the gh-style exit code. [`capture`]
+/// Derive the dispatched outcome from the process exit code. [`capture`]
 /// marks a successful parse `"ok"` before the command has run; by finalize
 /// time the exit code says how dispatch actually ended, so only that
 /// placeholder is rewritten — the parse kinds from [`capture_lossy`] and
 /// `"exec"` from [`finalize_before_exec`] pass through untouched. The mapping
-/// mirrors `Error::exit_code()`; issue #319 will move "cancelled" off exit
-/// code 2 (to stop the shell-level clash with clap's usage-error 2), and this
-/// mapping must follow when it lands.
+/// mirrors `Error::exit_code()`.
 fn dispatched_outcome(outcome: &'static str, exit_code: i32) -> &'static str {
     if outcome != "ok" {
         return outcome;
     }
     match exit_code {
         0 => "ok",
-        2 => "cancelled",
+        3 => "cancelled",
         4 => "auth_required",
         _ => "error",
     }
@@ -597,7 +591,7 @@ fn exec_invocation(stashed: &Invocation) -> Invocation {
 
 /// The telemetry hook, called once at the very end of `main` (after the
 /// command has run, so `telemetry disable` silences its own event), with the
-/// gh-style exit code the process is about to exit with. Never errors, never
+/// exit code the process is about to exit with. Never errors, never
 /// blocks beyond spawning a detached child.
 pub fn finalize(invocation: Invocation, exit_code: i32) {
     if !claim(&FINALIZED) {
@@ -900,13 +894,14 @@ mod tests {
     }
 
     #[test]
-    fn dispatched_outcome_derives_from_the_gh_style_exit_code() {
+    fn dispatched_outcome_derives_from_the_exit_code() {
         assert_eq!(dispatched_outcome("ok", 0), "ok");
         assert_eq!(dispatched_outcome("ok", 1), "error");
-        assert_eq!(dispatched_outcome("ok", 2), "cancelled");
+        assert_eq!(dispatched_outcome("ok", 2), "error");
+        assert_eq!(dispatched_outcome("ok", 3), "cancelled");
         assert_eq!(dispatched_outcome("ok", 4), "auth_required");
-        // Any exit code outside the gh-style vocabulary is still a failure.
-        assert_eq!(dispatched_outcome("ok", 3), "error");
+        // Any exit code outside the documented vocabulary is still a failure.
+        assert_eq!(dispatched_outcome("ok", 5), "error");
         // Non-"ok" outcomes are never rewritten, whatever the exit code.
         assert_eq!(
             dispatched_outcome("unknown_argument", 2),
@@ -932,7 +927,7 @@ mod tests {
     fn dispatched_payload_outcomes_track_the_exit_code() {
         assert_eq!(decided_outcome(&invocation(), 0), "ok");
         assert_eq!(decided_outcome(&invocation(), 1), "error");
-        assert_eq!(decided_outcome(&invocation(), 2), "cancelled");
+        assert_eq!(decided_outcome(&invocation(), 3), "cancelled");
     }
 
     #[test]

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -258,7 +258,7 @@ async fn failure_reported_and_positional_value_never_leaks() {
     let payloads = sandbox.wait_for_requests(1).await;
     let event = &payloads[0];
     assert_eq!(event["command"], "local remove");
-    // The event carries the gh-style exit code the process exited with, and
+    // The event carries the exit code the process exited with, and
     // the outcome derived from it — a failed handler is "error", not "ok".
     assert_eq!(event["exit_code"], 1);
     assert_eq!(event["exit_code"], output.status.code().unwrap());


### PR DESCRIPTION
Closes #319

## Summary
- Reserve exit code `2` for clap usage errors and move cancellation to `3`.
- Keep telemetry outcomes aligned and document the v0.4.1 breaking change in CLI help, README, and developer guidance.

## Tests
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo fmt --all --check`