### PR TITLE
Use concrete errors in Cloud handlers

### DIFF
--- a/crates/clickhousectl/src/cloud/activity.rs
+++ b/crates/clickhousectl/src/cloud/activity.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, Result as CloudResult};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use clap::Subcommand;
@@ -41,11 +41,7 @@ impl ActivityCommands {
     }
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: ActivityCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: ActivityCommands, json: bool) -> CloudResult<()> {
     match command {
         ActivityCommands::List {
             org_id,
@@ -74,7 +70,7 @@ async fn activity_list(
     from_date: Option<&str>,
     to_date: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let activities = client.list_activities(&org_id, from_date, to_date).await?;
 
@@ -112,7 +108,7 @@ async fn activity_get(
     activity_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let activity = client.get_activity(&org_id, activity_id).await?;
 

--- a/crates/clickhousectl/src/cloud/api_keys.rs
+++ b/crates/clickhousectl/src/cloud/api_keys.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::{parse_datetime, resolve_org_id};
@@ -121,11 +121,7 @@ impl KeyCommands {
     }
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: KeyCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: KeyCommands, json: bool) -> CloudResult<()> {
     match command {
         KeyCommands::List { org_id } => key_list(client, org_id.as_deref(), json).await,
         KeyCommands::Create {
@@ -207,7 +203,7 @@ fn parse_api_key_hash_data(
     key_id_hash: Option<&str>,
     key_id_suffix: Option<&str>,
     key_secret_hash: Option<&str>,
-) -> Result<Option<clickhouse_cloud_api::models::ApiKeyHashData>, Box<dyn std::error::Error>> {
+) -> CloudResult<Option<clickhouse_cloud_api::models::ApiKeyHashData>> {
     match (key_id_hash, key_id_suffix, key_secret_hash) {
         (None, None, None) => Ok(None),
         (Some(key_id_hash), Some(key_id_suffix), Some(key_secret_hash)) => {
@@ -217,10 +213,9 @@ fn parse_api_key_hash_data(
                 key_secret_hash: key_secret_hash.to_string(),
             }))
         }
-        _ => Err(
-            "pre-hashed API key input requires --hash-key-id, --hash-key-id-suffix, and --hash-key-secret together"
-                .into(),
-        ),
+        _ => Err(CloudError::new(
+            "pre-hashed API key input requires --hash-key-id, --hash-key-id-suffix, and --hash-key-secret together",
+        )),
     }
 }
 
@@ -236,64 +231,51 @@ fn parse_ip_access_entries(values: &[String]) -> Option<Vec<IpAccessListEntry>> 
     })
 }
 
-fn parse_uuid_list(
-    values: &[String],
-    field: &str,
-) -> Result<Vec<uuid::Uuid>, Box<dyn std::error::Error>> {
+fn parse_uuid_list(values: &[String], field: &str) -> CloudResult<Vec<uuid::Uuid>> {
     values
         .iter()
         .map(|value| {
-            uuid::Uuid::parse_str(value)
-                .map_err(|error| format!("invalid {} UUID '{}': {}", field, value, error).into())
+            uuid::Uuid::parse_str(value).map_err(|error| {
+                CloudError::new(format!("invalid {} UUID '{}': {}", field, value, error))
+            })
         })
         .collect()
 }
 
-fn parse_api_key_state_post(
-    value: &str,
-) -> Result<ApiKeyPostRequestState, Box<dyn std::error::Error>> {
+fn parse_api_key_state_post(value: &str) -> CloudResult<ApiKeyPostRequestState> {
     match value {
         "enabled" => Ok(ApiKeyPostRequestState::Enabled),
         "disabled" => Ok(ApiKeyPostRequestState::Disabled),
-        _ => Err(format!(
+        _ => Err(CloudError::new(format!(
             "invalid state: unknown value '{}', expected one of: enabled, disabled",
             value
-        )
-        .into()),
+        ))),
     }
 }
 
-fn parse_api_key_state_patch(
-    value: &str,
-) -> Result<ApiKeyPatchRequestState, Box<dyn std::error::Error>> {
+fn parse_api_key_state_patch(value: &str) -> CloudResult<ApiKeyPatchRequestState> {
     match value {
         "enabled" => Ok(ApiKeyPatchRequestState::Enabled),
         "disabled" => Ok(ApiKeyPatchRequestState::Disabled),
-        _ => Err(format!(
+        _ => Err(CloudError::new(format!(
             "invalid state: unknown value '{}', expected one of: enabled, disabled",
             value
-        )
-        .into()),
+        ))),
     }
 }
 
-fn parse_expire_at(
-    value: &str,
-) -> Result<chrono::DateTime<chrono::Utc>, Box<dyn std::error::Error>> {
+fn parse_expire_at(value: &str) -> CloudResult<chrono::DateTime<chrono::Utc>> {
     chrono::DateTime::parse_from_rfc3339(value)
         .map(|datetime| datetime.with_timezone(&chrono::Utc))
         .map_err(|error| {
-            format!(
+            CloudError::new(format!(
                 "invalid expire_at '{}': expected ISO 8601 / RFC 3339 format (e.g. 2025-12-31T23:59:59Z): {}",
                 value, error
-            )
-            .into()
+            ))
         })
 }
 
-fn build_api_key_create_request(
-    options: &KeyCreateOptions,
-) -> Result<ApiKeyPostRequest, Box<dyn std::error::Error>> {
+fn build_api_key_create_request(options: &KeyCreateOptions) -> CloudResult<ApiKeyPostRequest> {
     Ok(ApiKeyPostRequest {
         name: options.name.clone(),
         expire_at: options
@@ -317,9 +299,7 @@ fn build_api_key_create_request(
     })
 }
 
-fn build_api_key_update_request(
-    options: &KeyUpdateOptions,
-) -> Result<ApiKeyPatchRequest, Box<dyn std::error::Error>> {
+fn build_api_key_update_request(options: &KeyUpdateOptions) -> CloudResult<ApiKeyPatchRequest> {
     Ok(ApiKeyPatchRequest {
         name: options.name.clone(),
         assigned_role_ids: if options.role_ids.is_empty() {
@@ -343,11 +323,7 @@ fn build_api_key_update_request(
     })
 }
 
-async fn key_list(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn key_list(client: &CloudClient, org_id: Option<&str>, json: bool) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let keys = client.list_api_keys(&org_id).await?;
 
@@ -400,7 +376,7 @@ fn resolve_key_create_material<'a>(
     key_id: Option<&'a str>,
     key_secret: Option<&'a str>,
     key_name: Option<&str>,
-) -> Result<KeyCreateMaterial<'a>, Box<dyn std::error::Error>> {
+) -> CloudResult<KeyCreateMaterial<'a>> {
     if pre_hashed {
         return Ok(KeyCreateMaterial::PreHashed);
     }
@@ -411,13 +387,12 @@ fn resolve_key_create_material<'a>(
                 Some(name) => format!(" '{}'", name),
                 None => String::new(),
             };
-            Err(format!(
+            Err(CloudError::new(format!(
                 "the API response omitted the generated key material, so the one-time key secret \
                  cannot be shown: the key{} may still have been created — list the organization's \
                  keys and delete it if so",
                 named
-            )
-            .into())
+            )))
         }
     }
 }
@@ -426,7 +401,7 @@ async fn key_create(
     client: &CloudClient,
     options: KeyCreateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     // Validate before organization resolution so malformed inputs make no network call.
     let request = build_api_key_create_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
@@ -466,7 +441,7 @@ async fn key_get(
     key_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let key = client.get_api_key(&org_id, key_id).await?;
 
@@ -483,7 +458,7 @@ async fn key_update(
     key_id: &str,
     options: KeyUpdateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     // Validate before organization resolution so malformed inputs make no network call.
     let request = build_api_key_update_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
@@ -504,7 +479,7 @@ async fn key_delete(
     key_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let response = client.delete_api_key(&org_id, key_id).await?;
     if json {
@@ -521,7 +496,7 @@ async fn key_delete(
 pub(crate) fn service_query_key_cleanup(
     org_id: &str,
     service_id: &str,
-) -> Result<(Option<String>, bool), Box<dyn std::error::Error>> {
+) -> CloudResult<(Option<String>, bool)> {
     let Some(key) = credentials::try_get_service_query_key(service_id)? else {
         return Ok((None, false));
     };
@@ -541,11 +516,10 @@ pub(crate) fn service_query_key_cleanup(
         return Ok((None, true));
     };
     if key_org_id != org_id {
-        return Err(format!(
+        return Err(CloudError::new(format!(
             "the stored query key for service {service_id} belongs to organization {key_org_id}, \
              not {org_id}; refusing to delete either resource"
-        )
-        .into());
+        )));
     }
     Ok((Some(api_key_id), false))
 }
@@ -555,7 +529,7 @@ pub(crate) async fn cleanup_service_query_key(
     org_id: &str,
     service_id: &str,
     api_key_id: Option<&str>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let Some(api_key_id) = api_key_id else {
         return Ok(());
     };

--- a/crates/clickhousectl/src/cloud/backups.rs
+++ b/crates/clickhousectl/src/cloud/backups.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::resolve_org_id;
 use clap::Subcommand;
@@ -98,11 +98,7 @@ impl BackupConfigCommands {
     }
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: BackupCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: BackupCommands, json: bool) -> CloudResult<()> {
     match command {
         BackupCommands::List { service_id, org_id } => {
             backup_list(client, &service_id, org_id.as_deref(), json).await
@@ -119,7 +115,7 @@ pub async fn run_config(
     client: &CloudClient,
     command: BackupConfigCommands,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     match command {
         BackupConfigCommands::Get { service_id, org_id } => {
             backup_config_get(client, &service_id, org_id.as_deref(), json).await
@@ -172,13 +168,13 @@ fn parse_backup_start_time(value: &str) -> Result<String, String> {
 
 fn build_backup_config_update_request(
     options: &BackupConfigUpdateOptions,
-) -> Result<BackupConfigurationPatchRequest, Box<dyn std::error::Error>> {
+) -> CloudResult<BackupConfigurationPatchRequest> {
     if options.backup_start_time.is_some()
         && matches!(options.backup_period_hours, Some(period) if period != 24 && period != 48)
     {
-        return Err(
-            "--backup-period-hours must be 24 or 48 when --backup-start-time is set".into(),
-        );
+        return Err(CloudError::new(
+            "--backup-period-hours must be 24 or 48 when --backup-start-time is set",
+        ));
     }
 
     Ok(BackupConfigurationPatchRequest {
@@ -193,7 +189,7 @@ async fn backup_list(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let backups = client.list_backups(&org_id, service_id).await?;
 
@@ -235,7 +231,7 @@ async fn backup_get(
     backup_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let backup = client.get_backup(&org_id, service_id, backup_id).await?;
 
@@ -252,7 +248,7 @@ async fn backup_config_get(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let config = client.get_backup_config(&org_id, service_id).await?;
 
@@ -269,7 +265,7 @@ async fn backup_config_update(
     service_id: &str,
     options: BackupConfigUpdateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let request = build_backup_config_update_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let config = client

--- a/crates/clickhousectl/src/cloud/clickpipes.rs
+++ b/crates/clickhousectl/src/cloud/clickpipes.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{or_absent, print_human};
 use crate::cloud::shared::resolve_org_id;
 use clap::builder::PossibleValuesParser;
@@ -911,11 +911,7 @@ pub struct BigQueryCreateArgs {
     pub org_id: Option<String>,
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: ClickPipeCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: ClickPipeCommands, json: bool) -> CloudResult<()> {
     match command {
         ClickPipeCommands::List { service_id, org_id } => {
             clickpipe_list(client, &service_id, org_id.as_deref(), json).await
@@ -1075,7 +1071,7 @@ async fn clickpipe_list(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let clickpipes = client.list_clickpipes(&org_id, service_id).await?;
 
@@ -1101,7 +1097,7 @@ async fn clickpipe_create_object_storage(
     client: &CloudClient,
     args: &ObjectStorageCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipePostObjectStorageSource, ClickPipePostObjectStorageSourceAuthentication,
         ClickPipePostRequest, ClickPipePostSource, MskIamUser,
@@ -1199,7 +1195,7 @@ fn build_kafka_credentials(
     authentication: &clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication,
     args: &KafkaSourceFields,
     mtls_contents: Option<(String, String)>,
-) -> Result<serde_json::Value, String> {
+) -> CloudResult<serde_json::Value> {
     use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
     match authentication {
         Auth::PLAIN | Auth::SCRAM_SHA_256 | Auth::SCRAM_SHA_512 => {
@@ -1207,10 +1203,10 @@ fn build_kafka_credentials(
                 (Some(username), Some(password)) => {
                     Ok(serde_json::json!({ "username": username, "password": password }))
                 }
-                _ => Err(format!(
+                _ => Err(CloudError::new(format!(
                     "{} requires --username and --password",
                     args.auth.as_deref().unwrap_or("PLAIN")
-                )),
+                ))),
             }
         }
         Auth::IAM_USER => match (args.access_key_id.as_deref(), args.secret_key.as_deref()) {
@@ -1218,11 +1214,13 @@ fn build_kafka_credentials(
                 "accessKeyId": access_key_id,
                 "secretKey": secret_key
             })),
-            _ => Err("IAM_USER requires --access-key-id and --secret-key".into()),
+            _ => Err(CloudError::new(
+                "IAM_USER requires --access-key-id and --secret-key",
+            )),
         },
         Auth::IAM_ROLE => {
             if args.iam_role.is_none() {
-                Err("IAM_ROLE requires --iam-role".into())
+                Err(CloudError::new("IAM_ROLE requires --iam-role"))
             } else {
                 Ok(serde_json::Value::Null)
             }
@@ -1232,7 +1230,9 @@ fn build_kafka_credentials(
                 "certificate": certificate,
                 "privateKey": private_key
             })),
-            None => Err("MUTUAL_TLS requires --client-certificate and --client-key".into()),
+            None => Err(CloudError::new(
+                "MUTUAL_TLS requires --client-certificate and --client-key",
+            )),
         },
         Auth::Unknown(_) => Ok(serde_json::Value::Null),
     }
@@ -1245,7 +1245,7 @@ fn build_kafka_credentials(
 /// handlers.
 fn build_kafka_source(
     args: &KafkaSourceFields,
-) -> Result<clickhouse_cloud_api::models::ClickPipePostKafkaSource, Box<dyn std::error::Error>> {
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostKafkaSource> {
     use clickhouse_cloud_api::models::{
         ClickPipeKafkaOffset, ClickPipeKafkaSchemaRegistryCredentials,
         ClickPipeMutateKafkaSchemaRegistry, ClickPipePostKafkaSource,
@@ -1275,7 +1275,7 @@ fn build_kafka_source(
     let schema_registry = args
         .schema_registry_url
         .as_ref()
-        .map(|url| -> Result<_, Box<dyn std::error::Error>> {
+        .map(|url| -> CloudResult<_> {
             let credentials = match (
                 args.schema_registry_username.as_deref(),
                 args.schema_registry_password.as_deref(),
@@ -1329,7 +1329,7 @@ fn build_kafka_source(
 /// handlers.
 fn build_kinesis_source(
     args: &KinesisSourceFields,
-) -> Result<clickhouse_cloud_api::models::ClickPipePostKinesisSource, Box<dyn std::error::Error>> {
+) -> CloudResult<clickhouse_cloud_api::models::ClickPipePostKinesisSource> {
     use clickhouse_cloud_api::models::{ClickPipePostKinesisSource, MskIamUser};
 
     let access_key = match (args.access_key_id.as_deref(), args.secret_key.as_deref()) {
@@ -1356,8 +1356,9 @@ fn build_kinesis_source(
         timestamp: args
             .iterator_timestamp
             .map(|timestamp| {
-                i64::try_from(timestamp)
-                    .map_err(|_| format!("--iterator-timestamp {timestamp} is out of range"))
+                i64::try_from(timestamp).map_err(|_| {
+                    CloudError::new(format!("--iterator-timestamp {timestamp} is out of range"))
+                })
             })
             .transpose()?,
     })
@@ -1367,7 +1368,7 @@ async fn clickpipe_create_kafka(
     client: &CloudClient,
     args: &KafkaCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{ClickPipePostRequest, ClickPipePostSource};
 
     // Validate args and build the source before any network call so bad
@@ -1397,7 +1398,7 @@ async fn clickpipe_create_kinesis(
     client: &CloudClient,
     args: &KinesisCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{ClickPipePostRequest, ClickPipePostSource};
 
     let org_id = resolve_org_id(client, args.org_id.as_deref()).await?;
@@ -1431,7 +1432,7 @@ async fn clickpipe_schema_discover(
     command: &ClickPipeSchemaDiscoverCommands,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeSchemaDiscoveryRequest, ClickPipeSchemaDiscoverySource,
     };
@@ -1498,7 +1499,7 @@ async fn clickpipe_get(
     clickpipe_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let clickpipe = client
         .get_clickpipe(&org_id, service_id, clickpipe_id)
@@ -1518,7 +1519,7 @@ async fn clickpipe_delete(
     clickpipe_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     client
         .delete_clickpipe(&org_id, service_id, clickpipe_id)
@@ -1539,13 +1540,15 @@ async fn clickpipe_state(
     command: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::ClickPipeStatePatchRequestCommand;
     let command_value = match command {
         "start" => ClickPipeStatePatchRequestCommand::Start,
         "stop" => ClickPipeStatePatchRequestCommand::Stop,
         "resync" => ClickPipeStatePatchRequestCommand::Resync,
-        other => return Err(format!("Unknown state command: {}", other).into()),
+        other => {
+            return Err(CloudError::new(format!("Unknown state command: {}", other)));
+        }
     };
     let org_id = resolve_org_id(client, org_id).await?;
     let clickpipe = client
@@ -1575,7 +1578,7 @@ async fn clickpipe_scale(
     memory_gb: Option<f64>,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let request = clickhouse_cloud_api::models::ClickPipeScalingPatchRequest {
         replicas: replicas.map(i64::from),
@@ -1609,7 +1612,7 @@ async fn clickpipe_settings_get(
     clickpipe_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let settings = client
         .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
@@ -1639,7 +1642,7 @@ async fn clickpipe_settings_update(
     clickhouse_parallel_view_processing: Option<bool>,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let kafka_read_committed = client
         .get_clickpipe_settings(&org_id, service_id, clickpipe_id)
@@ -1684,21 +1687,24 @@ async fn clickpipe_settings_update(
 /// Parse a CLI string into a library enum. Library enums have a
 /// `#[serde(untagged)] Unknown(String)` variant so unknown inputs are
 /// forwarded to the API (which returns the canonical validation error).
-fn parse_enum<T: serde::de::DeserializeOwned>(value: &str) -> Result<T, String> {
+fn parse_enum<T: serde::de::DeserializeOwned>(value: &str) -> CloudResult<T> {
     serde_json::from_value(serde_json::Value::String(value.to_string()))
-        .map_err(|error| format!("invalid value '{}': {}", value, error))
+        .map_err(|error| CloudError::new(format!("invalid value '{}': {}", value, error)))
 }
 
 /// Parse `name:type` column specifications into library destination columns.
 fn parse_columns(
     columns: &[String],
-) -> Result<Vec<clickhouse_cloud_api::models::ClickPipeDestinationColumn>, String> {
+) -> CloudResult<Vec<clickhouse_cloud_api::models::ClickPipeDestinationColumn>> {
     columns
         .iter()
         .map(|column| {
-            let (name, column_type) = column
-                .split_once(':')
-                .ok_or_else(|| format!("Invalid column format '{}': expected name:type", column))?;
+            let (name, column_type) = column.split_once(':').ok_or_else(|| {
+                CloudError::new(format!(
+                    "Invalid column format '{}': expected name:type",
+                    column
+                ))
+            })?;
             Ok(clickhouse_cloud_api::models::ClickPipeDestinationColumn {
                 name: name.to_string(),
                 r#type: column_type.to_string(),
@@ -1739,7 +1745,7 @@ fn build_destination(
 /// base64-encoded contents. Used by both the object-storage and BigQuery
 /// `create` handlers — the upstream API wants the encoded blob regardless
 /// of which source it ends up on.
-fn read_gcp_service_account_file(path: &str) -> Result<String, Box<dyn std::error::Error>> {
+fn read_gcp_service_account_file(path: &str) -> CloudResult<String> {
     let contents = std::fs::read_to_string(path)?;
     Ok(base64::Engine::encode(
         &base64::engine::general_purpose::STANDARD,
@@ -1751,7 +1757,7 @@ fn read_gcp_service_account_file(path: &str) -> Result<String, Box<dyn std::erro
 fn print_created(
     clickpipe: &clickhouse_cloud_api::models::ClickPipe,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     if json {
         println!("{}", serde_json::to_string_pretty(clickpipe)?);
     } else {
@@ -1765,19 +1771,22 @@ fn print_created(
 
 /// Parse `schema.table:target_table` mappings into (schema, table, target) tuples.
 /// Source-specific handlers map these into their own TableMapping struct.
-fn parse_db_table_mappings(mappings: &[String]) -> Result<Vec<(String, String, String)>, String> {
+fn parse_db_table_mappings(mappings: &[String]) -> CloudResult<Vec<(String, String, String)>> {
     mappings
         .iter()
         .map(|mapping| {
             let (source, target) = mapping.split_once(':').ok_or_else(|| {
-                format!(
+                CloudError::new(format!(
                     "Invalid table mapping '{}': expected schema.table:target_table",
                     mapping
-                )
+                ))
             })?;
-            let (schema, table) = source
-                .split_once('.')
-                .ok_or_else(|| format!("Invalid source '{}': expected schema.table", source))?;
+            let (schema, table) = source.split_once('.').ok_or_else(|| {
+                CloudError::new(format!(
+                    "Invalid source '{}': expected schema.table",
+                    source
+                ))
+            })?;
             Ok((schema.to_string(), table.to_string(), target.to_string()))
         })
         .collect()
@@ -1787,7 +1796,7 @@ async fn clickpipe_create_postgres(
     client: &CloudClient,
     args: &PostgresCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeMutatePostgresSource, ClickPipePostRequest, ClickPipePostSource,
         ClickPipePostgresPipeSettings, ClickPipePostgresPipeTableMapping, PLAIN,
@@ -1858,7 +1867,7 @@ async fn clickpipe_create_mysql(
     client: &CloudClient,
     args: &MySqlCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeMutateMySQLSource, ClickPipeMySQLPipeSettings, ClickPipeMySQLPipeTableMapping,
         ClickPipePostRequest, ClickPipePostSource, PLAIN,
@@ -1932,7 +1941,7 @@ async fn clickpipe_create_mongodb(
     client: &CloudClient,
     args: &MongoDbCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeMongoDBPipeSettings, ClickPipeMongoDBPipeTableMapping,
         ClickPipeMutateMongoDBSource, ClickPipePostRequest, ClickPipePostSource, PLAIN,
@@ -1946,14 +1955,17 @@ async fn clickpipe_create_mongodb(
         .iter()
         .map(|mapping| {
             let (source, target_table) = mapping.split_once(':').ok_or_else(|| {
-                format!(
+                CloudError::new(format!(
                     "Invalid table mapping '{}': expected database.collection:target_table",
                     mapping
-                )
+                ))
             })?;
             let (source_database_name, source_collection) =
                 source.split_once('.').ok_or_else(|| {
-                    format!("Invalid source '{}': expected database.collection", source)
+                    CloudError::new(format!(
+                        "Invalid source '{}': expected database.collection",
+                        source
+                    ))
                 })?;
             Ok(ClickPipeMongoDBPipeTableMapping {
                 source_database_name: source_database_name.to_string(),
@@ -1962,7 +1974,7 @@ async fn clickpipe_create_mongodb(
                 table_engine: None,
             })
         })
-        .collect::<Result<Vec<_>, String>>()?;
+        .collect::<CloudResult<Vec<_>>>()?;
 
     let ca_certificate = match args.ca_certificate.as_deref() {
         Some(path) => Some(std::fs::read_to_string(path)?),
@@ -2008,7 +2020,7 @@ async fn clickpipe_create_bigquery(
     client: &CloudClient,
     args: &BigQueryCreateArgs,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     use clickhouse_cloud_api::models::{
         ClickPipeBigQueryPipeSettings, ClickPipeBigQueryPipeTableMapping,
         ClickPipeMutateBigQuerySource, ClickPipePostRequest, ClickPipePostSource, ServiceAccount,
@@ -2023,14 +2035,17 @@ async fn clickpipe_create_bigquery(
         .iter()
         .map(|mapping| {
             let (source, target_table) = mapping.split_once(':').ok_or_else(|| {
-                format!(
+                CloudError::new(format!(
                     "Invalid table mapping '{}': expected dataset.table:target_table",
                     mapping
-                )
+                ))
             })?;
-            let (source_dataset_name, source_table) = source
-                .split_once('.')
-                .ok_or_else(|| format!("Invalid source '{}': expected dataset.table", source))?;
+            let (source_dataset_name, source_table) = source.split_once('.').ok_or_else(|| {
+                CloudError::new(format!(
+                    "Invalid source '{}': expected dataset.table",
+                    source
+                ))
+            })?;
             Ok(ClickPipeBigQueryPipeTableMapping {
                 source_dataset_name: source_dataset_name.to_string(),
                 source_table: source_table.to_string(),
@@ -2038,7 +2053,7 @@ async fn clickpipe_create_bigquery(
                 ..Default::default()
             })
         })
-        .collect::<Result<Vec<_>, String>>()?;
+        .collect::<CloudResult<Vec<_>>>()?;
 
     let source = ClickPipeMutateBigQuerySource {
         credentials: ServiceAccount {
@@ -4014,6 +4029,7 @@ mod tests {
         assert!(
             result
                 .unwrap_err()
+                .message
                 .contains("expected schema.table:target_table")
         );
     }
@@ -4023,7 +4039,12 @@ mod tests {
         let mappings = vec!["users:target".to_string()];
         let result = parse_db_table_mappings(&mappings);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("expected schema.table"));
+        assert!(
+            result
+                .unwrap_err()
+                .message
+                .contains("expected schema.table")
+        );
     }
 
     #[test]
@@ -4083,7 +4104,7 @@ mod tests {
     fn parse_columns_missing_colon_errors() {
         let columns = vec!["id_without_type".to_string()];
         let error = parse_columns(&columns).unwrap_err();
-        assert!(error.contains("expected name:type"));
+        assert!(error.message.contains("expected name:type"));
     }
 
     #[test]
@@ -4351,7 +4372,7 @@ mod tests {
         use clickhouse_cloud_api::models::ClickPipePostKafkaSourceAuthentication as Auth;
         let args = kafka_args();
         let error = build_kafka_credentials(&Auth::IAM_USER, &args.source, None).unwrap_err();
-        assert!(error.contains("--access-key-id"));
+        assert!(error.message.contains("--access-key-id"));
     }
 
     #[test]
@@ -4360,6 +4381,6 @@ mod tests {
         let mut args = kafka_args();
         args.source.auth = Some("IAM_ROLE".into());
         let error = build_kafka_credentials(&Auth::IAM_ROLE, &args.source, None).unwrap_err();
-        assert!(error.contains("--iam-role"));
+        assert!(error.message.contains("--iam-role"));
     }
 }

--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -40,6 +40,18 @@ impl std::fmt::Display for CloudError {
 
 impl std::error::Error for CloudError {}
 
+impl From<std::io::Error> for CloudError {
+    fn from(error: std::io::Error) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
+impl From<serde_json::Error> for CloudError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::new(error.to_string())
+    }
+}
+
 pub type Result<T> = std::result::Result<T, CloudError>;
 
 enum AuthMode {

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -1,3 +1,4 @@
+use crate::cloud::client::{CloudError, Result as CloudResult};
 use crate::init;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -51,7 +52,7 @@ pub fn clear_credentials() {
     let _ = std::fs::remove_file(path);
 }
 
-pub fn save_credentials(creds: &Credentials) -> Result<(), Box<dyn std::error::Error>> {
+pub fn save_credentials(creds: &Credentials) -> CloudResult<()> {
     let dir = init::local_dir();
     if !dir.exists() {
         std::fs::create_dir_all(&dir)?;
@@ -76,32 +77,30 @@ pub fn get_service_query_key(service_id: &str) -> Option<ServiceQueryKey> {
     creds.service_query_keys.get(service_id).cloned()
 }
 
-pub fn try_get_service_query_key(
-    service_id: &str,
-) -> Result<Option<ServiceQueryKey>, Box<dyn std::error::Error>> {
+pub fn try_get_service_query_key(service_id: &str) -> CloudResult<Option<ServiceQueryKey>> {
     let path = credentials_path();
     let data = match std::fs::read_to_string(&path) {
         Ok(data) => data,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
-            return Err(format!("failed to read {}: {error}", path.display()).into());
+            return Err(CloudError::new(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )));
         }
     };
     let creds: Credentials = serde_json::from_str(&data)
-        .map_err(|error| format!("failed to parse {}: {error}", path.display()))?;
+        .map_err(|error| CloudError::new(format!("failed to parse {}: {error}", path.display())))?;
     Ok(creds.service_query_keys.get(service_id).cloned())
 }
 
-pub fn set_service_query_key(
-    service_id: &str,
-    key: ServiceQueryKey,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn set_service_query_key(service_id: &str, key: ServiceQueryKey) -> CloudResult<()> {
     let mut creds = load_credentials().unwrap_or_default();
     creds.service_query_keys.insert(service_id.to_string(), key);
     save_credentials(&creds)
 }
 
-pub fn remove_service_query_key(service_id: &str) -> Result<(), Box<dyn std::error::Error>> {
+pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {
     let Some(mut creds) = load_credentials() else {
         return Ok(());
     };

--- a/crates/clickhousectl/src/cloud/mod.rs
+++ b/crates/clickhousectl/src/cloud/mod.rs
@@ -98,7 +98,7 @@ pub async fn run(args: CloudArgs, json: bool) -> Result<()> {
 
     dispatch(&client, args.command, json)
         .await
-        .map_err(boxed_cloud_error_to_top_level)
+        .map_err(cloud_error_to_top_level)
 }
 
 fn cloud_error_to_top_level(e: CloudError) -> Error {
@@ -108,21 +108,7 @@ fn cloud_error_to_top_level(e: CloudError) -> Error {
     }
 }
 
-// Cloud command fns return `Box<dyn std::error::Error>`, so the `CloudError.kind`
-// only survives via downcast — without it, auth-flagged errors silently fall back
-// to `Error::Cloud` (exit 1) instead of `Error::AuthRequired` (exit 4).
-fn boxed_cloud_error_to_top_level(e: Box<dyn std::error::Error>) -> Error {
-    match e.downcast::<CloudError>() {
-        Ok(ce) => cloud_error_to_top_level(*ce),
-        Err(other) => Error::Cloud(other.to_string()),
-    }
-}
-
-async fn dispatch(
-    client: &CloudClient,
-    command: CloudCommands,
-    json: bool,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn dispatch(client: &CloudClient, command: CloudCommands, json: bool) -> client::Result<()> {
     match command {
         CloudCommands::Auth { .. } => unreachable!("handled above"),
         CloudCommands::Org { command } => organizations::run_org(client, command, json).await,
@@ -200,33 +186,21 @@ mod runtime_tests {
 
     #[test]
     fn cloud_error_kind_routes_to_top_level() {
-        assert!(matches!(
-            cloud_error_to_top_level(CloudError::auth("nope")),
-            Error::AuthRequired(_)
-        ));
-        assert!(matches!(
-            cloud_error_to_top_level(CloudError::new("boom")),
-            Error::Cloud(_)
-        ));
+        let auth = cloud_error_to_top_level(CloudError::auth("nope"));
+        assert!(matches!(&auth, Error::AuthRequired(message) if message == "nope"));
+        assert_eq!(auth.exit_code(), 4);
+
+        let generic = cloud_error_to_top_level(CloudError::new("boom"));
+        assert!(matches!(&generic, Error::Cloud(message) if message == "boom"));
+        assert_eq!(generic.exit_code(), 1);
         assert_eq!(CloudError::new("x").kind, CloudErrorKind::Generic);
     }
 
     #[test]
-    fn boxed_cloud_error_preserves_auth_kind_through_downcast() {
-        let boxed: Box<dyn std::error::Error> = Box::new(CloudError::auth("nope"));
+    fn concrete_cloud_error_preserves_auth_kind() {
         assert!(matches!(
-            boxed_cloud_error_to_top_level(boxed),
+            cloud_error_to_top_level(CloudError::auth("nope")),
             Error::AuthRequired(_)
-        ));
-    }
-
-    #[test]
-    fn boxed_non_cloud_error_falls_back_to_generic() {
-        // Anything that isn't a CloudError must not downcast to AuthRequired.
-        let boxed: Box<dyn std::error::Error> = "plain string error".into();
-        assert!(matches!(
-            boxed_cloud_error_to_top_level(boxed),
-            Error::Cloud(_)
         ));
     }
 }

--- a/crates/clickhousectl/src/cloud/organizations.rs
+++ b/crates/clickhousectl/src/cloud/organizations.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::{CloudClient, CloudError};
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_date_only, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
@@ -214,11 +214,7 @@ impl InvitationCommands {
     }
 }
 
-pub async fn run_org(
-    client: &CloudClient,
-    command: OrgCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_org(client: &CloudClient, command: OrgCommands, json: bool) -> CloudResult<()> {
     match command {
         OrgCommands::List => org_list(client, json).await,
         OrgCommands::Get { org_id } => org_get(client, &org_id, json).await,
@@ -260,7 +256,7 @@ pub async fn run_member(
     client: &CloudClient,
     command: MemberCommands,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     match command {
         MemberCommands::List { org_id } => member_list(client, org_id.as_deref(), json).await,
         MemberCommands::Get { user_id, org_id } => {
@@ -281,7 +277,7 @@ pub async fn run_invitation(
     client: &CloudClient,
     command: InvitationCommands,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     match command {
         InvitationCommands::List { org_id } => {
             invitation_list(client, org_id.as_deref(), json).await
@@ -309,9 +305,7 @@ struct OrgUpdateOptions {
     enable_core_dumps: Option<bool>,
 }
 
-fn parse_org_private_endpoint_remove(
-    value: &str,
-) -> Result<OrganizationPatchPrivateEndpoint, Box<dyn std::error::Error>> {
+fn parse_org_private_endpoint_remove(value: &str) -> CloudResult<OrganizationPatchPrivateEndpoint> {
     let mut endpoint = OrganizationPatchPrivateEndpoint {
         id: String::new(),
         description: None,
@@ -330,9 +324,12 @@ fn parse_org_private_endpoint_remove(
             continue;
         }
 
-        let (key, raw_value) = part
-            .split_once('=')
-            .ok_or_else(|| format!("invalid remove-private-endpoint segment '{}'", part))?;
+        let (key, raw_value) = part.split_once('=').ok_or_else(|| {
+            CloudError::new(format!(
+                "invalid remove-private-endpoint segment '{}'",
+                part
+            ))
+        })?;
 
         match key {
             "id" => endpoint.id = raw_value.to_string(),
@@ -345,28 +342,25 @@ fn parse_org_private_endpoint_remove(
                     .expect("enum with Unknown variant should always deserialize");
             }
             "region" => {
-                endpoint.region =
-                    serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
-                        serde_json::Value::String(raw_value.to_string()),
-                    )
-                    .expect("enum with Unknown variant should always deserialize");
+                endpoint.region = serde_json::from_value::<OrganizationPatchPrivateEndpointRegion>(
+                    serde_json::Value::String(raw_value.to_string()),
+                )
+                .expect("enum with Unknown variant should always deserialize");
             }
             _ => {
-                return Err(format!(
+                return Err(CloudError::new(format!(
                     "invalid remove-private-endpoint key '{}'; expected id, description, cloud-provider, or region",
                     key
-                )
-                .into())
+                )));
             }
         }
     }
 
     if endpoint.id.trim().is_empty() {
-        return Err(format!(
+        return Err(CloudError::new(format!(
             "remove-private-endpoint '{}' requires a non-empty id",
             value
-        )
-        .into());
+        )));
     }
 
     Ok(endpoint)
@@ -374,7 +368,7 @@ fn parse_org_private_endpoint_remove(
 
 fn parse_org_private_endpoints_patch(
     remove: &[String],
-) -> Result<Option<OrganizationPrivateEndpointsPatch>, Box<dyn std::error::Error>> {
+) -> CloudResult<Option<OrganizationPrivateEndpointsPatch>> {
     if remove.is_empty() {
         return Ok(None);
     }
@@ -391,9 +385,7 @@ fn parse_org_private_endpoints_patch(
     }))
 }
 
-fn build_org_update_request(
-    options: &OrgUpdateOptions,
-) -> Result<OrganizationPatchRequest, Box<dyn std::error::Error>> {
+fn build_org_update_request(options: &OrgUpdateOptions) -> CloudResult<OrganizationPatchRequest> {
     Ok(OrganizationPatchRequest {
         name: options.name.clone(),
         private_endpoints: parse_org_private_endpoints_patch(&options.remove_private_endpoints)?,
@@ -429,7 +421,7 @@ fn join_absent<T>(items: Option<&[T]>, render: impl Fn(&T) -> String) -> String 
     }
 }
 
-async fn org_list(client: &CloudClient, json: bool) -> Result<(), Box<dyn std::error::Error>> {
+async fn org_list(client: &CloudClient, json: bool) -> CloudResult<()> {
     let orgs = client.list_organizations().await?;
 
     if json {
@@ -458,11 +450,7 @@ async fn org_list(client: &CloudClient, json: bool) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
-async fn org_get(
-    client: &CloudClient,
-    org_id: &str,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn org_get(client: &CloudClient, org_id: &str, json: bool) -> CloudResult<()> {
     let organization = client.get_organization(org_id).await?;
 
     if json {
@@ -478,7 +466,7 @@ async fn org_update(
     org_id: &str,
     options: OrgUpdateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let request = build_org_update_request(&options)?;
     let organization = client.update_organization(org_id, &request).await?;
 
@@ -499,7 +487,7 @@ async fn org_prometheus(
     org_id: Option<&str>,
     filtered_metrics: Option<bool>,
     _json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let prometheus = client.get_org_prometheus(&org_id, filtered_metrics).await?;
     println!("{}", prometheus);
@@ -513,7 +501,7 @@ async fn org_usage(
     to_date: &str,
     filters: &[String],
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let usage = client
         .get_org_usage(&org_id, from_date, to_date, filters)
@@ -562,11 +550,7 @@ fn usage_entity_label(name: Option<&str>, id: Option<uuid::Uuid>) -> String {
     }
 }
 
-async fn member_list(
-    client: &CloudClient,
-    org_id: Option<&str>,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn member_list(client: &CloudClient, org_id: Option<&str>, json: bool) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let members = client.list_members(&org_id).await?;
 
@@ -609,7 +593,7 @@ async fn member_get(
     user_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let member = client.get_member(&org_id, user_id).await?;
 
@@ -627,7 +611,7 @@ async fn member_update(
     role_ids: &[String],
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let request = build_member_update_request(role_ids);
     let member = client.update_member(&org_id, user_id, &request).await?;
@@ -645,7 +629,7 @@ async fn member_remove(
     user_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let response = client.delete_member(&org_id, user_id).await?;
     if json {
@@ -660,7 +644,7 @@ async fn invitation_list(
     client: &CloudClient,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let invitations = client.list_invitations(&org_id).await?;
 
@@ -704,7 +688,7 @@ async fn invitation_create(
     role_ids: &[String],
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let request = build_invitation_create_request(email, role_ids);
     let invitation = client.create_invitation(&org_id, &request).await?;
@@ -726,7 +710,7 @@ async fn invitation_get(
     invitation_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let invitation = client.get_invitation(&org_id, invitation_id).await?;
 
@@ -743,7 +727,7 @@ async fn invitation_delete(
     invitation_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let response = client.delete_invitation(&org_id, invitation_id).await?;
     if json {

--- a/crates/clickhousectl/src/cloud/postgres.rs
+++ b/crates/clickhousectl/src/cloud/postgres.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::output::{ABSENT, or_absent};
 use crate::cloud::shared::{parse_datetime, parse_serde_enum, parse_tags, resolve_org_id};
 use clap::Subcommand;
@@ -241,11 +241,7 @@ impl PostgresCommands {
     }
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: PostgresCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: PostgresCommands, json: bool) -> CloudResult<()> {
     match command {
         PostgresCommands::List { org_id, filter } => {
             postgres_list(client, org_id.as_deref(), &filter, json).await
@@ -438,23 +434,21 @@ pub async fn run(
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn unwrap_api<T>(resp: ApiResponse<T>) -> Result<T, Box<dyn std::error::Error>> {
+fn unwrap_api<T>(resp: ApiResponse<T>) -> CloudResult<T> {
     resp.result
-        .ok_or_else(|| "API response was missing a result body".into())
+        .ok_or_else(|| CloudError::new("API response was missing a result body"))
 }
 
-fn parse_pg_size(
-    value: &str,
-) -> Result<clickhouse_cloud_api::models::PgSize, Box<dyn std::error::Error>> {
+fn parse_pg_size(value: &str) -> CloudResult<clickhouse_cloud_api::models::PgSize> {
     serde_json::from_value(serde_json::Value::String(value.to_string()))
-        .map_err(|e| format!("invalid size '{}': {}", value, e).into())
+        .map_err(|e| CloudError::new(format!("invalid size '{}': {}", value, e)))
 }
 
-fn load_json_file<T: DeserializeOwned>(path: &Path) -> Result<T, Box<dyn std::error::Error>> {
+fn load_json_file<T: DeserializeOwned>(path: &Path) -> CloudResult<T> {
     let contents = std::fs::read_to_string(path)
-        .map_err(|e| format!("failed to read {}: {}", path.display(), e))?;
+        .map_err(|e| CloudError::new(format!("failed to read {}: {}", path.display(), e)))?;
     serde_json::from_str(&contents)
-        .map_err(|e| format!("failed to parse {} as JSON: {}", path.display(), e).into())
+        .map_err(|e| CloudError::new(format!("failed to parse {} as JSON: {}", path.display(), e)))
 }
 
 /// Builds the `postgres config` write body from a user-supplied JSON document.
@@ -466,12 +460,10 @@ fn load_json_file<T: DeserializeOwned>(path: &Path) -> Result<T, Box<dyn std::er
 /// The API rejects a body that omits either `pgConfig` or `pgBouncerConfig`, and
 /// the request model is strict (no serde defaults), so an omitted key of an
 /// object root resolves to an empty object here — explicitly, at the point of use.
-fn instance_config_from_json(
-    doc: &serde_json::Value,
-) -> Result<PostgresInstanceConfig, Box<dyn std::error::Error>> {
+fn instance_config_from_json(doc: &serde_json::Value) -> CloudResult<PostgresInstanceConfig> {
     let root = doc
         .as_object()
-        .ok_or("configuration document must be a JSON object")?;
+        .ok_or_else(|| CloudError::new("configuration document must be a JSON object"))?;
     let section = |key: &str| {
         root.get(key)
             .cloned()
@@ -479,9 +471,9 @@ fn instance_config_from_json(
     };
     Ok(PostgresInstanceConfig {
         pg_config: serde_json::from_value(section("pgConfig"))
-            .map_err(|e| format!("invalid pgConfig: {}", e))?,
+            .map_err(|e| CloudError::new(format!("invalid pgConfig: {}", e)))?,
         pg_bouncer_config: serde_json::from_value(section("pgBouncerConfig"))
-            .map_err(|e| format!("invalid pgBouncerConfig: {}", e))?,
+            .map_err(|e| CloudError::new(format!("invalid pgBouncerConfig: {}", e)))?,
     })
 }
 
@@ -491,15 +483,18 @@ fn instance_config_from_json(
 /// falling back to a string if JSON parsing fails (`statement_timeout=5s`).
 pub(super) fn parse_pg_config_overrides(
     sets: &[String],
-) -> Result<serde_json::Map<String, serde_json::Value>, Box<dyn std::error::Error>> {
+) -> CloudResult<serde_json::Map<String, serde_json::Value>> {
     let mut out = serde_json::Map::new();
     for entry in sets {
-        let (key, val) = entry
-            .split_once('=')
-            .ok_or_else(|| format!("invalid --set '{}': expected key=value", entry))?;
+        let (key, val) = entry.split_once('=').ok_or_else(|| {
+            CloudError::new(format!("invalid --set '{}': expected key=value", entry))
+        })?;
         let key = key.trim();
         if key.is_empty() {
-            return Err(format!("invalid --set '{}': key cannot be empty", entry).into());
+            return Err(CloudError::new(format!(
+                "invalid --set '{}': key cannot be empty",
+                entry
+            )));
         }
         let parsed = serde_json::from_str::<serde_json::Value>(val)
             .unwrap_or_else(|_| serde_json::Value::String(val.to_string()));
@@ -516,22 +511,22 @@ fn generate_compliant_password() -> String {
     format!("A1{}{}", u1, u2)
 }
 
-fn validate_password(pw: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn validate_password(pw: &str) -> CloudResult<()> {
     if pw.len() < 12 {
-        return Err("password must be at least 12 characters".into());
+        return Err(CloudError::new("password must be at least 12 characters"));
     }
     let has_lower = pw.chars().any(|c| c.is_ascii_lowercase());
     let has_upper = pw.chars().any(|c| c.is_ascii_uppercase());
     let has_digit = pw.chars().any(|c| c.is_ascii_digit());
     if !(has_lower && has_upper && has_digit) {
-        return Err(
-            "password must include at least one lowercase, one uppercase, and one digit".into(),
-        );
+        return Err(CloudError::new(
+            "password must include at least one lowercase, one uppercase, and one digit",
+        ));
     }
     Ok(())
 }
 
-fn write_pem_file(path: &Path, pem: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn write_pem_file(path: &Path, pem: &str) -> CloudResult<()> {
     use std::io::Write;
     #[cfg(unix)]
     {
@@ -658,16 +653,19 @@ fn merge_response_tags(
     current: Option<Vec<ResourceTagsV1Response>>,
     add: &[ResourceTagsV1],
     remove_keys: &[String],
-) -> Result<Vec<ResourceTagsV1>, Box<dyn std::error::Error>> {
-    let current = current.ok_or(
-        "the API response omitted the tags field, so --add-tag/--remove-tag cannot be merged \
-         safely: an update replaces the tag set wholesale, and merging against an assumed empty \
-         set would delete any tags the service already has",
-    )?;
+) -> CloudResult<Vec<ResourceTagsV1>> {
+    let current = current.ok_or_else(|| {
+        CloudError::new(
+            "the API response omitted the tags field, so --add-tag/--remove-tag cannot be merged \
+             safely: an update replaces the tag set wholesale, and merging against an assumed empty \
+             set would delete any tags the service already has",
+        )
+    })?;
     let existing = current
         .into_iter()
         .map(ResourceTagsV1::try_from)
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| CloudError::new(error.to_string()))?;
     Ok(merge_tags(&existing, add, remove_keys))
 }
 
@@ -722,7 +720,7 @@ pub async fn postgres_list(
     org_id: Option<&str>,
     filters: &[String],
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
@@ -792,7 +790,7 @@ pub async fn postgres_get(
     postgres_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
@@ -858,7 +856,7 @@ pub async fn postgres_create(
     client: &CloudClient,
     opts: PostgresCreateOptions<'_>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, opts.org_id).await?;
 
     let provider: PgProvider = parse_serde_enum(opts.provider, "provider", PgProvider::VALUES)?;
@@ -932,7 +930,7 @@ pub async fn postgres_update(
     postgres_id: &str,
     opts: PostgresUpdateOptions<'_>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, opts.org_id).await?;
 
     let size = opts.size.map(parse_pg_size).transpose()?;
@@ -984,7 +982,7 @@ pub async fn postgres_delete(
     postgres_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
@@ -1006,7 +1004,7 @@ pub async fn postgres_certs_get(
     output: Option<&Path>,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let pem = client
         .api()
@@ -1048,7 +1046,7 @@ pub async fn postgres_config_get(
     postgres_id: &str,
     org_id: Option<&str>,
     _json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let resp = client
         .api()
@@ -1067,7 +1065,7 @@ pub async fn postgres_config_replace(
     file: &Path,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let cfg = instance_config_from_json(&load_json_file::<serde_json::Value>(file)?)?;
     let resp = client
@@ -1095,11 +1093,11 @@ pub async fn postgres_config_patch(
     file: Option<&Path>,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
 
     if sets.is_empty() && file.is_none() {
-        return Err("provide --set key=value... or --file PATH".into());
+        return Err(CloudError::new("provide --set key=value... or --file PATH"));
     }
 
     let cfg = if let Some(path) = file {
@@ -1111,7 +1109,7 @@ pub async fn postgres_config_patch(
         instance_config_from_json(&serde_json::json!({
             "pgConfig": serde_json::Value::Object(overrides),
         }))
-        .map_err(|e| format!("failed to build config from --set entries: {}", e))?
+        .map_err(|e| CloudError::new(format!("failed to build config from --set entries: {}", e)))?
     };
 
     let resp = client
@@ -1139,7 +1137,7 @@ pub async fn postgres_reset_password(
     generate: bool,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
 
     let pw = match (password, generate) {
@@ -1148,7 +1146,9 @@ pub async fn postgres_reset_password(
             p.to_string()
         }
         (None, true) => generate_compliant_password(),
-        (None, false) => return Err("provide --password VALUE or --generate".into()),
+        (None, false) => {
+            return Err(CloudError::new("provide --password VALUE or --generate"));
+        }
         (Some(_), true) => unreachable!("clap conflicts_with prevents this"),
     };
 
@@ -1188,7 +1188,7 @@ pub async fn postgres_read_replica_create(
     postgres_id: &str,
     opts: PostgresReadReplicaOptions<'_>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, opts.org_id).await?;
     let tags = parse_tags(opts.tags)?;
     let pg_config = opts
@@ -1229,7 +1229,7 @@ pub async fn postgres_restore(
     postgres_id: &str,
     opts: PostgresRestoreOptions<'_>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, opts.org_id).await?;
     let tags = parse_tags(opts.tags)?;
     let pg_config = opts
@@ -1241,7 +1241,7 @@ pub async fn postgres_restore(
         .map(load_json_file::<PgBouncerConfig>)
         .transpose()?;
     let restore_target = chrono::DateTime::parse_from_rfc3339(opts.restore_target)
-        .map_err(|e| format!("invalid restore-target: {}", e))?
+        .map_err(|e| CloudError::new(format!("invalid restore-target: {}", e)))?
         .with_timezone(&chrono::Utc);
 
     let req = PostgresServiceRestoreRequest {
@@ -1275,7 +1275,7 @@ pub async fn postgres_state_change(
     cmd: PostgresServiceSetStateCommand,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let req = PostgresServiceSetState { command: cmd };
     let resp = client

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -7,7 +7,7 @@
 //! control plane.
 
 use crate::cloud::api_keys::discard_api_key;
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials::{self, ServiceQueryKey};
 use chrono::{DateTime, Utc};
 use clickhouse_cloud_api::models::{
@@ -20,16 +20,18 @@ use clickhouse_cloud_api::models::{
 const ALLOWED_ORIGINS: &str = "*";
 
 /// Requires a response field the provisioning flow cannot proceed without.
-fn require_field<T>(value: Option<T>, field: &str) -> Result<T, Box<dyn std::error::Error>> {
-    value.ok_or_else(|| format!("the API response is missing required field '{field}'").into())
+fn require_field<T>(value: Option<T>, field: &str) -> CloudResult<T> {
+    value.ok_or_else(|| {
+        CloudError::new(format!(
+            "the API response is missing required field '{field}'"
+        ))
+    })
 }
 
 /// The `key_id`/`key_secret` pair the query host authenticates with, taken
 /// from the key-creation response. Both halves are required together: a key
 /// id without its secret is as unusable as neither.
-fn require_credential_pair(
-    key_response: &ApiKeyPostResponse,
-) -> Result<(String, String), Box<dyn std::error::Error>> {
+fn require_credential_pair(key_response: &ApiKeyPostResponse) -> CloudResult<(String, String)> {
     let key_id = require_field(key_response.key_id.clone(), "keyId")?;
     let key_secret = require_field(key_response.key_secret.clone(), "keySecret")?;
     Ok((key_id, key_secret))
@@ -65,7 +67,7 @@ pub async fn ensure_service_query_setup(
     org_id: &str,
     service_id: &str,
     service_name: &str,
-) -> Result<ServiceQueryKey, Box<dyn std::error::Error>> {
+) -> CloudResult<ServiceQueryKey> {
     if let Some(existing) = credentials::get_service_query_key(service_id) {
         return Ok(existing);
     }
@@ -145,13 +147,12 @@ pub async fn ensure_service_query_setup(
 /// report. An explicitly empty list is a real answer and merges normally.
 fn existing_open_api_keys(
     endpoint: Option<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint>,
-) -> Result<Vec<String>, Box<dyn std::error::Error>> {
-    let incomplete = |field: &str| -> Box<dyn std::error::Error> {
-        format!(
+) -> CloudResult<Vec<String>> {
+    let incomplete = |field: &str| {
+        CloudError::new(format!(
             "the query endpoint response is missing field '{field}', so the keys currently bound \
              to the endpoint are unknown; binding a new key would revoke them"
-        )
-        .into()
+        ))
     };
     endpoint
         .ok_or_else(|| incomplete("result"))?
@@ -168,7 +169,7 @@ async fn bind_query_endpoint(
     org_id: &str,
     service_id: &str,
     api_key_uuid: &str,
-) -> Result<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint, Box<dyn std::error::Error>> {
+) -> CloudResult<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint> {
     let mut open_api_keys = match client
         .api()
         .instance_query_endpoint_get(org_id, service_id)
@@ -178,7 +179,7 @@ async fn bind_query_endpoint(
         // Only a 404 means there is no endpoint yet, so this binding is the
         // first one and starts from an empty list.
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Vec::new(),
-        Err(e) => return Err(client.convert_error_for_organization(e, org_id).into()),
+        Err(e) => return Err(client.convert_error_for_organization(e, org_id)),
     };
     if !open_api_keys.iter().any(|k| k == api_key_uuid) {
         open_api_keys.push(api_key_uuid.to_string());
@@ -192,9 +193,9 @@ async fn bind_query_endpoint(
         allowed_origins: ALLOWED_ORIGINS.to_string(),
     };
 
-    Ok(client
+    client
         .create_query_endpoint(org_id, service_id, &endpoint_request)
-        .await?)
+        .await
 }
 
 #[cfg(test)]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1,6 +1,6 @@
 use crate::cloud::api_keys::{cleanup_service_query_key, service_query_key_cleanup};
 use crate::cloud::backups::BackupConfigCommands;
-use crate::cloud::client::{CloudClient, CloudError};
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use crate::cloud::credentials;
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
@@ -559,11 +559,7 @@ impl ServiceCommands {
     }
 }
 
-pub async fn run(
-    client: &CloudClient,
-    command: ServiceCommands,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run(client: &CloudClient, command: ServiceCommands, json: bool) -> CloudResult<()> {
     match command {
         ServiceCommands::List { org_id, filter } => {
             service_list(client, org_id.as_deref(), &filter, json).await
@@ -819,7 +815,7 @@ async fn resolve_service(
     org_id: &str,
     name: Option<&str>,
     id: Option<&str>,
-) -> Result<Service, Box<dyn std::error::Error>> {
+) -> CloudResult<Service> {
     match (name, id) {
         (Some(name), None) => {
             let services = client.list_services(org_id).await?;
@@ -828,18 +824,22 @@ async fn resolve_service(
                 .filter(|service| service.name.as_deref() == Some(name))
                 .collect();
             match matches.len() {
-                0 => Err(format!("no service found with name '{}'", name).into()),
+                0 => Err(CloudError::new(format!(
+                    "no service found with name '{}'",
+                    name
+                ))),
                 1 => Ok(matches.into_iter().next().unwrap()),
-                count => Err(format!(
+                count => Err(CloudError::new(format!(
                     "found {} services named '{}' — use --id to disambiguate",
                     count, name
-                )
-                .into()),
+                ))),
             }
         }
         (None, Some(id)) => Ok(client.get_service(org_id, id).await?),
-        (Some(_), Some(_)) => Err("specify either --name or --id, not both".into()),
-        (None, None) => Err("specify --name or --id to identify the service".into()),
+        (Some(_), Some(_)) => Err(CloudError::new("specify either --name or --id, not both")),
+        (None, None) => Err(CloudError::new(
+            "specify --name or --id to identify the service",
+        )),
     }
 }
 
@@ -883,7 +883,7 @@ fn parse_private_endpoint_ids_patch(
 fn parse_service_endpoint_changes(
     enable: &[String],
     disable: &[String],
-) -> Result<Option<Vec<ServiceEndpointChange>>, Box<dyn std::error::Error>> {
+) -> CloudResult<Option<Vec<ServiceEndpointChange>>> {
     let mut changes = Vec::new();
 
     for protocol in enable {
@@ -914,7 +914,7 @@ fn parse_service_endpoint_changes(
 fn parse_instance_tags_patch(
     add: &[String],
     remove: &[String],
-) -> Result<Option<InstanceTagsPatch>, Box<dyn std::error::Error>> {
+) -> CloudResult<Option<InstanceTagsPatch>> {
     let patch = InstanceTagsPatch {
         add: parse_tags(add)?.unwrap_or_default(),
         remove: parse_tags(remove)?.unwrap_or_default(),
@@ -928,7 +928,7 @@ async fn service_list(
     org_id: Option<&str>,
     filters: &[String],
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
 
     let services = if filters.is_empty() {
@@ -980,7 +980,7 @@ async fn service_get(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let service = client.get_service(&org_id, service_id).await?;
 
@@ -1065,9 +1065,11 @@ fn resolve_horizontal_autoscaling(
     autoscaling_mode: Option<&str>,
     min_replicas: Option<u32>,
     max_replicas: Option<u32>,
-) -> Result<HorizontalAutoscaling, Box<dyn std::error::Error>> {
+) -> CloudResult<HorizontalAutoscaling> {
     if min_replicas.is_some() != max_replicas.is_some() {
-        return Err("--min-replicas and --max-replicas must be specified together".into());
+        return Err(CloudError::new(
+            "--min-replicas and --max-replicas must be specified together",
+        ));
     }
     let autoscaling_mode = autoscaling_mode
         .map(|value| {
@@ -1081,9 +1083,7 @@ fn resolve_horizontal_autoscaling(
     })
 }
 
-fn build_create_service_request(
-    options: &CreateServiceOptions,
-) -> Result<ServicePostRequest, Box<dyn std::error::Error>> {
+fn build_create_service_request(options: &CreateServiceOptions) -> CloudResult<ServicePostRequest> {
     let ip_access_list = if options.ip_allow.is_empty() {
         vec![IpAccessListEntry {
             source: "0.0.0.0/0".to_string(),
@@ -1122,7 +1122,7 @@ fn build_create_service_request(
             .as_deref()
             .map(uuid::Uuid::parse_str)
             .transpose()
-            .map_err(|error| format!("invalid backup_id: {}", error))?,
+            .map_err(|error| CloudError::new(format!("invalid backup_id: {}", error)))?,
         release_channel: match options.release_channel.as_deref() {
             Some(value) => Some(parse_serde_enum::<ServicePostRequestReleasechannel>(
                 value,
@@ -1184,7 +1184,7 @@ fn build_create_service_request(
 
 fn build_update_service_request(
     options: &ServiceUpdateOptions,
-) -> Result<ServicePatchRequest, Box<dyn std::error::Error>> {
+) -> CloudResult<ServicePatchRequest> {
     Ok(ServicePatchRequest {
         name: options.name.clone(),
         ip_access_list: parse_ip_access_list_patch(&options.add_ip_allow, &options.remove_ip_allow),
@@ -1224,7 +1224,7 @@ fn build_service_password_patch_request(
 
 fn build_query_endpoint_create_request(
     options: &QueryEndpointCreateOptions,
-) -> Result<InstanceServiceQueryApiEndpointsPostRequest, Box<dyn std::error::Error>> {
+) -> CloudResult<InstanceServiceQueryApiEndpointsPostRequest> {
     Ok(InstanceServiceQueryApiEndpointsPostRequest {
         roles: options
             .roles
@@ -1292,7 +1292,7 @@ async fn service_create(
     client: &CloudClient,
     options: CreateServiceOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let request = build_create_service_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let response = client.create_service(&org_id, &request).await?;
@@ -1319,24 +1319,23 @@ async fn service_create(
     Ok(())
 }
 
-fn classify_stop_poll_state(
-    state: Option<&ServiceState>,
-) -> Result<bool, Box<dyn std::error::Error>> {
+fn classify_stop_poll_state(state: Option<&ServiceState>) -> CloudResult<bool> {
     let state = state
-        .ok_or(
-            "the API response omitted the service state while waiting for the service to stop, \
+        .ok_or_else(|| {
+            CloudError::new(
+                "the API response omitted the service state while waiting for the service to stop, \
              so the stop cannot be confirmed",
-        )?
+            )
+        })?
         .to_string();
     if matches!(state.as_str(), "stopped" | "idle") {
         return Ok(true);
     }
     if matches!(state.as_str(), "terminated" | "failed" | "deleted") {
-        return Err(format!(
+        return Err(CloudError::new(format!(
             "service entered unexpected state '{}' while waiting for stop",
             state
-        )
-        .into());
+        )));
     }
     Ok(false)
 }
@@ -1374,7 +1373,7 @@ async fn service_delete(
     force: bool,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let (query_key_id, retain_query_key) = service_query_key_cleanup(&org_id, service_id)?;
 
@@ -1430,7 +1429,7 @@ async fn service_start(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let service = client
         .change_service_state(&org_id, service_id, ServiceStatePatchRequestCommand::Start)
@@ -1453,7 +1452,7 @@ async fn service_stop(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let service = client
         .change_service_state(&org_id, service_id, ServiceStatePatchRequestCommand::Stop)
@@ -1476,7 +1475,7 @@ async fn service_update(
     service_id: &str,
     options: ServiceUpdateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let request = build_update_service_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let service = client.update_service(&org_id, service_id, &request).await?;
@@ -1506,7 +1505,7 @@ struct ServiceScaleOptions {
 
 fn build_service_scale_request(
     options: &ServiceScaleOptions,
-) -> Result<ServiceReplicaScalingPatchRequest, Box<dyn std::error::Error>> {
+) -> CloudResult<ServiceReplicaScalingPatchRequest> {
     let horizontal = resolve_horizontal_autoscaling(
         options.autoscaling_mode.as_deref(),
         options.min_replicas,
@@ -1530,7 +1529,7 @@ async fn service_scale(
     service_id: &str,
     options: ServiceScaleOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let request = build_service_scale_request(&options)?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let service = client
@@ -1579,7 +1578,7 @@ async fn service_reset_password(
     service_id: &str,
     options: ServiceResetPasswordOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let request = build_service_password_patch_request(&options);
     let response = client.reset_password(&org_id, service_id, &request).await?;
@@ -1617,18 +1616,17 @@ fn generation_requested(request: &ServicePasswordPatchRequest) -> bool {
 fn resolve_reset_password_outcome(
     generation_requested: bool,
     password: Option<&str>,
-) -> Result<ResetPasswordOutcome<'_>, Box<dyn std::error::Error>> {
+) -> CloudResult<ResetPasswordOutcome<'_>> {
     if !generation_requested {
         return Ok(ResetPasswordOutcome::HashUpdated);
     }
     match password {
         Some(password) => Ok(ResetPasswordOutcome::Generated(password)),
-        None => Err(
+        None => Err(CloudError::new(
             "the API response omitted the generated password, so it cannot be shown: the \
              service password may already have been rotated — run the reset again to get \
-             a password you can use"
-                .into(),
-        ),
+             a password you can use",
+        )),
     }
 }
 
@@ -1637,7 +1635,7 @@ async fn query_endpoint_get(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let endpoint = client.get_query_endpoint(&org_id, service_id).await?;
 
@@ -1654,7 +1652,7 @@ async fn query_endpoint_create(
     service_id: &str,
     options: QueryEndpointCreateOptions,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let request = build_query_endpoint_create_request(&options)?;
     let endpoint = client
@@ -1685,7 +1683,7 @@ async fn query_endpoint_delete(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let response = client.delete_query_endpoint(&org_id, service_id).await?;
     if json {
@@ -1743,10 +1741,7 @@ fn query_requires_provisioning(error: &clickhouse_cloud_api::Error) -> bool {
     )
 }
 
-async fn service_query(
-    client: &CloudClient,
-    options: ServiceQueryOptions,
-) -> Result<(), Box<dyn std::error::Error>> {
+async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> CloudResult<()> {
     let sql = read_query_sql(options.query.as_deref(), options.queries_file.as_deref())?;
     let org_id = resolve_org_id(client, options.org_id.as_deref()).await?;
     let service = resolve_service(
@@ -1761,7 +1756,7 @@ async fn service_query(
         None => options
             .id
             .clone()
-            .ok_or("the API response is missing the service id")?,
+            .ok_or_else(|| CloudError::new("the API response is missing the service id"))?,
     };
     let service_name = or_absent(service.name.as_deref());
 
@@ -1809,7 +1804,7 @@ async fn service_query(
         } else {
             let (key_id, key_secret) = client
                 .basic_auth_credentials()
-                .ok_or("API key credentials are unavailable")?;
+                .ok_or_else(|| CloudError::new("API key credentials are unavailable"))?;
             match run_basic_service_query(
                 client,
                 &service_id,
@@ -1824,10 +1819,9 @@ async fn service_query(
             {
                 Err(error) if query_requires_provisioning(&error) => {
                     if options.no_auto_enable {
-                        return Err(format!(
+                        return Err(CloudError::new(format!(
                             "the authenticated API key cannot use the Query API endpoint for service {service_id}, and --no-auto-enable prevents provisioning"
-                        )
-                        .into());
+                        )));
                     }
                     eprintln!(
                         "Provisioning Query API endpoint + key for service '{}'...",
@@ -1868,9 +1862,8 @@ async fn service_query(
     let mut byte_count = 0;
     let mut last_byte = None;
     while let Some(chunk) = stream.next().await {
-        let bytes = chunk.map_err(|error| -> Box<dyn std::error::Error> {
-            format!("Failed to read query response: {error}").into()
-        })?;
+        let bytes = chunk
+            .map_err(|error| CloudError::new(format!("Failed to read query response: {error}")))?;
         handle.write_all(&bytes)?;
         byte_count += bytes.len();
         if let Some(last) = bytes.last() {
@@ -1925,25 +1918,21 @@ fn convert_query_error(
     service_name: &str,
     service_id: &str,
     org_id: &str,
-) -> Box<dyn std::error::Error> {
+) -> CloudError {
     match error {
-        clickhouse_cloud_api::Error::ServiceStopped => format!(
+        clickhouse_cloud_api::Error::ServiceStopped => CloudError::new(format!(
             "service '{service_name}' is stopped; start it with `clickhousectl cloud service start {service_id} --org-id {org_id}` and retry"
-        )
-        .into(),
-        other => client.convert_error(other).into(),
+        )),
+        other => client.convert_error(other),
     }
 }
 
-fn read_query_sql(
-    inline: Option<&str>,
-    queries_file: Option<&str>,
-) -> Result<String, Box<dyn std::error::Error>> {
+fn read_query_sql(inline: Option<&str>, queries_file: Option<&str>) -> CloudResult<String> {
     use std::io::Read as _;
 
     if let Some(query) = inline {
         if query.trim().is_empty() {
-            return Err("--query was empty".into());
+            return Err(CloudError::new("--query was empty"));
         }
         return Ok(query.to_string());
     }
@@ -1956,19 +1945,21 @@ fn read_query_sql(
             content = std::fs::read_to_string(path)?;
         }
         if content.trim().is_empty() {
-            return Err("queries file was empty".into());
+            return Err(CloudError::new("queries file was empty"));
         }
         return Ok(content);
     }
 
     if std::io::stdin().is_terminal() {
-        return Err("no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.".into());
+        return Err(CloudError::new(
+            "no SQL provided. Pass --query, --queries-file, or pipe SQL on stdin.",
+        ));
     }
 
     let mut content = String::new();
     std::io::stdin().read_to_string(&mut content)?;
     if content.trim().is_empty() {
-        return Err("no SQL received on stdin".into());
+        return Err(CloudError::new("no SQL received on stdin"));
     }
     Ok(content)
 }
@@ -1988,7 +1979,7 @@ async fn private_endpoint_create(
     description: Option<&str>,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let request = build_private_endpoint_create_request(endpoint_id, description);
     let endpoint = client
@@ -2013,7 +2004,7 @@ async fn private_endpoint_get_config(
     service_id: &str,
     org_id: Option<&str>,
     json: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let config = client
         .get_service_private_endpoint_config(&org_id, service_id)
@@ -2032,7 +2023,7 @@ async fn service_prometheus(
     service_id: &str,
     org_id: Option<&str>,
     filtered_metrics: Option<bool>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> CloudResult<()> {
     let org_id = resolve_org_id(client, org_id).await?;
     let prometheus = client
         .get_service_prometheus(&org_id, service_id, filtered_metrics)

--- a/crates/clickhousectl/src/cloud/shared.rs
+++ b/crates/clickhousectl/src/cloud/shared.rs
@@ -1,4 +1,4 @@
-use crate::cloud::client::CloudClient;
+use crate::cloud::client::{CloudClient, CloudError, Result as CloudResult};
 use chrono::{DateTime, FixedOffset, NaiveDate};
 use clickhouse_cloud_api::models::ResourceTagsV1;
 
@@ -6,7 +6,7 @@ use clickhouse_cloud_api::models::ResourceTagsV1;
 pub(super) async fn resolve_org_id(
     client: &CloudClient,
     org_id: Option<&str>,
-) -> Result<String, Box<dyn std::error::Error>> {
+) -> CloudResult<String> {
     match org_id {
         Some(id) => Ok(id.to_string()),
         None => Ok(client.get_default_org_id().await?),
@@ -18,26 +18,28 @@ pub(super) fn parse_serde_enum<T: serde::de::DeserializeOwned>(
     value: &str,
     field: &str,
     known_values: &[&str],
-) -> Result<T, Box<dyn std::error::Error>> {
+) -> CloudResult<T> {
     if !known_values.contains(&value) {
-        return Err(format!(
+        return Err(CloudError::new(format!(
             "invalid {}: unknown value '{}', expected one of: {}",
             field,
             value,
             known_values.join(", ")
-        )
-        .into());
+        )));
     }
     serde_json::from_value(serde_json::Value::String(value.to_string()))
-        .map_err(|e| format!("invalid {}: {}", field, e).into())
+        .map_err(|e| CloudError::new(format!("invalid {}: {}", field, e)))
 }
 
-pub(super) fn parse_tag(value: &str) -> Result<ResourceTagsV1, Box<dyn std::error::Error>> {
+pub(super) fn parse_tag(value: &str) -> CloudResult<ResourceTagsV1> {
     match value.split_once('=') {
         Some((key, tag_value)) => {
             let key = key.trim();
             if key.is_empty() {
-                Err(format!("invalid tag '{}': tag key cannot be empty", value).into())
+                Err(CloudError::new(format!(
+                    "invalid tag '{}': tag key cannot be empty",
+                    value
+                )))
             } else {
                 Ok(ResourceTagsV1 {
                     key: key.to_string(),
@@ -48,7 +50,10 @@ pub(super) fn parse_tag(value: &str) -> Result<ResourceTagsV1, Box<dyn std::erro
         None => {
             let key = value.trim();
             if key.is_empty() {
-                Err(format!("invalid tag '{}': tag key cannot be empty", value).into())
+                Err(CloudError::new(format!(
+                    "invalid tag '{}': tag key cannot be empty",
+                    value
+                )))
             } else {
                 Ok(ResourceTagsV1 {
                     key: key.to_string(),
@@ -59,9 +64,7 @@ pub(super) fn parse_tag(value: &str) -> Result<ResourceTagsV1, Box<dyn std::erro
     }
 }
 
-pub(super) fn parse_tags(
-    values: &[String],
-) -> Result<Option<Vec<ResourceTagsV1>>, Box<dyn std::error::Error>> {
+pub(super) fn parse_tags(values: &[String]) -> CloudResult<Option<Vec<ResourceTagsV1>>> {
     if values.is_empty() {
         Ok(None)
     } else {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -234,6 +234,55 @@ async fn backup_config_rejects_incompatible_period_before_any_request() {
     assert!(mock.received_requests().await.unwrap().is_empty());
 }
 
+// ── Concrete Cloud error routing (issue #233) ──────────────────────────────
+
+async fn invoke_service_list_api_error(status: u16, message: &str) -> std::process::Output {
+    let mock = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services"))
+        .respond_with(
+            ResponseTemplate::new(status).set_body_json(serde_json::json!({
+                "status": status,
+                "error": message,
+                "requestId": format!("stub-{status}"),
+            })),
+        )
+        .mount(&mock)
+        .await;
+
+    invoke_cli_with_cloud_credentials(&mock, &["service", "list", "--org-id", "org-1"])
+}
+
+#[tokio::test]
+async fn dispatched_cloud_401_exits_with_auth_required() {
+    let output = invoke_service_list_api_error(401, "Unauthorized").await;
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Unauthorized\n"
+    );
+}
+
+#[tokio::test]
+async fn dispatched_cloud_403_exits_with_auth_required() {
+    let output = invoke_service_list_api_error(403, "Forbidden").await;
+    assert_eq!(output.status.code(), Some(4));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Forbidden\n"
+    );
+}
+
+#[tokio::test]
+async fn dispatched_cloud_500_remains_a_generic_error() {
+    let output = invoke_service_list_api_error(500, "Internal Server Error").await;
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "Error: Internal Server Error\n"
+    );
+}
+
 // ── Organization-scoped error context (issue #334) ─────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- return concrete `CloudError` values throughout dispatched Cloud handlers and helpers
- remove boxed-error downcasting from the Cloud runtime boundary
- preserve auth classification and current messages through explicit source conversions

## Testing

- `cargo test -p clickhousectl`
- `cargo test -p clickhousectl --all-features`
- focused subprocess 401/403/500 exit-code tests
- `cargo clippy -p clickhousectl --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Closes #233