### PR TITLE
Clarify CLI help for Cloud signup and agent workflows

### DIFF
--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -11,15 +11,15 @@ pub use crate::local::cli::LocalArgs;
 CONTEXT FOR AGENTS:
   With clickhousectl you can:
   1. Install and use ClickHouse and Postgres locally (`clickhousectl local` commands)
-  2. Manage ClickHouse and Postgres in ClickHouse Cloud  (`clickhousectl cloud` commands)
+  2. Manage ClickHouse and Postgres in ClickHouse Cloud (`clickhousectl cloud` commands)
 
   Install the ClickHouse Agent Skills: `clickhousectl skills --agent X`
 
   For ClickHouse Cloud:
   Create account: `cloud auth signup`
-  Authenticate: OAuth (`cloud auth login` is read-only) or API keys (`cloud auth login --api-key X --api-secret Y` is write)
+  Authenticate: OAuth (`cloud auth login` is read-only) or API keys (`cloud auth login --api-key X --api-secret Y` provides write access)
 
-  Typical local workflow: `clickhousectl local server start` → `chctl local client -q 'SELECT 1;'`
+  Typical local workflow: `clickhousectl local server start` → `clickhousectl local client -q 'SELECT 1;'`
   Typical cloud workflow: `clickhousectl cloud auth signup` → `clickhousectl cloud auth login --api-key X --api-secret Y` → `clickhousectl cloud service create`
   ")]
 pub struct Cli {
@@ -195,9 +195,7 @@ mod tests {
     fn help_points_agents_to_cloud_signup() {
         let mut command = Cli::command();
         let root_help = command.render_long_help().to_string();
-        assert!(root_help.contains(
-            "To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`."
-        ));
+        assert!(root_help.contains("Create account: `cloud auth signup`"));
 
         let auth = command
             .find_subcommand_mut("cloud")
@@ -205,9 +203,10 @@ mod tests {
             .find_subcommand_mut("auth")
             .expect("auth subcommand");
         let auth_help = auth.render_long_help().to_string();
-        assert!(auth_help.contains(
-            "To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`."
-        ));
+        assert!(
+            auth_help
+                .contains("Create a ClickHouse Cloud account: `clickhousectl cloud auth signup`.")
+        );
 
         let signup_help = auth
             .find_subcommand_mut("signup")

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -15,6 +15,8 @@ CONTEXT FOR AGENTS:
   1. Local: Install and interact with versions of ClickHouse to develop locally.
   2. Cloud: Manage ClickHouse Cloud infrastructure and push local work to cloud.
 
+  To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`.
+
   Authentication: OAuth (`cloud auth login`) is read-only. For write operations (create, update,
   delete), use API key auth: `cloud auth login --api-key X --api-secret Y`.
 
@@ -194,6 +196,33 @@ mod tests {
                 .exit_code(),
             2
         );
+    }
+
+    #[test]
+    fn help_points_agents_to_cloud_signup() {
+        let mut command = Cli::command();
+        let root_help = command.render_long_help().to_string();
+        assert!(root_help.contains(
+            "To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`."
+        ));
+
+        let auth = command
+            .find_subcommand_mut("cloud")
+            .expect("cloud subcommand")
+            .find_subcommand_mut("auth")
+            .expect("auth subcommand");
+        let auth_help = auth.render_long_help().to_string();
+        assert!(auth_help.contains(
+            "To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`."
+        ));
+
+        let signup_help = auth
+            .find_subcommand_mut("signup")
+            .expect("signup subcommand")
+            .render_long_help()
+            .to_string();
+        assert!(signup_help.contains("Create a ClickHouse Cloud account"));
+        assert!(!signup_help.to_lowercase().contains("browser"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/cli.rs
+++ b/crates/clickhousectl/src/cli.rs
@@ -9,22 +9,19 @@ pub use crate::local::cli::LocalArgs;
 #[command(version)]
 #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  clickhousectl is a CLI to work with local ClickHouse and ClickHouse Cloud.
+  With clickhousectl you can:
+  1. Install and use ClickHouse and Postgres locally (`clickhousectl local` commands)
+  2. Manage ClickHouse and Postgres in ClickHouse Cloud  (`clickhousectl cloud` commands)
 
-  Two main workflows:
-  1. Local: Install and interact with versions of ClickHouse to develop locally.
-  2. Cloud: Manage ClickHouse Cloud infrastructure and push local work to cloud.
+  Install the ClickHouse Agent Skills: `clickhousectl skills --agent X`
 
-  To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`.
+  For ClickHouse Cloud:
+  Create account: `cloud auth signup`
+  Authenticate: OAuth (`cloud auth login` is read-only) or API keys (`cloud auth login --api-key X --api-secret Y` is write)
 
-  Authentication: OAuth (`cloud auth login`) is read-only. For write operations (create, update,
-  delete), use API key auth: `cloud auth login --api-key X --api-secret Y`.
-
-  You can install the ClickHouse Agent Skills with:
-
-  `clickhousectl skills`
-
-  Typical local workflow: `clickhousectl local server start` (bootstraps from zero — installs `latest` if nothing is set up).")]
+  Typical local workflow: `clickhousectl local server start` → `chctl local client -q 'SELECT 1;'`
+  Typical cloud workflow: `clickhousectl cloud auth signup` → `clickhousectl cloud auth login --api-key X --api-secret Y` → `clickhousectl cloud service create`
+  ")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
@@ -53,14 +50,10 @@ Higher-precedence credentials override lower-precedence credentials. Use
 `clickhousectl cloud auth status` to see which configured source is active.
 
 CONTEXT FOR AGENTS:
-  Used for managing ClickHouse Cloud infrastructure. You need to have a ClickHouse Cloud account and be authenticated.
-  OAuth login (`cloud auth login`) is read-only — it can list and inspect resources but cannot create, modify, or delete.
-  For write operations, authenticate with API keys:
-    clickhousectl cloud auth login --api-key YOUR_KEY --api-secret YOUR_SECRET
-  If the user doesn't have an account, suggest `clickhousectl cloud auth signup` first.
-  JSON emitted automatically for known agents.
+  Create a ClickHouse Cloud account with `clickhousectl cloud auth signup`.
+  Auth with `clickhousectl cloud auth login` (use API keys for write access).
   Exit codes: 0 success, 1 error, 2 usage error, 3 cancelled, 4 auth required.
-  Typical workflow: `cloud auth login` → `cloud auth status` → `cloud org list` → `cloud service list`")]
+  Typical workflow: `cloud auth signup` → `cloud auth login` → `cloud auth status` → `cloud org list` → `cloud service list`")]
     Cloud(Box<CloudArgs>),
 
     /// Install ClickHouse agent skills into supported coding agents

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -50,11 +50,10 @@ CONTEXT FOR AGENTS:
     },
     /// Show current authentication status
     Status,
-    /// Open the ClickHouse Cloud sign-up page in your browser
+    /// Create a ClickHouse Cloud account
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Opens the ClickHouse Cloud sign-up page in the user's browser. This is an interactive flow —
-  it requires a human to complete sign-up in the browser. Do not use in fully autonomous or CI environments.")]
+  Create a ClickHouse Cloud account.")]
     Signup,
 }
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -49,12 +49,15 @@ pub enum CloudCommands {
     /// Manage authentication (OAuth login, API keys)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`.
-  Default `login` opens a browser for OAuth (read-only).
-  Use `login --api-key X --api-secret Y` for full read/write access, or set
-  CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET env vars (exported or in .env).
+  Create a ClickHouse Cloud account: `clickhousectl cloud auth signup`.
+
+  `login` without flags uses OAuth device flow (interactive, read-only).
+  Use API keys for write access (`login --api-key X --api-secret Y` or set CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET)
+
   Create API keys: https://clickhouse.com/docs/cloud/manage/openapi?referrer=clickhousectl
+
   `logout` clears all saved credentials (OAuth tokens and API keys).
+
   Related: `clickhousectl cloud org list` to verify credentials work.")]
     Auth {
         #[command(subcommand)]

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -52,7 +52,7 @@ CONTEXT FOR AGENTS:
   Create a ClickHouse Cloud account: `clickhousectl cloud auth signup`.
 
   `login` without flags uses OAuth device flow (interactive, read-only).
-  Use API keys for write access (`login --api-key X --api-secret Y` or set CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET)
+  Use API keys for write access (`login --api-key X --api-secret Y` or set CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET).
 
   Create API keys: https://clickhouse.com/docs/cloud/manage/openapi?referrer=clickhousectl
 

--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -49,6 +49,7 @@ pub enum CloudCommands {
     /// Manage authentication (OAuth login, API keys)
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
+  To create a ClickHouse Cloud account, use `clickhousectl cloud auth signup`.
   Default `login` opens a browser for OAuth (read-only).
   Use `login --api-key X --api-secret Y` for full read/write access, or set
   CLICKHOUSE_CLOUD_API_KEY / CLICKHOUSE_CLOUD_API_SECRET env vars (exported or in .env).


### PR DESCRIPTION
## Summary

- clarify the root agent context for local and Cloud ClickHouse/Postgres workflows
- surface `clickhousectl cloud auth signup` in root, Cloud, and auth help
- describe signup generically as creating a ClickHouse Cloud account rather than emphasizing browser interaction
- clarify OAuth read-only access and API key write access
- add regression coverage for signup guidance and browser-free signup help

CLI-only change stacked on #419.

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`