### PR TITLE
Extract organization, member, and invitation CLI domains

### DIFF
--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -2,7 +2,7 @@ pub use crate::cloud::activity::ActivityCommands;
 pub use crate::cloud::api_keys::KeyCommands;
 pub use crate::cloud::auth::AuthCommands;
 pub use crate::cloud::backups::{BackupCommands, BackupConfigCommands};
-use crate::cloud::shared::parse_date_only;
+pub use crate::cloud::organizations::{InvitationCommands, MemberCommands, OrgCommands};
 use clap::builder::PossibleValuesParser;
 use clap::{Args, Subcommand};
 
@@ -219,13 +219,7 @@ impl CloudCommands {
     pub fn is_write_command(&self) -> bool {
         match self {
             CloudCommands::Auth { command } => command.is_write(),
-            CloudCommands::Org { command } => match command {
-                OrgCommands::List => false,
-                OrgCommands::Get { .. } => false,
-                OrgCommands::Prometheus { .. } => false,
-                OrgCommands::Usage { .. } => false,
-                OrgCommands::Update { .. } => true,
-            },
+            CloudCommands::Org { command } => command.is_write(),
             CloudCommands::Service { command } => match command {
                 ServiceCommands::List { .. } => false,
                 ServiceCommands::Get { .. } => false,
@@ -250,18 +244,8 @@ impl CloudCommands {
                 ServiceCommands::BackupConfig { command } => command.is_write(),
             },
             CloudCommands::Backup { command } => command.is_write(),
-            CloudCommands::Member { command } => match command {
-                MemberCommands::List { .. } => false,
-                MemberCommands::Get { .. } => false,
-                MemberCommands::Update { .. } => true,
-                MemberCommands::Remove { .. } => true,
-            },
-            CloudCommands::Invitation { command } => match command {
-                InvitationCommands::List { .. } => false,
-                InvitationCommands::Get { .. } => false,
-                InvitationCommands::Create { .. } => true,
-                InvitationCommands::Delete { .. } => true,
-            },
+            CloudCommands::Member { command } => command.is_write(),
+            CloudCommands::Invitation { command } => command.is_write(),
             CloudCommands::Key { command } => command.is_write(),
             CloudCommands::Activity { command } => command.is_write(),
             CloudCommands::Postgres { command } => command.is_write(),
@@ -286,87 +270,6 @@ impl CloudCommands {
             },
         }
     }
-}
-
-#[derive(Subcommand)]
-pub enum OrgCommands {
-    /// List organizations
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Returns all organizations accessible with the current API credentials.
-  Use this to find org IDs needed by service and backup commands.
-  Add --json for machine-readable output.
-  Related: `clickhousectl cloud service list` next.")]
-    List,
-
-    /// Get organization details
-    #[command(after_help = "\
-CONTEXT FOR AGENTS:
-  Returns details for a single organization by ID.
-  Get org IDs from `clickhousectl cloud org list`.
-  Add --json for machine-readable output.
-  Related: `clickhousectl cloud org list` to find org IDs.")]
-    Get {
-        /// Organization ID
-        org_id: String,
-    },
-
-    /// Update organization settings
-    Update {
-        /// Organization ID
-        org_id: String,
-
-        /// New organization name
-        #[arg(long)]
-        name: Option<String>,
-
-        /// Remove a private endpoint from the organization allow list.
-        /// Format: id[,description=TEXT][,cloud-provider=aws|gcp|azure][,region=REGION]
-        #[arg(long = "remove-private-endpoint")]
-        remove_private_endpoint: Vec<String>,
-
-        /// Enable or disable core dump collection at the organization level
-        #[arg(long)]
-        enable_core_dumps: Option<bool>,
-    },
-
-    /// Get organization Prometheus configuration
-    Prometheus {
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-
-        /// Organization ID (deprecated positional form; use --org-id)
-        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
-        legacy_org_id: Option<String>,
-
-        /// Whether to request filtered metrics
-        #[arg(long)]
-        filtered_metrics: Option<bool>,
-    },
-
-    /// Get organization usage/billing information
-    Usage {
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-
-        /// Organization ID (deprecated positional form; use --org-id)
-        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
-        legacy_org_id: Option<String>,
-
-        /// Start date filter in UTC (YYYY-MM-DD, e.g. 2024-01-01)
-        #[arg(long, value_parser = parse_date_only)]
-        from_date: String,
-
-        /// End date filter in UTC (YYYY-MM-DD, e.g. 2024-01-31)
-        #[arg(long, value_parser = parse_date_only)]
-        to_date: String,
-
-        /// Filter by entity attributes
-        #[arg(long)]
-        filter: Vec<String>,
-    },
 }
 
 #[derive(Subcommand)]
@@ -1681,95 +1584,6 @@ pub struct BigQueryCreateArgs {
     pub org_id: Option<String>,
 }
 
-#[derive(Subcommand)]
-pub enum MemberCommands {
-    /// List organization members
-    List {
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Get member details
-    Get {
-        /// User ID
-        user_id: String,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Update member roles
-    Update {
-        /// User ID
-        user_id: String,
-
-        /// Role IDs to assign (can be specified multiple times)
-        #[arg(long)]
-        role_id: Vec<String>,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Remove a member from the organization
-    Remove {
-        /// User ID
-        user_id: String,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-}
-
-#[derive(Subcommand)]
-pub enum InvitationCommands {
-    /// List pending invitations
-    List {
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Create an invitation
-    Create {
-        /// Email address to invite
-        #[arg(long)]
-        email: String,
-
-        /// Role IDs to assign (can be specified multiple times)
-        #[arg(long)]
-        role_id: Vec<String>,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Get invitation details
-    Get {
-        /// Invitation ID
-        invitation_id: String,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-
-    /// Delete an invitation
-    Delete {
-        /// Invitation ID
-        invitation_id: String,
-
-        /// Organization ID (auto-detected if not specified)
-        #[arg(long)]
-        org_id: Option<String>,
-    },
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2431,213 +2245,6 @@ mod tests {
         assert_eq!(service_id, "svc-1");
     }
 
-    #[test]
-    fn parses_org_usage_date_only_flags() {
-        let cli = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "--from-date",
-            "2025-01-01",
-            "--to-date",
-            "2025-01-31",
-        ])
-        .unwrap();
-
-        let Commands::Cloud(args) = cli.command else {
-            panic!("expected cloud command");
-        };
-        let CloudCommands::Org { command } = args.command else {
-            panic!("expected org command");
-        };
-        let OrgCommands::Usage {
-            org_id,
-            legacy_org_id,
-            from_date,
-            to_date,
-            ..
-        } = command
-        else {
-            panic!("expected org usage");
-        };
-        assert_eq!(org_id, None);
-        assert_eq!(legacy_org_id, None);
-        assert_eq!(from_date, "2025-01-01");
-        assert_eq!(to_date, "2025-01-31");
-    }
-
-    #[test]
-    fn parses_org_prometheus_and_usage_org_id_flags() {
-        let prometheus = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "prometheus",
-            "--org-id",
-            "org-1",
-        ])
-        .unwrap();
-        let Commands::Cloud(args) = prometheus.command else {
-            panic!("expected cloud command");
-        };
-        let CloudCommands::Org { command } = args.command else {
-            panic!("expected org command");
-        };
-        let OrgCommands::Prometheus { org_id, .. } = command else {
-            panic!("expected org prometheus");
-        };
-        assert_eq!(org_id.as_deref(), Some("org-1"));
-
-        let usage = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "--org-id",
-            "org-1",
-            "--from-date",
-            "2025-01-01",
-            "--to-date",
-            "2025-01-31",
-        ])
-        .unwrap();
-        let Commands::Cloud(args) = usage.command else {
-            panic!("expected cloud command");
-        };
-        let CloudCommands::Org { command } = args.command else {
-            panic!("expected org command");
-        };
-        let OrgCommands::Usage { org_id, .. } = command else {
-            panic!("expected org usage");
-        };
-        assert_eq!(org_id.as_deref(), Some("org-1"));
-    }
-
-    #[test]
-    fn parses_legacy_org_id_positionals() {
-        let prometheus =
-            Cli::try_parse_from(["clickhousectl", "cloud", "org", "prometheus", "org-1"]).unwrap();
-        let Commands::Cloud(args) = prometheus.command else {
-            panic!("expected cloud command");
-        };
-        let CloudCommands::Org { command } = args.command else {
-            panic!("expected org command");
-        };
-        let OrgCommands::Prometheus {
-            org_id,
-            legacy_org_id,
-            ..
-        } = command
-        else {
-            panic!("expected org prometheus");
-        };
-        assert_eq!(org_id, None);
-        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
-
-        let usage = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "org-1",
-            "--from-date",
-            "2025-01-01",
-            "--to-date",
-            "2025-01-31",
-        ])
-        .unwrap();
-        let Commands::Cloud(args) = usage.command else {
-            panic!("expected cloud command");
-        };
-        let CloudCommands::Org { command } = args.command else {
-            panic!("expected org command");
-        };
-        let OrgCommands::Usage {
-            org_id,
-            legacy_org_id,
-            ..
-        } = command
-        else {
-            panic!("expected org usage");
-        };
-        assert_eq!(org_id, None);
-        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
-    }
-
-    #[test]
-    fn rejects_org_id_flag_with_legacy_positional() {
-        let prometheus = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "prometheus",
-            "org-1",
-            "--org-id",
-            "org-2",
-        ]);
-        match prometheus {
-            Ok(_) => panic!("expected conflicting org IDs to be rejected"),
-            Err(err) => assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict),
-        }
-
-        let usage = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "org-1",
-            "--org-id",
-            "org-2",
-            "--from-date",
-            "2025-01-01",
-            "--to-date",
-            "2025-01-31",
-        ]);
-        match usage {
-            Ok(_) => panic!("expected conflicting org IDs to be rejected"),
-            Err(err) => assert_eq!(err.kind(), clap::error::ErrorKind::ArgumentConflict),
-        }
-    }
-
-    #[test]
-    fn rejects_org_usage_timestamps() {
-        let result = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "--from-date",
-            "2025-01-01T00:00:00Z",
-            "--to-date",
-            "2025-01-31",
-        ]);
-
-        match result {
-            Ok(_) => panic!("expected timestamp input to be rejected"),
-            Err(err) => assert!(err.to_string().contains("expected YYYY-MM-DD")),
-        }
-    }
-
-    #[test]
-    fn rejects_invalid_org_usage_calendar_dates() {
-        let result = Cli::try_parse_from([
-            "clickhousectl",
-            "cloud",
-            "org",
-            "usage",
-            "--from-date",
-            "2025-02-31",
-            "--to-date",
-            "2025-03-01",
-        ]);
-
-        match result {
-            Ok(_) => panic!("expected invalid calendar date to be rejected"),
-            Err(err) => assert!(err.to_string().contains("expected YYYY-MM-DD")),
-        }
-    }
-
     /// Helper to assert a command parsed from CLI args is classified correctly.
     fn assert_write(args: &[&str], expected: bool) {
         let cli = Cli::try_parse_from(args).unwrap();
@@ -2654,24 +2261,6 @@ mod tests {
 
     #[test]
     fn is_write_command_read_only_commands() {
-        // Org reads
-        assert_write(&["clickhousectl", "cloud", "org", "list"], false);
-        assert_write(&["clickhousectl", "cloud", "org", "get", "org-1"], false);
-        assert_write(&["clickhousectl", "cloud", "org", "prometheus"], false);
-        assert_write(
-            &[
-                "clickhousectl",
-                "cloud",
-                "org",
-                "usage",
-                "--from-date",
-                "2025-01-01",
-                "--to-date",
-                "2025-01-31",
-            ],
-            false,
-        );
-
         // Service reads
         assert_write(&["clickhousectl", "cloud", "service", "list"], false);
         assert_write(
@@ -2703,17 +2292,6 @@ mod tests {
                 "get",
                 "svc-1",
             ],
-            false,
-        );
-
-        // Member reads
-        assert_write(&["clickhousectl", "cloud", "member", "list"], false);
-        assert_write(&["clickhousectl", "cloud", "member", "get", "usr-1"], false);
-
-        // Invitation reads
-        assert_write(&["clickhousectl", "cloud", "invitation", "list"], false);
-        assert_write(
-            &["clickhousectl", "cloud", "invitation", "get", "inv-1"],
             false,
         );
 
@@ -2799,20 +2377,6 @@ mod tests {
             true,
         );
 
-        // Org write
-        assert_write(
-            &[
-                "clickhousectl",
-                "cloud",
-                "org",
-                "update",
-                "org-1",
-                "--name",
-                "new",
-            ],
-            true,
-        );
-
         // Service writes
         assert_write(
             &[
@@ -2888,43 +2452,6 @@ mod tests {
                 "--backup-period-hours",
                 "12",
             ],
-            true,
-        );
-
-        // Member writes
-        assert_write(
-            &[
-                "clickhousectl",
-                "cloud",
-                "member",
-                "update",
-                "usr-1",
-                "--role-id",
-                "r1",
-            ],
-            true,
-        );
-        assert_write(
-            &["clickhousectl", "cloud", "member", "remove", "usr-1"],
-            true,
-        );
-
-        // Invitation writes
-        assert_write(
-            &[
-                "clickhousectl",
-                "cloud",
-                "invitation",
-                "create",
-                "--email",
-                "a@b.com",
-                "--role-id",
-                "r1",
-            ],
-            true,
-        );
-        assert_write(
-            &["clickhousectl", "cloud", "invitation", "delete", "inv-1"],
             true,
         );
 

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -450,30 +450,6 @@ impl CloudClient {
         }
     }
 
-    // Organization endpoints (delegated to library client)
-    pub async fn list_organizations(
-        &self,
-    ) -> Result<Vec<clickhouse_cloud_api::models::Organization>> {
-        let response = self
-            .api()
-            .organization_get_list()
-            .await
-            .map_err(|e| self.convert_error(e))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn get_organization(
-        &self,
-        org_id: &str,
-    ) -> Result<clickhouse_cloud_api::models::Organization> {
-        let response = self
-            .api()
-            .organization_get(org_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
     // Service endpoints (delegated to library client)
     pub async fn list_services(
         &self,
@@ -708,155 +684,6 @@ impl CloudClient {
             .map_err(|e| self.convert_error_for_organization(e, org_id))
     }
 
-    // Organization endpoints (delegated to library client)
-    pub async fn update_organization(
-        &self,
-        org_id: &str,
-        request: &clickhouse_cloud_api::models::OrganizationPatchRequest,
-    ) -> Result<clickhouse_cloud_api::models::Organization> {
-        let response = self
-            .api()
-            .organization_update(org_id, request)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn get_org_prometheus(
-        &self,
-        org_id: &str,
-        filtered_metrics: Option<bool>,
-    ) -> Result<String> {
-        let fm_str = filtered_metrics.map(|b| if b { "true" } else { "false" });
-        self.api()
-            .organization_prometheus_get(org_id, fm_str)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))
-    }
-
-    pub async fn get_org_usage(
-        &self,
-        org_id: &str,
-        from_date: &str,
-        to_date: &str,
-        filters: &[String],
-    ) -> Result<clickhouse_cloud_api::models::UsageCost> {
-        let filter_refs: Vec<&str> = filters.iter().map(|s| s.as_str()).collect();
-        let response = self
-            .api()
-            .usage_cost_get(org_id, from_date, to_date, &filter_refs)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    // Phase 4 - Member endpoints (delegated to library client)
-    pub async fn list_members(
-        &self,
-        org_id: &str,
-    ) -> Result<Vec<clickhouse_cloud_api::models::Member>> {
-        let response = self
-            .api()
-            .member_get_list(org_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn get_member(
-        &self,
-        org_id: &str,
-        user_id: &str,
-    ) -> Result<clickhouse_cloud_api::models::Member> {
-        let response = self
-            .api()
-            .member_get(org_id, user_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn update_member(
-        &self,
-        org_id: &str,
-        user_id: &str,
-        request: &clickhouse_cloud_api::models::MemberPatchRequest,
-    ) -> Result<clickhouse_cloud_api::models::Member> {
-        let response = self
-            .api()
-            .member_update(org_id, user_id, request)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn delete_member(&self, org_id: &str, user_id: &str) -> Result<DeleteResponse> {
-        let response = self
-            .api()
-            .member_delete(org_id, user_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Ok(DeleteResponse {
-            status: response.status,
-            request_id: response.request_id,
-        })
-    }
-
-    // Phase 4 - Invitation endpoints (delegated to library client)
-    pub async fn list_invitations(
-        &self,
-        org_id: &str,
-    ) -> Result<Vec<clickhouse_cloud_api::models::Invitation>> {
-        let response = self
-            .api()
-            .invitation_get_list(org_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn create_invitation(
-        &self,
-        org_id: &str,
-        request: &clickhouse_cloud_api::models::InvitationPostRequest,
-    ) -> Result<clickhouse_cloud_api::models::Invitation> {
-        let response = self
-            .api()
-            .invitation_create(org_id, request)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn get_invitation(
-        &self,
-        org_id: &str,
-        invitation_id: &str,
-    ) -> Result<clickhouse_cloud_api::models::Invitation> {
-        let response = self
-            .api()
-            .invitation_get(org_id, invitation_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Self::unwrap_response(response)
-    }
-
-    pub async fn delete_invitation(
-        &self,
-        org_id: &str,
-        invitation_id: &str,
-    ) -> Result<DeleteResponse> {
-        let response = self
-            .api()
-            .invitation_delete(org_id, invitation_id)
-            .await
-            .map_err(|e| self.convert_error_for_organization(e, org_id))?;
-        Ok(DeleteResponse {
-            status: response.status,
-            request_id: response.request_id,
-        })
-    }
-
     // ClickPipe endpoints (delegated to library client)
     pub async fn list_clickpipes(
         &self,
@@ -991,22 +818,6 @@ impl CloudClient {
             .await
             .map_err(|e| self.convert_error_for_organization(e, org_id))?;
         Self::unwrap_response(response)
-    }
-
-    // Helper to get the default organization
-    pub async fn get_default_org_id(&self) -> Result<String> {
-        let orgs = self.list_organizations().await?;
-        match orgs.len() {
-            0 => Err(CloudError::new("No organization found for this API key")),
-            1 => orgs[0]
-                .id
-                .map(|id| id.to_string())
-                .ok_or_else(|| CloudError::new("Organization response is missing its id")),
-            _ => Err(CloudError::new(
-                "Multiple organizations found. Specify --org-id to choose one. \
-                 Use `clickhousectl cloud org list` to see your organizations.",
-            )),
-        }
     }
 }
 

--- a/crates/clickhousectl/src/cloud/commands.rs
+++ b/crates/clickhousectl/src/cloud/commands.rs
@@ -5,9 +5,7 @@ use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use clickhouse_cloud_api::models::{
     AutoscalingMode, InstancePrivateEndpointsPatch, InstanceServiceQueryApiEndpointsPostRequest,
-    InstanceTagsPatch, IpAccessListEntry, IpAccessListPatch, OrganizationPatchPrivateEndpoint,
-    OrganizationPatchPrivateEndpointCloudprovider, OrganizationPatchPrivateEndpointRegion,
-    OrganizationPatchRequest, OrganizationPrivateEndpointsPatch, ServicPrivateEndpointePostRequest,
+    InstanceTagsPatch, IpAccessListEntry, IpAccessListPatch, ServicPrivateEndpointePostRequest,
     Service, ServiceEndpoint, ServiceEndpointChange, ServiceEndpointChangeProtocol,
     ServicePasswordPatchRequest, ServicePatchRequest, ServicePatchRequestReleasechannel,
     ServicePostRequest, ServicePostRequestCompliancetype, ServicePostRequestProfile,
@@ -16,18 +14,6 @@ use clickhouse_cloud_api::models::{
 };
 use std::io::IsTerminal;
 use tabled::{Table, Tabled, settings::Style};
-
-/// Comma-joins the rendered items of a response list.
-///
-/// An absent list renders as [`ABSENT`]; an absent field of an individual item
-/// renders as [`ABSENT`] inside the join, so a partially-returned list stays
-/// readable.
-fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String {
-    match items {
-        Some(items) => items.iter().map(render).collect::<Vec<_>>().join(", "),
-        None => ABSENT.to_string(),
-    }
-}
 
 /// `host:port` of a service's first endpoint, for list tables.
 ///
@@ -154,124 +140,6 @@ fn parse_instance_tags_patch(
     };
 
     Ok((!patch.add.is_empty() || !patch.remove.is_empty()).then_some(patch))
-}
-
-fn parse_org_private_endpoint_remove(
-    value: &str,
-) -> Result<OrganizationPatchPrivateEndpoint, Box<dyn std::error::Error>> {
-    let mut endpoint = OrganizationPatchPrivateEndpoint {
-        id: String::new(),
-        description: None,
-        cloud_provider: OrganizationPatchPrivateEndpointCloudprovider::default(),
-        region: OrganizationPatchPrivateEndpointRegion::default(),
-    };
-
-    for (index, part) in value.split(',').enumerate() {
-        let part = part.trim();
-        if part.is_empty() {
-            continue;
-        }
-
-        if index == 0 && !part.contains('=') {
-            endpoint.id = part.to_string();
-            continue;
-        }
-
-        let (key, raw_value) = part
-            .split_once('=')
-            .ok_or_else(|| format!("invalid remove-private-endpoint segment '{}'", part))?;
-
-        match key {
-            "id" => endpoint.id = raw_value.to_string(),
-            "description" => endpoint.description = Some(raw_value.to_string()),
-            "cloud-provider" => {
-                endpoint.cloud_provider =
-                    serde_json::from_value::<OrganizationPatchPrivateEndpointCloudprovider>(
-                        serde_json::Value::String(raw_value.to_string()),
-                    )
-                    .expect("enum with Unknown variant should always deserialize");
-            }
-            "region" => {
-                endpoint.region =
-                    serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
-                        serde_json::Value::String(raw_value.to_string()),
-                    )
-                    .expect("enum with Unknown variant should always deserialize");
-            }
-            _ => {
-                return Err(format!(
-                    "invalid remove-private-endpoint key '{}'; expected id, description, cloud-provider, or region",
-                    key
-                )
-                .into())
-            }
-        }
-    }
-
-    Ok(endpoint)
-}
-
-fn parse_org_private_endpoints_patch(
-    remove: &[String],
-) -> Result<Option<OrganizationPrivateEndpointsPatch>, Box<dyn std::error::Error>> {
-    if remove.is_empty() {
-        return Ok(None);
-    }
-
-    let endpoints = remove
-        .iter()
-        .map(|value| parse_org_private_endpoint_remove(value))
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(Some(OrganizationPrivateEndpointsPatch {
-        #[cfg(feature = "deprecated-fields")]
-        add: None,
-        remove: endpoints,
-    }))
-}
-
-pub async fn org_list(client: &CloudClient, json: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let orgs = client.list_organizations().await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&orgs)?);
-    } else {
-        if orgs.is_empty() {
-            println!("No organizations found");
-            return Ok(());
-        }
-        #[derive(Tabled)]
-        struct Row {
-            #[tabled(rename = "Name")]
-            name: String,
-            #[tabled(rename = "ID")]
-            id: String,
-        }
-        let rows: Vec<Row> = orgs
-            .into_iter()
-            .map(|o| Row {
-                name: or_absent(o.name.as_deref()),
-                id: or_absent(o.id),
-            })
-            .collect();
-        println!("{}", Table::new(rows).with(Style::markdown()));
-    }
-    Ok(())
-}
-
-pub async fn org_get(
-    client: &CloudClient,
-    org_id: &str,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org = client.get_organization(org_id).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&org)?);
-    } else {
-        print_human(&org)?;
-    }
-    Ok(())
 }
 
 pub async fn service_list(
@@ -406,13 +274,6 @@ pub struct QueryEndpointCreateOptions {
     pub open_api_keys: Vec<String>,
     pub allowed_origins: Option<String>,
     pub org_id: Option<String>,
-}
-
-#[derive(Default)]
-pub struct OrgUpdateOptions {
-    pub name: Option<String>,
-    pub remove_private_endpoints: Vec<String>,
-    pub enable_core_dumps: Option<bool>,
 }
 
 /// Resolved horizontal-autoscaling fields for a service create/scale request.
@@ -601,16 +462,6 @@ fn build_query_endpoint_create_request(
         open_api_keys: opts.open_api_keys.clone(),
         allowed_origins: opts.allowed_origins.clone().unwrap_or_default(),
     }
-}
-
-fn build_org_update_request(
-    opts: &OrgUpdateOptions,
-) -> Result<OrganizationPatchRequest, Box<dyn std::error::Error>> {
-    Ok(OrganizationPatchRequest {
-        name: opts.name.clone(),
-        private_endpoints: parse_org_private_endpoints_patch(&opts.remove_private_endpoints)?,
-        enable_core_dumps: opts.enable_core_dumps,
-    })
 }
 
 /// The post-create hint showing how to query the new service.
@@ -2422,44 +2273,6 @@ pub async fn private_endpoint_get_config(
     Ok(())
 }
 
-// =============================================================================
-// Phase 3 — Org command handlers
-// =============================================================================
-
-pub async fn org_update(
-    client: &CloudClient,
-    org_id: &str,
-    opts: OrgUpdateOptions,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let request = build_org_update_request(&opts)?;
-
-    let org = client.update_organization(org_id, &request).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&org)?);
-    } else {
-        println!(
-            "Organization updated: {} ({})",
-            or_absent(org.name.as_deref()),
-            or_absent(org.id)
-        );
-    }
-    Ok(())
-}
-
-pub async fn org_prometheus(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    filtered_metrics: Option<bool>,
-    _json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-    let prom = client.get_org_prometheus(&org_id, filtered_metrics).await?;
-    println!("{}", prom);
-    Ok(())
-}
-
 pub async fn service_prometheus(
     client: &CloudClient,
     service_id: &str,
@@ -2471,285 +2284,6 @@ pub async fn service_prometheus(
         .get_service_prometheus(&org_id, service_id, filtered_metrics)
         .await?;
     println!("{}", prom);
-    Ok(())
-}
-
-pub async fn org_usage(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    from_date: &str,
-    to_date: &str,
-    filters: &[String],
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-    let usage = client
-        .get_org_usage(&org_id, from_date, to_date, filters)
-        .await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&usage)?);
-    } else {
-        println!(
-            "Grand Total: {} CHC",
-            or_absent(usage.grand_total_chc.map(|total| format!("{total:.2}")))
-        );
-        let costs = usage.costs.unwrap_or_default();
-        if costs.is_empty() {
-            println!("No usage cost records found");
-            return Ok(());
-        }
-
-        #[derive(Tabled)]
-        struct Row {
-            #[tabled(rename = "Entity")]
-            entity: String,
-            #[tabled(rename = "Date")]
-            date: String,
-            #[tabled(rename = "Total (CHC)")]
-            total: String,
-        }
-        let rows: Vec<Row> = costs
-            .iter()
-            .map(|cost| Row {
-                entity: usage_entity_label(cost.entity_name.as_deref(), cost.entity_id),
-                date: or_absent(cost.date.as_deref()),
-                total: or_absent(cost.total_chc.map(|total| format!("{total:.2}"))),
-            })
-            .collect();
-        println!("{}", Table::new(rows).with(Style::markdown()));
-    }
-    Ok(())
-}
-
-fn usage_entity_label(name: Option<&str>, id: Option<uuid::Uuid>) -> String {
-    match (name.filter(|name| !name.is_empty()), id) {
-        (Some(name), _) => name.to_string(),
-        (None, Some(id)) => format!("{id} (unknown)"),
-        (None, None) => ABSENT.to_string(),
-    }
-}
-
-// =============================================================================
-// Phase 4 — Member command handlers
-// =============================================================================
-
-pub async fn member_list(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let members = client.list_members(&org_id).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&members)?);
-    } else {
-        if members.is_empty() {
-            println!("No members found");
-            return Ok(());
-        }
-        #[derive(Tabled)]
-        struct Row {
-            #[tabled(rename = "Email")]
-            email: String,
-            #[tabled(rename = "User ID")]
-            user_id: String,
-            #[tabled(rename = "Roles")]
-            roles: String,
-            #[tabled(rename = "Name")]
-            name: String,
-        }
-        let rows: Vec<Row> = members
-            .into_iter()
-            .map(|m| Row {
-                email: or_absent(m.email.as_deref()),
-                user_id: or_absent(m.user_id.as_deref()),
-                roles: join_absent(m.assigned_roles.as_deref(), |r| {
-                    or_absent(r.role_name.as_deref())
-                }),
-                name: or_absent(m.name.as_deref()),
-            })
-            .collect();
-        println!("{}", Table::new(rows).with(Style::markdown()));
-    }
-    Ok(())
-}
-
-pub async fn member_get(
-    client: &CloudClient,
-    user_id: &str,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let member = client.get_member(&org_id, user_id).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&member)?);
-    } else {
-        print_human(&member)?;
-    }
-    Ok(())
-}
-
-pub async fn member_update(
-    client: &CloudClient,
-    user_id: &str,
-    role_ids: &[String],
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let request = clickhouse_cloud_api::models::MemberPatchRequest {
-        assigned_role_ids: if role_ids.is_empty() {
-            None
-        } else {
-            Some(role_ids.to_vec())
-        },
-        #[cfg(feature = "deprecated-fields")]
-        role: None,
-    };
-
-    let member = client.update_member(&org_id, user_id, &request).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&member)?);
-    } else {
-        println!("Member {} updated", or_absent(member.email.as_deref()));
-    }
-    Ok(())
-}
-
-pub async fn member_remove(
-    client: &CloudClient,
-    user_id: &str,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let response = client.delete_member(&org_id, user_id).await?;
-    if json {
-        println!("{}", serde_json::to_string_pretty(&response)?);
-    } else {
-        println!("Member {} removed", user_id);
-    }
-    Ok(())
-}
-
-// =============================================================================
-// Phase 4 — Invitation command handlers
-// =============================================================================
-
-pub async fn invitation_list(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let invitations = client.list_invitations(&org_id).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&invitations)?);
-    } else {
-        if invitations.is_empty() {
-            println!("No invitations found");
-            return Ok(());
-        }
-        #[derive(Tabled)]
-        struct Row {
-            #[tabled(rename = "Email")]
-            email: String,
-            #[tabled(rename = "ID")]
-            id: String,
-            #[tabled(rename = "Roles")]
-            roles: String,
-            #[tabled(rename = "Expires")]
-            expires: String,
-        }
-        let rows: Vec<Row> = invitations
-            .into_iter()
-            .map(|inv| Row {
-                email: or_absent(inv.email.as_deref()),
-                id: or_absent(inv.id),
-                roles: join_absent(inv.assigned_roles.as_deref(), |r| {
-                    or_absent(r.role_name.as_deref())
-                }),
-                expires: or_absent(inv.expire_at.map(|at| at.to_rfc3339())),
-            })
-            .collect();
-        println!("{}", Table::new(rows).with(Style::markdown()));
-    }
-    Ok(())
-}
-
-pub async fn invitation_create(
-    client: &CloudClient,
-    email: &str,
-    role_ids: &[String],
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let request = clickhouse_cloud_api::models::InvitationPostRequest {
-        email: email.to_string(),
-        assigned_role_ids: role_ids.iter().map(|s| s.to_string()).collect(),
-        #[cfg(feature = "deprecated-fields")]
-        role: None,
-    };
-
-    let inv = client.create_invitation(&org_id, &request).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&inv)?);
-    } else {
-        println!(
-            "Invitation sent to {} ({})",
-            or_absent(inv.email.as_deref()),
-            or_absent(inv.id)
-        );
-    }
-    Ok(())
-}
-
-pub async fn invitation_get(
-    client: &CloudClient,
-    invitation_id: &str,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let inv = client.get_invitation(&org_id, invitation_id).await?;
-
-    if json {
-        println!("{}", serde_json::to_string_pretty(&inv)?);
-    } else {
-        print_human(&inv)?;
-    }
-    Ok(())
-}
-
-pub async fn invitation_delete(
-    client: &CloudClient,
-    invitation_id: &str,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let org_id = resolve_org_id(client, org_id).await?;
-
-    let response = client.delete_invitation(&org_id, invitation_id).await?;
-    if json {
-        println!("{}", serde_json::to_string_pretty(&response)?);
-    } else {
-        println!("Invitation {} deleted", invitation_id);
-    }
     Ok(())
 }
 
