### PR TITLE
Document native ClickHouse query alternative

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -411,6 +411,9 @@ CONTEXT FOR AGENTS:
   With OAuth (cloud auth login): sends your own bearer token — SQL runs as
   your cloud user with read-only access (SELECT only, no writes); no key
   provisioning and no query endpoint required on the service.
+  For queries that may exceed Query API timeouts, `clickhousectl local use latest`
+  puts the standard `clickhouse` binary on PATH; use `clickhouse client` to connect
+  to the service instead.
   SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
   on a TTY, TabSeparated when piped. --json selects JSONEachRow and cannot be
   combined with --format; an explicit --format takes precedence over agent
@@ -2285,6 +2288,19 @@ mod tests {
             "wrong classification for: {}",
             args.join(" ")
         );
+    }
+
+    #[test]
+    fn service_query_help_documents_native_client_for_long_queries() {
+        let error = Cli::try_parse_from(["clickhousectl", "cloud", "service", "query", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+
+        assert!(help.contains("Query API timeouts"), "{help}");
+        assert!(help.contains("`clickhousectl local use latest`"), "{help}");
+        assert!(help.contains("`clickhouse client`"), "{help}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -45,6 +45,7 @@ CONTEXT FOR AGENTS:
   Accepts version specs: \"latest\" (recommended), \"stable\", \"lts\", partial like \"25.12\", or exact like \"25.12.5.44\".
   Auto-installs the version if not already present.
   Also creates `~/.local/bin/clickhouse` as a symlink to the version's binary so the `clickhouse` command is on PATH. Pass --no-global to skip.
+  This makes standard subcommands such as `clickhouse client`, `clickhouse benchmark`, and `clickhouse format` available directly.
   Related: `clickhousectl local which` to verify, `clickhousectl local server start` to start a server.")]
     Use {
         /// Version to use as default. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.5.44".
@@ -481,6 +482,20 @@ mod tests {
             panic!("expected local command");
         };
         local.command
+    }
+
+    #[test]
+    fn use_help_documents_standard_clickhouse_subcommands() {
+        let error = Cli::try_parse_from(["clickhousectl", "local", "use", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+
+        assert!(help.contains("`~/.local/bin/clickhouse`"), "{help}");
+        assert!(help.contains("`clickhouse client`"), "{help}");
+        assert!(help.contains("`clickhouse benchmark`"), "{help}");
+        assert!(help.contains("`clickhouse format`"), "{help}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- document standard ClickHouse subcommands in `local use --help`
- point `cloud service query --help` to the native client for timeout-sensitive queries
- cover both user-visible help paths with tests

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #428