### PR TITLE
Hide Postgres storage keys in stop-all

### DIFF
--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -984,10 +984,19 @@ where
     let servers = servers
         .iter()
         .map(|server| {
-            let name = server.name.clone();
+            let (name, version) = match server.engine {
+                server::Engine::Clickhouse => (server.name.clone(), None),
+                server::Engine::Postgres => (
+                    postgres::user_name_from_key(&server.name).to_string(),
+                    Some(server.version.clone()),
+                ),
+            };
             let engine = server.engine.as_str().to_string();
             if !json {
-                print!("Stopping '{}' ({})...", name, engine);
+                match version.as_deref() {
+                    Some(version) => print!("Stopping '{}' ({}, {})...", name, engine, version),
+                    None => print!("Stopping '{}' ({})...", name, engine),
+                }
                 let _ = std::io::stdout().flush();
             }
             let result = stop(&server.name);
@@ -1000,6 +1009,7 @@ where
             output::ServerStopEntry {
                 name,
                 engine,
+                version,
                 stopped: result.is_ok(),
                 error: result.err().map(|error| error.to_string()),
             }
@@ -1030,6 +1040,7 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
                 stop_entries.push(output::ServerStopEntry {
                     name: s.name.clone(),
                     engine: s.engine.as_str().to_string(),
+                    version: None,
                     stopped: true,
                     error: None,
                 });
@@ -1041,6 +1052,7 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
                 stop_entries.push(output::ServerStopEntry {
                     name: s.name.clone(),
                     engine: s.engine.as_str().to_string(),
+                    version: None,
                     stopped: false,
                     error: Some(e.to_string()),
                 });
@@ -1064,14 +1076,11 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
 mod tests {
     use super::*;
 
-    fn server_info(name: &str, engine: server::Engine) -> server::ServerInfo {
+    fn server_info(name: &str, engine: server::Engine, version: &str) -> server::ServerInfo {
         server::ServerInfo {
             name: name.to_string(),
             pid: 1,
-            version: match engine {
-                server::Engine::Clickhouse => "25.12.9.61".to_string(),
-                server::Engine::Postgres => "postgres:18".to_string(),
-            },
+            version: version.to_string(),
             http_port: 0,
             tcp_port: 0,
             started_at: "test".to_string(),
@@ -1101,9 +1110,9 @@ mod tests {
     #[test]
     fn stop_servers_attempts_and_reports_both_engines() {
         let servers = vec![
-            server_info("default", server::Engine::Clickhouse),
-            server_info("default-pg17", server::Engine::Postgres),
-            server_info("default-pg18", server::Engine::Postgres),
+            server_info("default", server::Engine::Clickhouse, "25.12.9.61"),
+            server_info("default-pg17", server::Engine::Postgres, "postgres:17"),
+            server_info("default-pg18", server::Engine::Postgres, "postgres:18"),
         ];
         let mut attempts = Vec::new();
 
@@ -1120,17 +1129,20 @@ mod tests {
         assert_eq!(output.servers.len(), 3);
         assert_eq!(output.servers[0].name, "default");
         assert_eq!(output.servers[0].engine, "clickhouse");
+        assert_eq!(output.servers[0].version, None);
         assert!(!output.servers[0].stopped);
         assert_eq!(
             output.servers[0].error.as_deref(),
             Some("Failed to execute ClickHouse: process stop failed")
         );
-        assert_eq!(output.servers[1].name, "default-pg17");
+        assert_eq!(output.servers[1].name, "default");
         assert_eq!(output.servers[1].engine, "postgres");
+        assert_eq!(output.servers[1].version.as_deref(), Some("postgres:17"));
         assert!(output.servers[1].stopped);
         assert_eq!(output.servers[1].error, None);
-        assert_eq!(output.servers[2].name, "default-pg18");
+        assert_eq!(output.servers[2].name, "default");
         assert_eq!(output.servers[2].engine, "postgres");
+        assert_eq!(output.servers[2].version.as_deref(), Some("postgres:18"));
         assert!(output.servers[2].stopped);
         assert_eq!(output.servers[2].error, None);
     }

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -485,6 +485,9 @@ pub struct ServerStopEntry {
     pub name: String,
     /// "clickhouse" or "postgres".
     pub engine: String,
+    /// Postgres image version, used to distinguish same-name major versions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
     pub stopped: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -502,14 +505,18 @@ impl fmt::Display for ServerStopAllOutput {
             return Ok(());
         }
         for s in &self.servers {
+            let engine = match s.version.as_deref() {
+                Some(version) => format!("{}, {}", s.engine, version),
+                None => s.engine.clone(),
+            };
             if s.stopped {
-                writeln!(f, "Stopping '{}' ({})... stopped", s.name, s.engine)?;
+                writeln!(f, "Stopping '{}' ({})... stopped", s.name, engine)?;
             } else {
                 writeln!(
                     f,
                     "Stopping '{}' ({})... error: {}",
                     s.name,
-                    s.engine,
+                    engine,
                     s.error.as_deref().unwrap_or("unknown")
                 )?;
             }
@@ -805,12 +812,14 @@ mod tests {
                 ServerStopEntry {
                     name: "default".to_string(),
                     engine: "clickhouse".to_string(),
+                    version: None,
                     stopped: true,
                     error: None,
                 },
                 ServerStopEntry {
                     name: "default".to_string(),
                     engine: "postgres".to_string(),
+                    version: Some("postgres:18".to_string()),
                     stopped: false,
                     error: Some("container not found".to_string()),
                 },
@@ -822,9 +831,11 @@ mod tests {
         assert_eq!(json["servers"][0]["name"], "default");
         assert_eq!(json["servers"][0]["engine"], "clickhouse");
         assert_eq!(json["servers"][0]["stopped"], true);
+        assert!(json["servers"][0].get("version").is_none());
         assert!(json["servers"][0].get("error").is_none());
         assert_eq!(json["servers"][1]["name"], "default");
         assert_eq!(json["servers"][1]["engine"], "postgres");
+        assert_eq!(json["servers"][1]["version"], "postgres:18");
         assert_eq!(json["servers"][1]["stopped"], false);
         assert_eq!(json["servers"][1]["error"], "container not found");
     }
@@ -1113,12 +1124,14 @@ mod tests {
                 ServerStopEntry {
                     name: "default".to_string(),
                     engine: "clickhouse".to_string(),
+                    version: None,
                     stopped: true,
                     error: None,
                 },
                 ServerStopEntry {
                     name: "default".to_string(),
                     engine: "postgres".to_string(),
+                    version: Some("postgres:18".to_string()),
                     stopped: false,
                     error: Some("container not found".to_string()),
                 },
@@ -1126,7 +1139,11 @@ mod tests {
         };
         let text = output.to_string();
         assert!(text.contains("Stopping 'default' (clickhouse)... stopped"));
-        assert!(text.contains("Stopping 'default' (postgres)... error: container not found"));
+        assert!(
+            text.contains(
+                "Stopping 'default' (postgres, postgres:18)... error: container not found"
+            )
+        );
         assert!(text.contains("Done"));
     }
 

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -200,7 +200,7 @@ EOF
     local out; out=$("$CTL" local --json server stop-all 2>&1) || { die "server stop-all: $out"; return 1; }
     jq -e '.servers | any(.name == "c" and .engine == "clickhouse" and .stopped == true)' <<<"$out" >/dev/null \
         || { die "server stop-all did not report ClickHouse: $out"; return 1; }
-    jq -e '.servers | any(.name == "p-pg18" and .engine == "postgres" and .stopped == true)' <<<"$out" >/dev/null \
+    jq -e '.servers | any(.name == "p" and .engine == "postgres" and .version == "postgres:18-alpine" and .stopped == true)' <<<"$out" >/dev/null \
         || { die "server stop-all did not report Postgres: $out"; return 1; }
     ! kill -0 "$ch_pid" 2>/dev/null || { die "server stop-all left ClickHouse process running"; return 1; }
     trap - EXIT


### PR DESCRIPTION
## Summary

- keep internal Postgres instance keys private when reporting stop-all results
- expose the user-facing Postgres name with a separate version field
- preserve internal keys for process control and cover same-name major versions

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `bash -n scripts/test-postgres-integration.sh`
- `shellcheck scripts/test-postgres-integration.sh`
- `scripts/test-postgres-integration.sh` (15/15)
- `git diff --check`

Closes #426