### PR TITLE
Preserve Kafka setting during ClickPipe updates

### DIFF
--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1641,6 +1641,11 @@ async fn clickpipe_settings_update(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, org_id).await?;
+    let kafka_read_committed = client
+        .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
+        .await?
+        .kafka_read_committed
+        .ok_or("the API response is missing kafka_read_committed")?;
     let request = clickhouse_cloud_api::models::ClickPipeSettingsPutRequest {
         streaming_max_insert_wait_ms: streaming_max_insert_wait_ms.map(i64::from),
         object_storage_concurrency: object_storage_concurrency.map(i64::from),
@@ -1651,7 +1656,7 @@ async fn clickpipe_settings_update(
         clickhouse_max_insert_threads: clickhouse_max_insert_threads.map(i64::from),
         object_storage_use_cluster_function,
         clickhouse_parallel_view_processing,
-        kafka_read_committed: false,
+        kafka_read_committed,
         clickhouse_max_download_threads: None,
         clickhouse_min_insert_block_size_bytes: None,
         clickhouse_parallel_distributed_insert_select: None,

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1645,7 +1645,7 @@ async fn clickpipe_settings_update(
         .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
         .await?
         .kafka_read_committed
-        .ok_or("the API response is missing kafka_read_committed")?;
+        .unwrap_or(false);
     let request = clickhouse_cloud_api::models::ClickPipeSettingsPutRequest {
         streaming_max_insert_wait_ms: streaming_max_insert_wait_ms.map(i64::from),
         object_storage_concurrency: object_storage_concurrency.map(i64::from),

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3584,79 +3584,84 @@ async fn mysql_server_id_absent_when_not_passed() {
 // ── ClickPipe settings updates preserve required values ─────────────────────
 
 #[tokio::test]
-async fn clickpipe_settings_update_preserves_kafka_read_committed() {
-    let mock = MockServer::start().await;
+async fn clickpipe_settings_update_preserves_or_defaults_kafka_read_committed() {
     let settings_path = "/v1/organizations/org/services/svc-id/clickpipes/pipe-id/settings";
-    let current_settings = serde_json::json!({
-        "result": { "kafka_read_committed": true },
-        "status": 200,
-        "requestId": "stub-settings-get",
-    });
-    let updated_settings = serde_json::json!({
-        "result": {
-            "streaming_max_insert_wait_ms": 1000,
-            "kafka_read_committed": true,
-        },
-        "status": 200,
-        "requestId": "stub-settings-update",
-    });
+    for (current_settings, expected) in [
+        (serde_json::json!({ "kafka_read_committed": true }), true),
+        (serde_json::json!({}), false),
+    ] {
+        let mock = MockServer::start().await;
+        let current_settings = serde_json::json!({
+            "result": current_settings,
+            "status": 200,
+            "requestId": "stub-settings-get",
+        });
+        let updated_settings = serde_json::json!({
+            "result": {
+                "streaming_max_insert_wait_ms": 1000,
+                "kafka_read_committed": expected,
+            },
+            "status": 200,
+            "requestId": "stub-settings-update",
+        });
 
-    Mock::given(method("GET"))
-        .and(path(settings_path))
-        .respond_with(ResponseTemplate::new(200).set_body_json(current_settings))
-        .mount(&mock)
-        .await;
-    Mock::given(method("PUT"))
-        .and(path(settings_path))
-        .respond_with(ResponseTemplate::new(200).set_body_json(updated_settings))
-        .mount(&mock)
-        .await;
+        Mock::given(method("GET"))
+            .and(path(settings_path))
+            .respond_with(ResponseTemplate::new(200).set_body_json(current_settings))
+            .mount(&mock)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(settings_path))
+            .respond_with(ResponseTemplate::new(200).set_body_json(updated_settings))
+            .mount(&mock)
+            .await;
 
-    let output = invoke_cli_with_cloud_credentials(
-        &mock,
-        &[
-            "clickpipe",
-            "settings",
-            "update",
-            "svc-id",
-            "pipe-id",
-            "--streaming-max-insert-wait-ms",
-            "1000",
-            "--org-id",
-            "org",
-        ],
-    );
-    assert_success(&output);
+        let output = invoke_cli_with_cloud_credentials(
+            &mock,
+            &[
+                "clickpipe",
+                "settings",
+                "update",
+                "svc-id",
+                "pipe-id",
+                "--streaming-max-insert-wait-ms",
+                "1000",
+                "--org-id",
+                "org",
+            ],
+        );
+        assert_success(&output);
 
-    let requests = mock.received_requests().await.unwrap();
-    let request_shape = requests
-        .iter()
-        .map(|request| {
-            (
-                request.method.as_str().to_string(),
-                request.url.path().to_string(),
-            )
-        })
-        .collect::<Vec<_>>();
-    assert_eq!(
-        request_shape,
-        vec![
-            ("GET".to_string(), settings_path.to_string()),
-            ("PUT".to_string(), settings_path.to_string()),
-        ]
-    );
+        let requests = mock.received_requests().await.unwrap();
+        let request_shape = requests
+            .iter()
+            .map(|request| {
+                (
+                    request.method.as_str().to_string(),
+                    request.url.path().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            request_shape,
+            vec![
+                ("GET".to_string(), settings_path.to_string()),
+                ("PUT".to_string(), settings_path.to_string()),
+            ]
+        );
 
-    let put = requests
-        .iter()
-        .find(|request| request.method == wiremock::http::Method::PUT)
-        .expect("no settings PUT request recorded by mock");
-    assert_eq!(
-        serde_json::from_slice::<Value>(&put.body).unwrap(),
-        serde_json::json!({
-            "streaming_max_insert_wait_ms": 1000,
-            "kafka_read_committed": true,
-        })
-    );
+        let put = requests
+            .iter()
+            .find(|request| request.method == wiremock::http::Method::PUT)
+            .expect("no settings PUT request recorded by mock");
+        assert_eq!(
+            serde_json::from_slice::<Value>(&put.body).unwrap(),
+            serde_json::json!({
+                "streaming_max_insert_wait_ms": 1000,
+                "kafka_read_committed": expected,
+            })
+        );
+    }
 }
 
 // ── ClickPipe schema discovery (#289, beta) ────────────────────────────────

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3581,6 +3581,84 @@ async fn mysql_server_id_absent_when_not_passed() {
     );
 }
 
+// ── ClickPipe settings updates preserve required values ─────────────────────
+
+#[tokio::test]
+async fn clickpipe_settings_update_preserves_kafka_read_committed() {
+    let mock = MockServer::start().await;
+    let settings_path = "/v1/organizations/org/services/svc-id/clickpipes/pipe-id/settings";
+    let current_settings = serde_json::json!({
+        "result": { "kafka_read_committed": true },
+        "status": 200,
+        "requestId": "stub-settings-get",
+    });
+    let updated_settings = serde_json::json!({
+        "result": {
+            "streaming_max_insert_wait_ms": 1000,
+            "kafka_read_committed": true,
+        },
+        "status": 200,
+        "requestId": "stub-settings-update",
+    });
+
+    Mock::given(method("GET"))
+        .and(path(settings_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(current_settings))
+        .mount(&mock)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path(settings_path))
+        .respond_with(ResponseTemplate::new(200).set_body_json(updated_settings))
+        .mount(&mock)
+        .await;
+
+    let output = invoke_cli_with_cloud_credentials(
+        &mock,
+        &[
+            "clickpipe",
+            "settings",
+            "update",
+            "svc-id",
+            "pipe-id",
+            "--streaming-max-insert-wait-ms",
+            "1000",
+            "--org-id",
+            "org",
+        ],
+    );
+    assert_success(&output);
+
+    let requests = mock.received_requests().await.unwrap();
+    let request_shape = requests
+        .iter()
+        .map(|request| {
+            (
+                request.method.as_str().to_string(),
+                request.url.path().to_string(),
+            )
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        request_shape,
+        vec![
+            ("GET".to_string(), settings_path.to_string()),
+            ("PUT".to_string(), settings_path.to_string()),
+        ]
+    );
+
+    let put = requests
+        .iter()
+        .find(|request| request.method == wiremock::http::Method::PUT)
+        .expect("no settings PUT request recorded by mock");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&put.body).unwrap(),
+        serde_json::json!({
+            "streaming_max_insert_wait_ms": 1000,
+            "kafka_read_committed": true,
+        })
+    );
+}
+
 // ── ClickPipe schema discovery (#289, beta) ────────────────────────────────
 //
 // `clickpipe schema-discover` POSTs to .../clickpipes/schemaDiscovery with a


### PR DESCRIPTION
## Summary
- preserve the current `kafka_read_committed` value when updating unrelated ClickPipe settings
- fail instead of fabricating a value when the tolerant settings response omits the required field
- add subprocess and wiremock coverage for the settings `GET` to `PUT` request flow

## Verification
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo fmt --all --check`