@@ -2968,24 +2502,6 @@ mod tests {
                 "{format} output must stay byte-for-byte intact"
             );
         }
-    }
-
-    #[test]
-    fn usage_entity_label_distinguishes_named_unknown_and_absent_entities() {
-        let id = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
-        assert_eq!(
-            usage_entity_label(Some("production"), Some(id)),
-            "production"
-        );
-        assert_eq!(
-            usage_entity_label(None, Some(id)),
-            "11111111-2222-3333-4444-555555555555 (unknown)"
-        );
-        assert_eq!(
-            usage_entity_label(Some(""), Some(id)),
-            format!("{id} (unknown)")
-        );
-        assert_eq!(usage_entity_label(None, None), ABSENT);
     }
 
     #[test]
@@ -3255,25 +2771,6 @@ mod tests {
             err.to_string(),
             "invalid tag ' =prod': tag key cannot be empty"
         );
-    }
-
-    #[test]
-    fn build_org_update_request_matches_tested_shape() {
-        let org_opts = OrgUpdateOptions {
-            name: Some("Updated Org".to_string()),
-            remove_private_endpoints: vec![
-                "pe-1,description=old,cloud-provider=aws,region=us-east-1".to_string(),
-            ],
-            enable_core_dumps: Some(false),
-        };
-        let org_request = build_org_update_request(&org_opts).unwrap();
-        let org_json = serde_json::to_value(&org_request).unwrap();
-        assert_eq!(org_json["privateEndpoints"]["remove"][0]["id"], "pe-1");
-        assert_eq!(
-            org_json["privateEndpoints"]["remove"][0]["cloudProvider"],
-            "aws"
-        );
-        assert_eq!(org_json["enableCoreDumps"], false);
     }
 
     // Regression tests: invalid enum values must be rejected by build_* functions

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -6,6 +6,7 @@ pub mod cli;
 pub mod client;
 pub mod commands;
 pub mod credentials;
