### PR TITLE
Make Cloud integration CI on demand

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -5,14 +5,7 @@ on:
   schedule:
     - cron: "0 3 * * 1-5"
   pull_request:
-    paths:
-      - "crates/clickhouse-cloud-api/src/**"
-      - "crates/clickhouse-cloud-api/tests/**"
-      - "crates/clickhouse-cloud-api/Cargo.toml"
-      - "crates/clickhousectl/src/cloud/cli.rs"
-      - "crates/clickhousectl/src/cloud/commands.rs"
-      - "crates/clickhousectl/src/cloud/client.rs"
-      - "Cargo.lock"
+    types: [labeled]
 
 permissions:
   contents: read
@@ -21,12 +14,20 @@ env:
   DO_NOT_TRACK: "1"
 
 concurrency:
-  group: cloud-integration-${{ github.ref }}
+  group: cloud-integration
+  queue: max
   cancel-in-progress: false
 
 jobs:
   cloud-integration:
     name: Cloud integration tests
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       github.event.label.name == 'run-cloud-integration' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     environment: cloud-integration
     env:
@@ -49,7 +50,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+
+      - name: Log revisions
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || 'n/a' }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || 'n/a' }}
+        run: |
+          echo "Event SHA: $EVENT_SHA"
+          echo "PR base SHA: $PR_BASE_SHA"
+          echo "PR head SHA: $PR_HEAD_SHA"
+          echo "Checked-out SHA: $(git rev-parse HEAD)"
 
       - name: Resolve test run label
         run: |
@@ -69,15 +82,19 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Run cloud integration suite
+        if: ${{ !cancelled() }}
         run: cargo test -p clickhouse-cloud-api --test integration_test -- --ignored --nocapture
 
       - name: Run cloud Postgres integration suite
+        if: ${{ !cancelled() }}
         run: cargo test -p clickhouse-cloud-api --test integration_postgres_test -- --ignored --nocapture
 
       - name: Run cloud Org integration suite
+        if: ${{ !cancelled() }}
         run: cargo test -p clickhouse-cloud-api --test integration_org_test -- --ignored --nocapture
 
       - name: Run ClickPipe Postgres CDC integration test
+        if: ${{ !cancelled() }}
         run: cargo test -p clickhouse-cloud-api --test clickpipe_postgres_cdc_test -- --ignored --nocapture
 
       # ClickPipe create smoke tests run against a long-lived ClickHouse Cloud
@@ -86,5 +103,5 @@ jobs:
       # repository variable to its ID. The step is skipped if that variable
       # is unset so first-time setup doesn't block PRs.
       - name: Run ClickPipe create smoke suite
-        if: ${{ vars.CLICKHOUSE_CLOUD_TEST_CLICKPIPE_SERVICE_ID != '' }}
+        if: ${{ !cancelled() && vars.CLICKHOUSE_CLOUD_TEST_CLICKPIPE_SERVICE_ID != '' }}
         run: cargo test -p clickhouse-cloud-api --test clickpipe_smoke_test -- --ignored --nocapture


### PR DESCRIPTION
Closes #404

## Summary
- trigger live PR tests only from the `run-cloud-integration` label
- serialize all live runs in the repository-wide queued concurrency group
- test and log the exact captured PR head SHA with same-repository and Dependabot guards

## Verification
- YAML parse
- zizmor: no findings
- `git diff --check`

Stacked on #389.