### PR TITLE
Render Cloud query errors and add organization context

### DIFF
--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -56,6 +56,32 @@ fn derive_query_host(base_url: &str) -> Option<String> {
     Some(format!("{}://queries.{}{}", parsed.scheme(), rest, port))
 }
 
+fn query_api_error_message(status: reqwest::StatusCode, body: &str) -> String {
+    let sql_error = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            let error = value.get("error")?;
+            let code = match error.get("code")? {
+                serde_json::Value::String(code) if !code.is_empty() => code.clone(),
+                serde_json::Value::Number(code) => code.to_string(),
+                _ => return None,
+            };
+            let details = error.get("details")?.as_str()?;
+            if details.is_empty() {
+                return None;
+            }
+            Some(format!("SQL error {code}: {details}"))
+        });
+
+    sql_error.unwrap_or_else(|| {
+        if body.is_empty() {
+            format!("Query API returned HTTP {status} with an empty response body")
+        } else {
+            format!("Query API returned HTTP {status}: {body}")
+        }
+    })
+}
+
 impl Client {
     /// Create a new client with the default base URL (`https://api.clickhouse.cloud`).
     pub fn new(key_id: impl Into<String>, key_secret: impl Into<String>) -> Self {
@@ -319,7 +345,12 @@ impl Client {
         // wake confirmation to wake it and run the query), `Service is
         // stopped` for one that must be started explicitly.
         if status.as_u16() == 206 {
-            let body_text = response.text().await.unwrap_or_default();
+            let body_text = response.text().await.map_err(|error| Error::Api {
+                status: status.as_u16(),
+                message: format!(
+                    "Query API returned HTTP {status}, but its response body could not be read: {error}"
+                ),
+            })?;
             #[derive(serde::Deserialize)]
             struct StateBody {
                 data: Option<String>,
@@ -332,19 +363,20 @@ impl Client {
                 Some("Service is stopped") => Error::ServiceStopped,
                 _ => Error::Api {
                     status: 206,
-                    message: body_text,
+                    message: query_api_error_message(status, &body_text),
                 },
             });
         }
         if !status.is_success() {
-            let body_text = response.text().await.unwrap_or_default();
+            let body_text = response.text().await.map_err(|error| Error::Api {
+                status: status.as_u16(),
+                message: format!(
+                    "Query API returned HTTP {status}, but its response body could not be read: {error}"
+                ),
+            })?;
             return Err(Error::Api {
                 status: status.as_u16(),
-                message: if body_text.is_empty() {
-                    format!("Query API returned {status}")
-                } else {
-                    body_text
-                },
+                message: query_api_error_message(status, &body_text),
             });
         }
 
@@ -3999,7 +4031,7 @@ impl Client {
 
 #[cfg(test)]
 mod tests {
-    use super::derive_query_host;
+    use super::{derive_query_host, query_api_error_message};
 
     #[test]
     fn derive_query_host_prod() {
@@ -4055,6 +4087,37 @@ mod tests {
         assert_eq!(
             derive_query_host("https://api.clickhouse.cloud:443").as_deref(),
             Some("https://queries.clickhouse.cloud")
+        );
+    }
+
+    #[test]
+    fn query_api_error_extracts_documented_sql_error() {
+        let body = r#"{"error":{"code":"62","details":"Syntax error","extra":"ignored"}}"#;
+        assert_eq!(
+            query_api_error_message(reqwest::StatusCode::BAD_REQUEST, body),
+            "SQL error 62: Syntax error"
+        );
+    }
+
+    #[test]
+    fn query_api_error_accepts_numeric_codes() {
+        let body = r#"{"error":{"code":241,"details":"Memory limit exceeded"}}"#;
+        assert_eq!(
+            query_api_error_message(reqwest::StatusCode::INTERNAL_SERVER_ERROR, body),
+            "SQL error 241: Memory limit exceeded"
+        );
+    }
+
+    #[test]
+    fn query_api_error_preserves_status_and_unrecognized_body() {
+        let malformed = r#"{"error":{"code":"62","details":"truncated"#;
+        assert_eq!(
+            query_api_error_message(reqwest::StatusCode::BAD_REQUEST, malformed),
+            format!("Query API returned HTTP 400 Bad Request: {malformed}")
+        );
+        assert_eq!(
+            query_api_error_message(reqwest::StatusCode::BAD_GATEWAY, "upstream failed"),
+            "Query API returned HTTP 502 Bad Gateway: upstream failed"
         );
     }
 }

--- a/crates/clickhouse-cloud-api/tests/run_query_test.rs
+++ b/crates/clickhouse-cloud-api/tests/run_query_test.rs
@@ -194,7 +194,10 @@ async fn run_query_206_unrecognized_body_maps_to_api_error() {
     match err {
         Error::Api { status, message } => {
             assert_eq!(status, 206);
-            assert_eq!(message, r#"{"data":"Something new"}"#);
+            assert_eq!(
+                message,
+                r#"Query API returned HTTP 206 Partial Content: {"data":"Something new"}"#
+            );
         }
         other => panic!("expected Error::Api, got: {other:?}"),
     }
@@ -212,7 +215,54 @@ async fn run_query_non_success_status_maps_to_api_error() {
     match err {
         Error::Api { status, message } => {
             assert_eq!(status, 404);
-            assert_eq!(message, "query endpoint not found");
+            assert_eq!(
+                message,
+                "Query API returned HTTP 404 Not Found: query endpoint not found"
+            );
+        }
+        other => panic!("expected Error::Api, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn run_query_formats_documented_sql_error_envelope() {
+    let mock = start_mock_query_host(
+        400,
+        r#"{"error":{"code":"62","details":"Syntax error near FROM"}}"#,
+    )
+    .await;
+    let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());
+
+    let err = client
+        .run_query_bearer("svc-1", "SELECT broken FROM", None, "CSV", false)
+        .await
+        .expect_err("expected Api error");
+    match err {
+        Error::Api { status, message } => {
+            assert_eq!(status, 400);
+            assert_eq!(message, "SQL error 62: Syntax error near FROM");
+        }
+        other => panic!("expected Error::Api, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn run_query_preserves_malformed_json_error_with_status() {
+    let body = r#"{"error":{"code":"62","details":"truncated"#;
+    let mock = start_mock_query_host(400, body).await;
+    let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());
+
+    let err = client
+        .run_query_bearer("svc-1", "SELECT broken FROM", None, "CSV", false)
+        .await
+        .expect_err("expected Api error");
+    match err {
+        Error::Api { status, message } => {
+            assert_eq!(status, 400);
+            assert_eq!(
+                message,
+                format!("Query API returned HTTP 400 Bad Request: {body}")
+            );
         }
         other => panic!("expected Error::Api, got: {other:?}"),
     }

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -407,14 +407,15 @@ impl CloudClient {
         match &err {
             clickhouse_cloud_api::Error::Api { status, message } => {
                 let mut msg = message.clone();
+                let trimmed_message = message.trim();
                 if *status == 404
                     && matches!(
-                        message.trim().to_ascii_uppercase().as_str(),
+                        trimmed_message.to_ascii_uppercase().as_str(),
                         "NOT_FOUND" | "NOT FOUND"
                     )
                     && let Some(org_id) = org_id
                 {
-                    msg = format!("{msg}: request scoped to organization {org_id}");
+                    msg = format!("{trimmed_message}: request scoped to organization {org_id}");
                 }
                 if *status == 403 && self.is_bearer_auth() {
                     msg.push_str(
@@ -1320,7 +1321,7 @@ mod tests {
         let err = test_client().convert_error_for_organization(
             clickhouse_cloud_api::Error::Api {
                 status: 404,
-                message: "NOT_FOUND".into(),
+                message: " NOT_FOUND\n".into(),
             },
             "00000000-0000-4000-8000-000000000001",
         );

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -387,9 +387,35 @@ impl CloudClient {
 
     /// Convert a library error into a `CloudError`, appending OAuth hints when relevant.
     pub fn convert_error(&self, err: clickhouse_cloud_api::Error) -> CloudError {
+        self.convert_error_with_organization(err, None)
+    }
+
+    /// Add safe request scope to otherwise context-free organization errors.
+    pub fn convert_error_for_organization(
+        &self,
+        err: clickhouse_cloud_api::Error,
+        org_id: &str,
+    ) -> CloudError {
+        self.convert_error_with_organization(err, Some(org_id))
+    }
+
+    fn convert_error_with_organization(
+        &self,
+        err: clickhouse_cloud_api::Error,
+        org_id: Option<&str>,
+    ) -> CloudError {
         match &err {
             clickhouse_cloud_api::Error::Api { status, message } => {
                 let mut msg = message.clone();
+                if *status == 404
+                    && matches!(
+                        message.trim().to_ascii_uppercase().as_str(),
+                        "NOT_FOUND" | "NOT FOUND"
+                    )
+                    && let Some(org_id) = org_id
+                {
+                    msg = format!("{msg}: request scoped to organization {org_id}");
+                }
                 if *status == 403 && self.is_bearer_auth() {
                     msg.push_str(
                         "\n\nHint: You are authenticated via OAuth, which provides read-only access. \
@@ -429,7 +455,7 @@ impl CloudClient {
             .api()
             .organization_get(org_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -442,7 +468,7 @@ impl CloudClient {
             .api()
             .instance_get_list(org_id, &[])
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -456,7 +482,7 @@ impl CloudClient {
             .api()
             .instance_get_list(org_id, &filter_refs)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -469,7 +495,7 @@ impl CloudClient {
             .api()
             .instance_get(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -482,7 +508,7 @@ impl CloudClient {
             .api()
             .instance_create(org_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -491,7 +517,7 @@ impl CloudClient {
             .api()
             .instance_delete(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -512,7 +538,7 @@ impl CloudClient {
             .api()
             .instance_state_update(org_id, service_id, &request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -526,7 +552,7 @@ impl CloudClient {
             .api()
             .backup_get_list(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -540,7 +566,7 @@ impl CloudClient {
             .api()
             .backup_get(org_id, service_id, backup_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -555,7 +581,7 @@ impl CloudClient {
             .api()
             .instance_update(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -570,7 +596,7 @@ impl CloudClient {
             .api()
             .instance_replica_scaling_update(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -585,7 +611,7 @@ impl CloudClient {
             .api()
             .instance_password_update(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -599,7 +625,7 @@ impl CloudClient {
             .api()
             .instance_query_endpoint_get(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -613,7 +639,7 @@ impl CloudClient {
             .api()
             .instance_query_endpoint_upsert(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -626,7 +652,7 @@ impl CloudClient {
             .api()
             .instance_query_endpoint_delete(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -644,7 +670,7 @@ impl CloudClient {
             .api()
             .instance_private_endpoint_create(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -658,7 +684,7 @@ impl CloudClient {
             .api()
             .instance_private_endpoint_config_get(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -672,7 +698,7 @@ impl CloudClient {
         self.api()
             .instance_prometheus_get(org_id, service_id, filtered.as_deref())
             .await
-            .map_err(|e| self.convert_error(e))
+            .map_err(|e| self.convert_error_for_organization(e, org_id))
     }
 
     // Organization endpoints (delegated to library client)
@@ -685,7 +711,7 @@ impl CloudClient {
             .api()
             .organization_update(org_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -698,7 +724,7 @@ impl CloudClient {
         self.api()
             .organization_prometheus_get(org_id, fm_str)
             .await
-            .map_err(|e| self.convert_error(e))
+            .map_err(|e| self.convert_error_for_organization(e, org_id))
     }
 
     pub async fn get_org_usage(
@@ -713,7 +739,7 @@ impl CloudClient {
             .api()
             .usage_cost_get(org_id, from_date, to_date, &filter_refs)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -726,7 +752,7 @@ impl CloudClient {
             .api()
             .member_get_list(org_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -739,7 +765,7 @@ impl CloudClient {
             .api()
             .member_get(org_id, user_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -753,7 +779,7 @@ impl CloudClient {
             .api()
             .member_update(org_id, user_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -762,7 +788,7 @@ impl CloudClient {
             .api()
             .member_delete(org_id, user_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -778,7 +804,7 @@ impl CloudClient {
             .api()
             .invitation_get_list(org_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -791,7 +817,7 @@ impl CloudClient {
             .api()
             .invitation_create(org_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -804,7 +830,7 @@ impl CloudClient {
             .api()
             .invitation_get(org_id, invitation_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -817,7 +843,7 @@ impl CloudClient {
             .api()
             .invitation_delete(org_id, invitation_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -833,7 +859,7 @@ impl CloudClient {
             .api()
             .openapi_key_get_list(org_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -846,7 +872,7 @@ impl CloudClient {
             .api()
             .openapi_key_create(org_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -859,7 +885,7 @@ impl CloudClient {
             .api()
             .openapi_key_get(org_id, key_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -873,7 +899,7 @@ impl CloudClient {
             .api()
             .openapi_key_update(org_id, key_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -882,7 +908,7 @@ impl CloudClient {
             .api()
             .openapi_key_delete(org_id, key_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -900,7 +926,7 @@ impl CloudClient {
             .api()
             .activity_get_list(org_id, from_date, to_date)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -913,7 +939,7 @@ impl CloudClient {
             .api()
             .activity_get(org_id, activity_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -927,7 +953,7 @@ impl CloudClient {
             .api()
             .backup_configuration_get(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -941,7 +967,7 @@ impl CloudClient {
             .api()
             .backup_configuration_update(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -955,7 +981,7 @@ impl CloudClient {
             .api()
             .click_pipe_get_list(org_id, service_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -969,7 +995,7 @@ impl CloudClient {
             .api()
             .click_pipe_get(org_id, service_id, clickpipe_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -983,7 +1009,7 @@ impl CloudClient {
             .api()
             .click_pipe_create(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -997,7 +1023,7 @@ impl CloudClient {
             .api()
             .click_pipe_delete(org_id, service_id, clickpipe_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Ok(DeleteResponse {
             status: response.status,
             request_id: response.request_id,
@@ -1019,7 +1045,7 @@ impl CloudClient {
             .api()
             .click_pipe_state_update(org_id, service_id, clickpipe_id, &request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1034,7 +1060,7 @@ impl CloudClient {
             .api()
             .click_pipe_scaling_update(org_id, service_id, clickpipe_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1048,7 +1074,7 @@ impl CloudClient {
             .api()
             .click_pipe_settings_get(org_id, service_id, clickpipe_id)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1063,7 +1089,7 @@ impl CloudClient {
             .api()
             .click_pipe_settings_update(org_id, service_id, clickpipe_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1077,7 +1103,7 @@ impl CloudClient {
             .api()
             .click_pipe_schema_discovery(org_id, service_id, request)
             .await
-            .map_err(|e| self.convert_error(e))?;
+            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
     }
 
@@ -1287,6 +1313,34 @@ mod tests {
             message: "Internal Server Error".into(),
         });
         assert_eq!(err.kind, CloudErrorKind::Generic);
+    }
+
+    #[test]
+    fn convert_error_adds_organization_scope_to_bare_not_found() {
+        let err = test_client().convert_error_for_organization(
+            clickhouse_cloud_api::Error::Api {
+                status: 404,
+                message: "NOT_FOUND".into(),
+            },
+            "00000000-0000-4000-8000-000000000001",
+        );
+        assert_eq!(
+            err.message,
+            "NOT_FOUND: request scoped to organization 00000000-0000-4000-8000-000000000001"
+        );
+        assert_eq!(err.kind, CloudErrorKind::Generic);
+    }
+
+    #[test]
+    fn convert_error_preserves_detailed_not_found() {
+        let err = test_client().convert_error_for_organization(
+            clickhouse_cloud_api::Error::Api {
+                status: 404,
+                message: "Service svc-1 not found".into(),
+            },
+            "org-1",
+        );
+        assert_eq!(err.message, "Service svc-1 not found");
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -536,7 +536,7 @@ pub async fn postgres_list(
         .api()
         .postgres_service_get_list(&org_id)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let items = unwrap_api(resp)?;
     let filtered: Vec<PostgresServiceListItem> = items
         .into_iter()
@@ -606,7 +606,7 @@ pub async fn postgres_get(
         .api()
         .postgres_service_get(&org_id, postgres_id)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {
@@ -705,7 +705,7 @@ pub async fn postgres_create(
         .api()
         .postgres_service_create(&org_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {
@@ -755,7 +755,7 @@ pub async fn postgres_update(
             .api()
             .postgres_service_get(&org_id, postgres_id)
             .await
-            .map_err(|e| client.convert_error(e))?;
+            .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
         let current = unwrap_api(current)?;
         let add = parse_tags(opts.add_tag)?.unwrap_or_default();
         Some(merge_response_tags(current.tags, &add, opts.remove_tag)?)
@@ -774,7 +774,7 @@ pub async fn postgres_update(
         .api()
         .postgres_service_patch(&org_id, postgres_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {
@@ -798,7 +798,7 @@ pub async fn postgres_delete(
         .api()
         .postgres_service_delete(&org_id, postgres_id)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&resp)?);
@@ -820,7 +820,7 @@ pub async fn postgres_certs_get(
         .api()
         .postgres_service_certs_get(&org_id, postgres_id)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
 
     if let Some(path) = output {
         write_pem_file(path, &pem)?;
@@ -862,7 +862,7 @@ pub async fn postgres_config_get(
         .api()
         .postgres_instance_config_get(&org_id, postgres_id)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let cfg = unwrap_api(resp)?;
     // Config is a flat 20+ field object — always emit as JSON (pretty).
     println!("{}", serde_json::to_string_pretty(&cfg)?);
@@ -882,7 +882,7 @@ pub async fn postgres_config_replace(
         .api()
         .postgres_instance_config_post(&org_id, postgres_id, &cfg)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let out = unwrap_api(resp)?;
 
     if json {
@@ -926,7 +926,7 @@ pub async fn postgres_config_patch(
         .api()
         .postgres_instance_config_patch(&org_id, postgres_id, &cfg)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let out = unwrap_api(resp)?;
 
     if json {
@@ -967,7 +967,7 @@ pub async fn postgres_reset_password(
         .api()
         .postgres_service_set_password(&org_id, postgres_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let out = unwrap_api(resp)?;
     // Emit what the user now needs to use: the API echoes the password back, but
     // fall back to the one we sent if the response omits it.
@@ -1019,7 +1019,7 @@ pub async fn postgres_read_replica_create(
         .api()
         .postgres_instance_create_read_replica(&org_id, postgres_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {
@@ -1064,7 +1064,7 @@ pub async fn postgres_restore(
         .api()
         .postgres_instance_restore(&org_id, postgres_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {
@@ -1090,7 +1090,7 @@ pub async fn postgres_state_change(
         .api()
         .postgres_service_patch_state(&org_id, postgres_id, &req)
         .await
-        .map_err(|e| client.convert_error(e))?;
+        .map_err(|e| client.convert_error_for_organization(e, &org_id))?;
     let svc = unwrap_api(resp)?;
 
     if json {

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -170,7 +170,7 @@ async fn bind_query_endpoint(
         // Only a 404 means there is no endpoint yet, so this binding is the
         // first one and starts from an empty list.
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Vec::new(),
-        Err(e) => return Err(client.convert_error(e).into()),
+        Err(e) => return Err(client.convert_error_for_organization(e, org_id).into()),
     };
     if !open_api_keys.iter().any(|k| k == api_key_uuid) {
         open_api_keys.push(api_key_uuid.to_string());

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -191,6 +191,55 @@ fn write_project_api_credentials(root: &Path, key: &str, secret: &str) {
     .unwrap();
 }
 
+// ── Organization-scoped error context (issue #334) ─────────────────────────
+
+#[tokio::test]
+async fn service_list_bare_not_found_includes_the_requested_organization() {
+    const WRONG_ORG_ID: &str = "00000000-0000-4000-8000-000000000001";
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/organizations/{WRONG_ORG_ID}/services")))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "status": 404,
+            "error": "NOT_FOUND",
+            "requestId": "stub-wrong-org",
+        })))
+        .mount(&mock)
+        .await;
+
+    let output =
+        invoke_cli_with_cloud_credentials(&mock, &["service", "list", "--org-id", WRONG_ORG_ID]);
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!("Error: NOT_FOUND: request scoped to organization {WRONG_ORG_ID}\n")
+    );
+}
+
+#[tokio::test]
+async fn service_get_preserves_a_detailed_not_found_error() {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services/missing-service"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "status": 404,
+            "error": "Service missing-service was not found",
+            "requestId": "stub-missing-service",
+        })))
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &["service", "get", "missing-service", "--org-id", "org-1"],
+    );
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Service missing-service was not found\n"
+    );
+}
+
 // ── Credential precedence visibility (issue #336) ─────────────────────────
 
 #[tokio::test]
@@ -2141,6 +2190,80 @@ fn write_oauth_tokens(ch_dir: &std::path::Path, control_uri: &str) {
         serde_json::to_vec(&tokens).unwrap(),
     )
     .unwrap();
+}
+
+async fn invoke_oauth_service_query_error(body: &str) -> std::process::Output {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .respond_with(ResponseTemplate::new(400).set_body_string(body))
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
+    std::fs::create_dir_all(&ch_dir).unwrap();
+    write_oauth_tokens(&ch_dir, &control.uri());
+
+    let url = control.uri();
+    Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT broken FROM",
+        ])
+        .current_dir(dir.path())
+        .env("HOME", &home_dir)
+        .env_remove("CLICKHOUSE_CLOUD_API_KEY")
+        .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn service_query_renders_documented_sql_error() {
+    let output = invoke_oauth_service_query_error(
+        r#"{"error":{"code":"62","details":"Syntax error near FROM"}}"#,
+    )
+    .await;
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: SQL error 62: Syntax error near FROM\n"
+    );
+}
+
+#[tokio::test]
+async fn service_query_preserves_malformed_json_error_and_status() {
+    let body = r#"{"error":{"code":"62","details":"truncated"#;
+    let output = invoke_oauth_service_query_error(body).await;
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!("Error: Query API returned HTTP 400 Bad Request: {body}\n")
+    );
+}
+
+#[tokio::test]
+async fn service_query_preserves_non_json_error_and_status() {
+    let output = invoke_oauth_service_query_error("upstream proxy failed").await;
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Query API returned HTTP 400 Bad Request: upstream proxy failed\n"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Render documented Query API envelopes as `SQL error <code>: <details>`.
- Preserve HTTP status and raw response bodies for malformed, non-JSON, and alternate Query API errors.
- Add organization scope to bare `NOT_FOUND` errors while preserving detailed resource errors and existing error kinds/exit codes.

## Tests
- `cargo test -p clickhouse-cloud-api --test run_query_test`
- `cargo test -p clickhousectl -p clickhouse-cloud-api`
- `cargo clippy -p clickhousectl -p clickhouse-cloud-api --all-targets -- -D warnings`
- `cargo fmt --all --check`

Closes #334