### PR TITLE
Polish cloud command output

### DIFF
--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -844,7 +844,9 @@ CONTEXT FOR AGENTS:
   your cloud user with read-only access (SELECT only, no writes); no key
   provisioning and no query endpoint required on the service.
   SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
-  on a TTY, TabSeparated when piped.")]
+  on a TTY, TabSeparated when piped. --json selects JSONEachRow and cannot be
+  combined with --format; an explicit --format takes precedence over agent
+  auto-JSON.")]
     Query {
         /// Service name to query (exactly one of --name or --id is required)
         #[arg(long, conflicts_with = "id")]
@@ -867,7 +869,7 @@ CONTEXT FOR AGENTS:
         database: Option<String>,
 
         /// Response format (e.g. JSONEachRow, CSV, TabSeparated, PrettyCompact)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "json")]
         format: Option<String>,
 
         /// Organization ID (auto-detected if not specified)
@@ -2055,6 +2057,87 @@ mod tests {
     use super::*;
     use crate::cli::{Cli, Commands};
     use clap::Parser;
+
+    #[test]
+    fn parses_service_query_json_mode() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+            "--query",
+            "SELECT 1",
+            "--json",
+        ])
+        .unwrap();
+
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        assert!(args.json);
+        let CloudCommands::Service { command } = args.command else {
+            panic!("expected service command");
+        };
+        let ServiceCommands::Query { format, .. } = command else {
+            panic!("expected service query");
+        };
+        assert!(format.is_none());
+    }
+
+    #[test]
+    fn rejects_service_query_json_with_explicit_format() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+            "--query",
+            "SELECT 1",
+            "--json",
+            "--format",
+            "CSV",
+        ])
+        .err()
+        .expect("--json and --format should conflict");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        let rendered = error.to_string();
+        assert!(rendered.contains("--json"));
+        assert!(rendered.contains("--format"));
+    }
+
+    #[test]
+    fn parses_service_query_explicit_format_without_json() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+            "--query",
+            "SELECT 1",
+            "--format",
+            "CSV",
+        ])
+        .unwrap();
+
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        assert!(!args.json);
+        let CloudCommands::Service { command } = args.command else {
+            panic!("expected service command");
+        };
+        let ServiceCommands::Query { format, .. } = command else {
+            panic!("expected service query");
+        };
+        assert_eq!(format.as_deref(), Some("CSV"));
+    }
 
     #[test]
     fn parses_service_update_ga_patch_flags() {

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -2643,37 +2643,19 @@ fn query_output_completion(
         // still making successful no-output statements visible to the user.
         return QueryOutputCompletion::Acknowledge;
     }
-    if query_format_is_binary(format) || last_byte == Some(b'\n') {
-        QueryOutputCompletion::None
-    } else {
+    if query_format_uses_text_lines(format) && last_byte != Some(b'\n') {
         QueryOutputCompletion::Newline
+    } else {
+        QueryOutputCompletion::None
     }
 }
 
-fn query_format_is_binary(format: &str) -> bool {
+fn query_format_uses_text_lines(format: &str) -> bool {
+    // Preserve unknown and customizable formats byte-for-byte rather than
+    // guessing that anything not known to be binary is safe to normalize.
     matches!(
         format.to_ascii_lowercase().as_str(),
-        "arrow"
-            | "arrowstream"
-            | "avro"
-            | "avroconfluent"
-            | "bson"
-            | "capnproto"
-            | "messagepack"
-            | "msgpack"
-            | "native"
-            | "npy"
-            | "orc"
-            | "parquet"
-            | "parquetmetadata"
-            | "protobuf"
-            | "protobuflist"
-            | "protobufsingle"
-            | "rawblob"
-            | "rowbinary"
-            | "rowbinarywithdefaults"
-            | "rowbinarywithnames"
-            | "rowbinarywithnamesandtypes"
+        "jsoneachrow" | "prettycompact" | "tabseparated"
     )
 }
 
@@ -3616,10 +3598,12 @@ mod tests {
 
     #[test]
     fn query_output_completion_adds_only_a_missing_text_newline() {
-        assert_eq!(
-            query_output_completion("TabSeparated", 2, Some(b'K')),
-            QueryOutputCompletion::Newline
-        );
+        for format in ["TabSeparated", "PrettyCompact", "JSONEachRow"] {
+            assert_eq!(
+                query_output_completion(format, 2, Some(b'K')),
+                QueryOutputCompletion::Newline
+            );
+        }
         assert_eq!(
             query_output_completion("JSONEachRow", 2, Some(b'\n')),
             QueryOutputCompletion::None
@@ -3627,8 +3611,17 @@ mod tests {
     }
 
     #[test]
-    fn query_output_completion_never_changes_binary_bodies() {
-        for format in ["RowBinary", "Native", "Parquet", "ArrowStream", "MsgPack"] {
+    fn query_output_completion_preserves_exact_and_binary_bodies() {
+        for format in [
+            "Template",
+            "Buffers",
+            "BSONEachRow",
+            "RowBinary",
+            "Native",
+            "Parquet",
+            "ArrowStream",
+            "MsgPack",
+        ] {
             assert_eq!(
                 query_output_completion(format, 3, Some(0)),
                 QueryOutputCompletion::None,

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -974,6 +974,19 @@ fn classify_stop_poll_state(
     Ok(false)
 }
 
+#[derive(Default)]
+struct StopPollProgress {
+    previous_state: Option<String>,
+}
+
+impl StopPollProgress {
+    fn render(&mut self, state: &str, verbose: bool) -> Option<String> {
+        let changed = self.previous_state.as_deref() != Some(state);
+        self.previous_state = Some(state.to_string());
+        (verbose || changed).then(|| format!("  state: {state}"))
+    }
+}
+
 /// Replace the API's running-service conflict with the CLI remedy.
 ///
 /// Keep other conflicts intact: the API can reject deletion for reasons that
@@ -1077,10 +1090,16 @@ pub async fn service_delete(
                 .await?;
 
             // Poll until the service is stopped
+            let verbose_polling =
+                std::io::stderr().is_terminal() && !json && std::env::var_os("CI").is_none();
+            let mut progress = StopPollProgress::default();
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 let svc = client.get_service(&org_id, service_id).await?;
-                eprintln!("  state: {}", or_absent(svc.state.as_ref()));
+                let state = or_absent(svc.state.as_ref());
+                if let Some(line) = progress.render(&state, verbose_polling) {
+                    eprintln!("{line}");
+                }
                 if classify_stop_poll_state(svc.state.as_ref())? {
                     break;
                 }
@@ -2473,6 +2492,7 @@ pub struct ServiceQueryOptions {
     pub queries_file: Option<String>,
     pub database: Option<String>,
     pub format: Option<String>,
+    pub json: bool,
     pub org_id: Option<String>,
     pub no_auto_enable: bool,
 }
@@ -2498,7 +2518,15 @@ pub async fn service_query(
     };
     let service_name = or_absent(service.name.as_deref());
 
-    let format = opts.format.unwrap_or_else(default_query_format);
+    // An explicit format always wins over agent-triggered JSON mode. Clap
+    // rejects an explicit --json together with --format.
+    let format = opts.format.unwrap_or_else(|| {
+        if opts.json {
+            "JSONEachRow".to_string()
+        } else {
+            default_query_format()
+        }
+    });
 
     let response = if client.is_bearer_auth() {
         // OAuth: the Query API authenticates the user's bearer token
@@ -2577,14 +2605,76 @@ pub async fn service_query(
     let mut stream = response.bytes_stream();
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
+    let mut byte_count = 0;
+    let mut last_byte = None;
     while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| -> Box<dyn std::error::Error> {
             format!("Failed to read query response: {e}").into()
         })?;
         handle.write_all(&bytes)?;
+        byte_count += bytes.len();
+        if let Some(last) = bytes.last() {
+            last_byte = Some(*last);
+        }
+    }
+    match query_output_completion(&format, byte_count, last_byte) {
+        QueryOutputCompletion::None => {}
+        QueryOutputCompletion::Newline => handle.write_all(b"\n")?,
+        QueryOutputCompletion::Acknowledge => eprintln!("OK"),
     }
     handle.flush()?;
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum QueryOutputCompletion {
+    None,
+    Newline,
+    Acknowledge,
+}
+
+fn query_output_completion(
+    format: &str,
+    byte_count: usize,
+    last_byte: Option<u8>,
+) -> QueryOutputCompletion {
+    if byte_count == 0 {
+        // Keep an empty SELECT or DDL response out of the row stream while
+        // still making successful no-output statements visible to the user.
+        return QueryOutputCompletion::Acknowledge;
+    }
+    if query_format_is_binary(format) || last_byte == Some(b'\n') {
+        QueryOutputCompletion::None
+    } else {
+        QueryOutputCompletion::Newline
+    }
+}
+
+fn query_format_is_binary(format: &str) -> bool {
+    matches!(
+        format.to_ascii_lowercase().as_str(),
+        "arrow"
+            | "arrowstream"
+            | "avro"
+            | "avroconfluent"
+            | "bson"
+            | "capnproto"
+            | "messagepack"
+            | "msgpack"
+            | "native"
+            | "npy"
+            | "orc"
+            | "parquet"
+            | "parquetmetadata"
+            | "protobuf"
+            | "protobuflist"
+            | "protobufsingle"
+            | "rawblob"
+            | "rowbinary"
+            | "rowbinarywithdefaults"
+            | "rowbinarywithnames"
+            | "rowbinarywithnamesandtypes"
+    )
 }
 
 /// Stderr notice shown when the query host reports the service is idled and
@@ -2795,7 +2885,7 @@ pub async fn org_usage(
         let rows: Vec<Row> = costs
             .iter()
             .map(|cost| Row {
-                entity: or_absent(cost.entity_name.as_deref()),
+                entity: usage_entity_label(cost.entity_name.as_deref(), cost.entity_id),
                 date: or_absent(cost.date.as_deref()),
                 total: or_absent(cost.total_chc.map(|total| format!("{total:.2}"))),
             })
@@ -2803,6 +2893,14 @@ pub async fn org_usage(
         println!("{}", Table::new(rows).with(Style::markdown()));
     }
     Ok(())
+}
+
+fn usage_entity_label(name: Option<&str>, id: Option<uuid::Uuid>) -> String {
+    match (name.filter(|name| !name.is_empty()), id) {
+        (Some(name), _) => name.to_string(),
+        (None, Some(id)) => format!("{id} (unknown)"),
+        (None, None) => ABSENT.to_string(),
+    }
 }
 
 // =============================================================================
@@ -3477,6 +3575,84 @@ mod tests {
             err.to_string(),
             "service entered unexpected state 'deleted' while waiting for stop"
         );
+    }
+
+    #[test]
+    fn stop_poll_progress_collapses_repeats_but_keeps_transitions() {
+        let mut progress = StopPollProgress::default();
+        assert_eq!(
+            progress.render("stopping", false).as_deref(),
+            Some("  state: stopping")
+        );
+        assert_eq!(progress.render("stopping", false), None);
+        assert_eq!(
+            progress.render("running", false).as_deref(),
+            Some("  state: running")
+        );
+        assert_eq!(
+            progress.render("stopped", false).as_deref(),
+            Some("  state: stopped")
+        );
+    }
+
+    #[test]
+    fn stop_poll_progress_keeps_repeats_in_verbose_mode() {
+        let mut progress = StopPollProgress::default();
+        assert!(progress.render("stopping", true).is_some());
+        assert!(progress.render("stopping", true).is_some());
+    }
+
+    #[test]
+    fn query_output_completion_acknowledges_empty_responses() {
+        assert_eq!(
+            query_output_completion("TabSeparated", 0, None),
+            QueryOutputCompletion::Acknowledge
+        );
+        assert_eq!(
+            query_output_completion("RowBinary", 0, None),
+            QueryOutputCompletion::Acknowledge
+        );
+    }
+
+    #[test]
+    fn query_output_completion_adds_only_a_missing_text_newline() {
+        assert_eq!(
+            query_output_completion("TabSeparated", 2, Some(b'K')),
+            QueryOutputCompletion::Newline
+        );
+        assert_eq!(
+            query_output_completion("JSONEachRow", 2, Some(b'\n')),
+            QueryOutputCompletion::None
+        );
+    }
+
+    #[test]
+    fn query_output_completion_never_changes_binary_bodies() {
+        for format in ["RowBinary", "Native", "Parquet", "ArrowStream", "MsgPack"] {
+            assert_eq!(
+                query_output_completion(format, 3, Some(0)),
+                QueryOutputCompletion::None,
+                "{format} output must stay byte-for-byte intact"
+            );
+        }
+    }
+
+    #[test]
+    fn usage_entity_label_distinguishes_named_unknown_and_absent_entities() {
+        let id = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        assert_eq!(
+            usage_entity_label(Some("production"), Some(id)),
+            "production"
+        );
+        assert_eq!(
+            usage_entity_label(None, Some(id)),
+            "11111111-2222-3333-4444-555555555555 (unknown)"
+        );
+        assert_eq!(
+            usage_entity_label(Some(""), Some(id)),
+            format!("{id} (unknown)")
+        );
+        assert_eq!(usage_entity_label(None, None), ABSENT);
     }
 
     #[test]

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -876,6 +876,7 @@ async fn run_cloud(args: CloudArgs) -> Result<()> {
                     queries_file,
                     database,
                     format,
+                    json,
                     org_id,
                     no_auto_enable,
                 };

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -73,6 +73,22 @@ fn assert_success(output: &std::process::Output) {
     );
 }
 
+fn clear_agent_env(command: &mut Command) {
+    for name in [
+        "AGENT",
+        "AI_AGENT",
+        "OPENCODE",
+        "OPENCODE_PID",
+        "OPENCODE_BIN_PATH",
+        "OPENCODE_SERVER",
+        "OPENCODE_APP_INFO",
+        "OPENCODE_MODES",
+        "OPENCODE_CLIENT",
+    ] {
+        command.env_remove(name);
+    }
+}
+
 /// Run the clickhousectl binary against the mock, returning the JSON body
 /// the binary POSTed. Panics with the captured stderr if the binary exits
 /// non-zero — a failure here is almost always a clap-parsing error, which
@@ -575,6 +591,72 @@ async fn forced_service_delete_treats_an_absent_key_and_service_as_success() {
 }
 
 #[tokio::test]
+async fn forced_service_delete_reports_only_poll_state_transitions_when_redirected() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let mock = MockServer::start().await;
+    let states = ["running", "stopping", "stopping", "stopped"];
+    let request_index = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(move |_: &wiremock::Request| {
+            let index = request_index.fetch_add(1, Ordering::SeqCst);
+            let state = states[index.min(states.len() - 1)];
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": {
+                    "id": DELETE_TEST_SERVICE_ID,
+                    "name": "demo",
+                    "state": state,
+                },
+                "status": 200,
+                "requestId": format!("stub-service-get-{index}"),
+            }))
+        })
+        .expect(4)
+        .mount(&mock)
+        .await;
+    Mock::given(method("PATCH"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}/state"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "id": DELETE_TEST_SERVICE_ID,
+                "name": "demo",
+                "state": "stopping",
+            },
+            "status": 200,
+            "requestId": "stub-service-stop",
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-service-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let output = invoke_service_delete(&mock, dir.path(), true);
+    assert_success(&output);
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Stopping service {DELETE_TEST_SERVICE_ID} before deletion...\n  state: stopping\n  state: stopped\n"
+        )
+    );
+}
+
+#[tokio::test]
 async fn service_delete_cleanup_failure_preserves_credentials_for_retry() {
     let mock = MockServer::start().await;
     Mock::given(method("DELETE"))
@@ -884,6 +966,89 @@ async fn org_usage_accepts_legacy_positional_org_id() {
         requests[0].url.path(),
         format!("/v1/organizations/{AUTO_DETECTED_ORG_ID}/usageCost")
     );
+}
+
+async fn start_mock_usage_entities_api() -> MockServer {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/usageCost"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "grandTotalCHC": 3.0,
+                "costs": [
+                    {
+                        "entityId": "11111111-2222-3333-4444-555555555555",
+                        "entityName": "production",
+                        "date": "2025-01-01",
+                        "totalCHC": 1.0,
+                    },
+                    {
+                        "entityId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                        "date": "2025-01-01",
+                        "totalCHC": 2.0,
+                    },
+                ],
+            },
+            "status": 200,
+            "requestId": "stub-org-usage",
+        })))
+        .mount(&mock)
+        .await;
+    mock
+}
+
+fn invoke_org_usage(mock: &MockServer, json: bool) -> std::process::Output {
+    let dir = tempfile::tempdir().unwrap();
+    let url = mock.uri();
+    let mut args = vec!["cloud", "--url", &url];
+    if json {
+        args.push("--json");
+    }
+    args.extend([
+        "org",
+        "usage",
+        "--org-id",
+        "org-1",
+        "--from-date",
+        "2025-01-01",
+        "--to-date",
+        "2025-01-31",
+    ]);
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args(args)
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[tokio::test]
+async fn org_usage_marks_uuid_only_entities_as_unknown_in_human_output() {
+    let mock = start_mock_usage_entities_api().await;
+    let output = invoke_org_usage(&mock, false);
+    assert_success(&output);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("production"));
+    assert!(stdout.contains("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee (unknown)"));
+}
+
+#[tokio::test]
+async fn org_usage_json_keeps_uuid_only_entities_faithful_to_the_api() {
+    let mock = start_mock_usage_entities_api().await;
+    let output = invoke_org_usage(&mock, true);
+    assert_success(&output);
+
+    let usage: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let unknown = &usage["costs"][1];
+    assert_eq!(unknown["entityId"], "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    assert!(unknown.get("entityName").is_none());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("(unknown)"));
 }
 
 // ── Bug 1: Postgres CDC must NOT send publicationName / replicationSlotName ─
@@ -2070,6 +2235,147 @@ async fn start_mock_query_host() -> MockServer {
         .mount(&mock)
         .await;
     mock
+}
+
+async fn invoke_oauth_service_query_response(
+    body: Vec<u8>,
+    extra_args: &[&str],
+    agent: bool,
+) -> (std::process::Output, MockServer) {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+        .expect(1)
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    let ch_dir = home_dir.join(".clickhouse");
+    std::fs::create_dir_all(&ch_dir).unwrap();
+    write_oauth_tokens(&ch_dir, &control.uri());
+
+    let url = control.uri();
+    let mut args = vec![
+        "cloud".to_string(),
+        "--url".to_string(),
+        url,
+        "service".to_string(),
+        "query".to_string(),
+        "--id".to_string(),
+        QUERY_TEST_SERVICE_ID.to_string(),
+        "--org-id".to_string(),
+        "org-1".to_string(),
+        "--query".to_string(),
+        "SELECT 1".to_string(),
+    ];
+    args.extend(extra_args.iter().map(|arg| (*arg).to_string()));
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    if agent {
+        command.env("AGENT", "opencode");
+    }
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .args(args)
+        .current_dir(dir.path())
+        .env("HOME", &home_dir)
+        .env_remove("CLICKHOUSE_CLOUD_API_KEY")
+        .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    (output, query_host)
+}
+
+#[tokio::test]
+async fn service_query_completes_a_text_response_line_without_duplication() {
+    let (output, _) = invoke_oauth_service_query_response(b"OK".to_vec(), &[], false).await;
+    assert_success(&output);
+    assert_eq!(output.stdout, b"OK\n");
+
+    let (output, _) = invoke_oauth_service_query_response(b"1\n".to_vec(), &[], false).await;
+    assert_success(&output);
+    assert_eq!(output.stdout, b"1\n");
+}
+
+#[tokio::test]
+async fn service_query_acknowledges_an_empty_success_without_changing_stdout() {
+    let (output, _) = invoke_oauth_service_query_response(Vec::new(), &[], false).await;
+    assert_success(&output);
+    assert!(output.stdout.is_empty());
+    assert_eq!(output.stderr, b"OK\n");
+}
+
+#[tokio::test]
+async fn service_query_does_not_append_to_binary_output() {
+    let body = vec![0, 1, 2, 3];
+    let (output, _) =
+        invoke_oauth_service_query_response(body.clone(), &["--format", "RowBinary"], false).await;
+    assert_success(&output);
+    assert_eq!(output.stdout, body);
+}
+
+#[tokio::test]
+async fn service_query_json_selects_json_each_row_on_the_wire() {
+    let (output, query_host) = invoke_oauth_service_query_response(
+        br#"{"value":1}
+"#
+        .to_vec(),
+        &["--json"],
+        false,
+    )
+    .await;
+    assert_success(&output);
+
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests[0].url.query(), Some("format=JSONEachRow"));
+}
+
+#[tokio::test]
+async fn service_query_agent_json_uses_json_each_row_unless_format_is_explicit() {
+    let (output, query_host) =
+        invoke_oauth_service_query_response(b"1\n".to_vec(), &[], true).await;
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests[0].url.query(), Some("format=JSONEachRow"));
+
+    let (output, query_host) =
+        invoke_oauth_service_query_response(b"1\n".to_vec(), &["--format", "CSV"], true).await;
+    assert_success(&output);
+    let requests = query_host.received_requests().await.unwrap();
+    assert_eq!(requests[0].url.query(), Some("format=CSV"));
+}
+
+#[test]
+fn service_query_rejects_json_with_an_explicit_format_before_network_access() {
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .args([
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--query",
+            "SELECT 1",
+            "--json",
+            "--format",
+            "CSV",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--json"));
+    assert!(stderr.contains("--format"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #338

## Summary
- Complete text query output lines, acknowledge empty successes without contaminating row/binary stdout, and preserve binary response bytes.
- Map query JSON mode to `JSONEachRow`, reject explicit `--json` plus `--format`, and preserve explicit formats under agent auto-JSON.
- Collapse repeated forced-delete poll states outside interactive human terminals while retaining transitions and final/error visibility.
- Mark UUID-only usage entities as `(unknown)` in human tables while keeping JSON responses unchanged.

## Tests
- `cargo fmt --all --check`
- `cargo test -p clickhousectl -p clickhouse-cloud-api`
- `cargo clippy -p clickhousectl -p clickhouse-cloud-api --all-targets -- -D warnings`