### PR TITLE
Fix all-feature Cloud API tests

### DIFF
--- a/crates/clickhouse-cloud-api/tests/client_test.rs
+++ b/crates/clickhouse-cloud-api/tests/client_test.rs
@@ -485,7 +485,7 @@ async fn get_invitation() {
     let inv = resp.result.unwrap();
     assert_eq!(inv.email.as_deref(), Some("bob@example.com"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(inv.role, InvitationRole::Admin);
+    assert_eq!(inv.role, Some(InvitationRole::Admin));
 }
 
 #[tokio::test]
@@ -663,8 +663,8 @@ async fn list_members() {
     assert_eq!(members.len(), 2);
     #[cfg(feature = "deprecated-fields")]
     {
-        assert_eq!(members[0].role, MemberRole::Admin);
-        assert_eq!(members[1].role, MemberRole::Developer);
+        assert_eq!(members[0].role, Some(MemberRole::Admin));
+        assert_eq!(members[1].role, Some(MemberRole::Developer));
     }
 }
 
@@ -687,7 +687,7 @@ async fn get_member() {
     let member = resp.result.unwrap();
     assert_eq!(member.name.as_deref(), Some("Alice"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(member.role, MemberRole::Admin);
+    assert_eq!(member.role, Some(MemberRole::Admin));
 }
 
 #[tokio::test]
@@ -714,7 +714,7 @@ async fn update_member() {
     let member = resp.result.unwrap();
     assert_eq!(member.email.as_deref(), Some("alice@example.com"));
     #[cfg(feature = "deprecated-fields")]
-    assert_eq!(member.role, MemberRole::Admin);
+    assert_eq!(member.role, Some(MemberRole::Admin));
 }
 
 #[tokio::test]

--- a/crates/clickhouse-cloud-api/tests/integration_org_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_org_test.rs
@@ -406,8 +406,8 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
             );
             #[cfg(feature = "deprecated-fields")]
             assert_eq!(
-                invitation.role.to_string(),
-                InvitationPostRequestRole::Developer.to_string(),
+                invitation.role,
+                Some(InvitationRole::Developer),
                 "invitation create echoed unexpected role"
             );
 
@@ -468,9 +468,9 @@ async fn cloud_org_lifecycle() -> TestResult<()> {
                             .into());
                         }
                         #[cfg(feature = "deprecated-fields")]
-                        if fetched.role.to_string() != "developer" {
+                        if fetched.role != Some(InvitationRole::Developer) {
                             return Err(format!(
-                                "invitation get returned wrong role {}; wanted developer",
+                                "invitation get returned wrong role {:?}; wanted developer",
                                 fetched.role
                             )
                             .into());

--- a/crates/clickhouse-cloud-api/tests/integration_test.rs
+++ b/crates/clickhouse-cloud-api/tests/integration_test.rs
@@ -1936,8 +1936,12 @@ async fn cloud_service_crud_lifecycle() -> TestResult<()> {
         // Sanity: the deprecated body's totals only equal per-replica when
         // num_replicas == 1. We rely on the previous step landing us there.
         assert_eq!(pre_vertical.num_replicas, Some(base_replicas));
-        let pre_min_total = pre_vertical.min_total_memory_gb;
-        let pre_max_total = pre_vertical.max_total_memory_gb;
+        let pre_min_total = pre_vertical
+            .min_total_memory_gb
+            .ok_or("service response omitted minTotalMemoryGb before deprecated vertical scaling")?;
+        let pre_max_total = pre_vertical
+            .max_total_memory_gb
+            .ok_or("service response omitted maxTotalMemoryGb before deprecated vertical scaling")?;
 
         failures
             .run(
@@ -2725,8 +2729,8 @@ async fn scale_service_vertical_and_wait(
             async move {
                 let resp = client.instance_get(&org_id, &service_id).await?;
                 let svc = resp.result.ok_or("service get returned no result")?;
-                if min_total_memory_gb.is_none_or(|v| svc.min_total_memory_gb == v)
-                    && max_total_memory_gb.is_none_or(|v| svc.max_total_memory_gb == v)
+                if min_total_memory_gb.is_none_or(|v| svc.min_total_memory_gb == Some(v))
+                    && max_total_memory_gb.is_none_or(|v| svc.max_total_memory_gb == Some(v))
                 {
                     Ok(Some(()))
                 } else {


### PR DESCRIPTION
## Summary

- update deprecated-field fixtures to assert optional response roles
- make live invitation checks resolve missing roles explicitly
- fix optional service memory assertions in scaling integration helpers

## Testing

- `cargo fmt --all --check`
- `cargo test --workspace --all-features --locked --no-run`
- `cargo test --workspace --locked`
- `cargo test -p clickhouse-cloud-api --all-features --test client_test`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

Closes #424