### PR TITLE
Add scoped Cloud integration runs

### DIFF
--- a/.github/workflows/cloud-integration.yml
+++ b/.github/workflows/cloud-integration.yml
@@ -2,6 +2,17 @@ name: Cloud Integration
 
 on:
   workflow_dispatch:
+    inputs:
+      scope:
+        description: Integration test scope
+        required: true
+        type: choice
+        options:
+          - all
+          - service
+          - postgres
+          - organization
+          - clickpipes
   schedule:
     - cron: "0 3 * * 1-5"
   pull_request:
@@ -58,10 +69,16 @@ jobs:
           EVENT_SHA: ${{ github.sha }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || 'n/a' }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || 'n/a' }}
+          SELECTED_REF: ${{ github.ref }}
+          SELECTED_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          REQUESTED_SCOPE: ${{ github.event_name == 'workflow_dispatch' && inputs.scope || 'all (non-dispatch)' }}
         run: |
           echo "Event SHA: $EVENT_SHA"
           echo "PR base SHA: $PR_BASE_SHA"
           echo "PR head SHA: $PR_HEAD_SHA"
+          echo "Selected ref: $SELECTED_REF"
+          echo "Selected SHA: $SELECTED_SHA"
+          echo "Requested scope: $REQUESTED_SCOPE"
           echo "Checked-out SHA: $(git rev-parse HEAD)"
 
       - name: Resolve test run label
@@ -82,19 +99,31 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
 
       - name: Run cloud integration suite
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'workflow_dispatch' ||
+               inputs.scope == 'all' || inputs.scope == 'service') }}
         run: cargo test -p clickhouse-cloud-api --test integration_test -- --ignored --nocapture
 
       - name: Run cloud Postgres integration suite
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'workflow_dispatch' ||
+               inputs.scope == 'all' || inputs.scope == 'postgres') }}
         run: cargo test -p clickhouse-cloud-api --test integration_postgres_test -- --ignored --nocapture
 
       - name: Run cloud Org integration suite
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'workflow_dispatch' ||
+               inputs.scope == 'all' || inputs.scope == 'organization') }}
         run: cargo test -p clickhouse-cloud-api --test integration_org_test -- --ignored --nocapture
 
       - name: Run ClickPipe Postgres CDC integration test
-        if: ${{ !cancelled() }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'workflow_dispatch' ||
+               inputs.scope == 'all' || inputs.scope == 'clickpipes') }}
         run: cargo test -p clickhouse-cloud-api --test clickpipe_postgres_cdc_test -- --ignored --nocapture
 
       # ClickPipe create smoke tests run against a long-lived ClickHouse Cloud
@@ -103,5 +132,9 @@ jobs:
       # repository variable to its ID. The step is skipped if that variable
       # is unset so first-time setup doesn't block PRs.
       - name: Run ClickPipe create smoke suite
-        if: ${{ !cancelled() && vars.CLICKHOUSE_CLOUD_TEST_CLICKPIPE_SERVICE_ID != '' }}
+        if: >-
+          ${{ !cancelled() &&
+              (github.event_name != 'workflow_dispatch' ||
+               inputs.scope == 'all' || inputs.scope == 'clickpipes') &&
+              vars.CLICKHOUSE_CLOUD_TEST_CLICKPIPE_SERVICE_ID != '' }}
         run: cargo test -p clickhouse-cloud-api --test clickpipe_smoke_test -- --ignored --nocapture

--- a/crates/clickhouse-cloud-api/README.md
+++ b/crates/clickhouse-cloud-api/README.md
@@ -85,6 +85,8 @@ cargo test --test clickpipe_smoke_test -- --ignored --nocapture          # creat
 
 All require `CLICKHOUSE_CLOUD_API_KEY`, `CLICKHOUSE_CLOUD_API_SECRET`, `CLICKHOUSE_CLOUD_TEST_ORG_ID`, `CLICKHOUSE_CLOUD_TEST_PROVIDER`, and `CLICKHOUSE_CLOUD_TEST_REGION` in the environment, and are wired into the scheduled `Cloud Integration` GitHub Actions workflow. The ClickPipes E2E suites additionally need AWS credentials and an `eu-west-1` region quota; `clickpipe_smoke_test` reads a pre-provisioned service ID from `CLICKHOUSE_CLOUD_TEST_CLICKPIPE_SERVICE_ID`.
 
+Manual `Cloud Integration` dispatches accept `scope=all`, `service`, `postgres`, `organization`, or `clickpipes`. The focused scopes run only their corresponding suite; `clickpipes` runs Postgres CDC plus the fixture-gated smoke test, while `all` runs all four mandatory suites plus that optional smoke test. For full-stack validation, manually run `scope=all` against the top stack branch.
+
 `spec_coverage_test` sends the checked-in sources and snapshot through the
 private `clickhouse-openapi-analyzer` crate. That same analyzer powers the
 scheduled live-spec issue, so operation, model, field, optionality, beta,


### PR DESCRIPTION
Closes #405

## Summary
- add required manual `all`, `service`, `postgres`, `organization`, and `clickpipes` scopes
- skip unselected suites while preserving full label and scheduled runs
- document manual `all` validation against the top stack branch

## Verification
- scope truth table
- YAML parse
- zizmor: no findings
- `git diff --check`

Stacked on the #404 implementation PR.