### PR TITLE
Stop all local server engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ clickhousectl local server stop                           # Stop "default"
 clickhousectl local server stop dev                       # Stop by name
 clickhousectl local server stop default --global          # Stop from any project
 clickhousectl local server stop default --global --project /path/to/project  # Disambiguate
-clickhousectl local server stop-all                       # Stop all running servers
-clickhousectl local server stop-all --global              # Stop all servers system-wide
+clickhousectl local server stop-all                       # Stop all ClickHouse and Postgres servers in this project
+clickhousectl local server stop-all --global              # Stop all ClickHouse servers system-wide
 
 # Remove a stopped server and its data
 clickhousectl local server remove                         # Remove "default"
@@ -264,7 +264,7 @@ clickhousectl local postgres remove                       # Remove "default"
 clickhousectl local postgres remove dev
 ```
 
-`local postgres start --name dev` (no `--version`) resumes the existing instance when there's exactly one for that name; if multiple majors share the name, you'll be asked to pick. Stop preserves the container and metadata so the next start resumes it; only `remove` tears down the container and deletes the data directory.
+`local postgres start --name dev` (no `--version`) resumes the existing instance when there's exactly one for that name; if multiple majors share the name, you'll be asked to pick. Stop preserves the container and metadata so the next start resumes it; only `remove` tears down the container and deletes the data directory. The unified `local server stop-all` stops both ClickHouse and Postgres instances in the current project; the dedicated `local postgres stop-all` remains available when only Postgres should be stopped.
 
 Containers are tagged with `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`, `clickhousectl.major=<major>`, `clickhousectl.project=<cwd>`, and `created_by=clickhousectl_<version>` labels. `server list` recovers orphaned containers belonging to the current project via these labels, so deleting `.clickhouse/servers/<name>-pg<major>.json` is non-destructive — the next list/start rediscovers it.
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -128,10 +128,13 @@ CONTEXT FOR AGENTS:
         args: Vec<String>,
     },
 
-    /// Manage local ClickHouse server instances
+    /// Manage local server instances
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Manage named ClickHouse server instances. Each server has its own data directory.
+  Manage named local server instances. Project-scoped `server list` and `server stop-all`
+  include both ClickHouse processes and Docker-backed Postgres containers; other commands
+  here manage ClickHouse.
+  Each server has its own data directory.
   Data is stored in .clickhouse/servers/<name>/data/ and persists between restarts.
   Typical: `clickhousectl local server start` (starts \"default\"), `clickhousectl local server start --name test`.
   Related: `clickhousectl local client` to connect to a running server.")]
@@ -268,12 +271,14 @@ CONTEXT FOR AGENTS:
     /// Stop all running server instances
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Stops all running ClickHouse server instances.
-  Sends SIGTERM first, then SIGKILL if processes don't exit.
+  Stops all running ClickHouse and Postgres server instances in this project.
+  ClickHouse processes receive SIGTERM first, then SIGKILL if they don't exit.
+  Postgres containers are stopped but retained for a subsequent start.
+  With --global, stops ClickHouse servers only; global Postgres discovery is not supported.
   Data and metadata are preserved, and stopped servers remain visible in `server list`.
   Related: `clickhousectl local server list` to see servers.")]
     StopAll {
-        /// System-wide maintenance only: stop all servers across all projects. You almost certainly want the default project-scoped stop-all instead.
+        /// System-wide maintenance only: stop all ClickHouse servers across all projects. You almost certainly want the default project-scoped stop-all instead.
         #[arg(long)]
         global: bool,
     },
@@ -590,6 +595,17 @@ mod tests {
             panic!("expected server remove");
         };
         assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn server_stop_all_help_describes_engine_scope() {
+        let help = Cli::try_parse_from(["clickhousectl", "local", "server", "stop-all", "--help"])
+            .err()
+            .expect("help should exit through clap")
+            .to_string();
+
+        assert!(help.contains("Stops all running ClickHouse and Postgres server instances"));
+        assert!(help.contains("global Postgres discovery is not supported"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -961,46 +961,9 @@ fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<(
 }
 
 fn stop_all_servers_local(json: bool) -> Result<()> {
-    // `local server stop-all` historically only managed ClickHouse processes.
-    // Postgres has its own `local postgres stop-all`; don't silently sweep it
-    // up here.
-    let servers: Vec<_> = server::list_running_servers()
-        .into_iter()
-        .filter(|s| s.engine == server::Engine::Clickhouse)
-        .collect();
-    let mut stop_entries = Vec::new();
-    for s in &servers {
-        if !json {
-            print!("Stopping '{}'...", s.name);
-            let _ = std::io::stdout().flush();
-        }
-        match server::kill_server(&s.name) {
-            Ok(()) => {
-                if !json {
-                    println!(" stopped");
-                }
-                stop_entries.push(output::ServerStopEntry {
-                    name: s.name.clone(),
-                    stopped: true,
-                    error: None,
-                });
-            }
-            Err(e) => {
-                if !json {
-                    println!(" error: {}", e);
-                }
-                stop_entries.push(output::ServerStopEntry {
-                    name: s.name.clone(),
-                    stopped: false,
-                    error: Some(e.to_string()),
-                });
-            }
-        }
-    }
+    let servers = server::list_running_servers();
+    let out = stop_servers(&servers, json, server::kill_server);
     if json {
-        let out = output::ServerStopAllOutput {
-            servers: stop_entries,
-        };
         output::print_output(&out, json);
     } else if servers.is_empty() {
         println!("No running servers");
@@ -1010,12 +973,56 @@ fn stop_all_servers_local(json: bool) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn stop_servers<F>(
+    servers: &[server::ServerInfo],
+    json: bool,
+    mut stop: F,
+) -> output::ServerStopAllOutput
+where
+    F: FnMut(&str) -> Result<()>,
+{
+    let servers = servers
+        .iter()
+        .map(|server| {
+            let name = match server.engine {
+                server::Engine::Clickhouse => server.name.clone(),
+                server::Engine::Postgres => postgres::user_name_from_key(&server.name).to_string(),
+            };
+            let engine = server.engine.as_str().to_string();
+            if !json {
+                print!("Stopping '{}' ({})...", name, engine);
+                let _ = std::io::stdout().flush();
+            }
+            let result = stop(&server.name);
+            if !json {
+                match &result {
+                    Ok(()) => println!(" stopped"),
+                    Err(error) => println!(" error: {error}"),
+                }
+            }
+            output::ServerStopEntry {
+                name,
+                engine,
+                stopped: result.is_ok(),
+                error: result.err().map(|error| error.to_string()),
+            }
+        })
+        .collect();
+
+    output::ServerStopAllOutput { servers }
+}
+
 fn stop_all_servers_global(json: bool) -> Result<()> {
     let servers = server::list_all_servers_global();
     let mut stop_entries = Vec::new();
     for s in &servers {
         if !json {
-            print!("Stopping '{}' ({})...", s.name, s.project);
+            print!(
+                "Stopping '{}' ({}, {})...",
+                s.name,
+                s.engine.as_str(),
+                s.project
+            );
             let _ = std::io::stdout().flush();
         }
         match server::kill_server_by_pid(s.pid) {
@@ -1025,6 +1032,7 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
                 }
                 stop_entries.push(output::ServerStopEntry {
                     name: s.name.clone(),
+                    engine: s.engine.as_str().to_string(),
                     stopped: true,
                     error: None,
                 });
@@ -1035,6 +1043,7 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
                 }
                 stop_entries.push(output::ServerStopEntry {
                     name: s.name.clone(),
+                    engine: s.engine.as_str().to_string(),
                     stopped: false,
                     error: Some(e.to_string()),
                 });
@@ -1058,6 +1067,23 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
 mod tests {
     use super::*;
 
+    fn server_info(name: &str, engine: server::Engine) -> server::ServerInfo {
+        server::ServerInfo {
+            name: name.to_string(),
+            pid: 1,
+            version: match engine {
+                server::Engine::Clickhouse => "25.12.9.61".to_string(),
+                server::Engine::Postgres => "postgres:18".to_string(),
+            },
+            http_port: 0,
+            tcp_port: 0,
+            started_at: "test".to_string(),
+            cwd: "/tmp/project".to_string(),
+            engine,
+            container_id: None,
+        }
+    }
+
     #[test]
     fn classify_stop_running_server_is_stopped() {
         // Running takes precedence regardless of on-disk state.
@@ -1073,6 +1099,38 @@ mod tests {
     #[test]
     fn classify_stop_unknown_name_is_not_found() {
         assert_eq!(classify_stop(false, false), StopOutcome::NotFound);
+    }
+
+    #[test]
+    fn stop_servers_attempts_and_reports_both_engines() {
+        let servers = vec![
+            server_info("default", server::Engine::Clickhouse),
+            server_info("default-pg18", server::Engine::Postgres),
+        ];
+        let mut attempts = Vec::new();
+
+        let output = stop_servers(&servers, true, |name| {
+            attempts.push(name.to_string());
+            if name == "default" {
+                Err(Error::Exec("process stop failed".to_string()))
+            } else {
+                Ok(())
+            }
+        });
+
+        assert_eq!(attempts, ["default", "default-pg18"]);
+        assert_eq!(output.servers.len(), 2);
+        assert_eq!(output.servers[0].name, "default");
+        assert_eq!(output.servers[0].engine, "clickhouse");
+        assert!(!output.servers[0].stopped);
+        assert_eq!(
+            output.servers[0].error.as_deref(),
+            Some("Failed to execute ClickHouse: process stop failed")
+        );
+        assert_eq!(output.servers[1].name, "default");
+        assert_eq!(output.servers[1].engine, "postgres");
+        assert!(output.servers[1].stopped);
+        assert_eq!(output.servers[1].error, None);
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -984,10 +984,7 @@ where
     let servers = servers
         .iter()
         .map(|server| {
-            let name = match server.engine {
-                server::Engine::Clickhouse => server.name.clone(),
-                server::Engine::Postgres => postgres::user_name_from_key(&server.name).to_string(),
-            };
+            let name = server.name.clone();
             let engine = server.engine.as_str().to_string();
             if !json {
                 print!("Stopping '{}' ({})...", name, engine);
@@ -1105,6 +1102,7 @@ mod tests {
     fn stop_servers_attempts_and_reports_both_engines() {
         let servers = vec![
             server_info("default", server::Engine::Clickhouse),
+            server_info("default-pg17", server::Engine::Postgres),
             server_info("default-pg18", server::Engine::Postgres),
         ];
         let mut attempts = Vec::new();
@@ -1118,8 +1116,8 @@ mod tests {
             }
         });
 
-        assert_eq!(attempts, ["default", "default-pg18"]);
-        assert_eq!(output.servers.len(), 2);
+        assert_eq!(attempts, ["default", "default-pg17", "default-pg18"]);
+        assert_eq!(output.servers.len(), 3);
         assert_eq!(output.servers[0].name, "default");
         assert_eq!(output.servers[0].engine, "clickhouse");
         assert!(!output.servers[0].stopped);
@@ -1127,10 +1125,14 @@ mod tests {
             output.servers[0].error.as_deref(),
             Some("Failed to execute ClickHouse: process stop failed")
         );
-        assert_eq!(output.servers[1].name, "default");
+        assert_eq!(output.servers[1].name, "default-pg17");
         assert_eq!(output.servers[1].engine, "postgres");
         assert!(output.servers[1].stopped);
         assert_eq!(output.servers[1].error, None);
+        assert_eq!(output.servers[2].name, "default-pg18");
+        assert_eq!(output.servers[2].engine, "postgres");
+        assert!(output.servers[2].stopped);
+        assert_eq!(output.servers[2].error, None);
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -483,6 +483,8 @@ impl fmt::Display for ServerStopOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct ServerStopEntry {
     pub name: String,
+    /// "clickhouse" or "postgres".
+    pub engine: String,
     pub stopped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -501,12 +503,13 @@ impl fmt::Display for ServerStopAllOutput {
         }
         for s in &self.servers {
             if s.stopped {
-                writeln!(f, "Stopping '{}'... stopped", s.name)?;
+                writeln!(f, "Stopping '{}' ({})... stopped", s.name, s.engine)?;
             } else {
                 writeln!(
                     f,
-                    "Stopping '{}'... error: {}",
+                    "Stopping '{}' ({})... error: {}",
                     s.name,
+                    s.engine,
                     s.error.as_deref().unwrap_or("unknown")
                 )?;
             }
@@ -801,13 +804,15 @@ mod tests {
             servers: vec![
                 ServerStopEntry {
                     name: "default".to_string(),
+                    engine: "clickhouse".to_string(),
                     stopped: true,
                     error: None,
                 },
                 ServerStopEntry {
-                    name: "test".to_string(),
+                    name: "default".to_string(),
+                    engine: "postgres".to_string(),
                     stopped: false,
-                    error: Some("process not found".to_string()),
+                    error: Some("container not found".to_string()),
                 },
             ],
         };
@@ -815,11 +820,13 @@ mod tests {
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
         assert_eq!(json["servers"][0]["name"], "default");
+        assert_eq!(json["servers"][0]["engine"], "clickhouse");
         assert_eq!(json["servers"][0]["stopped"], true);
         assert!(json["servers"][0].get("error").is_none());
-        assert_eq!(json["servers"][1]["name"], "test");
+        assert_eq!(json["servers"][1]["name"], "default");
+        assert_eq!(json["servers"][1]["engine"], "postgres");
         assert_eq!(json["servers"][1]["stopped"], false);
-        assert_eq!(json["servers"][1]["error"], "process not found");
+        assert_eq!(json["servers"][1]["error"], "container not found");
     }
 
     #[test]
@@ -1105,19 +1112,21 @@ mod tests {
             servers: vec![
                 ServerStopEntry {
                     name: "default".to_string(),
+                    engine: "clickhouse".to_string(),
                     stopped: true,
                     error: None,
                 },
                 ServerStopEntry {
-                    name: "test".to_string(),
+                    name: "default".to_string(),
+                    engine: "postgres".to_string(),
                     stopped: false,
-                    error: Some("process not found".to_string()),
+                    error: Some("container not found".to_string()),
                 },
             ],
         };
         let text = output.to_string();
-        assert!(text.contains("Stopping 'default'... stopped"));
-        assert!(text.contains("Stopping 'test'... error: process not found"));
+        assert!(text.contains("Stopping 'default' (clickhouse)... stopped"));
+        assert!(text.contains("Stopping 'default' (postgres)... error: container not found"));
         assert!(text.contains("Done"));
     }
 

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -418,41 +418,14 @@ async fn stop_all(json: bool) -> Result<()> {
         .into_iter()
         .filter(|s| s.engine == Engine::Postgres)
         .collect();
-    let mut stop_entries = Vec::new();
-    for s in &servers {
-        if !json {
-            print!("Stopping '{}'...", s.name);
-        }
-        match server::kill_server(&s.name) {
-            Ok(()) => {
-                if !json {
-                    println!(" stopped");
-                }
-                stop_entries.push(output::ServerStopEntry {
-                    name: s.name.clone(),
-                    stopped: true,
-                    error: None,
-                });
-            }
-            Err(e) => {
-                if !json {
-                    println!(" error: {}", e);
-                }
-                stop_entries.push(output::ServerStopEntry {
-                    name: s.name.clone(),
-                    stopped: false,
-                    error: Some(e.to_string()),
-                });
-            }
-        }
-    }
-    if json {
-        let out = output::ServerStopAllOutput {
-            servers: stop_entries,
-        };
-        output::print_output(&out, json);
-    } else if servers.is_empty() {
+    if !json && servers.is_empty() {
         println!("No running Postgres servers");
+        return Ok(());
+    }
+
+    let out = super::stop_servers(&servers, json, server::kill_server);
+    if json {
+        output::print_output(&out, json);
     } else {
         println!("Done");
     }

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -176,14 +176,40 @@ EOF
     "$CTL" local postgres remove shared >/dev/null 2>&1
 }
 
-# ── 10. local server stop-all leaves Postgres running ──
-case_stop_all_isolates_postgres() {
-    "$CTL" local postgres start --name p --version 18-alpine >/dev/null 2>&1 || { die "start"; return 1; }
-    "$CTL" local server stop-all >/dev/null 2>&1
-    "$CTL" local server list 2>&1 | grep -E "^\| p " | grep -q running || { die "postgres got stopped"; return 1; }
-    "$CTL" local postgres stop p >/dev/null 2>&1
-    "$CTL" local postgres remove p >/dev/null 2>&1
-}
+# ── 10. Engine-specific and unified stop-all scopes ──
+case_stop_all_engine_scopes() (
+    sleep 300 &
+    local ch_pid; ch_pid=$!
+    disown "$ch_pid"
+    trap 'kill "$ch_pid" 2>/dev/null || true; wait "$ch_pid" 2>/dev/null || true' EXIT
+
+    mkdir -p .clickhouse/servers/c/data
+    cat > .clickhouse/servers/c.json <<EOF
+{"name":"c","pid":$ch_pid,"version":"25.12.5.44","http_port":8123,"tcp_port":9000,"started_at":"0","cwd":"$PWD","engine":"clickhouse"}
+EOF
+    "$CTL" local postgres start --name p --version 18-alpine >/dev/null 2>&1 || { die "start postgres"; return 1; }
+
+    "$CTL" local postgres stop-all >/dev/null 2>&1 || { die "postgres stop-all"; return 1; }
+    local list; list=$("$CTL" local --json server list 2>&1) || { die "list after postgres stop-all: $list"; return 1; }
+    jq -e '.servers | any(.name == "c" and .engine == "clickhouse" and .running == true)' <<<"$list" >/dev/null \
+        || { die "postgres stop-all stopped ClickHouse: $list"; return 1; }
+    jq -e '.servers | any(.name == "p" and .engine == "postgres" and .running == false)' <<<"$list" >/dev/null \
+        || { die "postgres stop-all did not stop Postgres: $list"; return 1; }
+
+    "$CTL" local postgres start --name p --version 18-alpine >/dev/null 2>&1 || { die "restart postgres"; return 1; }
+    local out; out=$("$CTL" local --json server stop-all 2>&1) || { die "server stop-all: $out"; return 1; }
+    jq -e '.servers | any(.name == "c" and .engine == "clickhouse" and .stopped == true)' <<<"$out" >/dev/null \
+        || { die "server stop-all did not report ClickHouse: $out"; return 1; }
+    jq -e '.servers | any(.name == "p" and .engine == "postgres" and .stopped == true)' <<<"$out" >/dev/null \
+        || { die "server stop-all did not report Postgres: $out"; return 1; }
+    ! kill -0 "$ch_pid" 2>/dev/null || { die "server stop-all left ClickHouse process running"; return 1; }
+    wait "$ch_pid" 2>/dev/null || true
+
+    list=$("$CTL" local --json server list 2>&1) || { die "list after server stop-all: $list"; return 1; }
+    jq -e '[.servers[] | select((.name == "c" or .name == "p") and .running == false)] | length == 2' <<<"$list" >/dev/null \
+        || { die "server stop-all left an engine running: $list"; return 1; }
+    "$CTL" local postgres remove p >/dev/null 2>&1 || { die "remove postgres"; return 1; }
+)
 
 # ── 11. --port 0 rejected ──
 case_port_zero_rejected() {
@@ -283,7 +309,7 @@ run_case dotenv_password_consistency    case_dotenv_password_consistency
 run_case path_traversal_name            case_path_traversal_name
 run_case install_rejects_latest         case_install_rejects_latest
 run_case cross_engine_coexist           case_cross_engine_coexist
-run_case stop_all_isolates_postgres     case_stop_all_isolates_postgres
+run_case stop_all_engine_scopes         case_stop_all_engine_scopes
 run_case port_zero_rejected             case_port_zero_rejected
 run_case non_tty_query                  case_non_tty_query
 run_case dotenv_preserves_other_vars    case_dotenv_preserves_other_vars

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -203,6 +203,7 @@ EOF
     jq -e '.servers | any(.name == "p-pg18" and .engine == "postgres" and .stopped == true)' <<<"$out" >/dev/null \
         || { die "server stop-all did not report Postgres: $out"; return 1; }
     ! kill -0 "$ch_pid" 2>/dev/null || { die "server stop-all left ClickHouse process running"; return 1; }
+    trap - EXIT
     wait "$ch_pid" 2>/dev/null || true
 
     list=$("$CTL" local --json server list 2>&1) || { die "list after server stop-all: $list"; return 1; }

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -200,7 +200,7 @@ EOF
     local out; out=$("$CTL" local --json server stop-all 2>&1) || { die "server stop-all: $out"; return 1; }
     jq -e '.servers | any(.name == "c" and .engine == "clickhouse" and .stopped == true)' <<<"$out" >/dev/null \
         || { die "server stop-all did not report ClickHouse: $out"; return 1; }
-    jq -e '.servers | any(.name == "p" and .engine == "postgres" and .stopped == true)' <<<"$out" >/dev/null \
+    jq -e '.servers | any(.name == "p-pg18" and .engine == "postgres" and .stopped == true)' <<<"$out" >/dev/null \
         || { die "server stop-all did not report Postgres: $out"; return 1; }
     ! kill -0 "$ch_pid" 2>/dev/null || { die "server stop-all left ClickHouse process running"; return 1; }
     wait "$ch_pid" 2>/dev/null || true


### PR DESCRIPTION
Closes #327

## Summary
- Make project-scoped `local server stop-all` stop both ClickHouse and Postgres instances shown by `server list`.
- Report each attempted engine and per-instance error consistently in human and JSON output.
- Preserve `local postgres stop-all` and document that `--global` remains ClickHouse-only because global Postgres discovery is unsupported.
- Align the Postgres integration battery with the unified stop-all contract while retaining dedicated Postgres scope coverage.

## Tests
- `cargo fmt --all`
- `cargo test -p clickhousectl server_stop_all`
- `cargo test -p clickhousectl stop_servers_attempts_and_reports_both_engines`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `bash -n scripts/test-postgres-integration.sh`
- `shellcheck scripts/test-postgres-integration.sh`
- `env -u AGENT -u OPENCODE -u OPENCODE_PID scripts/test-postgres-integration.sh` (15 passed)

Ready for review.