### PR TITLE
Render Cloud JSON integer fields as integers

### DIFF
--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -15873,12 +15873,14 @@ pub struct ServiceClickhouseSettingsSchema {
 
 /// `ServiceEndpoint` from the ClickHouse Cloud API.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(from = "crate::serde_helpers::ServiceEndpointWire")]
 pub struct ServiceEndpoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     // The schema currently says `number`, but Cloud endpoints are TCP ports and
-    // the API sends integral values. Keep JSON output integral for consumers.
+    // the API sends integral values. Accept integral float syntax from the API,
+    // but keep JSON output integral for consumers.
     pub port: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<ServiceEndpointProtocol>,
@@ -17061,6 +17063,7 @@ pub struct UdfVersionListResponse {
 
 /// Standard API response wrapper.
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(from = "crate::serde_helpers::ApiResponseWire<T>")]
 pub struct ApiResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<i64>,

--- a/crates/clickhouse-cloud-api/src/models.rs
+++ b/crates/clickhouse-cloud-api/src/models.rs
@@ -15754,21 +15754,21 @@ pub struct Service {
     #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
     #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
-    pub max_replicas: Option<f64>,
+    pub max_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_total_memory_gb: Option<f64>,
     #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
     #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
-    pub min_replicas: Option<f64>,
+    pub min_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
-    pub num_replicas: Option<f64>,
+    pub num_replicas: Option<i64>,
     #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15877,7 +15877,9 @@ pub struct ServiceEndpoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub host: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub port: Option<f64>,
+    // The schema currently says `number`, but Cloud endpoints are TCP ports and
+    // the API sends integral values. Keep JSON output integral for consumers.
+    pub port: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub protocol: Option<ServiceEndpointProtocol>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -15971,20 +15973,20 @@ pub struct ServicePostRequest {
     #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
     #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
-    pub max_replicas: Option<f64>,
+    pub max_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_total_memory_gb: Option<f64>,
     #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
     #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
-    pub min_replicas: Option<f64>,
+    pub min_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
     pub name: String,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
-    pub num_replicas: Option<f64>,
+    pub num_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<Vec<String>>,
@@ -16040,13 +16042,13 @@ pub struct ServiceReplicaScalingPatchRequest {
     #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
     #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
-    pub max_replicas: Option<f64>,
+    pub max_replicas: Option<i64>,
     #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
     #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
-    pub min_replicas: Option<f64>,
+    pub min_replicas: Option<i64>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
-    pub num_replicas: Option<f64>,
+    pub num_replicas: Option<i64>,
 }
 
 /// `ServiceScalingPatchRequest` from the ClickHouse Cloud API.
@@ -16063,7 +16065,7 @@ pub struct ServiceScalingPatchRequest {
     #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
-    pub num_replicas: Option<f64>,
+    pub num_replicas: Option<i64>,
 }
 
 /// `ServiceScalingPatchResponse` from the ClickHouse Cloud API.
@@ -16123,21 +16125,21 @@ pub struct ServiceScalingPatchResponse {
     #[serde(rename = "maxReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_replica_memory_gb: Option<f64>,
     #[serde(rename = "maxReplicas", skip_serializing_if = "Option::is_none")]
-    pub max_replicas: Option<f64>,
+    pub max_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "maxTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub max_total_memory_gb: Option<f64>,
     #[serde(rename = "minReplicaMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_replica_memory_gb: Option<f64>,
     #[serde(rename = "minReplicas", skip_serializing_if = "Option::is_none")]
-    pub min_replicas: Option<f64>,
+    pub min_replicas: Option<i64>,
     #[cfg(feature = "deprecated-fields")]
     #[serde(rename = "minTotalMemoryGb", skip_serializing_if = "Option::is_none")]
     pub min_total_memory_gb: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     #[serde(rename = "numReplicas", skip_serializing_if = "Option::is_none")]
-    pub num_replicas: Option<f64>,
+    pub num_replicas: Option<i64>,
     #[serde(rename = "privateEndpointIds", skip_serializing_if = "Option::is_none")]
     pub private_endpoint_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -17061,7 +17063,7 @@ pub struct UdfVersionListResponse {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct ApiResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<f64>,
+    pub status: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "requestId")]
     pub request_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/clickhouse-cloud-api/src/serde_helpers.rs
+++ b/crates/clickhouse-cloud-api/src/serde_helpers.rs
@@ -10,6 +10,8 @@ pub fn deserialize_optional_integral_i64<'de, D>(deserializer: D) -> Result<Opti
 where
     D: serde::Deserializer<'de>,
 {
+    const MAX_SAFE_FLOAT_INTEGER_EXCLUSIVE: f64 = (1_u64 << f64::MANTISSA_DIGITS) as f64;
+
     Option::<serde_json::Number>::deserialize(deserializer)?
         .map(|number| {
             if let Some(value) = number.as_i64() {
@@ -20,8 +22,8 @@ where
             }
             if let Some(value) = number.as_f64()
                 && value.fract() == 0.0
-                && value >= i64::MIN as f64
-                && value < i64::MAX as f64
+                && value > -MAX_SAFE_FLOAT_INTEGER_EXCLUSIVE
+                && value < MAX_SAFE_FLOAT_INTEGER_EXCLUSIVE
             {
                 return Ok(value as i64);
             }

--- a/crates/clickhouse-cloud-api/src/serde_helpers.rs
+++ b/crates/clickhouse-cloud-api/src/serde_helpers.rs
@@ -1,5 +1,78 @@
 //! Serde helpers used by generated models.
 
+use serde::Deserialize;
+
+use crate::models::{ApiResponse, ServiceEndpoint, ServiceEndpointProtocol};
+
+/// Deserialize an optional integer from either JSON integer syntax or an
+/// integral JSON float such as `200.0`.
+pub fn deserialize_optional_integral_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<serde_json::Number>::deserialize(deserializer)?
+        .map(|number| {
+            if let Some(value) = number.as_i64() {
+                return Ok(value);
+            }
+            if let Some(value) = number.as_u64() {
+                return i64::try_from(value).map_err(serde::de::Error::custom);
+            }
+            if let Some(value) = number.as_f64()
+                && value.fract() == 0.0
+                && value >= i64::MIN as f64
+                && value < i64::MAX as f64
+            {
+                return Ok(value as i64);
+            }
+            Err(serde::de::Error::custom(format!(
+                "expected an integer-valued i64, got {number}"
+            )))
+        })
+        .transpose()
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ServiceEndpointWire {
+    host: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_integral_i64")]
+    port: Option<i64>,
+    protocol: Option<ServiceEndpointProtocol>,
+    username: Option<String>,
+}
+
+impl From<ServiceEndpointWire> for ServiceEndpoint {
+    fn from(value: ServiceEndpointWire) -> Self {
+        Self {
+            host: value.host,
+            port: value.port,
+            protocol: value.protocol,
+            username: value.username,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ApiResponseWire<T> {
+    #[serde(default, deserialize_with = "deserialize_optional_integral_i64")]
+    status: Option<i64>,
+    #[serde(rename = "requestId")]
+    request_id: Option<String>,
+    result: Option<T>,
+    error: Option<String>,
+}
+
+impl<T> From<ApiResponseWire<T>> for ApiResponse<T> {
+    fn from(value: ApiResponseWire<T>) -> Self {
+        Self {
+            status: value.status,
+            request_id: value.request_id,
+            result: value.result,
+            error: value.error,
+        }
+    }
+}
+
 /// Deserialize a buffered payload into `T`, handing the payload back unchanged
 /// if it does not fit `T`.
 ///

--- a/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/postgres_cdc_test.rs
@@ -121,7 +121,7 @@ async fn cloud_clickpipe_postgres_cdc() -> TestResult<()> {
             region: ServicePostRequestRegion::Unknown(ctx.region.clone()),
             min_replica_memory_gb: Some(8.0),
             max_replica_memory_gb: Some(8.0),
-            num_replicas: Some(1.0),
+            num_replicas: Some(1),
             idle_scaling: Some(true),
             idle_timeout_minutes: Some(5.0),
             // Test runner needs to query the service to verify CDC results;

--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -64,7 +64,7 @@ async fn list_organizations() {
 
     let client = Client::with_base_url(mock_server.uri(), "test-key", "test-secret");
     let resp = client.organization_get_list().await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
     let orgs = resp.result.unwrap();
     assert_eq!(orgs.len(), 1);
     assert_eq!(orgs[0].name.as_deref(), Some("Test Org"));
@@ -334,7 +334,7 @@ async fn delete_byoc_infrastructure() {
         .organization_byoc_infrastructure_delete("org-1", "byoc-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -427,7 +427,7 @@ async fn delete_invitation() {
         .await;
 
     let resp = c.invitation_delete("org-1", "inv-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -552,7 +552,7 @@ async fn delete_api_key() {
         .await;
 
     let resp = c.openapi_key_delete("org-1", "key-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -656,7 +656,7 @@ async fn delete_member() {
         .await;
 
     let resp = c.member_delete("org-1", "user-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -767,7 +767,7 @@ async fn get_service_details() {
     let svc = resp.result.unwrap();
     assert_eq!(svc.name.as_deref(), Some("prod-service"));
     assert_eq!(svc.provider, Some(ServiceProvider::Gcp));
-    assert_eq!(svc.num_replicas, Some(3.0));
+    assert_eq!(svc.num_replicas, Some(3));
 }
 
 #[tokio::test]
@@ -811,7 +811,7 @@ async fn delete_service() {
 
     let client = Client::with_base_url(mock_server.uri(), "key", "secret");
     let resp = client.instance_delete("org-123", "svc-456").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 #[tokio::test]
@@ -882,7 +882,7 @@ async fn update_replica_scaling() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/services/svc-1/replicaScaling"))
-        .and(body_partial_json(serde_json::json!({"numReplicas": 5.0, "minReplicaMemoryGb": 16.0, "maxReplicaMemoryGb": 64.0})))
+        .and(body_partial_json(serde_json::json!({"numReplicas": 5, "minReplicaMemoryGb": 16.0, "maxReplicaMemoryGb": 64.0})))
         .respond_with(ok_json(serde_json::json!({
             "id": "11111111-2222-3333-4444-555555555555",
             "name": "svc-1",
@@ -894,7 +894,7 @@ async fn update_replica_scaling() {
         .await;
 
     let body = ServiceReplicaScalingPatchRequest {
-        num_replicas: Some(5.0),
+        num_replicas: Some(5),
         min_replica_memory_gb: Some(16.0),
         max_replica_memory_gb: Some(64.0),
         ..Default::default()
@@ -904,7 +904,7 @@ async fn update_replica_scaling() {
         .await
         .unwrap();
     let result = resp.result.unwrap();
-    assert_eq!(result.num_replicas, Some(5.0));
+    assert_eq!(result.num_replicas, Some(5));
 }
 
 #[tokio::test]
@@ -914,7 +914,7 @@ async fn update_scaling_deprecated() {
 
     Mock::given(method("PATCH"))
         .and(path("/v1/organizations/org-1/services/svc-1/scaling"))
-        .and(body_partial_json(serde_json::json!({"numReplicas": 3.0})))
+        .and(body_partial_json(serde_json::json!({"numReplicas": 3})))
         .respond_with(ok_json(serde_json::json!({
             "id": "11111111-2222-3333-4444-555555555555",
             "name": "svc-1",
@@ -924,7 +924,7 @@ async fn update_scaling_deprecated() {
         .await;
 
     let body = ServiceScalingPatchRequest {
-        num_replicas: Some(3.0),
+        num_replicas: Some(3),
         ..Default::default()
     };
     let resp = c
@@ -932,7 +932,7 @@ async fn update_scaling_deprecated() {
         .await
         .unwrap();
     let svc = resp.result.unwrap();
-    assert_eq!(svc.num_replicas, Some(3.0));
+    assert_eq!(svc.num_replicas, Some(3));
 }
 
 #[tokio::test]
@@ -1102,7 +1102,7 @@ async fn delete_query_endpoint() {
         .instance_query_endpoint_delete("org-1", "svc-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -1310,7 +1310,7 @@ async fn delete_backup_bucket() {
         .await;
 
     let resp = c.backup_bucket_delete("org-1", "svc-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -1495,7 +1495,7 @@ async fn delete_click_pipe() {
         .click_pipe_delete("org-1", "svc-1", "pipe-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 #[tokio::test]
@@ -1800,7 +1800,7 @@ async fn delete_reverse_private_endpoint() {
         .click_pipe_reverse_private_endpoint_delete("org-1", "svc-1", "rpe-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -1923,7 +1923,7 @@ async fn delete_alert() {
         .click_stack_delete_alert("org-1", "svc-1", "alert-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -2060,7 +2060,7 @@ async fn delete_saved_search() {
         .click_stack_delete_saved_search("org-1", "svc-1", "search-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -2190,7 +2190,7 @@ async fn delete_dashboard() {
         .click_stack_delete_dashboard("org-1", "svc-1", "dash-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -2336,7 +2336,7 @@ async fn delete_source() {
         .click_stack_delete_source("org-1", "svc-1", "source-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 #[tokio::test]
@@ -2371,7 +2371,7 @@ async fn delete_udf() {
 
     assert_eq!(
         c.udf_delete("org-1", "my_udf").await.unwrap().status,
-        Some(200.0)
+        Some(200)
     );
 }
 
@@ -2391,7 +2391,7 @@ async fn detach_udf() {
             .await
             .unwrap()
             .status,
-        Some(200.0)
+        Some(200)
     );
 }
 
@@ -2409,7 +2409,7 @@ async fn delete_udf_version() {
             .await
             .unwrap()
             .status,
-        Some(200.0)
+        Some(200)
     );
 }
 
@@ -2812,7 +2812,7 @@ async fn delete_role() {
         .click_stack_delete_role("org-1", "svc-1", "role-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -2995,7 +2995,7 @@ async fn delete_webhook() {
         .click_stack_delete_webhook("org-1", "svc-1", "webhook-1")
         .await
         .unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 #[tokio::test]
@@ -3220,7 +3220,7 @@ async fn delete_postgres_service() {
         .await;
 
     let resp = c.postgres_service_delete("org-1", "pg-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 #[tokio::test]
@@ -4022,7 +4022,7 @@ async fn scaling_schedule_delete_succeeds() {
         .await;
 
     let resp = c.scaling_schedule_delete("org-1", "svc-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================
@@ -4092,7 +4092,7 @@ async fn upgrade_window_delete_succeeds() {
         .await;
 
     let resp = c.upgrade_window_delete("org-1", "svc-1").await.unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
 }
 
 // ===========================================================================

--- a/crates/clickhouse-cloud-api/tests/common/support.rs
+++ b/crates/clickhouse-cloud-api/tests/common/support.rs
@@ -1343,7 +1343,7 @@ pub async fn provision_clickhouse(
         region: ServicePostRequestRegion::Unknown(ctx.region.clone()),
         min_replica_memory_gb: Some(8.0),
         max_replica_memory_gb: Some(8.0),
-        num_replicas: Some(1.0),
+        num_replicas: Some(1),
         idle_scaling: Some(true),
         idle_timeout_minutes: Some(5.0),
         ip_access_list: vec![IpAccessListEntry {

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -25,8 +25,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
         let deprecated_base_total_memory_gb = 12.0_f64;
         #[cfg(feature = "deprecated-fields")]
         let deprecated_scaled_total_memory_gb = 24.0_f64;
-        let base_replicas = 1.0_f64;
-        let scaled_replicas = 3.0_f64;
+        let base_replicas = 1_i64;
+        let scaled_replicas = 3_i64;
         let primary_ip = "203.0.113.10/32";
         let secondary_ip = "203.0.113.11/32";
 
@@ -1935,7 +1935,7 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
             .expect("blocking steps always return a value");
         // Sanity: the deprecated body's totals only equal per-replica when
         // num_replicas == 1. We rely on the previous step landing us there.
-        assert_eq!(pre_vertical.num_replicas, base_replicas);
+        assert_eq!(pre_vertical.num_replicas, Some(base_replicas));
         let pre_min_total = pre_vertical.min_total_memory_gb;
         let pre_max_total = pre_vertical.max_total_memory_gb;
 
@@ -2068,8 +2068,8 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
                 end_hour_utc: 2,
                 min_replica_memory_gb: Some(base_memory_gb),
                 max_replica_memory_gb: Some(base_memory_gb),
-                min_replicas: Some(base_replicas as i64),
-                max_replicas: Some(base_replicas as i64),
+                min_replicas: Some(base_replicas),
+                max_replicas: Some(base_replicas),
                 idle_scaling: Some(true),
                 idle_timeout_minutes: Some(5),
                 // Vertical entry expressed as equal min/max; the fixed-count
@@ -2594,7 +2594,7 @@ async fn scale_service_and_wait(
     service_id: &str,
     min_memory_gb: Option<f64>,
     max_memory_gb: Option<f64>,
-    replicas: Option<f64>,
+    replicas: Option<i64>,
     description: &str,
     timeout: std::time::Duration,
     interval: std::time::Duration,

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -141,7 +141,7 @@ fn deserialize_api_response_with_org_list() {
         ]
     }"#;
     let resp: ApiResponse<Vec<Organization>> = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
     assert_eq!(resp.request_id, Some("req-uuid-123".to_string()));
     let result = resp.result.unwrap();
     assert_eq!(result.len(), 2);
@@ -157,7 +157,7 @@ fn deserialize_api_response_error() {
         "requestId": "req-uuid-456"
     }"#;
     let resp: ApiResponse<serde_json::Value> = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.status, Some(401.0));
+    assert_eq!(resp.status, Some(401));
     assert_eq!(resp.error, Some("Unauthorized".to_string()));
     assert!(resp.result.is_none());
 }
@@ -202,7 +202,7 @@ fn deserialize_service() {
     assert_eq!(svc.state, Some(ServiceState::Running));
     #[cfg(feature = "deprecated-fields")]
     assert_eq!(svc.tier, Some(ServiceTier::Production));
-    assert_eq!(svc.num_replicas, Some(3.0));
+    assert_eq!(svc.num_replicas, Some(3));
     assert_eq!(svc.idle_scaling, Some(true));
     assert_eq!(svc.is_primary, Some(true));
 }
@@ -219,7 +219,7 @@ fn serialize_service_post_request() {
         min_total_memory_gb: Some(24.0),
         #[cfg(feature = "deprecated-fields")]
         max_total_memory_gb: Some(48.0),
-        num_replicas: Some(3.0),
+        num_replicas: Some(3),
         idle_scaling: Some(true),
         idle_timeout_minutes: Some(5.0),
         ip_access_list: vec![IpAccessListEntry {
@@ -244,14 +244,14 @@ fn serialize_service_post_request_horizontal_autoscaling() {
     let req = ServicePostRequest {
         name: "horizontal-service".to_string(),
         autoscaling_mode: Some(AutoscalingMode::Horizontal),
-        min_replicas: Some(1.0),
-        max_replicas: Some(5.0),
+        min_replicas: Some(1),
+        max_replicas: Some(5),
         ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
     assert_eq!(json["autoscalingMode"], "horizontal");
-    assert_eq!(json["minReplicas"], 1.0);
-    assert_eq!(json["maxReplicas"], 5.0);
+    assert_eq!(json["minReplicas"], 1);
+    assert_eq!(json["maxReplicas"], 5);
 
     // Omitted entirely when unset — mutually exclusive with the vertical
     // scaling fields, so they must not serialize as null/defaults.
@@ -425,7 +425,66 @@ fn deserialize_service_endpoint() {
     let ep: ServiceEndpoint = serde_json::from_str(json).unwrap();
     assert_eq!(ep.protocol, Some(ServiceEndpointProtocol::Nativesecure));
     assert_eq!(ep.host.as_deref(), Some("abc123.clickhouse.cloud"));
-    assert_eq!(ep.port, Some(9440.0));
+    assert_eq!(ep.port, Some(9440));
+}
+
+#[test]
+fn api_integer_fields_round_trip_as_json_integers() {
+    let response: ApiResponse<Service> = serde_json::from_value(serde_json::json!({
+        "status": 200,
+        "result": {
+            "numReplicas": 3,
+            "minReplicas": 1,
+            "maxReplicas": 5,
+            "endpoints": [{"port": 9440}]
+        }
+    }))
+    .unwrap();
+
+    let rendered = serde_json::to_string(&response).unwrap();
+    assert!(
+        !rendered.contains(".0"),
+        "unexpected float JSON: {rendered}"
+    );
+    let json = serde_json::to_value(response).unwrap();
+    assert!(json["status"].is_i64());
+    assert!(json["result"]["numReplicas"].is_i64());
+    assert!(json["result"]["minReplicas"].is_i64());
+    assert!(json["result"]["maxReplicas"].is_i64());
+    assert!(json["result"]["endpoints"][0]["port"].is_i64());
+    assert_eq!(json["status"], 200);
+    assert_eq!(json["result"]["numReplicas"], 3);
+    assert_eq!(json["result"]["endpoints"][0]["port"], 9440);
+}
+
+#[test]
+fn api_integer_fields_tolerate_missing_and_null_values() {
+    let missing: ApiResponse<Service> = serde_json::from_str("{}").unwrap();
+    assert_eq!(
+        serde_json::to_value(missing).unwrap(),
+        serde_json::json!({})
+    );
+
+    let nulled: ApiResponse<Service> = serde_json::from_value(serde_json::json!({
+        "status": null,
+        "result": {
+            "numReplicas": null,
+            "minReplicas": null,
+            "maxReplicas": null,
+            "endpoints": [{"port": null}]
+        }
+    }))
+    .unwrap();
+    assert_eq!(nulled.status, None);
+    let service = nulled.result.as_ref().unwrap();
+    assert_eq!(service.num_replicas, None);
+    assert_eq!(service.min_replicas, None);
+    assert_eq!(service.max_replicas, None);
+    assert_eq!(service.endpoints.as_ref().unwrap()[0].port, None);
+    assert_eq!(
+        serde_json::to_value(nulled).unwrap(),
+        serde_json::json!({"result": {"endpoints": [{}]}})
+    );
 }
 
 #[test]
@@ -585,7 +644,7 @@ fn unknown_enum_display() {
 fn api_response_result_explicitly_null() {
     let json = r#"{"status": 200, "requestId": "req-1", "result": null}"#;
     let resp: ApiResponse<Vec<Organization>> = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
     assert!(resp.result.is_none());
 }
 
@@ -609,7 +668,7 @@ fn api_response_extra_fields_ignored() {
         "nestedExtra": {"a": 1}
     }"#;
     let resp: ApiResponse<Organization> = serde_json::from_str(json).unwrap();
-    assert_eq!(resp.status, Some(200.0));
+    assert_eq!(resp.status, Some(200));
     let org = resp.result.unwrap();
     assert_eq!(org.name.as_deref(), Some("Test"));
 }
@@ -668,7 +727,7 @@ fn serialize_service_state_patch_request_stop() {
 #[test]
 fn serialize_service_replica_scaling_patch_request() {
     let req = ServiceReplicaScalingPatchRequest {
-        num_replicas: Some(5.0),
+        num_replicas: Some(5),
         min_replicas: None,
         max_replicas: None,
         min_replica_memory_gb: Some(16.0),
@@ -678,7 +737,7 @@ fn serialize_service_replica_scaling_patch_request() {
         ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
-    assert_eq!(json["numReplicas"], 5.0);
+    assert_eq!(json["numReplicas"], 5);
     assert_eq!(json["minReplicaMemoryGb"], 16.0);
     assert_eq!(json["maxReplicaMemoryGb"], 64.0);
     assert_eq!(json["idleScaling"], true);
@@ -688,7 +747,7 @@ fn serialize_service_replica_scaling_patch_request() {
 #[test]
 fn serialize_service_scaling_patch_request() {
     let req = ServiceScalingPatchRequest {
-        num_replicas: Some(3.0),
+        num_replicas: Some(3),
         #[cfg(feature = "deprecated-fields")]
         min_total_memory_gb: Some(24.0),
         #[cfg(feature = "deprecated-fields")]
@@ -696,7 +755,7 @@ fn serialize_service_scaling_patch_request() {
         ..Default::default()
     };
     let json = serde_json::to_value(&req).unwrap();
-    assert_eq!(json["numReplicas"], 3.0);
+    assert_eq!(json["numReplicas"], 3);
     #[cfg(feature = "deprecated-fields")]
     assert_eq!(json["minTotalMemoryGb"], 24.0);
     #[cfg(feature = "deprecated-fields")]
@@ -873,7 +932,7 @@ fn deprecated_request_fields_absent_by_default() {
     );
 
     let scaling = ServiceScalingPatchRequest {
-        num_replicas: Some(3.0),
+        num_replicas: Some(3),
         ..Default::default()
     };
     let scaling = serde_json::to_value(&scaling).unwrap();

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -520,6 +520,9 @@ fn de_facto_integer_fields_accept_integral_float_syntax() {
     assert!(
         serde_json::from_value::<ServiceEndpoint>(serde_json::json!({"port": 9440.5})).is_err()
     );
+    assert!(
+        serde_json::from_str::<ApiResponse<Service>>(r#"{"status":9007199254740993.0}"#).is_err()
+    );
 }
 
 #[test]

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -464,6 +464,8 @@ fn api_integer_fields_tolerate_missing_and_null_values() {
         serde_json::to_value(missing).unwrap(),
         serde_json::json!({})
     );
+    let missing_endpoint: ServiceEndpoint = serde_json::from_str("{}").unwrap();
+    assert_eq!(missing_endpoint.port, None);
 
     let nulled: ApiResponse<Service> = serde_json::from_value(serde_json::json!({
         "status": null,
@@ -484,6 +486,39 @@ fn api_integer_fields_tolerate_missing_and_null_values() {
     assert_eq!(
         serde_json::to_value(nulled).unwrap(),
         serde_json::json!({"result": {"endpoints": [{}]}})
+    );
+}
+
+#[test]
+fn de_facto_integer_fields_accept_integral_float_syntax() {
+    let response: ApiResponse<Service> = serde_json::from_value(serde_json::json!({
+        "status": 200.0,
+        "result": {"endpoints": [{"port": 9440.0}]}
+    }))
+    .unwrap();
+    assert_eq!(response.status, Some(200));
+    assert_eq!(
+        response
+            .result
+            .as_ref()
+            .unwrap()
+            .endpoints
+            .as_ref()
+            .unwrap()[0]
+            .port,
+        Some(9440)
+    );
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        serde_json::json!({"status": 200, "result": {"endpoints": [{"port": 9440}]}})
+    );
+
+    assert!(
+        serde_json::from_value::<ApiResponse<Service>>(serde_json::json!({"status": 200.5}))
+            .is_err()
+    );
+    assert!(
+        serde_json::from_value::<ServiceEndpoint>(serde_json::json!({"port": 9440.5})).is_err()
     );
 }
 

--- a/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
+++ b/crates/clickhouse-cloud-api/tests/spec_coverage_test.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeSet;
 
 use clickhouse_openapi_analyzer::config::clickhouse_cloud_config;
 use clickhouse_openapi_analyzer::{
-    AnalysisInput, analyze, model_fields_with_serde_default, response_tree,
+    AnalysisInput, analyze, integer_model_fields_typed_as_float, model_fields_with_serde_default,
+    response_tree,
 };
 
 const SPEC_JSON: &str = include_str!("../clickhouse_cloud_openapi.json");
@@ -88,6 +89,25 @@ fn every_response_tree_option_field_omits_none_when_serialized() {
         "response fields must omit None instead of serializing null; add \
          skip_serializing_if to: {:?}",
         tree.option_fields_missing_skip_serializing_if
+    );
+}
+
+/// Integer-valued fields must use the repository-standard signed integer type
+/// rather than `f64`; otherwise serde changes API integers such as `3` into
+/// `3.0` when the CLI renders a model as JSON. The analyzer derives this set
+/// from the vendored schema and request/response model mapping.
+#[test]
+fn integer_schema_fields_are_not_typed_as_float() {
+    let offenders = integer_model_fields_typed_as_float(
+        SPEC_JSON,
+        CLIENT_RS,
+        MODELS_RS,
+        &clickhouse_cloud_config(),
+    )
+    .unwrap();
+    assert!(
+        offenders.is_empty(),
+        "OpenAPI integer fields must use i64, not f64: {offenders:?}"
     );
 }
 

--- a/crates/clickhouse-openapi-analyzer/src/compare.rs
+++ b/crates/clickhouse-openapi-analyzer/src/compare.rs
@@ -108,7 +108,7 @@ fn compare_models_and_refs(
 /// by policy, so optionality findings are suppressed there and field presence
 /// (plus enum values) is the retained drift signal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Direction {
+pub(crate) enum Direction {
     Request,
     Response,
 }
@@ -130,7 +130,7 @@ fn response_position_type(rust: &RustInventory, spec: &OpenApiInventory, base: &
 /// schema is used in. A bidirectional schema maps to two Rust types once the
 /// split `{Name}Response` variant exists; until then both directions collapse
 /// onto `{Name}` and only the request-direction target is kept.
-fn field_check_targets(
+pub(crate) fn field_check_targets(
     rust: &RustInventory,
     spec: &OpenApiInventory,
     schema_name: &str,

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -275,6 +275,7 @@ mod tests {
                         "type": "object",
                         "properties": {
                             "count": {"type": "integer"},
+                            "nullableCount": {"type": ["integer", "null"]},
                             "ratio": {"type": "number"}
                         }
                     }
@@ -290,9 +291,16 @@ mod tests {
             }
         "#;
         let models = r#"
-            pub struct Widget { pub count: f64, pub ratio: f64 }
+            pub struct Widget {
+                pub count: f64,
+                #[serde(rename = "nullableCount")]
+                pub nullable_count: Option<f64>,
+                pub ratio: f64,
+            }
             pub struct WidgetResponse {
                 pub count: Option<f64>,
+                #[serde(rename = "nullableCount")]
+                pub nullable_count: Option<f64>,
                 pub ratio: Option<f64>,
             }
         "#;
@@ -302,7 +310,9 @@ mod tests {
                 .unwrap(),
             BTreeSet::from([
                 ("Widget".to_string(), "count".to_string()),
+                ("Widget".to_string(), "nullableCount".to_string()),
                 ("WidgetResponse".to_string(), "count".to_string()),
+                ("WidgetResponse".to_string(), "nullableCount".to_string()),
             ])
         );
     }

--- a/crates/clickhouse-openapi-analyzer/src/lib.rs
+++ b/crates/clickhouse-openapi-analyzer/src/lib.rs
@@ -120,6 +120,48 @@ pub fn response_tree(client_rs: &str, models_rs: &str) -> Result<ResponseTree, A
     })
 }
 
+/// Lists direct OpenAPI `integer` properties represented as `f64` in a request
+/// model or a model reachable from a wired `Client` response.
+///
+/// The analyzer resolves request/response split variants with the same mapping
+/// used by drift analysis. Response targets are additionally constrained to the
+/// Rust response tree, so unused schemas do not expand the policy surface.
+pub fn integer_model_fields_typed_as_float(
+    spec_json: &str,
+    client_rs: &str,
+    models_rs: &str,
+    config: &AnalyzerConfig,
+) -> Result<BTreeSet<(String, String)>, AnalyzeError> {
+    let spec = serde_json::from_str(spec_json).map_err(AnalyzeError::SpecJson)?;
+    let spec = OpenApiInventory::build(&spec, config).map_err(AnalyzeError::SpecInventory)?;
+    let rust = RustInventory::parse(client_rs, models_rs, "").map_err(AnalyzeError::RustSource)?;
+    let response_types = rust.response_reachable_types();
+    let mut offenders = BTreeSet::new();
+
+    for ((schema_name, property_name), property) in &spec.properties {
+        if property.schema_type.as_deref() != Some("integer") {
+            continue;
+        }
+        for (rust_name, direction) in compare::field_check_targets(&rust, &spec, schema_name) {
+            if direction == compare::Direction::Response && !response_types.contains(&rust_name) {
+                continue;
+            }
+            let Some(field) = rust
+                .structs
+                .get(&rust_name)
+                .and_then(|info| info.fields.get(property_name))
+            else {
+                continue;
+            };
+            if rust.terminal_type(&field.rust_type).as_deref() == Some("f64") {
+                offenders.insert((rust_name, property_name.clone()));
+            }
+        }
+    }
+
+    Ok(offenders)
+}
+
 /// Lists every public model struct field in `models_rs` that carries a
 /// field-level `#[serde(default)]` (a container-level one reports every field
 /// of its struct), as `StructName.rust_field_name`.
@@ -194,6 +236,74 @@ mod tests {
             BTreeSet::from([("WidgetLeaf".to_string(), "value".to_string())]),
             "request-only fields (WidgetPostRequest.note) must not be reported, \
              and Option fields with skip_serializing_if (Widget.name) are compliant"
+        );
+    }
+
+    #[test]
+    fn integer_float_inventory_resolves_split_models_and_ignores_number_fields() {
+        let spec = r##"{
+            "paths": {
+                "/widgets": {
+                    "get": {
+                        "operationId": "getWidgets",
+                        "responses": {
+                            "200": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {"$ref": "#/components/schemas/Widget"}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "post": {
+                        "operationId": "createWidget",
+                        "requestBody": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Widget"}
+                                }
+                            }
+                        },
+                        "responses": {}
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "Widget": {
+                        "type": "object",
+                        "properties": {
+                            "count": {"type": "integer"},
+                            "ratio": {"type": "number"}
+                        }
+                    }
+                }
+            }
+        }"##;
+        let client = r#"
+            pub struct Client;
+            impl Client {
+                pub async fn get_widgets(&self) -> Result<WidgetResponse, Error> {
+                    unimplemented!()
+                }
+            }
+        "#;
+        let models = r#"
+            pub struct Widget { pub count: f64, pub ratio: f64 }
+            pub struct WidgetResponse {
+                pub count: Option<f64>,
+                pub ratio: Option<f64>,
+            }
+        "#;
+
+        assert_eq!(
+            integer_model_fields_typed_as_float(spec, client, models, &AnalyzerConfig::default())
+                .unwrap(),
+            BTreeSet::from([
+                ("Widget".to_string(), "count".to_string()),
+                ("WidgetResponse".to_string(), "count".to_string()),
+            ])
         );
     }
 }

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -21,6 +21,7 @@ pub(crate) struct OperationInfo {
 pub(crate) struct PropertyInfo {
     pub(crate) pointer: String,
     pub(crate) required_non_nullable: bool,
+    pub(crate) schema_type: Option<String>,
 }
 
 /// One hop in a property chain from a named schema down to an enum position.
@@ -193,6 +194,10 @@ impl OpenApiInventory {
                     PropertyInfo {
                         pointer: pointer.clone(),
                         required_non_nullable: required.contains(property_name),
+                        schema_type: property
+                            .get("type")
+                            .and_then(Value::as_str)
+                            .map(str::to_string),
                     },
                 );
                 if property.get("deprecated").and_then(Value::as_bool) == Some(true) {

--- a/crates/clickhouse-openapi-analyzer/src/openapi.rs
+++ b/crates/clickhouse-openapi-analyzer/src/openapi.rs
@@ -194,10 +194,7 @@ impl OpenApiInventory {
                     PropertyInfo {
                         pointer: pointer.clone(),
                         required_non_nullable: required.contains(property_name),
-                        schema_type: property
-                            .get("type")
-                            .and_then(Value::as_str)
-                            .map(str::to_string),
+                        schema_type: schema_type(property).map(str::to_string),
                     },
                 );
                 if property.get("deprecated").and_then(Value::as_bool) == Some(true) {
@@ -411,6 +408,17 @@ fn is_nullable(property: &Value) -> bool {
                     .any(|value| value.get("type").and_then(Value::as_str) == Some("null"))
             })
     })
+}
+
+fn schema_type(property: &Value) -> Option<&str> {
+    match property.get("type")? {
+        Value::String(value) => Some(value),
+        Value::Array(values) => values
+            .iter()
+            .filter_map(Value::as_str)
+            .find(|value| *value != "null"),
+        _ => None,
+    }
 }
 
 fn collect_refs(value: &Value, path: &mut Vec<String>, refs: &mut BTreeMap<String, String>) {

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -1177,7 +1177,7 @@ mod tests {
     #[test]
     fn unwrap_response_extracts_result() {
         let response = clickhouse_cloud_api::models::ApiResponse {
-            status: Some(200.0),
+            status: Some(200),
             request_id: None,
             result: Some(vec!["hello".to_string()]),
             error: None,
@@ -1190,7 +1190,7 @@ mod tests {
     fn unwrap_response_errors_on_empty_result() {
         let response: clickhouse_cloud_api::models::ApiResponse<String> =
             clickhouse_cloud_api::models::ApiResponse {
-                status: Some(200.0),
+                status: Some(200),
                 request_id: None,
                 result: None,
                 error: None,

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -612,8 +612,8 @@ pub struct BackupConfigUpdateOptions {
 /// Resolved horizontal-autoscaling fields for a service create/scale request.
 struct HorizontalAutoscaling {
     autoscaling_mode: Option<AutoscalingMode>,
-    min_replicas: Option<f64>,
-    max_replicas: Option<f64>,
+    min_replicas: Option<i64>,
+    max_replicas: Option<i64>,
 }
 
 /// Resolve the horizontal-autoscaling fields shared by `service create` and
@@ -648,8 +648,8 @@ fn resolve_horizontal_autoscaling(
         .transpose()?;
     Ok(HorizontalAutoscaling {
         autoscaling_mode,
-        min_replicas: min_replicas.map(f64::from),
-        max_replicas: max_replicas.map(f64::from),
+        min_replicas: min_replicas.map(i64::from),
+        max_replicas: max_replicas.map(i64::from),
     })
 }
 
@@ -686,7 +686,7 @@ fn build_create_service_request(
         ip_access_list,
         min_replica_memory_gb: opts.min_replica_memory_gb.map(f64::from),
         max_replica_memory_gb: opts.max_replica_memory_gb.map(f64::from),
-        num_replicas: opts.num_replicas.map(f64::from),
+        num_replicas: opts.num_replicas.map(i64::from),
         idle_scaling: opts.idle_scaling,
         idle_timeout_minutes: opts.idle_timeout_minutes.map(f64::from),
         backup_id: opts
@@ -2208,7 +2208,7 @@ fn build_service_scale_request(
         max_replica_memory_gb: opts.max_replica_memory_gb.map(f64::from),
         min_replicas: horizontal.min_replicas,
         max_replicas: horizontal.max_replicas,
-        num_replicas: opts.num_replicas.map(f64::from),
+        num_replicas: opts.num_replicas.map(i64::from),
         idle_scaling: opts.idle_scaling,
         idle_timeout_minutes: opts.idle_timeout_minutes.map(f64::from),
     })
@@ -3292,7 +3292,7 @@ mod tests {
 
     #[test]
     fn first_endpoint_keeps_the_present_half_of_a_partial_endpoint() {
-        let endpoint = |host: Option<&str>, port: Option<f64>| ServiceEndpoint {
+        let endpoint = |host: Option<&str>, port: Option<i64>| ServiceEndpoint {
             host: host.map(str::to_string),
             port,
             ..Default::default()
@@ -3301,7 +3301,7 @@ mod tests {
         assert_eq!(first_endpoint(None), ABSENT);
         assert_eq!(first_endpoint(Some(&[])), ABSENT);
         assert_eq!(
-            first_endpoint(Some(&[endpoint(Some("host"), Some(9440.0))])),
+            first_endpoint(Some(&[endpoint(Some("host"), Some(9440))])),
             "host:9440"
         );
         assert_eq!(
@@ -3309,7 +3309,7 @@ mod tests {
             "host"
         );
         assert_eq!(
-            first_endpoint(Some(&[endpoint(None, Some(9440.0))])),
+            first_endpoint(Some(&[endpoint(None, Some(9440))])),
             format!("{ABSENT}:9440")
         );
         assert_eq!(first_endpoint(Some(&[endpoint(None, None)])), ABSENT);
@@ -3910,8 +3910,10 @@ mod tests {
         let request = build_create_service_request(&opts).unwrap();
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["autoscalingMode"], "horizontal");
-        assert_eq!(json["minReplicas"], 2.0);
-        assert_eq!(json["maxReplicas"], 8.0);
+        assert_eq!(json["minReplicas"], 2);
+        assert_eq!(json["maxReplicas"], 8);
+        assert!(json["minReplicas"].is_i64());
+        assert!(json["maxReplicas"].is_i64());
         // Vertical fields stay absent.
         assert!(json.get("numReplicas").is_none());
         assert!(json.get("minReplicaMemoryGb").is_none());
@@ -3935,8 +3937,8 @@ mod tests {
         let request = build_create_service_request(&opts).unwrap();
         let json = serde_json::to_value(&request).unwrap();
         assert!(json.get("autoscalingMode").is_none());
-        assert_eq!(json["minReplicas"], 1.0);
-        assert_eq!(json["maxReplicas"], 4.0);
+        assert_eq!(json["minReplicas"], 1);
+        assert_eq!(json["maxReplicas"], 4);
     }
 
     #[test]
@@ -3956,7 +3958,8 @@ mod tests {
         assert!(json.get("autoscalingMode").is_none());
         assert!(json.get("minReplicas").is_none());
         assert!(json.get("maxReplicas").is_none());
-        assert_eq!(json["numReplicas"], 3.0);
+        assert_eq!(json["numReplicas"], 3);
+        assert!(json["numReplicas"].is_i64());
     }
 
     #[test]
@@ -4030,8 +4033,8 @@ mod tests {
         let request = build_service_scale_request(&opts).unwrap();
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["autoscalingMode"], "horizontal");
-        assert_eq!(json["minReplicas"], 2.0);
-        assert_eq!(json["maxReplicas"], 8.0);
+        assert_eq!(json["minReplicas"], 2);
+        assert_eq!(json["maxReplicas"], 8);
         assert!(json.get("numReplicas").is_none());
         assert!(json.get("minReplicaMemoryGb").is_none());
         assert!(json.get("maxReplicaMemoryGb").is_none());
@@ -4051,7 +4054,7 @@ mod tests {
         let request = build_service_scale_request(&opts).unwrap();
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["autoscalingMode"], "vertical");
-        assert_eq!(json["numReplicas"], 3.0);
+        assert_eq!(json["numReplicas"], 3);
         assert_eq!(json["minReplicaMemoryGb"], 8.0);
         assert_eq!(json["maxReplicaMemoryGb"], 32.0);
         assert!(json.get("minReplicas").is_none());
@@ -4073,8 +4076,8 @@ mod tests {
         let request = build_service_scale_request(&opts).unwrap();
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["autoscalingMode"], "horizontal");
-        assert_eq!(json["minReplicas"], 2.0);
-        assert_eq!(json["maxReplicas"], 8.0);
+        assert_eq!(json["minReplicas"], 2);
+        assert_eq!(json["maxReplicas"], 8);
         assert_eq!(json["minReplicaMemoryGb"], 16.0);
         assert_eq!(json["maxReplicaMemoryGb"], 16.0);
         assert!(json.get("numReplicas").is_none());

--- a/crates/clickhousectl/src/cloud/types.rs
+++ b/crates/clickhousectl/src/cloud/types.rs
@@ -8,7 +8,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteResponse {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "clickhouse_cloud_api::serde_helpers::deserialize_optional_integral_i64"
+    )]
     pub status: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,

--- a/crates/clickhousectl/src/cloud/types.rs
+++ b/crates/clickhousectl/src/cloud/types.rs
@@ -4,12 +4,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// Fields the API omitted stay `None` and are omitted from `--json` output,
 /// matching the library-wide all-`Option` response policy — never fabricate a
-/// `0.0` status or empty request ID the server did not send.
+/// `0` status or empty request ID the server did not send.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<f64>,
+    pub status: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub request_id: Option<String>,
 }

--- a/crates/clickhousectl/src/cloud/types_test.rs
+++ b/crates/clickhousectl/src/cloud/types_test.rs
@@ -15,7 +15,7 @@ fn test_delete_response_deserialize() {
         "requestId": "0182edf5-8c5b-4586-a6f8-78452320e4b1"
     });
     let response: DeleteResponse = serde_json::from_value(json).unwrap();
-    assert_eq!(response.status, Some(200.0));
+    assert_eq!(response.status, Some(200));
     assert_eq!(
         response.request_id.as_deref(),
         Some("0182edf5-8c5b-4586-a6f8-78452320e4b1")
@@ -25,11 +25,12 @@ fn test_delete_response_deserialize() {
 #[test]
 fn test_delete_response_serialize() {
     let response = DeleteResponse {
-        status: Some(200.0),
+        status: Some(200),
         request_id: Some("0182edf5-8c5b-4586-a6f8-78452320e4b1".to_string()),
     };
     let json = serde_json::to_value(&response).unwrap();
-    assert_eq!(json["status"], 200.0);
+    assert_eq!(json["status"], 200);
+    assert!(json["status"].is_i64());
     assert_eq!(json["requestId"], "0182edf5-8c5b-4586-a6f8-78452320e4b1");
     assert!(json.get("request_id").is_none());
 }
@@ -40,9 +41,21 @@ fn test_delete_response_omits_absent_fields_instead_of_fabricating() {
     assert_eq!(response.status, None);
     assert_eq!(response.request_id, None);
     // `--json` output must reflect the key set the API actually sent — no
-    // fabricated `"status": 0.0` or `"requestId": ""`.
+    // fabricated `"status": 0` or `"requestId": ""`.
     let json = serde_json::to_value(&response).unwrap();
     assert_eq!(json, serde_json::json!({}));
+}
+
+#[test]
+fn test_delete_response_tolerates_null_fields() {
+    let response: DeleteResponse =
+        serde_json::from_value(serde_json::json!({"status": null, "requestId": null})).unwrap();
+    assert_eq!(response.status, None);
+    assert_eq!(response.request_id, None);
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        serde_json::json!({})
+    );
 }
 
 // ── Activity tests (library types) ─────────────────────────────────

--- a/crates/clickhousectl/src/cloud/types_test.rs
+++ b/crates/clickhousectl/src/cloud/types_test.rs
@@ -58,6 +58,20 @@ fn test_delete_response_tolerates_null_fields() {
     );
 }
 
+#[test]
+fn test_delete_response_accepts_integral_float_status() {
+    let response: DeleteResponse =
+        serde_json::from_value(serde_json::json!({"status": 200.0})).unwrap();
+    assert_eq!(response.status, Some(200));
+    assert_eq!(
+        serde_json::to_value(response).unwrap(),
+        serde_json::json!({"status": 200})
+    );
+    assert!(
+        serde_json::from_value::<DeleteResponse>(serde_json::json!({"status": 200.5})).is_err()
+    );
+}
+
 // ── Activity tests (library types) ─────────────────────────────────
 
 /// The wire value of a response enum field, or an empty string when the API


### PR DESCRIPTION
## Summary
- use `i64` for API status values, service replica counts, and endpoint ports so JSON output preserves integer types
- keep OpenAPI `number` fields such as memory, backup metrics, and idle timeout as `f64`
- add an analyzer-backed guard plus serde, request-builder, and CLI response regressions for integer output and null/missing tolerance

## Tests
- `cargo fmt --all --check`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer -p clickhousectl`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer -p clickhousectl --all-targets -- -D warnings`
- `cargo test -p clickhouse-cloud-api --test spec_coverage_test integer_schema_fields_are_not_typed_as_float`

Closes #331