### PR TITLE
Require a cloud query service selector

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -5,8 +5,8 @@ use crate::cloud::credentials;
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
-use clap::Subcommand;
 use clap::builder::PossibleValuesParser;
+use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
     AutoscalingMode, InstancePrivateEndpointsPatch, InstanceServiceQueryApiEndpointsPostRequest,
     InstanceTagsPatch, IpAccessListEntry, IpAccessListPatch, QueryEndpointRole,
@@ -402,7 +402,9 @@ CONTEXT FOR AGENTS:
     },
 
     /// Run a SQL query against a cloud service over HTTP via the Query API
-    #[command(after_help = "\
+    #[command(
+        group(ArgGroup::new("service_selector").required(true).args(["name", "id"])),
+        after_help = "\
 CONTEXT FOR AGENTS:
   Runs SQL over HTTP — no local clickhouse binary or service password required.
   With API key auth: first uses the authenticated key directly when the query
@@ -417,7 +419,8 @@ CONTEXT FOR AGENTS:
   SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
   on a TTY, TabSeparated when piped. --json selects JSONEachRow and cannot be
   combined with --format; an explicit --format takes precedence over agent
-  auto-JSON.")]
+  auto-JSON."
+    )]
     Query {
         /// Service name to query (exactly one of --name or --id is required)
         #[arg(long, conflicts_with = "id")]
@@ -3149,7 +3152,14 @@ mod tests {
 
     #[test]
     fn parses_service_query_options() {
-        let command = parse_service(&["clickhousectl", "cloud", "service", "query"]);
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+        ]);
         let crate::cloud::cli::ServiceCommands::Query {
             name,
             id,
@@ -3164,7 +3174,7 @@ mod tests {
             panic!("expected service query");
         };
         assert!(name.is_none());
-        assert!(id.is_none());
+        assert_eq!(id.as_deref(), Some("svc-1"));
         assert!(query.is_none());
         assert!(queries_file.is_none());
         assert!(database.is_none());
@@ -3216,8 +3226,29 @@ mod tests {
     }
 
     #[test]
+    fn rejects_service_query_without_selector() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--query",
+            "SELECT 1",
+        ])
+        .err()
+        .expect("service query without a selector should fail");
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        assert!(error.to_string().contains("--name <NAME>"));
+        assert!(error.to_string().contains("--id <ID>"));
+    }
+
+    #[test]
     fn rejects_service_query_name_with_id() {
-        let result = Cli::try_parse_from([
+        let error = Cli::try_parse_from([
             "clickhousectl",
             "cloud",
             "service",
@@ -3228,8 +3259,11 @@ mod tests {
             "svc-1",
             "--query",
             "SELECT 1",
-        ]);
-        assert!(result.is_err());
+        ])
+        .err()
+        .expect("service query with both selectors should fail");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2454,7 +2454,7 @@ async fn service_query_requires_exactly_one_selector_before_network_access() {
         args.extend_from_slice(selector);
 
         let mut command = Command::new(clickhousectl_binary());
-        clear_agent_env(&mut command);
+        clear_inherited_env(&mut command);
         command
             .env("DO_NOT_TRACK", "1")
             .env("HOME", &home_dir)

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2373,11 +2373,21 @@ async fn start_mock_control_plane_with_service() -> MockServer {
         "status": 200,
         "requestId": "stub-service-get",
     });
+    let stub_services = serde_json::json!({
+        "result": [{ "id": QUERY_TEST_SERVICE_ID, "name": "demo" }],
+        "status": 200,
+        "requestId": "stub-service-list",
+    });
     Mock::given(method("GET"))
         .and(path(format!(
             "/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}"
         )))
         .respond_with(ResponseTemplate::new(200).set_body_json(stub_service))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(stub_services))
         .mount(&mock)
         .await;
     mock
@@ -2418,6 +2428,74 @@ async fn start_mock_query_host_for_provisioning() -> MockServer {
         .mount(&mock)
         .await;
     mock
+}
+
+#[tokio::test]
+async fn service_query_requires_exactly_one_selector_before_network_access() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let url = control.uri();
+
+    let invoke = |selector: &[&str], authenticated: bool| {
+        let mut args = vec![
+            "cloud",
+            "--url",
+            url.as_str(),
+            "service",
+            "query",
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ];
+        args.extend_from_slice(selector);
+
+        let mut command = Command::new(clickhousectl_binary());
+        clear_agent_env(&mut command);
+        command
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", &home_dir)
+            .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+            .current_dir(dir.path())
+            .args(args);
+        if authenticated {
+            command
+                .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+                .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests");
+        } else {
+            command
+                .env_remove("CLICKHOUSE_CLOUD_API_KEY")
+                .env_remove("CLICKHOUSE_CLOUD_API_SECRET");
+        }
+        command.output().expect("failed to spawn clickhousectl")
+    };
+
+    let missing = invoke(&[], false);
+    assert_eq!(missing.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&missing.stderr);
+    assert!(stderr.contains("--name <NAME>"), "{stderr}");
+    assert!(stderr.contains("--id <ID>"), "{stderr}");
+
+    let both = invoke(&["--name", "demo", "--id", QUERY_TEST_SERVICE_ID], false);
+    assert_eq!(both.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&both.stderr);
+    assert!(stderr.contains("--name <NAME>"), "{stderr}");
+    assert!(stderr.contains("--id <ID>"), "{stderr}");
+
+    assert!(control.received_requests().await.unwrap().is_empty());
+    assert!(query_host.received_requests().await.unwrap().is_empty());
+
+    for selector in [["--name", "demo"], ["--id", QUERY_TEST_SERVICE_ID]] {
+        let output = invoke(&selector, true);
+        assert_success(&output);
+        assert_eq!(output.stdout, b"1\n");
+    }
+
+    assert_eq!(control.received_requests().await.unwrap().len(), 2);
+    assert_eq!(query_host.received_requests().await.unwrap().len(), 2);
 }
 
 async fn invoke_oauth_service_query_response(


### PR DESCRIPTION
## Summary

- require exactly one of `--name` and `--id` during `cloud service query` clap parsing
- preserve name-only and ID-only parsing while rejecting both selectors
- cover all four selector combinations with parser and real-binary tests, including zero control-plane or query-host requests for invalid combinations

Closes #452

## Verification

- `cargo test -p clickhousectl --bin clickhousectl service_query` (18 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test service_query_requires_exactly_one_selector_before_network_access -- --exact` (1 passed)
- `cargo test -p clickhousectl --bin clickhousectl` (606 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test` (100 passed)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo check -p clickhousectl --all-targets`

## Stack

This PR is the bottom of the Cloud-query stack and targets `main`.