### PR TITLE
Synchronize OpenAPI drift issues

### DIFF
--- a/.github/workflows/openapi-drift.yml
+++ b/.github/workflows/openapi-drift.yml
@@ -13,6 +13,11 @@ permissions:
 env:
   DO_NOT_TRACK: "1"
 
+concurrency:
+  group: openapi-drift
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   check-drift:
     name: Check for OpenAPI spec drift
@@ -28,7 +33,7 @@ jobs:
       - name: Cache Rust build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - name: Check for drift and create issue
+      - name: Check for drift and synchronize issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 scripts/check-openapi-drift.py

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -25,6 +25,10 @@ LIVE_SPEC_URL = os.environ.get(
     "CLICKHOUSE_OPENAPI_SPEC_URL", "https://api.clickhouse.cloud/v1"
 )
 ISSUE_LABEL = "openapi-drift"
+GENERATED_ISSUE_MARKER = "<!-- clickhousectl-openapi-drift -->"
+REPORT_INTRO = (
+    "The live ClickHouse Cloud OpenAPI spec has drifted from the Rust API library."
+)
 # GitHub rejects issue bodies and comments over 65,536 characters.
 MAX_ISSUE_BODY_CHARS = 65536
 CONTINUATION_NOTICE = "\n---\n\n**Report continues in the next comment.**\n"
@@ -152,7 +156,7 @@ def open_drift_issues() -> list[dict]:
             "--state",
             "open",
             "--json",
-            "number,title,body,url",
+            "number,title,body,url,author",
             "--limit",
             "100",
         ],
@@ -197,6 +201,16 @@ def is_bot_generated_comment(comment: dict) -> bool:
     return user.get("login") in GITHUB_ACTIONS_LOGINS and (
         body.startswith(CONTINUATION_HEADER) or body.startswith(INCOMPLETE_REPORT_PREFIX)
     )
+
+
+def is_generated_drift_issue(issue: dict) -> bool:
+    body = issue.get("body") or ""
+    if body.startswith(GENERATED_ISSUE_MARKER):
+        return True
+
+    # Migrate the bot-authored issue created before generated issues had a marker.
+    author = issue.get("author") or {}
+    return author.get("login") in GITHUB_ACTIONS_LOGINS and body.startswith(REPORT_INTRO)
 
 
 def edit_issue(issue_url: str, title: str, body: str):
@@ -400,6 +414,12 @@ def sync_drift_issue(title: str | None, body: str | None) -> str:
         )
 
     issue = existing[0] if existing else None
+    if issue is not None and not is_generated_drift_issue(issue):
+        raise RuntimeError(
+            f"Open {ISSUE_LABEL} issue #{issue.get('number', 'unknown')} is not generated "
+            "by this script; refusing to modify it"
+        )
+
     if title is None or body is None:
         if title is not None or body is not None:
             raise ValueError("title and body must either both be set or both be None")
@@ -410,11 +430,12 @@ def sync_drift_issue(title: str | None, body: str | None) -> str:
         close_issue(issue["url"])
         return "closed"
 
-    chunks = split_issue_body(body)
+    generated_body = f"{GENERATED_ISSUE_MARKER}\n\n{body}"
+    chunks = split_issue_body(generated_body)
     if issue is None:
         ensure_label_exists()
         print(f"Creating issue: {title}", file=sys.stderr)
-        create_issue(title, body)
+        create_issue(title, generated_body)
         return "created"
 
     comments = issue_comments(issue["number"])