+pub mod organizations;
 pub mod output;
 pub mod postgres;
 pub mod service_query;
@@ -23,8 +24,7 @@ pub use client::{
 use crate::error::{Error, Result};
 use cli::{
     ClickPipeCommands, ClickPipeCreateCommands, ClickPipeSettingsCommands, CloudArgs,
-    CloudCommands, InvitationCommands, MemberCommands, OrgCommands, PrivateEndpointCommands,
-    QueryEndpointCommands, ServiceCommands,
+    CloudCommands, PrivateEndpointCommands, QueryEndpointCommands, ServiceCommands,
 };
 
 /// Explain when a configured environment credential cannot participate in
@@ -127,41 +127,7 @@ async fn dispatch(
 ) -> std::result::Result<(), Box<dyn std::error::Error>> {
     match command {
         CloudCommands::Auth { .. } => unreachable!("handled above"),
-        CloudCommands::Org { command } => match command {
-            OrgCommands::List => commands::org_list(client, json).await,
-            OrgCommands::Get { org_id } => commands::org_get(client, &org_id, json).await,
-            OrgCommands::Update {
-                org_id,
-                name,
-                remove_private_endpoint,
-                enable_core_dumps,
-            } => {
-                let opts = commands::OrgUpdateOptions {
-                    name,
-                    remove_private_endpoints: remove_private_endpoint,
-                    enable_core_dumps,
-                };
-                commands::org_update(client, &org_id, opts, json).await
-            }
-            OrgCommands::Prometheus {
-                org_id,
-                legacy_org_id,
-                filtered_metrics,
-            } => {
-                let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
-                commands::org_prometheus(client, org_id, filtered_metrics, json).await
-            }
-            OrgCommands::Usage {
-                org_id,
-                legacy_org_id,
-                from_date,
-                to_date,
-                filter,
-            } => {
-                let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
-                commands::org_usage(client, org_id, &from_date, &to_date, &filter, json).await
-            }
-        },
+        CloudCommands::Org { command } => organizations::run_org(client, command, json).await,
         CloudCommands::Service { command } => match command {
             ServiceCommands::List { org_id, filter } => {
                 commands::service_list(client, org_id.as_deref(), &filter, json).await
@@ -409,42 +375,10 @@ async fn dispatch(
                 commands::service_query(client, opts).await
             }
         },
-        CloudCommands::Member { command } => match command {
-            MemberCommands::List { org_id } => {
-                commands::member_list(client, org_id.as_deref(), json).await
-            }
-            MemberCommands::Get { user_id, org_id } => {
-                commands::member_get(client, &user_id, org_id.as_deref(), json).await
-            }
-            MemberCommands::Update {
-                user_id,
-                role_id,
-                org_id,
-            } => commands::member_update(client, &user_id, &role_id, org_id.as_deref(), json).await,
-            MemberCommands::Remove { user_id, org_id } => {
-                commands::member_remove(client, &user_id, org_id.as_deref(), json).await
-            }
-        },
-        CloudCommands::Invitation { command } => match command {
-            InvitationCommands::List { org_id } => {
-                commands::invitation_list(client, org_id.as_deref(), json).await
-            }
-            InvitationCommands::Create {
-                email,
-                role_id,
-                org_id,
-            } => {
-                commands::invitation_create(client, &email, &role_id, org_id.as_deref(), json).await
-            }
-            InvitationCommands::Get {
-                invitation_id,
-                org_id,
-            } => commands::invitation_get(client, &invitation_id, org_id.as_deref(), json).await,
-            InvitationCommands::Delete {
-                invitation_id,
-                org_id,
-            } => commands::invitation_delete(client, &invitation_id, org_id.as_deref(), json).await,
-        },
+        CloudCommands::Member { command } => organizations::run_member(client, command, json).await,
+        CloudCommands::Invitation { command } => {
+            organizations::run_invitation(client, command, json).await
+        }
         CloudCommands::Key { command } => api_keys::run(client, command, json).await,
         CloudCommands::Activity { command } => activity::run(client, command, json).await,
         CloudCommands::Backup { command } => backups::run(client, command, json).await,

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -361,6 +361,14 @@ fn parse_org_private_endpoint_remove(
         }
     }
 
+    if endpoint.id.trim().is_empty() {
+        return Err(format!(
+            "remove-private-endpoint '{}' requires a non-empty id",
+            value
+        )
+        .into());
+    }
+
     Ok(endpoint)
 }
 
@@ -1265,5 +1273,16 @@ mod tests {
             "aws"
         );
         assert_eq!(json["enableCoreDumps"], false);
+    }
+
+    #[test]
+    fn parse_org_private_endpoint_remove_requires_non_empty_id() {
+        for value in ["", "description=old", "id="] {
+            let error = parse_org_private_endpoint_remove(value).unwrap_err();
+            assert!(
+                error.to_string().contains("requires a non-empty id"),
+                "unexpected error for {value:?}: {error}"
+            );
+        }
     }
 }

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,0 +1,1269 @@
+use crate::cloud::client::{CloudClient, CloudError};
+use crate::cloud::output::{ABSENT, or_absent, print_human};
+use crate::cloud::shared::{parse_date_only, resolve_org_id};
+use crate::cloud::types::DeleteResponse;
+use clap::Subcommand;
+use clickhouse_cloud_api::models::{
+    InvitationPostRequest, MemberPatchRequest, OrganizationPatchPrivateEndpoint,
+    OrganizationPatchPrivateEndpointCloudprovider, OrganizationPatchPrivateEndpointRegion,
+    OrganizationPatchRequest, OrganizationPrivateEndpointsPatch,
+};
+use tabled::{Table, Tabled, settings::Style};
+
+#[derive(Subcommand)]
+pub enum OrgCommands {
+    /// List organizations
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Returns all organizations accessible with the current API credentials.
+  Use this to find org IDs needed by service and backup commands.
+  Add --json for machine-readable output.
+  Related: `clickhousectl cloud service list` next.")]
+    List,
+
+    /// Get organization details
+    #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  Returns details for a single organization by ID.
+  Get org IDs from `clickhousectl cloud org list`.
+  Add --json for machine-readable output.
+  Related: `clickhousectl cloud org list` to find org IDs.")]
+    Get {
+        /// Organization ID
+        org_id: String,
+    },
+
+    /// Update organization settings
+    Update {
+        /// Organization ID
+        org_id: String,
+
+        /// New organization name
+        #[arg(long)]
+        name: Option<String>,
+
+        /// Remove a private endpoint from the organization allow list.
+        /// Format: id[,description=TEXT][,cloud-provider=aws|gcp|azure][,region=REGION]
+        #[arg(long = "remove-private-endpoint")]
+        remove_private_endpoint: Vec<String>,
+
+        /// Enable or disable core dump collection at the organization level
+        #[arg(long)]
+        enable_core_dumps: Option<bool>,
+    },
+
+    /// Get organization Prometheus configuration
+    Prometheus {
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+
+        /// Organization ID (deprecated positional form; use --org-id)
+        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
+        legacy_org_id: Option<String>,
+
+        /// Whether to request filtered metrics
+        #[arg(long)]
+        filtered_metrics: Option<bool>,
+    },
+
+    /// Get organization usage/billing information
+    Usage {
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+
+        /// Organization ID (deprecated positional form; use --org-id)
+        #[arg(value_name = "ORG_ID", hide = true, conflicts_with = "org_id")]
+        legacy_org_id: Option<String>,
+
+        /// Start date filter in UTC (YYYY-MM-DD, e.g. 2024-01-01)
+        #[arg(long, value_parser = parse_date_only)]
+        from_date: String,
+
+        /// End date filter in UTC (YYYY-MM-DD, e.g. 2024-01-31)
+        #[arg(long, value_parser = parse_date_only)]
+        to_date: String,
+
+        /// Filter by entity attributes
+        #[arg(long)]
+        filter: Vec<String>,
+    },
+}
+
+impl OrgCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            OrgCommands::List => false,
+            OrgCommands::Get { .. } => false,
+            OrgCommands::Prometheus { .. } => false,
+            OrgCommands::Usage { .. } => false,
+            OrgCommands::Update { .. } => true,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum MemberCommands {
+    /// List organization members
+    List {
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Get member details
+    Get {
+        /// User ID
+        user_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Update member roles
+    Update {
+        /// User ID
+        user_id: String,
+
+        /// Role IDs to assign (can be specified multiple times)
+        #[arg(long)]
+        role_id: Vec<String>,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Remove a member from the organization
+    Remove {
+        /// User ID
+        user_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl MemberCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            MemberCommands::List { .. } => false,
+            MemberCommands::Get { .. } => false,
+            MemberCommands::Update { .. } => true,
+            MemberCommands::Remove { .. } => true,
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum InvitationCommands {
+    /// List pending invitations
+    List {
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Create an invitation
+    Create {
+        /// Email address to invite
+        #[arg(long)]
+        email: String,
+
+        /// Role IDs to assign (can be specified multiple times)
+        #[arg(long)]
+        role_id: Vec<String>,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Get invitation details
+    Get {
+        /// Invitation ID
+        invitation_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+
+    /// Delete an invitation
+    Delete {
+        /// Invitation ID
+        invitation_id: String,
+
+        /// Organization ID (auto-detected if not specified)
+        #[arg(long)]
+        org_id: Option<String>,
+    },
+}
+
+impl InvitationCommands {
+    pub fn is_write(&self) -> bool {
+        match self {
+            InvitationCommands::List { .. } => false,
+            InvitationCommands::Get { .. } => false,
+            InvitationCommands::Create { .. } => true,
+            InvitationCommands::Delete { .. } => true,
+        }
+    }
+}
+
+pub async fn run_org(
+    client: &CloudClient,
+    command: OrgCommands,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        OrgCommands::List => org_list(client, json).await,
+        OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
+        OrgCommands::Update {
+            org_id,
+            name,
+            remove_private_endpoint,
+            enable_core_dumps,
+        } => {
+            let options = OrgUpdateOptions {
+                name,
+                remove_private_endpoints: remove_private_endpoint,
+                enable_core_dumps,
+            };
+            org_update(client, &org_id, options, json).await
+        }
+        OrgCommands::Prometheus {
+            org_id,
+            legacy_org_id,
+            filtered_metrics,
+        } => {
+            let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
+            org_prometheus(client, org_id, filtered_metrics, json).await
+        }
+        OrgCommands::Usage {
+            org_id,
+            legacy_org_id,
+            from_date,
+            to_date,
+            filter,
+        } => {
+            let org_id = org_id.as_deref().or(legacy_org_id.as_deref());
+            org_usage(client, org_id, &from_date, &to_date, &filter, json).await
+        }
+    }
+}
+
+pub async fn run_member(
+    client: &CloudClient,
+    command: MemberCommands,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        MemberCommands::List { org_id } => member_list(client, org_id.as_deref(), json).await,
+        MemberCommands::Get { user_id, org_id } => {
+            member_get(client, &user_id, org_id.as_deref(), json).await
+        }
+        MemberCommands::Update {
+            user_id,
+            role_id,
+            org_id,
+        } => member_update(client, &user_id, &role_id, org_id.as_deref(), json).await,
+        MemberCommands::Remove { user_id, org_id } => {
+            member_remove(client, &user_id, org_id.as_deref(), json).await
+        }
+    }
+}
+
+pub async fn run_invitation(
+    client: &CloudClient,
+    command: InvitationCommands,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match command {
+        InvitationCommands::List { org_id } => {
+            invitation_list(client, org_id.as_deref(), json).await
+        }
+        InvitationCommands::Create {
+            email,
+            role_id,
+            org_id,
+        } => invitation_create(client, &email, &role_id, org_id.as_deref(), json).await,
+        InvitationCommands::Get {
+            invitation_id,
+            org_id,
+        } => invitation_get(client, &invitation_id, org_id.as_deref(), json).await,
+        InvitationCommands::Delete {
+            invitation_id,
+            org_id,
+        } => invitation_delete(client, &invitation_id, org_id.as_deref(), json).await,
+    }
+}
+
+#[derive(Default)]
+struct OrgUpdateOptions {
+    name: Option<String>,
+    remove_private_endpoints: Vec<String>,
+    enable_core_dumps: Option<bool>,
+}
+
+fn parse_org_private_endpoint_remove(
+    value: &str,
+) -> Result<OrganizationPatchPrivateEndpoint, Box<dyn std::error::Error>> {
+    let mut endpoint = OrganizationPatchPrivateEndpoint {
+        id: String::new(),
+        description: None,
+        cloud_provider: OrganizationPatchPrivateEndpointCloudprovider::default(),
+        region: OrganizationPatchPrivateEndpointRegion::default(),
+    };
+
+    for (index, part) in value.split(',').enumerate() {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+
+        if index == 0 && !part.contains('=') {
+            endpoint.id = part.to_string();
+            continue;
+        }
+
+        let (key, raw_value) = part
+            .split_once('=')
+            .ok_or_else(|| format!("invalid remove-private-endpoint segment '{}'", part))?;
+
+        match key {
+            "id" => endpoint.id = raw_value.to_string(),
+            "description" => endpoint.description = Some(raw_value.to_string()),
+            "cloud-provider" => {
+                endpoint.cloud_provider =
+                    serde_json::from_value::<OrganizationPatchPrivateEndpointCloudprovider>(
+                        serde_json::Value::String(raw_value.to_string()),
+                    )
+                    .expect("enum with Unknown variant should always deserialize");
+            }
+            "region" => {
+                endpoint.region =
+                    serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
+                        serde_json::Value::String(raw_value.to_string()),
+                    )
+                    .expect("enum with Unknown variant should always deserialize");
+            }
+            _ => {
+                return Err(format!(
+                    "invalid remove-private-endpoint key '{}'; expected id, description, cloud-provider, or region",
+                    key
+                )
+                .into())
+            }
+        }
+    }
+
+    Ok(endpoint)
+}
+
+fn parse_org_private_endpoints_patch(
+    remove: &[String],
+) -> Result<Option<OrganizationPrivateEndpointsPatch>, Box<dyn std::error::Error>> {
+    if remove.is_empty() {
+        return Ok(None);
+    }
+
+    let endpoints = remove
+        .iter()
+        .map(|value| parse_org_private_endpoint_remove(value))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(Some(OrganizationPrivateEndpointsPatch {
+        #[cfg(feature = "deprecated-fields")]
+        add: None,
+        remove: endpoints,
+    }))
+}
+
+fn build_org_update_request(
+    options: &OrgUpdateOptions,
+) -> Result<OrganizationPatchRequest, Box<dyn std::error::Error>> {
+    Ok(OrganizationPatchRequest {
+        name: options.name.clone(),
+        private_endpoints: parse_org_private_endpoints_patch(&options.remove_private_endpoints)?,
+        enable_core_dumps: options.enable_core_dumps,
+    })
+}
+
+fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String {
+    match items {
+        Some(items) => items.iter().map(render).collect::<Vec<_>>().join(", "),
+        None => ABSENT.to_string(),
+    }
+}
+
+async fn org_list(client: &CloudClient, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let orgs = client.list_organizations().await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&orgs)?);
+    } else {
+        if orgs.is_empty() {
+            println!("No organizations found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Name")]
+            name: String,
+            #[tabled(rename = "ID")]
+            id: String,
+        }
+        let rows: Vec<Row> = orgs
+            .into_iter()
+            .map(|organization| Row {
+                name: or_absent(organization.name.as_deref()),
+                id: or_absent(organization.id),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn org_get(
+    client: &CloudClient,
+    org_id: &str,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let organization = client.get_organization(org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&organization)?);
+    } else {
+        print_human(&organization)?;
+    }
+    Ok(())
+}
+
+async fn org_update(
+    client: &CloudClient,
+    org_id: &str,
+    options: OrgUpdateOptions,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let request = build_org_update_request(&options)?;
+    let organization = client.update_organization(org_id, &request).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&organization)?);
+    } else {
+        println!(
+            "Organization updated: {} ({})",
+            or_absent(organization.name.as_deref()),
+            or_absent(organization.id)
+        );
+    }
+    Ok(())
+}
+
+async fn org_prometheus(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    filtered_metrics: Option<bool>,
+    _json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let prometheus = client.get_org_prometheus(&org_id, filtered_metrics).await?;
+    println!("{}", prometheus);
+    Ok(())
+}
+
+async fn org_usage(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    from_date: &str,
+    to_date: &str,
+    filters: &[String],
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let usage = client
+        .get_org_usage(&org_id, from_date, to_date, filters)
+        .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&usage)?);
+    } else {
+        println!(
+            "Grand Total: {} CHC",
+            or_absent(usage.grand_total_chc.map(|total| format!("{total:.2}")))
+        );
+        let costs = usage.costs.unwrap_or_default();
+        if costs.is_empty() {
+            println!("No usage cost records found");
+            return Ok(());
+        }
+
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Entity")]
+            entity: String,
+            #[tabled(rename = "Date")]
+            date: String,
+            #[tabled(rename = "Total (CHC)")]
+            total: String,
+        }
+        let rows: Vec<Row> = costs
+            .iter()
+            .map(|cost| Row {
+                entity: usage_entity_label(cost.entity_name.as_deref(), cost.entity_id),
+                date: or_absent(cost.date.as_deref()),
+                total: or_absent(cost.total_chc.map(|total| format!("{total:.2}"))),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+fn usage_entity_label(name: Option<&str>, id: Option<uuid::Uuid>) -> String {
+    match (name.filter(|name| !name.is_empty()), id) {
+        (Some(name), _) => name.to_string(),
+        (None, Some(id)) => format!("{id} (unknown)"),
+        (None, None) => ABSENT.to_string(),
+    }
+}
+
+async fn member_list(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let members = client.list_members(&org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&members)?);
+    } else {
+        if members.is_empty() {
+            println!("No members found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Email")]
+            email: String,
+            #[tabled(rename = "User ID")]
+            user_id: String,
+            #[tabled(rename = "Roles")]
+            roles: String,
+            #[tabled(rename = "Name")]
+            name: String,
+        }
+        let rows: Vec<Row> = members
+            .into_iter()
+            .map(|member| Row {
+                email: or_absent(member.email.as_deref()),
+                user_id: or_absent(member.user_id.as_deref()),
+                roles: join_absent(member.assigned_roles.as_deref(), |role| {
+                    or_absent(role.role_name.as_deref())
+                }),
+                name: or_absent(member.name.as_deref()),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn member_get(
+    client: &CloudClient,
+    user_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let member = client.get_member(&org_id, user_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&member)?);
+    } else {
+        print_human(&member)?;
+    }
+    Ok(())
+}
+
+async fn member_update(
+    client: &CloudClient,
+    user_id: &str,
+    role_ids: &[String],
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let request = MemberPatchRequest {
+        assigned_role_ids: if role_ids.is_empty() {
+            None
+        } else {
+            Some(role_ids.to_vec())
+        },
+        #[cfg(feature = "deprecated-fields")]
+        role: None,
+    };
+    let member = client.update_member(&org_id, user_id, &request).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&member)?);
+    } else {
+        println!("Member {} updated", or_absent(member.email.as_deref()));
+    }
+    Ok(())
+}
+
+async fn member_remove(
+    client: &CloudClient,
+    user_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_member(&org_id, user_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Member {} removed", user_id);
+    }
+    Ok(())
+}
+
+async fn invitation_list(
+    client: &CloudClient,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let invitations = client.list_invitations(&org_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&invitations)?);
+    } else {
+        if invitations.is_empty() {
+            println!("No invitations found");
+            return Ok(());
+        }
+        #[derive(Tabled)]
+        struct Row {
+            #[tabled(rename = "Email")]
+            email: String,
+            #[tabled(rename = "ID")]
+            id: String,
+            #[tabled(rename = "Roles")]
+            roles: String,
+            #[tabled(rename = "Expires")]
+            expires: String,
+        }
+        let rows: Vec<Row> = invitations
+            .into_iter()
+            .map(|invitation| Row {
+                email: or_absent(invitation.email.as_deref()),
+                id: or_absent(invitation.id),
+                roles: join_absent(invitation.assigned_roles.as_deref(), |role| {
+                    or_absent(role.role_name.as_deref())
+                }),
+                expires: or_absent(invitation.expire_at.map(|at| at.to_rfc3339())),
+            })
+            .collect();
+        println!("{}", Table::new(rows).with(Style::markdown()));
+    }
+    Ok(())
+}
+
+async fn invitation_create(
+    client: &CloudClient,
+    email: &str,
+    role_ids: &[String],
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let request = InvitationPostRequest {
+        email: email.to_string(),
+        assigned_role_ids: role_ids.to_vec(),
+        #[cfg(feature = "deprecated-fields")]
+        role: None,
+    };
+    let invitation = client.create_invitation(&org_id, &request).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&invitation)?);
+    } else {
+        println!(
+            "Invitation sent to {} ({})",
+            or_absent(invitation.email.as_deref()),
+            or_absent(invitation.id)
+        );
+    }
+    Ok(())
+}
+
+async fn invitation_get(
+    client: &CloudClient,
+    invitation_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let invitation = client.get_invitation(&org_id, invitation_id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&invitation)?);
+    } else {
+        print_human(&invitation)?;
+    }
+    Ok(())
+}
+
+async fn invitation_delete(
+    client: &CloudClient,
+    invitation_id: &str,
+    org_id: Option<&str>,
+    json: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let org_id = resolve_org_id(client, org_id).await?;
+    let response = client.delete_invitation(&org_id, invitation_id).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("Invitation {} deleted", invitation_id);
+    }
+    Ok(())
+}
+
+impl CloudClient {
+    pub async fn list_organizations(
+        &self,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::Organization>> {
+        let response = self
+            .api()
+            .organization_get_list()
+            .await
+            .map_err(|error| self.convert_error(error))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_organization(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Organization> {
+        let response = self
+            .api()
+            .organization_get(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_organization(
+        &self,
+        org_id: &str,
+        request: &OrganizationPatchRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Organization> {
+        let response = self
+            .api()
+            .organization_update(org_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_org_prometheus(
+        &self,
+        org_id: &str,
+        filtered_metrics: Option<bool>,
+    ) -> crate::cloud::client::Result<String> {
+        let filtered_metrics = filtered_metrics.map(|value| if value { "true" } else { "false" });
+        self.api()
+            .organization_prometheus_get(org_id, filtered_metrics)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))
+    }
+
+    pub async fn get_org_usage(
+        &self,
+        org_id: &str,
+        from_date: &str,
+        to_date: &str,
+        filters: &[String],
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::UsageCost> {
+        let filters: Vec<&str> = filters.iter().map(String::as_str).collect();
+        let response = self
+            .api()
+            .usage_cost_get(org_id, from_date, to_date, &filters)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn list_members(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::Member>> {
+        let response = self
+            .api()
+            .member_get_list(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_member(
+        &self,
+        org_id: &str,
+        user_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Member> {
+        let response = self
+            .api()
+            .member_get(org_id, user_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn update_member(
+        &self,
+        org_id: &str,
+        user_id: &str,
+        request: &MemberPatchRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Member> {
+        let response = self
+            .api()
+            .member_update(org_id, user_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_member(
+        &self,
+        org_id: &str,
+        user_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .member_delete(org_id, user_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
+    pub async fn list_invitations(
+        &self,
+        org_id: &str,
+    ) -> crate::cloud::client::Result<Vec<clickhouse_cloud_api::models::Invitation>> {
+        let response = self
+            .api()
+            .invitation_get_list(org_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn create_invitation(
+        &self,
+        org_id: &str,
+        request: &InvitationPostRequest,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Invitation> {
+        let response = self
+            .api()
+            .invitation_create(org_id, request)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn get_invitation(
+        &self,
+        org_id: &str,
+        invitation_id: &str,
+    ) -> crate::cloud::client::Result<clickhouse_cloud_api::models::Invitation> {
+        let response = self
+            .api()
+            .invitation_get(org_id, invitation_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Self::unwrap_response(response)
+    }
+
+    pub async fn delete_invitation(
+        &self,
+        org_id: &str,
+        invitation_id: &str,
+    ) -> crate::cloud::client::Result<DeleteResponse> {
+        let response = self
+            .api()
+            .invitation_delete(org_id, invitation_id)
+            .await
+            .map_err(|error| self.convert_error_for_organization(error, org_id))?;
+        Ok(DeleteResponse {
+            status: response.status,
+            request_id: response.request_id,
+        })
+    }
+
+    pub async fn get_default_org_id(&self) -> crate::cloud::client::Result<String> {
+        let organizations = self.list_organizations().await?;
+        match organizations.len() {
+            0 => Err(CloudError::new("No organization found for this API key")),
+            1 => organizations[0]
+                .id
+                .map(|id| id.to_string())
+                .ok_or_else(|| CloudError::new("Organization response is missing its id")),
+            _ => Err(CloudError::new(
+                "Multiple organizations found. Specify --org-id to choose one. \
+                 Use `clickhousectl cloud org list` to see your organizations.",
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{Cli, Commands};
+    use crate::cloud::cli::CloudCommands;
+    use clap::Parser;
+
+    fn assert_write(args: &[&str], expected: bool) {
+        let cli = Cli::try_parse_from(args).expect("parse");
+        let Commands::Cloud(cloud_args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let command = cloud_args.command;
+        assert!(matches!(
+            &command,
+            CloudCommands::Org { .. }
+                | CloudCommands::Member { .. }
+                | CloudCommands::Invitation { .. }
+        ));
+        assert_eq!(
+            command.is_write_command(),
+            expected,
+            "wrong classification for: {}",
+            args.join(" ")
+        );
+    }
+
+    #[test]
+    fn parses_org_usage_date_only_flags() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ])
+        .unwrap();
+
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Usage {
+            org_id,
+            legacy_org_id,
+            from_date,
+            to_date,
+            ..
+        } = command
+        else {
+            panic!("expected org usage");
+        };
+        assert_eq!(org_id, None);
+        assert_eq!(legacy_org_id, None);
+        assert_eq!(from_date, "2025-01-01");
+        assert_eq!(to_date, "2025-01-31");
+    }
+
+    #[test]
+    fn parses_org_prometheus_and_usage_org_id_flags() {
+        let prometheus = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "prometheus",
+            "--org-id",
+            "org-1",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = prometheus.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Prometheus { org_id, .. } = command else {
+            panic!("expected org prometheus");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let usage = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "--org-id",
+            "org-1",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = usage.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Usage { org_id, .. } = command else {
+            panic!("expected org usage");
+        };
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_legacy_org_id_positionals() {
+        let prometheus =
+            Cli::try_parse_from(["clickhousectl", "cloud", "org", "prometheus", "org-1"]).unwrap();
+        let Commands::Cloud(args) = prometheus.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Prometheus {
+            org_id,
+            legacy_org_id,
+            ..
+        } = command
+        else {
+            panic!("expected org prometheus");
+        };
+        assert_eq!(org_id, None);
+        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
+
+        let usage = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "org-1",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = usage.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Org { command } = args.command else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Usage {
+            org_id,
+            legacy_org_id,
+            ..
+        } = command
+        else {
+            panic!("expected org usage");
+        };
+        assert_eq!(org_id, None);
+        assert_eq!(legacy_org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn rejects_org_id_flag_with_legacy_positional() {
+        let prometheus = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "prometheus",
+            "org-1",
+            "--org-id",
+            "org-2",
+        ]);
+        match prometheus {
+            Ok(_) => panic!("expected conflicting org IDs to be rejected"),
+            Err(error) => assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict),
+        }
+
+        let usage = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "org-1",
+            "--org-id",
+            "org-2",
+            "--from-date",
+            "2025-01-01",
+            "--to-date",
+            "2025-01-31",
+        ]);
+        match usage {
+            Ok(_) => panic!("expected conflicting org IDs to be rejected"),
+            Err(error) => assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict),
+        }
+    }
+
+    #[test]
+    fn rejects_org_usage_timestamps() {
+        let result = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "--from-date",
+            "2025-01-01T00:00:00Z",
+            "--to-date",
+            "2025-01-31",
+        ]);
+
+        match result {
+            Ok(_) => panic!("expected timestamp input to be rejected"),
+            Err(error) => assert!(error.to_string().contains("expected YYYY-MM-DD")),
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_org_usage_calendar_dates() {
+        let result = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "org",
+            "usage",
+            "--from-date",
+            "2025-02-31",
+            "--to-date",
+            "2025-03-01",
+        ]);
+
+        match result {
+            Ok(_) => panic!("expected invalid calendar date to be rejected"),
+            Err(error) => assert!(error.to_string().contains("expected YYYY-MM-DD")),
+        }
+    }
+
+    #[test]
+    fn top_level_write_classification_covers_every_organization_access_command() {
+        assert_write(&["clickhousectl", "cloud", "org", "list"], false);
+        assert_write(&["clickhousectl", "cloud", "org", "get", "org-1"], false);
+        assert_write(&["clickhousectl", "cloud", "org", "prometheus"], false);
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "org",
+                "usage",
+                "--from-date",
+                "2025-01-01",
+                "--to-date",
+                "2025-01-31",
+            ],
+            false,
+        );
+        assert_write(&["clickhousectl", "cloud", "org", "update", "org-1"], true);
+
+        assert_write(&["clickhousectl", "cloud", "member", "list"], false);
+        assert_write(
+            &["clickhousectl", "cloud", "member", "get", "user-1"],
+            false,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "member", "update", "user-1"],
+            true,
+        );
+        assert_write(
+            &["clickhousectl", "cloud", "member", "remove", "user-1"],
+            true,
+        );
+
+        assert_write(&["clickhousectl", "cloud", "invitation", "list"], false);
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "invitation",
+                "get",
+                "invitation-1",
+            ],
+            false,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "invitation",
+                "create",
+                "--email",
+                "user@example.com",
+            ],
+            true,
+        );
+        assert_write(
+            &[
+                "clickhousectl",
+                "cloud",
+                "invitation",
+                "delete",
+                "invitation-1",
+            ],
+            true,
+        );
+    }
+
+    #[test]
+    fn usage_entity_label_distinguishes_named_unknown_and_absent_entities() {
+        let id = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        assert_eq!(
+            usage_entity_label(Some("production"), Some(id)),
+            "production"
+        );
+        assert_eq!(
+            usage_entity_label(None, Some(id)),
+            "11111111-2222-3333-4444-555555555555 (unknown)"
+        );
+        assert_eq!(
+            usage_entity_label(Some(""), Some(id)),
+            format!("{id} (unknown)")
+        );
+        assert_eq!(usage_entity_label(None, None), ABSENT);
+    }
+
+    #[test]
+    fn build_org_update_request_matches_tested_shape() {
+        let options = OrgUpdateOptions {
+            name: Some("Updated Org".to_string()),
+            remove_private_endpoints: vec![
+                "pe-1,description=old,cloud-provider=aws,region=us-east-1".to_string(),
+            ],
+            enable_core_dumps: Some(false),
+        };
+        let request = build_org_update_request(&options).unwrap();
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["privateEndpoints"]["remove"][0]["id"], "pe-1");
+        assert_eq!(
+            json["privateEndpoints"]["remove"][0]["cloudProvider"],
+            "aws"
+        );
+        assert_eq!(json["enableCoreDumps"], false);
+    }
+}


### PR DESCRIPTION
Closes #382

## Summary
- Extract organization, member, and invitation clap contracts, dispatch, handlers, builders, output, client wrappers, and tests into one organization-access module.
- Preserve legacy positional organization IDs and pin all moved write classifications through the real top-level CLI parser.
- Keep organization lookup wrappers available to shared resolution and service deletion.
- Remove the moved code from generic cloud CLI, client, commands, and dispatch modules without behavior changes.

## Tests
- `cargo fmt --all`
- `cargo check --workspace --all-features`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`