### PR TITLE
Complete Cloud CLI contract tests

### DIFF
--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -683,9 +683,74 @@ mod tests {
             .command
     }
 
+    fn parse_top_level_key(args: &[&str]) -> KeyCommands {
+        let cli = Cli::try_parse_from(args).expect("parse");
+        let Commands::Cloud(cloud_args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Key { command } = cloud_args.command else {
+            panic!("expected key command");
+        };
+        command
+    }
+
+    #[test]
+    fn parses_key_body_command_defaults() {
+        let KeyCommands::Create {
+            name,
+            role_id,
+            expires_at,
+            state,
+            ip_allow,
+            hash_key_id,
+            hash_key_id_suffix,
+            hash_key_secret,
+            org_id,
+        } = parse_top_level_key(&[
+            "clickhousectl",
+            "cloud",
+            "key",
+            "create",
+            "--name",
+            "ci-key",
+        ])
+        else {
+            panic!("expected key create");
+        };
+        assert_eq!(name, "ci-key");
+        assert!(role_id.is_empty());
+        assert!(expires_at.is_none());
+        assert!(state.is_none());
+        assert!(ip_allow.is_empty());
+        assert!(hash_key_id.is_none());
+        assert!(hash_key_id_suffix.is_none());
+        assert!(hash_key_secret.is_none());
+        assert!(org_id.is_none());
+
+        let KeyCommands::Update {
+            key_id,
+            name,
+            role_id,
+            expires_at,
+            state,
+            ip_allow,
+            org_id,
+        } = parse_top_level_key(&["clickhousectl", "cloud", "key", "update", "key-1"])
+        else {
+            panic!("expected key update");
+        };
+        assert_eq!(key_id, "key-1");
+        assert!(name.is_none());
+        assert!(role_id.is_empty());
+        assert!(expires_at.is_none());
+        assert!(state.is_none());
+        assert!(ip_allow.is_empty());
+        assert!(org_id.is_none());
+    }
+
     #[test]
     fn parses_key_create_flags() {
-        let cli = Cli::try_parse_from([
+        let command = parse_top_level_key(&[
             "clickhousectl",
             "cloud",
             "key",
@@ -706,16 +771,15 @@ mod tests {
             "abcd",
             "--hash-key-secret",
             "secret-hash",
-        ])
-        .unwrap();
+            "--expires-at",
+            "2025-12-31T23:59:59Z",
+            "--state",
+            "disabled",
+            "--org-id",
+            "org-1",
+        ]);
 
-        let Commands::Cloud(args) = cli.command else {
-            panic!("expected cloud command");
-        };
-        let crate::cloud::cli::CloudCommands::Key { command } = args.command else {
-            panic!("expected key command");
-        };
-        let crate::cloud::cli::KeyCommands::Create {
+        let KeyCommands::Create {
             name,
             role_id,
             expires_at,
@@ -731,13 +795,60 @@ mod tests {
         };
         assert_eq!(name, "ci-key");
         assert_eq!(role_id, vec!["role-1", "role-2"]);
-        assert!(expires_at.is_none());
-        assert!(state.is_none());
+        assert_eq!(expires_at.as_deref(), Some("2025-12-31T23:59:59Z"));
+        assert_eq!(state.as_deref(), Some("disabled"));
         assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
         assert_eq!(hash_key_id.as_deref(), Some("id-hash"));
         assert_eq!(hash_key_id_suffix.as_deref(), Some("abcd"));
         assert_eq!(hash_key_secret.as_deref(), Some("secret-hash"));
-        assert!(org_id.is_none());
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+    }
+
+    #[test]
+    fn parses_key_update_flags() {
+        let command = parse_top_level_key(&[
+            "clickhousectl",
+            "cloud",
+            "key",
+            "update",
+            "key-1",
+            "--name",
+            "renamed",
+            "--role-id",
+            "role-1",
+            "--role-id",
+            "role-2",
+            "--expires-at",
+            "2025-01-01T00:00:00Z",
+            "--state",
+            "enabled",
+            "--ip-allow",
+            "10.0.0.0/8",
+            "--ip-allow",
+            "192.0.2.0/24",
+            "--org-id",
+            "org-1",
+        ]);
+
+        let KeyCommands::Update {
+            key_id,
+            name,
+            role_id,
+            expires_at,
+            state,
+            ip_allow,
+            org_id,
+        } = command
+        else {
+            panic!("expected key update");
+        };
+        assert_eq!(key_id, "key-1");
+        assert_eq!(name.as_deref(), Some("renamed"));
+        assert_eq!(role_id, vec!["role-1", "role-2"]);
+        assert_eq!(expires_at.as_deref(), Some("2025-01-01T00:00:00Z"));
+        assert_eq!(state.as_deref(), Some("enabled"));
+        assert_eq!(ip_allow, vec!["10.0.0.0/8", "192.0.2.0/24"]);
+        assert_eq!(org_id.as_deref(), Some("org-1"));
     }
 
     #[test]
@@ -807,6 +918,8 @@ mod tests {
         assert!(create.hash_data.is_none());
         assert!(create.ip_access_list.is_empty());
         assert_eq!(create.state, ApiKeyPostRequestState::Enabled);
+        #[cfg(feature = "deprecated-fields")]
+        assert!(create.roles.is_none());
 
         let update = build_api_key_update_request(&KeyUpdateOptions::default()).unwrap();
         assert!(update.name.is_none());
@@ -814,6 +927,8 @@ mod tests {
         assert!(update.expire_at.is_none());
         assert!(update.state.is_none());
         assert!(update.ip_access_list.is_none());
+        #[cfg(feature = "deprecated-fields")]
+        assert!(update.roles.is_none());
     }
 
     #[test]
@@ -823,7 +938,7 @@ mod tests {
             name: "ci-key".to_string(),
             role_ids: vec![role_id.to_string()],
             expires_at: Some("2025-12-31T23:59:59Z".to_string()),
-            state: Some("enabled".to_string()),
+            state: Some("disabled".to_string()),
             ip_allow: vec!["10.0.0.0/8".to_string()],
             hash_key_id: Some("id-hash".to_string()),
             hash_key_id_suffix: Some("abcd".to_string()),
@@ -839,12 +954,16 @@ mod tests {
         assert_eq!(create.name, "ci-key");
         assert_eq!(create.assigned_role_ids, vec![expected_role_id]);
         assert_eq!(create.expire_at, Some(expected_create_expiration));
-        assert_eq!(create.state, ApiKeyPostRequestState::Enabled);
+        assert_eq!(create.state, ApiKeyPostRequestState::Disabled);
+        assert_eq!(create.ip_access_list.len(), 1);
         assert_eq!(create.ip_access_list[0].source, "10.0.0.0/8");
+        assert!(create.ip_access_list[0].description.is_none());
         let hash_data = create.hash_data.as_ref().expect("maximal hash data");
         assert_eq!(hash_data.key_id_hash, "id-hash");
         assert_eq!(hash_data.key_id_suffix, "abcd");
         assert_eq!(hash_data.key_secret_hash, "secret-hash");
+        #[cfg(feature = "deprecated-fields")]
+        assert!(create.roles.is_none());
 
         let update = build_api_key_update_request(&KeyUpdateOptions {
             name: Some("renamed".to_string()),
@@ -863,7 +982,12 @@ mod tests {
         assert_eq!(update.assigned_role_ids, Some(vec![expected_role_id]));
         assert_eq!(update.expire_at, Some(expected_update_expiration));
         assert_eq!(update.state, Some(ApiKeyPatchRequestState::Disabled));
-        assert_eq!(update.ip_access_list.unwrap()[0].source, "0.0.0.0/0");
+        let ip_access_list = update.ip_access_list.as_ref().unwrap();
+        assert_eq!(ip_access_list.len(), 1);
+        assert_eq!(ip_access_list[0].source, "0.0.0.0/0");
+        assert!(ip_access_list[0].description.is_none());
+        #[cfg(feature = "deprecated-fields")]
+        assert!(update.roles.is_none());
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/backups.rs
+++ b/crates/clickhousectl/src/cloud/backups.rs
@@ -449,6 +449,43 @@ mod tests {
     }
 
     #[test]
+    fn parses_backup_config_update_defaults() {
+        let cli = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "backup-config",
+            "update",
+            "svc-1",
+        ])
+        .unwrap();
+        let Commands::Cloud(args) = cli.command else {
+            panic!("expected cloud command");
+        };
+        let crate::cloud::cli::CloudCommands::Service { command } = args.command else {
+            panic!("expected service command");
+        };
+        let crate::cloud::cli::ServiceCommands::BackupConfig { command } = command else {
+            panic!("expected backup-config command");
+        };
+        let crate::cloud::cli::BackupConfigCommands::Update {
+            service_id,
+            backup_period_hours,
+            backup_retention_period_hours,
+            backup_start_time,
+            org_id,
+        } = command
+        else {
+            panic!("expected backup-config update");
+        };
+        assert_eq!(service_id, "svc-1");
+        assert!(backup_period_hours.is_none());
+        assert!(backup_retention_period_hours.is_none());
+        assert!(backup_start_time.is_none());
+        assert!(org_id.is_none());
+    }
+
+    #[test]
     fn parses_backup_list_with_top_level_cli_defaults() {
         let cli =
             Cli::try_parse_from(["clickhousectl", "cloud", "backup", "list", "svc-1"]).unwrap();

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -401,6 +401,27 @@ fn build_org_update_request(
     })
 }
 
+fn build_member_update_request(role_ids: &[String]) -> MemberPatchRequest {
+    MemberPatchRequest {
+        assigned_role_ids: if role_ids.is_empty() {
+            None
+        } else {
+            Some(role_ids.to_vec())
+        },
+        #[cfg(feature = "deprecated-fields")]
+        role: None,
+    }
+}
+
+fn build_invitation_create_request(email: &str, role_ids: &[String]) -> InvitationPostRequest {
+    InvitationPostRequest {
+        email: email.to_string(),
+        assigned_role_ids: role_ids.to_vec(),
+        #[cfg(feature = "deprecated-fields")]
+        role: None,
+    }
+}
+
 fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String {
     match items {
         Some(items) => items.iter().map(render).collect::<Vec<_>>().join(", "),
@@ -608,15 +629,7 @@ async fn member_update(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let request = MemberPatchRequest {
-        assigned_role_ids: if role_ids.is_empty() {
-            None
-        } else {
-            Some(role_ids.to_vec())
-        },
-        #[cfg(feature = "deprecated-fields")]
-        role: None,
-    };
+    let request = build_member_update_request(role_ids);
     let member = client.update_member(&org_id, user_id, &request).await?;
 
     if json {
@@ -693,12 +706,7 @@ async fn invitation_create(
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let org_id = resolve_org_id(client, org_id).await?;
-    let request = InvitationPostRequest {
-        email: email.to_string(),
-        assigned_role_ids: role_ids.to_vec(),
-        #[cfg(feature = "deprecated-fields")]
-        role: None,
-    };
+    let request = build_invitation_create_request(email, role_ids);
     let invitation = client.create_invitation(&org_id, &request).await?;
 
     if json {
@@ -943,12 +951,16 @@ mod tests {
     use crate::cloud::cli::CloudCommands;
     use clap::Parser;
 
-    fn assert_write(args: &[&str], expected: bool) {
+    fn parse_cloud_command(args: &[&str]) -> CloudCommands {
         let cli = Cli::try_parse_from(args).expect("parse");
         let Commands::Cloud(cloud_args) = cli.command else {
             panic!("expected cloud command");
         };
-        let command = cloud_args.command;
+        cloud_args.command
+    }
+
+    fn assert_write(args: &[&str], expected: bool) {
+        let command = parse_cloud_command(args);
         assert!(matches!(
             &command,
             CloudCommands::Org { .. }
@@ -961,6 +973,162 @@ mod tests {
             "wrong classification for: {}",
             args.join(" ")
         );
+    }
+
+    #[test]
+    fn parses_organization_body_command_defaults() {
+        let CloudCommands::Org { command } =
+            parse_cloud_command(&["clickhousectl", "cloud", "org", "update", "org-1"])
+        else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Update {
+            org_id,
+            name,
+            remove_private_endpoint,
+            enable_core_dumps,
+        } = command
+        else {
+            panic!("expected org update");
+        };
+        assert_eq!(org_id, "org-1");
+        assert!(name.is_none());
+        assert!(remove_private_endpoint.is_empty());
+        assert!(enable_core_dumps.is_none());
+
+        let CloudCommands::Member { command } =
+            parse_cloud_command(&["clickhousectl", "cloud", "member", "update", "user-1"])
+        else {
+            panic!("expected member command");
+        };
+        let MemberCommands::Update {
+            user_id,
+            role_id,
+            org_id,
+        } = command
+        else {
+            panic!("expected member update");
+        };
+        assert_eq!(user_id, "user-1");
+        assert!(role_id.is_empty());
+        assert!(org_id.is_none());
+
+        let CloudCommands::Invitation { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "invitation",
+            "create",
+            "--email",
+            "user@example.com",
+        ]) else {
+            panic!("expected invitation command");
+        };
+        let InvitationCommands::Create {
+            email,
+            role_id,
+            org_id,
+        } = command
+        else {
+            panic!("expected invitation create");
+        };
+        assert_eq!(email, "user@example.com");
+        assert!(role_id.is_empty());
+        assert!(org_id.is_none());
+    }
+
+    #[test]
+    fn parses_organization_body_command_maximal_and_repeatable_flags() {
+        let CloudCommands::Org { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "org",
+            "update",
+            "org-1",
+            "--name",
+            "Updated Org",
+            "--remove-private-endpoint",
+            "pe-1,description=old,cloud-provider=aws,region=us-east-1",
+            "--remove-private-endpoint",
+            "pe-2,description=legacy,cloud-provider=azure,region=eastus",
+            "--enable-core-dumps",
+            "false",
+        ]) else {
+            panic!("expected org command");
+        };
+        let OrgCommands::Update {
+            org_id,
+            name,
+            remove_private_endpoint,
+            enable_core_dumps,
+        } = command
+        else {
+            panic!("expected org update");
+        };
+        assert_eq!(org_id, "org-1");
+        assert_eq!(name.as_deref(), Some("Updated Org"));
+        assert_eq!(
+            remove_private_endpoint,
+            vec![
+                "pe-1,description=old,cloud-provider=aws,region=us-east-1",
+                "pe-2,description=legacy,cloud-provider=azure,region=eastus",
+            ]
+        );
+        assert_eq!(enable_core_dumps, Some(false));
+
+        let CloudCommands::Member { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "member",
+            "update",
+            "user-1",
+            "--role-id",
+            "role-1",
+            "--role-id",
+            "role-2",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected member command");
+        };
+        let MemberCommands::Update {
+            user_id,
+            role_id,
+            org_id,
+        } = command
+        else {
+            panic!("expected member update");
+        };
+        assert_eq!(user_id, "user-1");
+        assert_eq!(role_id, vec!["role-1", "role-2"]);
+        assert_eq!(org_id.as_deref(), Some("org-1"));
+
+        let CloudCommands::Invitation { command } = parse_cloud_command(&[
+            "clickhousectl",
+            "cloud",
+            "invitation",
+            "create",
+            "--email",
+            "user@example.com",
+            "--role-id",
+            "role-1",
+            "--role-id",
+            "role-2",
+            "--org-id",
+            "org-1",
+        ]) else {
+            panic!("expected invitation command");
+        };
+        let InvitationCommands::Create {
+            email,
+            role_id,
+            org_id,
+        } = command
+        else {
+            panic!("expected invitation create");
+        };
+        assert_eq!(email, "user@example.com");
+        assert_eq!(role_id, vec!["role-1", "role-2"]);
+        assert_eq!(org_id.as_deref(), Some("org-1"));
     }
 
     #[test]
@@ -1257,22 +1425,102 @@ mod tests {
     }
 
     #[test]
-    fn build_org_update_request_matches_tested_shape() {
+    fn build_org_update_request_supports_minimal_fields() {
+        let request = build_org_update_request(&OrgUpdateOptions::default()).unwrap();
+
+        assert!(request.name.is_none());
+        assert!(request.private_endpoints.is_none());
+        assert!(request.enable_core_dumps.is_none());
+    }
+
+    #[test]
+    fn build_org_update_request_supports_maximal_fields() {
         let options = OrgUpdateOptions {
             name: Some("Updated Org".to_string()),
             remove_private_endpoints: vec![
                 "pe-1,description=old,cloud-provider=aws,region=us-east-1".to_string(),
+                "pe-2,description=legacy,cloud-provider=azure,region=eastus".to_string(),
             ],
             enable_core_dumps: Some(false),
         };
         let request = build_org_update_request(&options).unwrap();
-        let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["privateEndpoints"]["remove"][0]["id"], "pe-1");
+
+        assert_eq!(request.name.as_deref(), Some("Updated Org"));
+        assert_eq!(request.enable_core_dumps, Some(false));
+        let private_endpoints = request.private_endpoints.as_ref().unwrap();
+        #[cfg(feature = "deprecated-fields")]
+        assert!(private_endpoints.add.is_none());
+        assert_eq!(private_endpoints.remove.len(), 2);
+        assert_eq!(private_endpoints.remove[0].id, "pe-1");
         assert_eq!(
-            json["privateEndpoints"]["remove"][0]["cloudProvider"],
-            "aws"
+            private_endpoints.remove[0].description.as_deref(),
+            Some("old")
         );
-        assert_eq!(json["enableCoreDumps"], false);
+        assert_eq!(
+            private_endpoints.remove[0].cloud_provider,
+            OrganizationPatchPrivateEndpointCloudprovider::Aws
+        );
+        assert_eq!(
+            private_endpoints.remove[0].region,
+            OrganizationPatchPrivateEndpointRegion::Us_east_1
+        );
+        assert_eq!(private_endpoints.remove[1].id, "pe-2");
+        assert_eq!(
+            private_endpoints.remove[1].description.as_deref(),
+            Some("legacy")
+        );
+        assert_eq!(
+            private_endpoints.remove[1].cloud_provider,
+            OrganizationPatchPrivateEndpointCloudprovider::Azure
+        );
+        assert_eq!(
+            private_endpoints.remove[1].region,
+            OrganizationPatchPrivateEndpointRegion::Eastus
+        );
+    }
+
+    #[test]
+    fn build_member_update_request_supports_minimal_fields() {
+        let request = build_member_update_request(&[]);
+
+        assert!(request.assigned_role_ids.is_none());
+        #[cfg(feature = "deprecated-fields")]
+        assert!(request.role.is_none());
+    }
+
+    #[test]
+    fn build_member_update_request_supports_maximal_fields() {
+        let request = build_member_update_request(&["role-1".to_string(), "role-2".to_string()]);
+
+        assert_eq!(
+            request.assigned_role_ids,
+            Some(vec!["role-1".to_string(), "role-2".to_string()])
+        );
+        #[cfg(feature = "deprecated-fields")]
+        assert!(request.role.is_none());
+    }
+
+    #[test]
+    fn build_invitation_create_request_supports_minimal_fields() {
+        let request = build_invitation_create_request("user@example.com", &[]);
+
+        assert_eq!(request.email, "user@example.com");
+        assert!(request.assigned_role_ids.is_empty());
+        #[cfg(feature = "deprecated-fields")]
+        assert!(request.role.is_none());
+    }
+
+    #[test]
+    fn build_invitation_create_request_supports_maximal_fields() {
+        let request = build_invitation_create_request(
+            "user@example.com",
+            &["role-1".to_string(), "role-2".to_string()],
+        );
+
+        assert_eq!(request.email, "user@example.com");
+        assert_eq!(request.assigned_role_ids, vec!["role-1", "role-2"]);
+        #[cfg(feature = "deprecated-fields")]
+        assert!(request.role.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- extract member-update and invitation-create request builders without changing behavior
- add direct minimal/maximal request-field assertions in current Cloud domain modules
- complete top-level Clap coverage for organization, API-key, member, invitation, and backup bodies

## Testing

- `cargo test -p clickhousectl`
- `cargo test -p clickhousectl --all-features`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo clippy -p clickhousectl --all-targets --all-features -- -D warnings`
- `git diff --check`

Closes #214