### PR TITLE
Fix local server start help quotes

### DIFF
--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -188,7 +188,7 @@ CONTEXT FOR AGENTS:
   Additional clickhouse-server arguments must follow `--`.
   Related: `clickhousectl local server list` to see servers, `clickhousectl local server stop [name]` to stop one.")]
     Start {
-        /// Server name (default: \"default\", or random if default is already running)
+        /// Server name (default: "default", or random if default is already running)
         #[arg(value_name = "NAME", conflicts_with = "name_flag")]
         name: Option<String>,
 
@@ -528,6 +528,22 @@ mod tests {
             panic!("expected server start");
         };
         assert_eq!(config_file.as_deref(), Some("analytics"));
+    }
+
+    #[test]
+    fn server_start_help_renders_default_name_quotes_without_escaping() {
+        let help = Cli::try_parse_from(["clickhousectl", "local", "server", "start", "--help"])
+            .err()
+            .expect("help should exit through clap")
+            .to_string();
+
+        assert!(
+            help.contains(
+                r#"  [NAME]               Server name (default: "default", or random if default is already running)"#
+            ),
+            "{help}"
+        );
+        assert!(!help.contains(r#"\"default\""#), "{help}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- render normal quotes around the default local server name in `local server start --help`
- add a rendered-help regression test for the exact argument line and absence of escaped quotes

Closes #476

## Verification

- `cargo test -p clickhousectl server_start_help_renders_default_name_quotes_without_escaping` (1 passed)
- `cargo test -p clickhousectl local::cli::tests::` (20 passed)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`