### PR TITLE
Enforce global JSON query format conflict

### DIFF
--- a/crates/clickhousectl/src/cloud/cli.rs
+++ b/crates/clickhousectl/src/cloud/cli.rs
@@ -44,6 +44,21 @@ pub struct CloudArgs {
     pub command: CloudCommands,
 }
 
+impl CloudArgs {
+    pub fn has_explicit_json_format_conflict(&self) -> bool {
+        self.json
+            && matches!(
+                &self.command,
+                CloudCommands::Service {
+                    command: ServiceCommands::Query {
+                        format: Some(_),
+                        ..
+                    }
+                }
+            )
+    }
+}
+
 #[derive(Subcommand)]
 pub enum CloudCommands {
     /// Manage authentication (OAuth login, API keys)

--- a/crates/clickhousectl/src/main.rs
+++ b/crates/clickhousectl/src/main.rs
@@ -64,7 +64,13 @@ async fn main() {
             // a clap derive bug, not a user error.
             let cli = Cli::from_arg_matches(&matches)
                 .expect("Cli::from_arg_matches must accept matches from Cli::command()");
-            let (exit_code, is_child_exit) = run_parsed(cli).await;
+            let (exit_code, is_child_exit) = match validate_post_parse(&cli, &mut cmd) {
+                Ok(()) => run_parsed(cli).await,
+                Err(e) => {
+                    let _ = e.print();
+                    (e.exit_code(), false)
+                }
+            };
             #[cfg(feature = "telemetry")]
             if is_child_exit {
                 invocation.mark_child_exit();
@@ -113,6 +119,28 @@ async fn main() {
     let () = telemetry_invocation;
 
     std::process::exit(exit_code);
+}
+
+fn validate_post_parse(cli: &Cli, cmd: &mut clap::Command) -> std::result::Result<(), clap::Error> {
+    let Commands::Cloud(args) = &cli.command else {
+        return Ok(());
+    };
+    if !args.has_explicit_json_format_conflict() {
+        return Ok(());
+    }
+
+    // clap validates each subcommand before propagating values supplied for a
+    // global argument at a parent level, so this cross-level conflict needs a
+    // post-parse check. Format the error against the owning command.
+    let query = cmd
+        .find_subcommand_mut("cloud")
+        .and_then(|cloud| cloud.find_subcommand_mut("service"))
+        .and_then(|service| service.find_subcommand_mut("query"))
+        .expect("service query command must exist");
+    Err(query.error(
+        ErrorKind::ArgumentConflict,
+        "the argument '--json' cannot be used with '--format <FORMAT>'",
+    ))
 }
 
 /// Run a successfully parsed invocation to completion and report the exit
@@ -258,6 +286,60 @@ mod tests {
 
     fn parse(args: &[&str]) -> Commands {
         Cli::try_parse_from(args).unwrap().command
+    }
+
+    fn parse_and_validate(args: &[&str]) -> std::result::Result<Cli, clap::Error> {
+        let mut cmd = Cli::command();
+        let matches = cmd.try_get_matches_from_mut(args)?;
+        let cli = Cli::from_arg_matches(&matches)
+            .expect("Cli::from_arg_matches must accept matches from Cli::command()");
+        validate_post_parse(&cli, &mut cmd)?;
+        Ok(cli)
+    }
+
+    #[test]
+    fn service_query_rejects_explicit_json_with_format_in_both_orders() {
+        for args in [
+            &[
+                "clickhousectl",
+                "cloud",
+                "--json",
+                "service",
+                "query",
+                "--id",
+                "svc-1",
+                "--query",
+                "SELECT 1",
+                "--format",
+                "CSV",
+            ][..],
+            &[
+                "clickhousectl",
+                "cloud",
+                "service",
+                "query",
+                "--id",
+                "svc-1",
+                "--query",
+                "SELECT 1",
+                "--json",
+                "--format",
+                "CSV",
+            ][..],
+        ] {
+            let error = parse_and_validate(args)
+                .err()
+                .expect("explicit --json and --format should conflict");
+            assert_eq!(error.kind(), ErrorKind::ArgumentConflict);
+            assert_eq!(error.exit_code(), 2);
+            let message = error.to_string();
+            assert!(message.contains("--json"), "{message}");
+            assert!(message.contains("--format"), "{message}");
+            assert!(
+                message.contains("clickhousectl cloud service query"),
+                "{message}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2425,14 +2425,29 @@ async fn service_query_agent_json_uses_json_each_row_unless_format_is_explicit()
     assert_eq!(requests[0].url.query(), Some("format=CSV"));
 }
 
-#[test]
-fn service_query_rejects_json_with_an_explicit_format_before_network_access() {
-    let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
-    let output = command
-        .env("DO_NOT_TRACK", "1")
-        .args([
+#[tokio::test]
+async fn service_query_rejects_json_with_an_explicit_format_before_network_access() {
+    let control = MockServer::start().await;
+    let url = control.uri();
+    let cases = [
+        vec![
             "cloud",
+            "--url",
+            &url,
+            "--json",
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--query",
+            "SELECT 1",
+            "--format",
+            "CSV",
+        ],
+        vec![
+            "cloud",
+            "--url",
+            &url,
             "service",
             "query",
             "--id",
@@ -2442,14 +2457,31 @@ fn service_query_rejects_json_with_an_explicit_format_before_network_access() {
             "--json",
             "--format",
             "CSV",
-        ])
-        .output()
-        .expect("failed to spawn clickhousectl");
+        ],
+    ];
 
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("--json"));
-    assert!(stderr.contains("--format"));
+    for args in cases {
+        let mut command = Command::new(clickhousectl_binary());
+        clear_agent_env(&mut command);
+        let output = command
+            .env("DO_NOT_TRACK", "1")
+            .env("CLICKHOUSE_CLOUD_API_KEY", "unused-key")
+            .env("CLICKHOUSE_CLOUD_API_SECRET", "unused-secret")
+            .args(args)
+            .output()
+            .expect("failed to spawn clickhousectl");
+
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("--json"), "{stderr}");
+        assert!(stderr.contains("--format"), "{stderr}");
+        assert!(
+            stderr.contains("clickhousectl cloud service query"),
+            "{stderr}"
+        );
+    }
+
+    assert!(control.received_requests().await.unwrap().is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- reject explicit Cloud `--json` with service query `--format` in either argument order
- perform cross-level validation before runtime or network work
- preserve explicit formats when JSON mode comes only from coding-agent detection

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- focused subprocess tests for both flag orders and zero requests
- `git diff --check`

Closes #422