### PR TITLE
Disable telemetry in repository CI

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -17,6 +17,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 concurrency:
   group: cloud-integration-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   fmt:
     name: cargo fmt --check

--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   check-drift:
     name: Check for OpenAPI spec drift

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   build:
     name: Build ${{ matrix.target }}
@@ -123,6 +126,7 @@ jobs:
       - name: Run smoke test in ${{ matrix.distro }}
         run: |
           docker run --rm \
+            -e DO_NOT_TRACK=1 \
             -v "${BIN_PATH}:/usr/local/bin/clickhousectl:ro" \
             ${{ matrix.distro }} \
             sh -c 'clickhousectl --version && clickhousectl --help'

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -11,6 +11,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   test:
     name: Test clickhousectl

--- a/.github/workflows/test-cloud-api.yml
+++ b/.github/workflows/test-cloud-api.yml
@@ -15,6 +15,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   test:
     name: Test clickhouse-cloud-api

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -12,6 +12,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   unit-tests:
     name: Unit Tests

--- a/.github/workflows/test-postgres-integration.yml
+++ b/.github/workflows/test-postgres-integration.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DO_NOT_TRACK: "1"
+
 jobs:
   integration:
     name: local postgres edge cases


### PR DESCRIPTION
Closes #373

## Summary
- Set `DO_NOT_TRACK=1` at workflow scope for every repository GitHub Actions workflow.
- Pass the opt-out explicitly into release smoke-test containers, which do not inherit host environment variables automatically.
- Preserve telemetry end-to-end coverage because the test harness explicitly removes inherited DNT and sends only to WireMock.

## Tests
- Parsed all eight workflow YAML files and verified each has workflow-level `DO_NOT_TRACK=1`.
- `DO_NOT_TRACK=1 cargo test -p clickhousectl --test telemetry_test`
- `git diff --check`