@@ -471,7 +492,7 @@ def build_issue_body(report: dict, live_spec: dict) -> str:
         return sum(counts[kind] for kind in kinds)
 
     lines = [
-        "The live ClickHouse Cloud OpenAPI spec has drifted from the Rust API library.",
+        REPORT_INTRO,
         "The comparison was produced by the shared `syn`-based analyzer.",
         "",
         f"- **Live spec:** `{LIVE_SPEC_URL}`",

--- a/scripts/check-openapi-drift.py
+++ b/scripts/check-openapi-drift.py
@@ -29,6 +29,12 @@ ISSUE_LABEL = "openapi-drift"
 MAX_ISSUE_BODY_CHARS = 65536
 CONTINUATION_NOTICE = "\n---\n\n**Report continues in the next comment.**\n"
 CONTINUATION_HEADER = "**Drift report, continued from above.**\n\n---\n\n"
+INCOMPLETE_REPORT_PREFIX = "**This drift report is incomplete.**"
+CLEAN_ISSUE_COMMENT = (
+    "The automated drift check now reports no actionable drift. Closing this issue "
+    "because its report is no longer current."
+)
+GITHUB_ACTIONS_LOGINS = {"github-actions", "github-actions[bot]", "app/github-actions"}
 
 
 def fetch_live_spec() -> dict | None:
@@ -130,6 +136,8 @@ def ensure_label_exists():
             "--force",
         ],
         capture_output=True,
+        text=True,
+        check=True,
     )
 
 
@@ -144,14 +152,112 @@ def open_drift_issues() -> list[dict]:
             "--state",
             "open",
             "--json",
-            "number,title",
+            "number,title,body,url",
+            "--limit",
+            "100",
         ],
         capture_output=True,
         text=True,
+        check=True,
     )
