### PR TITLE
Add GCP Postgres provider and sizes

### DIFF
--- a/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
+++ b/crates/clickhouse-cloud-api/clickhouse_cloud_openapi.json
@@ -5,7 +5,7 @@
     "version": "1.0",
     "contact": {
       "name": "ClickHouse Support",
-      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1064384",
+      "url": "https://clickhouse.com/docs/en/cloud/manage/openapi?referrer=openapi-1066254",
       "email": "support@clickhouse.com"
     }
   },
@@ -363,7 +363,7 @@
     "/v1/organizations/{organizationId}/prometheus": {
       "get": {
         "summary": "Get organization metrics",
-        "description": "Returns Prometheus metrics for the services in an organization that the caller is authorized to view. Services the caller lacks view access to are omitted.",
+        "description": "Deprecated. Use the Prometheus service discovery endpoint (/v1/organizations/{organizationId}/prometheus/discovery) instead. This endpoint is not available for new organizations; contact ClickHouse support to request access. Returns Prometheus metrics for the services in an organization that the caller is authorized to view. Services the caller lacks view access to are omitted.",
         "operationId": "organizationPrometheusGet",
         "parameters": [
           {
@@ -450,6 +450,7 @@
             }
           }
         },
+        "deprecated": true,
         "tags": [
           "Prometheus"
         ]
@@ -457,8 +458,8 @@
     },
     "/v1/organizations/{organizationId}/prometheus/discovery": {
       "get": {
-        "summary": "Discover Prometheus scrape targets for an organization",
-        "description": "**Disclaimer:** This beta endpoint is evolving; the API contract may change. <br /><br /> Returns one Prometheus scrape target per service in the organization that the caller is authorized to view, in HTTP service discovery (http_sd) format. Services the caller lacks view access to, and services in a terminated, terminating, or (soft-)deleted state, are omitted — the response can have fewer groups than the organization has services. Point a Prometheus http_sd_configs job at this endpoint to discover and scrape all services automatically; targets are refreshed on every discovery poll, so created and deleted services are picked up without reconfiguration. Targets scrape with filtered_metrics=true by default; pass ?filtered_metrics=false to this endpoint to discover unfiltered targets.\n\nSample Prometheus scrape config:\n\n```yaml\nscrape_configs:\n  - job_name: clickhouse-cloud\n    http_sd_configs:\n      - url: https://api.clickhouse.cloud/v1/organizations/<organizationId>/prometheus/discovery\n        refresh_interval: 60s\n        basic_auth:\n          username: <key-id>\n          password: <key-secret>\n    basic_auth:\n      username: <key-id>\n      password: <key-secret>\n```\n\nThe `basic_auth` block must be set both under `http_sd_configs` (used to authenticate discovery polls against this endpoint) and on the scrape job itself (used to authenticate the actual per-service scrapes) — omitting either one is the most common misconfiguration.",
+        "summary": "List Prometheus scrape targets",
+        "description": "**This endpoint is in beta.** API contract is stable, and no breaking changes are expected in the future. <br /><br /> Returns one Prometheus scrape target per service in the organization, in the [HTTP service discovery](https://prometheus.io/docs/prometheus/latest/http_sd/) (`http_sd`) format. Only services the API key is authorized to view are included; services that are being deleted or have been deleted are omitted.\n\nPoint an [`http_sd_configs`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#http_sd_config) job at this endpoint to discover and scrape all services in the organization automatically. Prometheus refreshes the target list on every discovery poll, so newly created and deleted services are picked up without configuration changes.\n\nDiscovered targets scrape with `filtered_metrics=true` by default; pass `?filtered_metrics=false` to this endpoint to discover unfiltered targets. See the [Prometheus integration guide](https://clickhouse.com/docs/integrations/prometheus) for more on the exported metrics.",
         "operationId": "organizationPrometheusDiscoveryGet",
         "parameters": [
           {
@@ -474,7 +475,7 @@
           {
             "in": "query",
             "name": "filtered_metrics",
-            "description": "Whether discovered targets carry filtered_metrics=true or =false as a scrape param. Accepts true or false; defaults to true — the opposite default from the per-service prometheus endpoint.",
+            "description": "Whether discovered targets scrape a filtered list of metrics. Sets the filtered_metrics parameter on each discovered target. Defaults to true.",
             "schema": {
               "type": "string",
               "format": "boolean"
@@ -2345,7 +2346,7 @@
     "/v1/organizations/{organizationId}/services/{serviceId}/state": {
       "patch": {
         "summary": "Update service state",
-        "description": "Starts or stop service",
+        "description": "Starts, stops, or wakes a service. The `start` and `stop` commands require the `control-plane:service:manage` permission on the service. The `awake` command requires only `control-plane:service:view` and applies to an idle service; it does not start a stopped service.",
         "operationId": "instanceStateUpdate",
         "parameters": [
           {
@@ -23783,7 +23784,7 @@
           },
           "roles": {
             "type": "array",
-            "description": "Optional. Roles to grant to the ClickHouse user that ClickPipe creates. If omitted, the user is granted the default role (`default_role`). Add your custom roles here if required.",
+            "description": "Optional. Roles to grant to the ClickHouse user that ClickPipe creates. If omitted, the user is granted the default role (`default_role`). Add your custom roles here if required. The role names `clickpipes` and `clickpipes_system` are reserved for internal use and cannot be assigned.",
             "items": {
               "type": "string"
             }
@@ -31712,7 +31713,68 @@
           "r8gd.12xlarge",
           "r8gd.16xlarge",
           "r8gd.24xlarge",
-          "r8gd.48xlarge"
+          "r8gd.48xlarge",
+          "c4a-highmem-4",
+          "c4a-highmem-8",
+          "c4a-highmem-16",
+          "c4a-highmem-32",
+          "c4a-highmem-48",
+          "c4a-highmem-64",
+          "c4a-highmem-72",
+          "c4a-standard-4",
+          "c4a-standard-8",
+          "c4a-standard-16",
+          "c4a-standard-32",
+          "c4a-standard-48",
+          "c4a-standard-64",
+          "c4a-standard-72",
+          "c4-highmem-4",
+          "c4-highmem-8",
+          "c4-highmem-16",
+          "c4-highmem-24",
+          "c4-highmem-32",
+          "c4-highmem-48",
+          "c4-highmem-96",
+          "c4-highmem-144",
+          "c4-highmem-192",
+          "c4-highmem-288",
+          "c4-standard-4",
+          "c4-standard-8",
+          "c4-standard-16",
+          "c4-standard-24",
+          "c4-standard-32",
+          "c4-standard-48",
+          "c4-standard-96",
+          "c4-standard-144",
+          "c4-standard-192",
+          "c4-standard-288",
+          "c4d-highmem-8",
+          "c4d-highmem-16",
+          "c4d-highmem-32",
+          "c4d-highmem-48",
+          "c4d-highmem-64",
+          "c4d-highmem-96",
+          "c4d-highmem-192",
+          "c4d-highmem-384",
+          "c4d-standard-8",
+          "c4d-standard-16",
+          "c4d-standard-32",
+          "c4d-standard-48",
+          "c4d-standard-64",
+          "c4d-standard-96",
+          "c4d-standard-192",
+          "c4d-standard-384",
+          "z3-highlssd-8",
+          "z3-highlssd-16",
+          "z3-highlssd-22",
+          "z3-highlssd-32",
+          "z3-highlssd-44",
+          "z3-highlssd-88",
+          "z3-standardlssd-14",
+          "z3-standardlssd-22",
+          "z3-standardlssd-44",
+          "z3-standardlssd-88",
+          "z3-standardlssd-176"
         ]
       },
       "pgHaType": {
@@ -31727,7 +31789,8 @@
       "pgProvider": {
         "type": "string",
         "enum": [
-          "aws"
+          "aws",
+          "gcp"
         ],
         "title": "Cloud provider",
         "description": "The cloud provider for a Postgres service."

--- a/crates/clickhouse-cloud-api/src/models/postgres.rs
+++ b/crates/clickhouse-cloud-api/src/models/postgres.rs
@@ -38,6 +38,8 @@ pub enum PgProvider {
     #[serde(rename = "aws")]
     #[default]
     Aws,
+    #[serde(rename = "gcp")]
+    Gcp,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -47,6 +49,7 @@ impl std::fmt::Display for PgProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Aws => write!(f, "aws"),
+            Self::Gcp => write!(f, "gcp"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -54,7 +57,7 @@ impl std::fmt::Display for PgProvider {
 
 impl PgProvider {
     /// Wire values accepted by the API, excluding the catch-all.
-    pub const VALUES: &'static [&'static str] = &["aws"];
+    pub const VALUES: &'static [&'static str] = &["aws", "gcp"];
 }
 
 /// Inline enum for `postgresLogsGetList.sort_order`.
@@ -327,6 +330,128 @@ pub enum PgSize {
     R8gd_24xlarge,
     #[serde(rename = "r8gd.48xlarge")]
     R8gd_48xlarge,
+    #[serde(rename = "c4a-highmem-4")]
+    C4a_highmem_4,
+    #[serde(rename = "c4a-highmem-8")]
+    C4a_highmem_8,
+    #[serde(rename = "c4a-highmem-16")]
+    C4a_highmem_16,
+    #[serde(rename = "c4a-highmem-32")]
+    C4a_highmem_32,
+    #[serde(rename = "c4a-highmem-48")]
+    C4a_highmem_48,
+    #[serde(rename = "c4a-highmem-64")]
+    C4a_highmem_64,
+    #[serde(rename = "c4a-highmem-72")]
+    C4a_highmem_72,
+    #[serde(rename = "c4a-standard-4")]
+    C4a_standard_4,
+    #[serde(rename = "c4a-standard-8")]
+    C4a_standard_8,
+    #[serde(rename = "c4a-standard-16")]
+    C4a_standard_16,
+    #[serde(rename = "c4a-standard-32")]
+    C4a_standard_32,
+    #[serde(rename = "c4a-standard-48")]
+    C4a_standard_48,
+    #[serde(rename = "c4a-standard-64")]
+    C4a_standard_64,
+    #[serde(rename = "c4a-standard-72")]
+    C4a_standard_72,
+    #[serde(rename = "c4-highmem-4")]
+    C4_highmem_4,
+    #[serde(rename = "c4-highmem-8")]
+    C4_highmem_8,
+    #[serde(rename = "c4-highmem-16")]
+    C4_highmem_16,
+    #[serde(rename = "c4-highmem-24")]
+    C4_highmem_24,
+    #[serde(rename = "c4-highmem-32")]
+    C4_highmem_32,
+    #[serde(rename = "c4-highmem-48")]
+    C4_highmem_48,
+    #[serde(rename = "c4-highmem-96")]
+    C4_highmem_96,
+    #[serde(rename = "c4-highmem-144")]
+    C4_highmem_144,
+    #[serde(rename = "c4-highmem-192")]
+    C4_highmem_192,
+    #[serde(rename = "c4-highmem-288")]
+    C4_highmem_288,
+    #[serde(rename = "c4-standard-4")]
+    C4_standard_4,
+    #[serde(rename = "c4-standard-8")]
+    C4_standard_8,
+    #[serde(rename = "c4-standard-16")]
+    C4_standard_16,
+    #[serde(rename = "c4-standard-24")]
+    C4_standard_24,
+    #[serde(rename = "c4-standard-32")]
+    C4_standard_32,
+    #[serde(rename = "c4-standard-48")]
+    C4_standard_48,
+    #[serde(rename = "c4-standard-96")]
+    C4_standard_96,
+    #[serde(rename = "c4-standard-144")]
+    C4_standard_144,
+    #[serde(rename = "c4-standard-192")]
+    C4_standard_192,
+    #[serde(rename = "c4-standard-288")]
+    C4_standard_288,
+    #[serde(rename = "c4d-highmem-8")]
+    C4d_highmem_8,
+    #[serde(rename = "c4d-highmem-16")]
+    C4d_highmem_16,
+    #[serde(rename = "c4d-highmem-32")]
+    C4d_highmem_32,
+    #[serde(rename = "c4d-highmem-48")]
+    C4d_highmem_48,
+    #[serde(rename = "c4d-highmem-64")]
+    C4d_highmem_64,
+    #[serde(rename = "c4d-highmem-96")]
+    C4d_highmem_96,
+    #[serde(rename = "c4d-highmem-192")]
+    C4d_highmem_192,
+    #[serde(rename = "c4d-highmem-384")]
+    C4d_highmem_384,
+    #[serde(rename = "c4d-standard-8")]
+    C4d_standard_8,
+    #[serde(rename = "c4d-standard-16")]
+    C4d_standard_16,
+    #[serde(rename = "c4d-standard-32")]
+    C4d_standard_32,
+    #[serde(rename = "c4d-standard-48")]
+    C4d_standard_48,
+    #[serde(rename = "c4d-standard-64")]
+    C4d_standard_64,
+    #[serde(rename = "c4d-standard-96")]
+    C4d_standard_96,
+    #[serde(rename = "c4d-standard-192")]
+    C4d_standard_192,
+    #[serde(rename = "c4d-standard-384")]
+    C4d_standard_384,
+    #[serde(rename = "z3-highlssd-8")]
+    Z3_highlssd_8,
+    #[serde(rename = "z3-highlssd-16")]
+    Z3_highlssd_16,
+    #[serde(rename = "z3-highlssd-22")]
+    Z3_highlssd_22,
+    #[serde(rename = "z3-highlssd-32")]
+    Z3_highlssd_32,
+    #[serde(rename = "z3-highlssd-44")]
+    Z3_highlssd_44,
+    #[serde(rename = "z3-highlssd-88")]
+    Z3_highlssd_88,
+    #[serde(rename = "z3-standardlssd-14")]
+    Z3_standardlssd_14,
+    #[serde(rename = "z3-standardlssd-22")]
+    Z3_standardlssd_22,
+    #[serde(rename = "z3-standardlssd-44")]
+    Z3_standardlssd_44,
+    #[serde(rename = "z3-standardlssd-88")]
+    Z3_standardlssd_88,
+    #[serde(rename = "z3-standardlssd-176")]
+    Z3_standardlssd_176,
     /// Catch-all for unknown or newly-added values.
     #[serde(untagged)]
     Unknown(String),
@@ -417,6 +542,67 @@ impl std::fmt::Display for PgSize {
             Self::R8gd_16xlarge => write!(f, "r8gd.16xlarge"),
             Self::R8gd_24xlarge => write!(f, "r8gd.24xlarge"),
             Self::R8gd_48xlarge => write!(f, "r8gd.48xlarge"),
+            Self::C4a_highmem_4 => write!(f, "c4a-highmem-4"),
+            Self::C4a_highmem_8 => write!(f, "c4a-highmem-8"),
+            Self::C4a_highmem_16 => write!(f, "c4a-highmem-16"),
+            Self::C4a_highmem_32 => write!(f, "c4a-highmem-32"),
+            Self::C4a_highmem_48 => write!(f, "c4a-highmem-48"),
+            Self::C4a_highmem_64 => write!(f, "c4a-highmem-64"),
+            Self::C4a_highmem_72 => write!(f, "c4a-highmem-72"),
+            Self::C4a_standard_4 => write!(f, "c4a-standard-4"),
+            Self::C4a_standard_8 => write!(f, "c4a-standard-8"),
+            Self::C4a_standard_16 => write!(f, "c4a-standard-16"),
+            Self::C4a_standard_32 => write!(f, "c4a-standard-32"),
+            Self::C4a_standard_48 => write!(f, "c4a-standard-48"),
+            Self::C4a_standard_64 => write!(f, "c4a-standard-64"),
+            Self::C4a_standard_72 => write!(f, "c4a-standard-72"),
+            Self::C4_highmem_4 => write!(f, "c4-highmem-4"),
+            Self::C4_highmem_8 => write!(f, "c4-highmem-8"),
+            Self::C4_highmem_16 => write!(f, "c4-highmem-16"),
+            Self::C4_highmem_24 => write!(f, "c4-highmem-24"),
+            Self::C4_highmem_32 => write!(f, "c4-highmem-32"),
+            Self::C4_highmem_48 => write!(f, "c4-highmem-48"),
+            Self::C4_highmem_96 => write!(f, "c4-highmem-96"),
+            Self::C4_highmem_144 => write!(f, "c4-highmem-144"),
+            Self::C4_highmem_192 => write!(f, "c4-highmem-192"),
+            Self::C4_highmem_288 => write!(f, "c4-highmem-288"),
+            Self::C4_standard_4 => write!(f, "c4-standard-4"),
+            Self::C4_standard_8 => write!(f, "c4-standard-8"),
+            Self::C4_standard_16 => write!(f, "c4-standard-16"),
+            Self::C4_standard_24 => write!(f, "c4-standard-24"),
+            Self::C4_standard_32 => write!(f, "c4-standard-32"),
+            Self::C4_standard_48 => write!(f, "c4-standard-48"),
+            Self::C4_standard_96 => write!(f, "c4-standard-96"),
+            Self::C4_standard_144 => write!(f, "c4-standard-144"),
+            Self::C4_standard_192 => write!(f, "c4-standard-192"),
+            Self::C4_standard_288 => write!(f, "c4-standard-288"),
+            Self::C4d_highmem_8 => write!(f, "c4d-highmem-8"),
+            Self::C4d_highmem_16 => write!(f, "c4d-highmem-16"),
+            Self::C4d_highmem_32 => write!(f, "c4d-highmem-32"),
+            Self::C4d_highmem_48 => write!(f, "c4d-highmem-48"),
+            Self::C4d_highmem_64 => write!(f, "c4d-highmem-64"),
+            Self::C4d_highmem_96 => write!(f, "c4d-highmem-96"),
+            Self::C4d_highmem_192 => write!(f, "c4d-highmem-192"),
+            Self::C4d_highmem_384 => write!(f, "c4d-highmem-384"),
+            Self::C4d_standard_8 => write!(f, "c4d-standard-8"),
+            Self::C4d_standard_16 => write!(f, "c4d-standard-16"),
+            Self::C4d_standard_32 => write!(f, "c4d-standard-32"),
+            Self::C4d_standard_48 => write!(f, "c4d-standard-48"),
+            Self::C4d_standard_64 => write!(f, "c4d-standard-64"),
+            Self::C4d_standard_96 => write!(f, "c4d-standard-96"),
+            Self::C4d_standard_192 => write!(f, "c4d-standard-192"),
+            Self::C4d_standard_384 => write!(f, "c4d-standard-384"),
+            Self::Z3_highlssd_8 => write!(f, "z3-highlssd-8"),
+            Self::Z3_highlssd_16 => write!(f, "z3-highlssd-16"),
+            Self::Z3_highlssd_22 => write!(f, "z3-highlssd-22"),
+            Self::Z3_highlssd_32 => write!(f, "z3-highlssd-32"),
+            Self::Z3_highlssd_44 => write!(f, "z3-highlssd-44"),
+            Self::Z3_highlssd_88 => write!(f, "z3-highlssd-88"),
+            Self::Z3_standardlssd_14 => write!(f, "z3-standardlssd-14"),
+            Self::Z3_standardlssd_22 => write!(f, "z3-standardlssd-22"),
+            Self::Z3_standardlssd_44 => write!(f, "z3-standardlssd-44"),
+            Self::Z3_standardlssd_88 => write!(f, "z3-standardlssd-88"),
+            Self::Z3_standardlssd_176 => write!(f, "z3-standardlssd-176"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }

--- a/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
+++ b/crates/clickhouse-cloud-api/tests/clickpipes/support.rs
@@ -120,7 +120,7 @@ impl AwsCleanupRegistry {
 
         // Terminate instances first so they release their ENIs, then drop SGs.
         if !self.ec2_instances.is_empty() {
-            let ids: Vec<String> = self.ec2_instances.drain(..).collect();
+            let ids = std::mem::take(&mut self.ec2_instances);
             if let Err(error) = terminate_and_wait(ec2_client, &ids).await {
                 failures.push(format!("ec2 instances {ids:?}: {error}"));
             }

--- a/crates/clickhouse-cloud-api/tests/models_test.rs
+++ b/crates/clickhouse-cloud-api/tests/models_test.rs
@@ -641,6 +641,92 @@ fn deserialize_postgres_service() {
 }
 
 #[test]
+fn postgres_gcp_provider_roundtrips() {
+    let provider: PgProvider = serde_json::from_str(r#""gcp""#).unwrap();
+    assert_eq!(provider, PgProvider::Gcp);
+    assert_eq!(provider.to_string(), "gcp");
+    assert_eq!(serde_json::to_string(&provider).unwrap(), r#""gcp""#);
+    assert_eq!(PgProvider::VALUES, &["aws", "gcp"]);
+}
+
+#[test]
+fn postgres_gcp_sizes_roundtrip_as_known_variants() {
+    let sizes = [
+        "c4a-highmem-4",
+        "c4a-highmem-8",
+        "c4a-highmem-16",
+        "c4a-highmem-32",
+        "c4a-highmem-48",
+        "c4a-highmem-64",
+        "c4a-highmem-72",
+        "c4a-standard-4",
+        "c4a-standard-8",
+        "c4a-standard-16",
+        "c4a-standard-32",
+        "c4a-standard-48",
+        "c4a-standard-64",
+        "c4a-standard-72",
+        "c4-highmem-4",
+        "c4-highmem-8",
+        "c4-highmem-16",
+        "c4-highmem-24",
+        "c4-highmem-32",
+        "c4-highmem-48",
+        "c4-highmem-96",
+        "c4-highmem-144",
+        "c4-highmem-192",
+        "c4-highmem-288",
+        "c4-standard-4",
+        "c4-standard-8",
+        "c4-standard-16",
+        "c4-standard-24",
+        "c4-standard-32",
+        "c4-standard-48",
+        "c4-standard-96",
+        "c4-standard-144",
+        "c4-standard-192",
+        "c4-standard-288",
+        "c4d-highmem-8",
+        "c4d-highmem-16",
+        "c4d-highmem-32",
+        "c4d-highmem-48",
+        "c4d-highmem-64",
+        "c4d-highmem-96",
+        "c4d-highmem-192",
+        "c4d-highmem-384",
+        "c4d-standard-8",
+        "c4d-standard-16",
+        "c4d-standard-32",
+        "c4d-standard-48",
+        "c4d-standard-64",
+        "c4d-standard-96",
+        "c4d-standard-192",
+        "c4d-standard-384",
+        "z3-highlssd-8",
+        "z3-highlssd-16",
+        "z3-highlssd-22",
+        "z3-highlssd-32",
+        "z3-highlssd-44",
+        "z3-highlssd-88",
+        "z3-standardlssd-14",
+        "z3-standardlssd-22",
+        "z3-standardlssd-44",
+        "z3-standardlssd-88",
+        "z3-standardlssd-176",
+    ];
+
+    for wire_value in sizes {
+        let size: PgSize = serde_json::from_value(wire_value.into()).unwrap();
+        assert!(
+            !matches!(&size, PgSize::Unknown(_)),
+            "{wire_value} deserialized through the catch-all"
+        );
+        assert_eq!(size.to_string(), wire_value);
+        assert_eq!(serde_json::to_value(&size).unwrap(), wire_value);
+    }
+}
+
+#[test]
 fn unknown_enum_variant_deserializes() {
     // An unknown service state from the API should deserialize into Unknown(String)
     let json = r#"{"state": "brand-new-state"}"#;


### PR DESCRIPTION
## Summary

- refresh the vendored ClickHouse Cloud OpenAPI snapshot
- add the GCP Postgres provider and 61 GCP Postgres sizes
- cover provider and size wire-value round trips

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhouse-cloud-api -p clickhouse-openapi-analyzer`
- `cargo clippy -p clickhouse-cloud-api -p clickhouse-openapi-analyzer --all-targets -- -D warnings`
- Python renderer tests
- `python3 scripts/check-openapi-drift.py --dry-run`
- `git diff --check`

Closes #427