### PR TITLE
Recognize stopped service query responses

### DIFF
--- a/crates/clickhouse-cloud-api/src/client.rs
+++ b/crates/clickhouse-cloud-api/src/client.rs
@@ -91,6 +91,19 @@ fn query_api_error_message(status: reqwest::StatusCode, body: &str) -> String {
     })
 }
 
+fn query_api_reports_stopped_service(status: reqwest::StatusCode, body: &str) -> bool {
+    const STOPPED_SERVICE_MESSAGE: &str =
+        "ClickHouse service is currently unavailable. Please try again later.";
+
+    status == reqwest::StatusCode::NOT_FOUND
+        && serde_json::from_str::<serde_json::Value>(body)
+            .ok()
+            .is_some_and(|value| {
+                value.get("error").and_then(serde_json::Value::as_str)
+                    == Some(STOPPED_SERVICE_MESSAGE)
+            })
+}
+
 impl Client {
     /// Create a new client with the default base URL (`https://api.clickhouse.cloud`).
     pub fn new(key_id: impl Into<String>, key_secret: impl Into<String>) -> Self {
@@ -383,6 +396,9 @@ impl Client {
                     "Query API returned HTTP {status}, but its response body could not be read: {error}"
                 ),
             })?;
+            if query_api_reports_stopped_service(status, &body_text) {
+                return Err(Error::ServiceStopped);
+            }
             return Err(Error::Api {
                 status: status.as_u16(),
                 message: query_api_error_message(status, &body_text),

--- a/crates/clickhouse-cloud-api/src/error.rs
+++ b/crates/clickhouse-cloud-api/src/error.rs
@@ -26,8 +26,8 @@ pub enum Error {
     ServiceIdle,
 
     /// The Query API reported the service is stopped (HTTP 206 `Service is
-    /// stopped`). A stopped service is never woken by the Query API; it must
-    /// be started explicitly.
+    /// stopped`, or its HTTP 404 unavailable-service response). A stopped
+    /// service is never woken by the Query API; it must be started explicitly.
     #[error("service is stopped; it must be started before it can be queried")]
     ServiceStopped,
 }

--- a/crates/clickhouse-cloud-api/tests/run_query_test.rs
+++ b/crates/clickhouse-cloud-api/tests/run_query_test.rs
@@ -183,6 +183,25 @@ async fn run_query_206_service_stopped_maps_to_service_stopped() {
 }
 
 #[tokio::test]
+async fn run_query_404_unavailable_service_maps_to_service_stopped() {
+    let mock = start_mock_query_host(
+        404,
+        r#"{"error":"ClickHouse service is currently unavailable. Please try again later."}"#,
+    )
+    .await;
+    let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());
+
+    let err = client
+        .run_query_bearer("svc-1", "SELECT 1", None, "CSV", false)
+        .await
+        .expect_err("expected ServiceStopped");
+    assert!(
+        matches!(err, Error::ServiceStopped),
+        "expected ServiceStopped, got: {err:?}"
+    );
+}
+
+#[tokio::test]
 async fn run_query_206_unrecognized_body_maps_to_api_error() {
     let mock = start_mock_query_host(206, r#"{"data":"Something new"}"#).await;
     let client = Client::with_bearer_token(mock.uri(), "oauth-token").with_query_host(mock.uri());

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1790,7 +1790,7 @@ async fn service_query(
             }
             other => other,
         };
-        result.map_err(|error| convert_query_error(client, error, &service_name))?
+        result.map_err(|error| convert_query_error(client, error, &service_name, &service_id))?
     } else {
         let result = if let Some(key) = credentials::get_service_query_key(&service_id) {
             run_basic_service_query(
@@ -1853,7 +1853,7 @@ async fn service_query(
                 other => other,
             }
         };
-        result.map_err(|error| convert_query_error(client, error, &service_name))?
+        result.map_err(|error| convert_query_error(client, error, &service_name, &service_id))?
     };
 
     use futures_util::StreamExt;
@@ -1919,10 +1919,11 @@ fn convert_query_error(
     client: &CloudClient,
     error: clickhouse_cloud_api::Error,
     service_name: &str,
+    service_id: &str,
 ) -> Box<dyn std::error::Error> {
     match error {
         clickhouse_cloud_api::Error::ServiceStopped => format!(
-            "service '{service_name}' is stopped; start it with `clickhousectl cloud service start` and retry"
+            "service '{service_name}' is stopped; start it with `clickhousectl cloud service start {service_id}` and retry"
         )
         .into(),
         other => client.convert_error(other).into(),

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1790,7 +1790,9 @@ async fn service_query(
             }
             other => other,
         };
-        result.map_err(|error| convert_query_error(client, error, &service_name, &service_id))?
+        result.map_err(|error| {
+            convert_query_error(client, error, &service_name, &service_id, &org_id)
+        })?
     } else {
         let result = if let Some(key) = credentials::get_service_query_key(&service_id) {
             run_basic_service_query(
@@ -1853,7 +1855,9 @@ async fn service_query(
                 other => other,
             }
         };
-        result.map_err(|error| convert_query_error(client, error, &service_name, &service_id))?
+        result.map_err(|error| {
+            convert_query_error(client, error, &service_name, &service_id, &org_id)
+        })?
     };
 
     use futures_util::StreamExt;
@@ -1920,10 +1924,11 @@ fn convert_query_error(
     error: clickhouse_cloud_api::Error,
     service_name: &str,
     service_id: &str,
+    org_id: &str,
 ) -> Box<dyn std::error::Error> {
     match error {
         clickhouse_cloud_api::Error::ServiceStopped => format!(
-            "service '{service_name}' is stopped; start it with `clickhousectl cloud service start {service_id}` and retry"
+            "service '{service_name}' is stopped; start it with `clickhousectl cloud service start {service_id} --org-id {org_id}` and retry"
         )
         .into(),
         other => client.convert_error(other).into(),

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3274,6 +3274,8 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
         .await;
 
     let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    std::fs::create_dir(&home_dir).unwrap();
 
     let url = control.uri();
     let output = Command::new(clickhousectl_binary())
@@ -3292,6 +3294,7 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
             "SELECT 1",
         ])
         .current_dir(dir.path())
+        .env("HOME", home_dir)
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
         .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
@@ -3303,7 +3306,7 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
         format!(
-            "Error: service 'demo' is stopped; start it with `clickhousectl cloud service start {QUERY_TEST_SERVICE_ID}` and retry\n"
+            "Error: service 'demo' is stopped; start it with `clickhousectl cloud service start {QUERY_TEST_SERVICE_ID} --org-id org-1` and retry\n"
         ),
     );
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3084,13 +3084,12 @@ async fn service_query_merges_the_new_key_into_the_reported_keys() {
     );
 }
 
-// ── Idled / stopped services (query host 206 protocol) ─────────────────────
+// ── Idled / stopped services ───────────────────────────────────────────────
 //
-// An idled or stopped service answers the run request with 206 and
-// `{"data": "<state>"}` instead of executing the query. For `Confirm wake
-// service` the CLI must resend the query once with the `wake-service: true`
-// header (waking the service, like the SQL console does after prompting);
-// for `Service is stopped` it must fail with a hint to start the service.
+// An idled service answers 206 `Confirm wake service`, which the CLI retries
+// with `wake-service: true`. A stopped service currently answers 404 with an
+// unavailable-service error; the CLI must not treat that 404 as a missing
+// query endpoint and must instead fail with a hint to start the service.
 
 /// Write an OAuth tokens.json into `ch_dir` (the caller's `$HOME/.clickhouse`)
 /// so the binary authenticates with a bearer token against the given control
@@ -3268,17 +3267,13 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
     let query_host = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
-        .respond_with(
-            ResponseTemplate::new(206).set_body_string(r#"{"data":"Service is stopped"}"#),
-        )
+        .respond_with(ResponseTemplate::new(404).set_body_string(
+            r#"{"error":"ClickHouse service is currently unavailable. Please try again later."}"#,
+        ))
         .mount(&query_host)
         .await;
 
     let dir = tempfile::tempdir().unwrap();
-    let home_dir = dir.path().join("home");
-    let ch_dir = home_dir.join(".clickhouse");
-    std::fs::create_dir_all(&ch_dir).unwrap();
-    write_oauth_tokens(&ch_dir, &control.uri());
 
     let url = control.uri();
     let output = Command::new(clickhousectl_binary())
@@ -3297,27 +3292,37 @@ async fn service_query_fails_with_start_hint_when_service_is_stopped() {
             "SELECT 1",
         ])
         .current_dir(dir.path())
-        .env("HOME", &home_dir)
-        .env_remove("CLICKHOUSE_CLOUD_API_KEY")
-        .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
         .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
         .output()
         .expect("failed to spawn clickhousectl");
 
-    assert!(
-        !output.status.success(),
-        "querying a stopped service must fail\nstdout:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-    );
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("stopped") && stderr.contains("service start"),
-        "stderr should say the service is stopped and hint at `service start`:\n{stderr}",
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Error: service 'demo' is stopped; start it with `clickhousectl cloud service start {QUERY_TEST_SERVICE_ID}` and retry\n"
+        ),
     );
 