-    if result.returncode != 0:
-        return []
-    return json.loads(result.stdout)
+    try:
+        issues = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("GitHub returned invalid JSON while listing drift issues") from error
+    if not isinstance(issues, list):
+        raise RuntimeError("GitHub returned an invalid drift issue list")
+    return issues
+
+
+def issue_comments(issue_number: int) -> list[dict]:
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "--slurp",
+            f"repos/{{owner}}/{{repo}}/issues/{issue_number}/comments?per_page=100",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    try:
+        pages = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise RuntimeError("GitHub returned invalid JSON while listing issue comments") from error
+    if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+        raise RuntimeError("GitHub returned an invalid issue comment list")
+    return [comment for page in pages for comment in page]
+
+
+def is_bot_generated_comment(comment: dict) -> bool:
+    user = comment.get("user") or {}
+    body = comment.get("body") or ""
+    return user.get("login") in GITHUB_ACTIONS_LOGINS and (
+        body.startswith(CONTINUATION_HEADER) or body.startswith(INCOMPLETE_REPORT_PREFIX)
+    )
+
+
+def edit_issue(issue_url: str, title: str, body: str):
+    subprocess.run(
+        ["gh", "issue", "edit", issue_url, "--title", title, "--body-file", "-"],
+        input=body,
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+
+
+def edit_comment(comment_id: int, body: str):
+    subprocess.run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "PATCH",
+            f"repos/{{owner}}/{{repo}}/issues/comments/{comment_id}",
+            "--input",
+            "-",
+        ],
+        input=json.dumps({"body": body}),
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+
+
+def delete_comment(comment_id: int):
+    subprocess.run(
+        [
+            "gh",
+            "api",
+            "--method",
+            "DELETE",
+            f"repos/{{owner}}/{{repo}}/issues/comments/{comment_id}",
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+
+
+def close_issue(issue_url: str):
+    subprocess.run(
+        [
+            "gh",
+            "issue",
+            "close",
+            issue_url,
+            "--reason",
+            "completed",
+            "--comment",
+            CLEAN_ISSUE_COMMENT,
+        ],
+        text=True,
+        check=True,
+        capture_output=True,
+    )
 
 
 def split_issue_body(body: str) -> list[str]:
@@ -225,6 +331,49 @@ def split_issue_body(body: str) -> list[str]:
     return chunks
 
 
+def post_continuation_comment(issue_url: str, body: str):
+    try:
+        subprocess.run(
+            ["gh", "issue", "comment", issue_url, "--body-file", "-"],
+            input=body,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # Retry once; transient GitHub failures are common.
+        try:
+            subprocess.run(
+                ["gh", "issue", "comment", issue_url, "--body-file", "-"],
+                input=body,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            # Never leave an issue that silently looks complete after a failed
+            # continuation update. The next successful sync removes this notice.
+            fallback = (
+                f"{INCOMPLETE_REPORT_PREFIX} A continuation comment failed to post "
+                "after a retry; check the workflow logs and re-run the drift check "
+                "to regenerate the full report.\n"
+            )
+            try:
+                subprocess.run(
+                    ["gh", "issue", "comment", issue_url, "--body-file", "-"],
+                    input=fallback,
+                    text=True,
+                    check=False,
+                    capture_output=True,
+                )
+            except Exception:  # noqa: BLE001 - the fallback must never mask the failure
+                pass
+            print(
+                f"ERROR: failed to post a continuation comment to {issue_url}; "
+                "the drift report is incomplete.",
+                file=sys.stderr,
+            )
+            raise
+
+
 def create_issue(title: str, body: str):
     chunks = split_issue_body(body)
     # The body can exceed the kernel's per-argument size limit; feed it via stdin.
@@ -238,47 +387,78 @@ def create_issue(title: str, body: str):
     issue_url = result.stdout.strip().splitlines()[-1]
     print(issue_url, file=sys.stderr)
     for chunk in chunks[1:]:
-        try:
-            subprocess.run(
-                ["gh", "issue", "comment", issue_url, "--body-file", "-"],
-                input=chunk,
-                text=True,
-                check=True,
-            )
-        except subprocess.CalledProcessError:
-            # Retry once; transient GitHub failures are common.
-            try:
-                subprocess.run(
-                    ["gh", "issue", "comment", issue_url, "--body-file", "-"],
-                    input=chunk,
-                    text=True,
-                    check=True,
-                )
-            except subprocess.CalledProcessError:
-                # A comment failed twice. Never leave an issue that silently
-                # looks complete: best-effort flag it as truncated, then fail
-                # loudly so the CI run still reports the problem.
-                fallback = (
-                    "**This drift report is incomplete.** A continuation comment "
-                    "failed to post after a retry; check the workflow logs and "
-                    "re-run the drift check to regenerate the full report.\n"
-                )
-                try:
-                    subprocess.run(
-                        ["gh", "issue", "comment", issue_url, "--body-file", "-"],
-                        input=fallback,
-                        text=True,
-                        check=False,
-                        capture_output=True,
-                    )
-                except Exception:  # noqa: BLE001 - the fallback must never mask the failure
-                    pass
-                print(
-                    f"ERROR: failed to post a continuation comment to {issue_url}; "
-                    "the drift report is incomplete.",
-                    file=sys.stderr,
-                )
-                raise
+        post_continuation_comment(issue_url, chunk)
+
+
+def sync_drift_issue(title: str | None, body: str | None) -> str:
+    """Synchronize the one open generated drift issue with the latest report."""
+    existing = open_drift_issues()
+    if len(existing) > 1:
+        numbers = ", ".join(f"#{issue.get('number', 'unknown')}" for issue in existing)
+        raise RuntimeError(
+            f"Multiple open {ISSUE_LABEL} issues exist ({numbers}); refusing to choose one"
+        )
+
+    issue = existing[0] if existing else None
+    if title is None or body is None:
+        if title is not None or body is not None:
+            raise ValueError("title and body must either both be set or both be None")
+        if issue is None:
+            print("No open drift issue to close.", file=sys.stderr)
+            return "clean"
+        print(f"Closing clean drift issue #{issue['number']}.", file=sys.stderr)
+        close_issue(issue["url"])
+        return "closed"
+
+    chunks = split_issue_body(body)
+    if issue is None:
+        ensure_label_exists()
+        print(f"Creating issue: {title}", file=sys.stderr)
+        create_issue(title, body)
+        return "created"
+
+    comments = issue_comments(issue["number"])
+    managed = [comment for comment in comments if is_bot_generated_comment(comment)]
+    for comment in managed:
+        if not isinstance(comment.get("id"), int):
+            raise RuntimeError("GitHub returned a generated issue comment without a numeric ID")
+
+    continuations = [
+        comment
+        for comment in managed
+        if (comment.get("body") or "").startswith(CONTINUATION_HEADER)
+    ]
+    incomplete_notices = [
+        comment
+        for comment in managed
+        if (comment.get("body") or "").startswith(INCOMPLETE_REPORT_PREFIX)
+    ]
+    desired_continuations = chunks[1:]
+    unchanged = (
+        issue.get("title") == title
+        and issue.get("body") == chunks[0]
+        and [comment.get("body") for comment in continuations] == desired_continuations
+        and not incomplete_notices
+    )
+    if unchanged:
+        print(f"Open drift issue #{issue['number']} is already current.", file=sys.stderr)
+        return "unchanged"
+
+    print(f"Updating drift issue #{issue['number']}: {title}", file=sys.stderr)
+    if issue.get("title") != title or issue.get("body") != chunks[0]:
+        edit_issue(issue["url"], title, chunks[0])
+
+    shared_count = min(len(continuations), len(desired_continuations))
+    for index in range(shared_count):
+        if continuations[index].get("body") != desired_continuations[index]:
+            edit_comment(continuations[index]["id"], desired_continuations[index])
+    for continuation in desired_continuations[shared_count:]:
+        post_continuation_comment(issue["url"], continuation)
+    for continuation in continuations[shared_count:]:
+        delete_comment(continuation["id"])
+    for notice in incomplete_notices:
+        delete_comment(notice["id"])
+    return "updated"
 
 
 def build_issue_body(report: dict, live_spec: dict) -> str:
@@ -462,23 +642,27 @@ def main():
     print(f"Acknowledged unsupported enum constraints: {acknowledged}", file=sys.stderr)
     if total == 0:
         print("No actionable drift. Library fully covers the live spec.", file=sys.stderr)
-        return
+        if args.dry_run:
+            return
+        title = None
+        body = None
+    else:
+        title = (
+            f"OpenAPI drift: {total} gap{'s' if total != 1 else ''} "
+            "between live spec and library"
+        )
+        body = build_issue_body(report, live_spec)
+        if args.dry_run:
+            print(body)
+            return
 
-    body = build_issue_body(report, live_spec)
-    if args.dry_run:
-        print(body)
-        return
-
-    existing = open_drift_issues()
-    if existing:
-        numbers = ", ".join(f"#{issue['number']}" for issue in existing)
-        print(f"Open drift issue(s) already exist ({numbers}); skipping.", file=sys.stderr)
-        return
-
-    title = f"OpenAPI drift: {total} gap{'s' if total != 1 else ''} between live spec and library"
-    ensure_label_exists()
-    print(f"Creating issue: {title}", file=sys.stderr)
-    create_issue(title, body)
+    try:
+        sync_drift_issue(title, body)
+    except (RuntimeError, subprocess.CalledProcessError) as error:
+        detail = getattr(error, "stderr", None)
+        message = detail.strip() if isinstance(detail, str) and detail.strip() else str(error)
+        print(f"ERROR: Could not synchronize the OpenAPI drift issue: {message}", file=sys.stderr)
+        raise SystemExit(1) from error
     print("Done.", file=sys.stderr)
 
 

--- a/scripts/tests/test_check_openapi_drift.py
+++ b/scripts/tests/test_check_openapi_drift.py
@@ -13,6 +13,10 @@ sys.modules[SPEC.name] = drift
 SPEC.loader.exec_module(drift)
 
 
+def generated_issue_body(body):
+    return f"{drift.GENERATED_ISSUE_MARKER}\n\n{body}"
+
+
 class DriftScriptTests(unittest.TestCase):
     def test_groups_findings_and_renders_spec_snippets(self):
         report = {
@@ -78,13 +82,13 @@ class DriftScriptTests(unittest.TestCase):
 
         self.assertEqual(action, "created")
         ensure_label.assert_called_once_with()
-        create_issue.assert_called_once_with("new title", "new body")
+        create_issue.assert_called_once_with("new title", generated_issue_body("new body"))
 
     def test_sync_updates_issue_and_only_reconciles_bot_generated_comments(self):
         issue = {
             "number": 42,
             "title": "old title",
-            "body": "old body",
+            "body": generated_issue_body("old body"),
             "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
         }
         old_first = drift.CONTINUATION_HEADER + "old first"
@@ -125,7 +129,11 @@ class DriftScriptTests(unittest.TestCase):
         with (
             mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
             mock.patch.object(drift, "issue_comments", return_value=comments),
-            mock.patch.object(drift, "split_issue_body", return_value=["new body", desired]),
+            mock.patch.object(
+                drift,
+                "split_issue_body",
+                return_value=[generated_issue_body("new body"), desired],
+            ),
             mock.patch.object(drift, "edit_issue") as edit_issue,
             mock.patch.object(drift, "edit_comment") as edit_comment,
             mock.patch.object(drift, "delete_comment") as delete_comment,
@@ -134,7 +142,9 @@ class DriftScriptTests(unittest.TestCase):
             action = drift.sync_drift_issue("new title", "rendered body")
 
         self.assertEqual(action, "updated")
-        edit_issue.assert_called_once_with(issue["url"], "new title", "new body")
+        edit_issue.assert_called_once_with(
+            issue["url"], "new title", generated_issue_body("new body")
+        )
         edit_comment.assert_called_once_with(101, desired)
         self.assertEqual(delete_comment.call_args_list, [mock.call(102), mock.call(103)])
         post_comment.assert_not_called()
@@ -143,7 +153,7 @@ class DriftScriptTests(unittest.TestCase):
         issue = {
             "number": 42,
             "title": "current title",
-            "body": "current body",
+            "body": generated_issue_body("current body"),
             "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
         }
         desired = drift.CONTINUATION_HEADER + "new continuation"
@@ -158,7 +168,9 @@ class DriftScriptTests(unittest.TestCase):
             mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
             mock.patch.object(drift, "issue_comments", return_value=comments),
             mock.patch.object(
-                drift, "split_issue_body", return_value=["current body", desired]
+                drift,
+                "split_issue_body",
+                return_value=[generated_issue_body("current body"), desired],
             ),
             mock.patch.object(drift, "edit_issue") as edit_issue,
             mock.patch.object(drift, "post_continuation_comment") as post_comment,
@@ -174,7 +186,7 @@ class DriftScriptTests(unittest.TestCase):
         issue = {
             "number": 42,
             "title": "current title",
-            "body": "current body",
+            "body": generated_issue_body("current body"),
             "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
         }
         comments = [
@@ -193,7 +205,9 @@ class DriftScriptTests(unittest.TestCase):
             mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
             mock.patch.object(drift, "issue_comments", return_value=comments),
             mock.patch.object(
-                drift, "split_issue_body", return_value=["current body", desired]
+                drift,
+                "split_issue_body",
+                return_value=[generated_issue_body("current body"), desired],
             ),
             mock.patch.object(drift, "edit_issue") as edit_issue,
             mock.patch.object(drift, "edit_comment") as edit_comment,
@@ -214,7 +228,7 @@ class DriftScriptTests(unittest.TestCase):
         issue = {
             "number": 42,
             "title": "old title",
-            "body": "old body",
+            "body": generated_issue_body("old body"),
             "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
         }
         with (
@@ -237,6 +251,49 @@ class DriftScriptTests(unittest.TestCase):
 
         self.assertEqual(action, "clean")
         close_issue.assert_not_called()
+
+    def test_sync_refuses_to_modify_manually_created_labeled_issue(self):
+        issue = {
+            "number": 42,
+            "title": "manual report",
+            "body": "Manually maintained drift notes",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+            "author": {"login": "alice"},
+        }
+        for title, body in (("new title", "new body"), (None, None)):
+            with self.subTest(clean=title is None):
+                with (
+                    mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+                    mock.patch.object(drift, "issue_comments") as issue_comments,
+                    mock.patch.object(drift, "edit_issue") as edit_issue,
+                    mock.patch.object(drift, "close_issue") as close_issue,
+                ):
+                    with self.assertRaisesRegex(RuntimeError, "is not generated"):
+                        drift.sync_drift_issue(title, body)
+
+                issue_comments.assert_not_called()
+                edit_issue.assert_not_called()
+                close_issue.assert_not_called()
+
+    def test_sync_migrates_legacy_bot_generated_issue(self):
+        issue = {
+            "number": 42,
+            "title": "old title",
+            "body": f"{drift.REPORT_INTRO}\n\nold report",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+            "author": {"login": "github-actions[bot]"},
+        }
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments", return_value=[]),
+            mock.patch.object(drift, "edit_issue") as edit_issue,
+        ):
+            action = drift.sync_drift_issue("new title", "new body")
+
+        self.assertEqual(action, "updated")
+        edit_issue.assert_called_once_with(
+            issue["url"], "new title", generated_issue_body("new body")
+        )
 
     def test_sync_refuses_multiple_open_drift_issues(self):
         issues = [
@@ -269,7 +326,7 @@ class DriftScriptTests(unittest.TestCase):
         issue = {
             "number": 42,
             "title": "old title",
-            "body": "old body",
+            "body": generated_issue_body("old body"),
             "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
         }
         error = drift.subprocess.CalledProcessError(1, ["gh", "issue", "edit"])
@@ -297,6 +354,9 @@ class DriftScriptTests(unittest.TestCase):
         with self.assertRaises(drift.subprocess.CalledProcessError):
             drift.open_drift_issues()
 
+        command = run.call_args.args[0]
+        fields = command[command.index("--json") + 1].split(",")
+        self.assertIn("author", fields)
         self.assertTrue(run.call_args.kwargs["check"])
 
     @mock.patch.object(drift.subprocess, "run")

--- a/scripts/tests/test_check_openapi_drift.py
+++ b/scripts/tests/test_check_openapi_drift.py
@@ -68,6 +68,304 @@ class DriftScriptTests(unittest.TestCase):
         self.assertIn("## Acknowledged Unsupported Enum Constraints", body)
         self.assertIn("## Enum VALUES Const Mismatches", body)
 
+    def test_sync_creates_issue_when_none_is_open(self):
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[]),
+            mock.patch.object(drift, "ensure_label_exists") as ensure_label,
+            mock.patch.object(drift, "create_issue") as create_issue,
+        ):
+            action = drift.sync_drift_issue("new title", "new body")
+
+        self.assertEqual(action, "created")
+        ensure_label.assert_called_once_with()
+        create_issue.assert_called_once_with("new title", "new body")
+
+    def test_sync_updates_issue_and_only_reconciles_bot_generated_comments(self):
+        issue = {
+            "number": 42,
+            "title": "old title",
+            "body": "old body",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+        }
+        old_first = drift.CONTINUATION_HEADER + "old first"
+        stale_second = drift.CONTINUATION_HEADER + "stale second"
+        desired = drift.CONTINUATION_HEADER + "new first"
+        comments = [
+            {
+                "id": 101,
+                "user": {"login": "github-actions[bot]"},
+                "body": old_first,
+            },
+            {
+                "id": 201,
+                "user": {"login": "alice"},
+                "body": stale_second,
+            },
+            {
+                "id": 202,
+                "user": {"login": "another-bot[bot]"},
+                "body": stale_second,
+            },
+            {
+                "id": 102,
+                "user": {"login": "github-actions[bot]"},
+                "body": stale_second,
+            },
+            {
+                "id": 103,
+                "user": {"login": "github-actions[bot]"},
+                "body": drift.INCOMPLETE_REPORT_PREFIX + " retry failed",
+            },
+            {
+                "id": 104,
+                "user": {"login": "github-actions[bot]"},
+                "body": "Unrelated automation comment",
+            },
+        ]
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments", return_value=comments),
+            mock.patch.object(drift, "split_issue_body", return_value=["new body", desired]),
+            mock.patch.object(drift, "edit_issue") as edit_issue,
+            mock.patch.object(drift, "edit_comment") as edit_comment,
+            mock.patch.object(drift, "delete_comment") as delete_comment,
+            mock.patch.object(drift, "post_continuation_comment") as post_comment,
+        ):
+            action = drift.sync_drift_issue("new title", "rendered body")
+
+        self.assertEqual(action, "updated")
+        edit_issue.assert_called_once_with(issue["url"], "new title", "new body")
+        edit_comment.assert_called_once_with(101, desired)
+        self.assertEqual(delete_comment.call_args_list, [mock.call(102), mock.call(103)])
+        post_comment.assert_not_called()
+
+    def test_sync_adds_new_continuation_comments_on_update(self):
+        issue = {
+            "number": 42,
+            "title": "current title",
+            "body": "current body",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+        }
+        desired = drift.CONTINUATION_HEADER + "new continuation"
+        comments = [
+            {
+                "id": 201,
+                "user": {"login": "alice"},
+                "body": "Keep this human comment",
+            }
+        ]
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments", return_value=comments),
+            mock.patch.object(
+                drift, "split_issue_body", return_value=["current body", desired]
+            ),
+            mock.patch.object(drift, "edit_issue") as edit_issue,
+            mock.patch.object(drift, "post_continuation_comment") as post_comment,
+        ):
+            action = drift.sync_drift_issue("current title", "rendered body")
+
+        self.assertEqual(action, "updated")
+        edit_issue.assert_not_called()
+        post_comment.assert_called_once_with(issue["url"], desired)
+
+    def test_sync_leaves_unchanged_report_and_human_comments_untouched(self):
+        desired = drift.CONTINUATION_HEADER + "current continuation"
+        issue = {
+            "number": 42,
+            "title": "current title",
+            "body": "current body",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+        }
+        comments = [
+            {
+                "id": 101,
+                "user": {"login": "github-actions[bot]"},
+                "body": desired,
+            },
+            {
+                "id": 201,
+                "user": {"login": "alice"},
+                "body": "Keep this human comment",
+            },
+        ]
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments", return_value=comments),
+            mock.patch.object(
+                drift, "split_issue_body", return_value=["current body", desired]
+            ),
+            mock.patch.object(drift, "edit_issue") as edit_issue,
+            mock.patch.object(drift, "edit_comment") as edit_comment,
+            mock.patch.object(drift, "delete_comment") as delete_comment,
+            mock.patch.object(drift, "post_continuation_comment") as post_comment,
+            mock.patch.object(drift, "close_issue") as close_issue,
+        ):
+            action = drift.sync_drift_issue("current title", "rendered body")
+
+        self.assertEqual(action, "unchanged")
+        edit_issue.assert_not_called()
+        edit_comment.assert_not_called()
+        delete_comment.assert_not_called()
+        post_comment.assert_not_called()
+        close_issue.assert_not_called()
+
+    def test_sync_closes_open_issue_for_clean_report(self):
+        issue = {
+            "number": 42,
+            "title": "old title",
+            "body": "old body",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+        }
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments") as issue_comments,
+            mock.patch.object(drift, "close_issue") as close_issue,
+        ):
+            action = drift.sync_drift_issue(None, None)
+
+        self.assertEqual(action, "closed")
+        close_issue.assert_called_once_with(issue["url"])
+        issue_comments.assert_not_called()
+
+    def test_sync_clean_report_without_open_issue_is_noop(self):
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[]),
+            mock.patch.object(drift, "close_issue") as close_issue,
+        ):
+            action = drift.sync_drift_issue(None, None)
+
+        self.assertEqual(action, "clean")
+        close_issue.assert_not_called()
+
+    def test_sync_refuses_multiple_open_drift_issues(self):
+        issues = [
+            {"number": 41, "url": "https://example.test/41"},
+            {"number": 42, "url": "https://example.test/42"},
+        ]
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=issues),
+            mock.patch.object(drift, "create_issue") as create_issue,
+            mock.patch.object(drift, "close_issue") as close_issue,
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Multiple open"):
+                drift.sync_drift_issue("title", "body")
+
+        create_issue.assert_not_called()
+        close_issue.assert_not_called()
+
+    def test_sync_propagates_lookup_failure_without_creating_issue(self):
+        error = drift.subprocess.CalledProcessError(1, ["gh", "issue", "list"])
+        with (
+            mock.patch.object(drift, "open_drift_issues", side_effect=error),
+            mock.patch.object(drift, "create_issue") as create_issue,
+        ):
+            with self.assertRaises(drift.subprocess.CalledProcessError):
+                drift.sync_drift_issue("title", "body")
+
+        create_issue.assert_not_called()
+
+    def test_sync_propagates_update_failure_without_touching_comments(self):
+        issue = {
+            "number": 42,
+            "title": "old title",
+            "body": "old body",
+            "url": "https://github.com/ClickHouse/clickhousectl/issues/42",
+        }
+        error = drift.subprocess.CalledProcessError(1, ["gh", "issue", "edit"])
+        with (
+            mock.patch.object(drift, "open_drift_issues", return_value=[issue]),
+            mock.patch.object(drift, "issue_comments", return_value=[]),
+            mock.patch.object(drift, "edit_issue", side_effect=error),
+            mock.patch.object(drift, "edit_comment") as edit_comment,
+            mock.patch.object(drift, "delete_comment") as delete_comment,
+            mock.patch.object(drift, "post_continuation_comment") as post_comment,
+        ):
+            with self.assertRaises(drift.subprocess.CalledProcessError):
+                drift.sync_drift_issue("new title", "new body")
+
+        edit_comment.assert_not_called()
+        delete_comment.assert_not_called()
+        post_comment.assert_not_called()
+
+    @mock.patch.object(drift.subprocess, "run")
+    def test_open_issue_lookup_fails_closed(self, run):
+        run.side_effect = drift.subprocess.CalledProcessError(
+            1, ["gh", "issue", "list"], stderr="lookup failed"
+        )
+
+        with self.assertRaises(drift.subprocess.CalledProcessError):
+            drift.open_drift_issues()
+
+        self.assertTrue(run.call_args.kwargs["check"])
+
+    @mock.patch.object(drift.subprocess, "run")
+    def test_issue_comment_lookup_flattens_all_pages(self, run):
+        comments = [
+            {"id": 1, "body": "first"},
+            {"id": 2, "body": "second"},
+        ]
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps([[comments[0]], [comments[1]]]),
+            stderr="",
+        )
+
+        self.assertEqual(drift.issue_comments(42), comments)
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:2], ["gh", "api"])
+        self.assertIn("--paginate", command)
+        self.assertIn("--slurp", command)
+        self.assertTrue(run.call_args.kwargs["check"])
+
+    def test_dry_run_never_queries_or_mutates_github(self):
+        reports = [
+            {"schema_version": 3, "findings": []},
+            {"schema_version": 3, "findings": [{"kind": "missing_struct_field"}]},
+        ]
+        for report in reports:
+            with self.subTest(findings=len(report["findings"])):
+                with (
+                    mock.patch.object(sys, "argv", [str(SCRIPT), "--dry-run"]),
+                    mock.patch.object(drift, "fetch_live_spec", return_value={}),
+                    mock.patch.object(drift, "run_analyzer", return_value=report),
+                    mock.patch.object(drift, "build_issue_body", return_value="body"),
+                    mock.patch.object(drift, "sync_drift_issue") as sync_issue,
+                    mock.patch("builtins.print"),
+                ):
+                    drift.main()
+
+                sync_issue.assert_not_called()
+
+    def test_main_exits_nonzero_when_synchronization_fails(self):
+        report = {"schema_version": 3, "findings": []}
+        with (
+            mock.patch.object(sys, "argv", [str(SCRIPT)]),
+            mock.patch.object(drift, "fetch_live_spec", return_value={}),
+            mock.patch.object(drift, "run_analyzer", return_value=report),
+            mock.patch.object(
+                drift, "sync_drift_issue", side_effect=RuntimeError("lookup failed")
+            ),
+            mock.patch("builtins.print"),
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                drift.main()
+
+        self.assertEqual(raised.exception.code, 1)
+
+    @mock.patch.object(drift.subprocess, "run")
+    def test_close_issue_marks_report_completed(self, run):
+        run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        drift.close_issue("https://github.com/ClickHouse/clickhousectl/issues/42")
+
+        command = run.call_args.args[0]
+        self.assertEqual(command[:3], ["gh", "issue", "close"])
+        self.assertIn("completed", command)
+        self.assertIn(drift.CLEAN_ISSUE_COMMENT, command)
+        self.assertTrue(run.call_args.kwargs["check"])
+
     def test_split_issue_body_keeps_short_bodies_intact(self):
         body = "short body"
         self.assertEqual(drift.split_issue_body(body), [body])


### PR DESCRIPTION
## Summary

- create, update, no-op, or close the single managed OpenAPI drift issue
- reconcile generated continuation comments while preserving human discussion
- fail closed on GitHub lookup/update errors and serialize workflow runs

## Testing

- Python test suite (41 passed)
- `python3 scripts/check-openapi-drift.py --dry-run`
- Python AST and workflow YAML parsing
- `git diff --check`

`ruff` and `actionlint` were not available locally.

Closes #414