-    // A stopped service is never woken: no wake-service resend.
+    // The stopped response is terminal: no wake resend and no endpoint/key
+    // provisioning despite its HTTP 404 status.
     let query_requests = query_host.received_requests().await.unwrap();
     assert_eq!(query_requests.len(), 1);
+    let control_requests = control.received_requests().await.unwrap();
+    assert!(
+        control_requests
+            .iter()
+            .all(|request| request.method == wiremock::http::Method::GET),
+        "stopped service query attempted provisioning: {:?}",
+        control_requests
+            .iter()
+            .map(|request| format!("{} {}", request.method, request.url.path()))
+            .collect::<Vec<_>>(),
+    );
+    assert!(!dir.path().join(".clickhouse/credentials.json").exists());
 }
 
 // Shell env vars must win over `.env` — if both are set, the request is


### PR DESCRIPTION
## Summary

- classify the live stopped-service Query API 404 as `ServiceStopped`
- preserve generic 404 handling and endpoint provisioning behavior
- include the service ID in the actionable start command

## Testing

- `cargo fmt --all --check`
- `cargo test -p clickhouse-cloud-api --test run_query_test`
- `cargo test -p clickhousectl --test cli_request_shape_test`
- focused service provisioning classification test
- `cargo clippy -p clickhouse-cloud-api -p clickhousectl --all-targets -- -D warnings`
- `git diff --check`

Closes #423