### PR TITLE
Validate local Postgres start options before Docker work

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ clickhousectl local postgres start
 clickhousectl local postgres start --name dev --version 17 --port 5433
 clickhousectl local postgres start --user app --database myapp  # Generates a random password
 clickhousectl local postgres start -e POSTGRES_INITDB_ARGS=--data-checksums
+clickhousectl local postgres start --password flag-value -e POSTGRES_PASSWORD=env-value
 
 # List everything (ClickHouse + Postgres are merged in `server list`)
 clickhousectl local server list
@@ -344,6 +345,8 @@ clickhousectl local postgres remove dev
 ```
 
 The Postgres `dotenv` command includes the generated password. Do not commit its output; prefer `--local` when your application reads `.env.local`.
+
+When `--port` is omitted, `start` uses port 5432 or selects the next available port. An explicit `--port` must be available and is never changed. Container variables use `KEY=VALUE` syntax. The first `-e POSTGRES_PASSWORD=...` takes precedence over `--password`, preserving the existing environment override. The dedicated `--user` and `--database` options (or their defaults) take precedence over `-e POSTGRES_USER=...` and `-e POSTGRES_DB=...`; clickhousectl also owns `PGDATA` so the managed data directory cannot be redirected.
 
 `local postgres start --name dev` (no `--version`) resumes the existing instance when there's exactly one for that name; if multiple majors share the name, the command exits and asks you to pass `--version`. Stop preserves the container and metadata so the next start resumes it; only `remove` tears down the container and deletes the data directory. The unified `local server stop-all` stops both ClickHouse and Postgres instances in the current project; the dedicated `local postgres stop-all` remains available when only Postgres should be stopped.
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -398,9 +398,12 @@ CONTEXT FOR AGENTS:
   a random name is generated (e.g. \"bold-crane\").
   --version (-v) selects a postgres image tag (17 or 18 — e.g. 17, 17-alpine, 18.1, 18-bookworm).
   Defaults to 18. Image is pulled if not already present locally.
-  --port defaults to 5432; if taken, a free port is auto-assigned.
+  --port defaults to 5432; if omitted and taken, a free port is auto-assigned.
+  An explicitly requested port must be available and is never changed.
   Data persists at .clickhouse/servers/<name>/data/ and is bind-mounted into the container.
   A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
+  The first `-e POSTGRES_PASSWORD=...` overrides --password. --user, --database, and
+  managed PGDATA take precedence over same-named `-e` variables.
   Containers are labeled `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`,
   `clickhousectl.project=<cwd>`, `created_by=clickhousectl_<version>` for safe discovery.
   Requires Docker to be installed and running.")]
@@ -429,7 +432,7 @@ CONTEXT FOR AGENTS:
         #[arg(long)]
         database: Option<String>,
 
-        /// Extra env vars for the container, repeatable: -e KEY=VALUE
+        /// Extra env vars for the container, repeatable: -e KEY=VALUE. The first POSTGRES_PASSWORD overrides --password; --user, --database, and managed PGDATA take precedence.
         #[arg(short = 'e', long = "env", value_name = "KEY=VALUE")]
         env: Vec<String>,
     },
@@ -1388,6 +1391,55 @@ mod tests {
             panic!("expected postgres remove");
         };
         assert_eq!(name, "default");
+    }
+
+    #[test]
+    fn postgres_start_parses_definition_options() {
+        let LocalCommands::Postgres {
+            command:
+                PostgresCommands::Start {
+                    name,
+                    version,
+                    port,
+                    user,
+                    password,
+                    database,
+                    env,
+                },
+        } = local_command(&[
+            "postgres",
+            "start",
+            "--name",
+            "analytics",
+            "-v",
+            "17-alpine",
+            "--port",
+            "5544",
+            "--user",
+            "app",
+            "--password",
+            "secret",
+            "--database",
+            "warehouse",
+            "-e",
+            "POSTGRES_INITDB_ARGS=--data-checksums",
+            "--env",
+            "CUSTOM=one=two",
+        ])
+        else {
+            panic!("expected postgres start");
+        };
+
+        assert_eq!(name.as_deref(), Some("analytics"));
+        assert_eq!(version.as_deref(), Some("17-alpine"));
+        assert_eq!(port, Some(5544));
+        assert_eq!(user.as_deref(), Some("app"));
+        assert_eq!(password.as_deref(), Some("secret"));
+        assert_eq!(database.as_deref(), Some("warehouse"));
+        assert_eq!(
+            env,
+            ["POSTGRES_INITDB_ARGS=--data-checksums", "CUSTOM=one=two"]
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -769,6 +769,16 @@ mod tests {
     }
 
     #[test]
+    fn resolve_port_auto_selects_when_default_is_bound() {
+        // If another process already owns 5432, leaving this as None still
+        // exercises the same occupied-default path.
+        let _listener = std::net::TcpListener::bind(("127.0.0.1", DEFAULT_PG_PORT)).ok();
+
+        let port = resolve_port(None).unwrap();
+        assert_ne!(port, DEFAULT_PG_PORT);
+    }
+
+    #[test]
     fn validate_pg_tag_accepts_supported_majors() {
         for tag in [
             "17",

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -26,14 +26,23 @@ pub(crate) fn pg_major_from_tag(tag: &str) -> String {
     tag.chars().take_while(|c| c.is_ascii_digit()).collect()
 }
 
-/// Accept Postgres image tags whose major version is 17 or 18 — anything
-/// else is unsupported for now. Examples that pass: `17`, `17.0`, `17-alpine`,
-/// `18-bookworm`, `18.1-alpine3.20`. Examples that fail: `latest`, `16`, `19`.
+/// Accept syntactically valid Docker image tags for Postgres 17 and 18. The
+/// major must be the complete first component, followed by an optional `.` or
+/// `-` suffix. Examples that pass: `17`, `17.0`, `17-alpine`, `18-bookworm`,
+/// `18.1-alpine3.20`. Examples that fail: `latest`, `16`, `19`, `18garbage`.
 pub(crate) fn validate_pg_tag(tag: &str) -> Result<()> {
-    let major: String = tag.chars().take_while(|c| c.is_ascii_digit()).collect();
-    if !matches!(major.as_str(), "17" | "18") {
+    let suffix = tag.strip_prefix("17").or_else(|| tag.strip_prefix("18"));
+    let valid_suffix = suffix.is_some_and(|suffix| {
+        suffix.is_empty()
+            || (matches!(suffix.as_bytes().first(), Some(b'.' | b'-'))
+                && suffix.len() > 1
+                && suffix[1..]
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || matches!(c, b'_' | b'.' | b'-')))
+    });
+    if tag.len() > 128 || !valid_suffix {
         return Err(Error::Exec(format!(
-            "postgres version '{}' is not supported. Use a 17 or 18 image tag \
+            "postgres version '{}' is not supported. Use a valid 17 or 18 image tag \
              (for example: 17, 17-alpine, 18.1, 18-bookworm).",
             tag
         )));
@@ -83,15 +92,19 @@ async fn start(
     extra_env: Vec<String>,
     json: bool,
 ) -> Result<()> {
+    let has_extra_env = !extra_env.is_empty();
+    let StartPreflight {
+        host_port,
+        extra_env,
+        password_from_env,
+    } = preflight_start_options(name.as_deref(), version.as_deref(), port, extra_env)?;
+
     server::recover_current_project_servers();
 
     // User-facing name (no version suffix). Defaults to "default" when no
     // postgres "default" is currently running.
     let user_name = match name.as_deref() {
-        Some(n) => {
-            server::validate_server_name(n)?;
-            n.to_string()
-        }
+        Some(n) => n.to_string(),
         None => default_pg_name(),
     };
 
@@ -101,10 +114,7 @@ async fn start(
     // instances, we ask them to disambiguate. Only when zero exist do we
     // default to DEFAULT_PG_TAG.
     let (tag, major) = match version.as_deref() {
-        Some(v) => {
-            validate_pg_tag(v)?;
-            (v.to_string(), pg_major_from_tag(v))
-        }
+        Some(v) => (v.to_string(), pg_major_from_tag(v)),
         None => {
             let existing = server::find_pg_instances(&user_name);
             match existing.len() {
@@ -158,7 +168,7 @@ async fn start(
                 || user.is_some()
                 || password.is_some()
                 || database.is_some()
-                || !extra_env.is_empty()
+                || has_extra_env
             {
                 eprintln!(
                     "Note: postgres:{major} '{}' already exists; resuming with stored settings. \
@@ -183,8 +193,6 @@ async fn start(
         docker::pull_image(&docker, tag, json).await?;
     }
 
-    let host_port = resolve_port(port)?;
-
     server::ensure_pg_data_dir(&user_name, &major)?;
     let data_dir = server::pg_data_dir(&user_name, &major);
 
@@ -195,10 +203,6 @@ async fn start(
     let user = user.unwrap_or_else(|| DEFAULT_USER.to_string());
     let database = database.unwrap_or_else(|| DEFAULT_DATABASE.to_string());
 
-    let password_from_env = extra_env
-        .iter()
-        .find_map(|kv| kv.strip_prefix("POSTGRES_PASSWORD="))
-        .map(|s| s.to_string());
     let password = password_from_env
         .or(password)
         .unwrap_or_else(generate_password);
@@ -373,6 +377,11 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
                 "--port 0 is not allowed; pick a specific port or omit the flag".into(),
             ));
         }
+        if std::net::TcpListener::bind(("127.0.0.1", p)).is_err() {
+            return Err(Error::Exec(format!(
+                "Postgres port {p} is already in use; choose a free --port or omit the flag to auto-select"
+            )));
+        }
         return Ok(p);
     }
     if std::net::TcpListener::bind(("127.0.0.1", DEFAULT_PG_PORT)).is_ok() {
@@ -386,6 +395,70 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
     Err(Error::Exec(
         "could not find a free TCP port for Postgres".into(),
     ))
+}
+
+struct StartPreflight {
+    host_port: u16,
+    extra_env: Vec<String>,
+    password_from_env: Option<String>,
+}
+
+fn preflight_start_options(
+    name: Option<&str>,
+    version: Option<&str>,
+    port: Option<u16>,
+    extra_env: Vec<String>,
+) -> Result<StartPreflight> {
+    if let Some(name) = name {
+        server::validate_server_name(name)?;
+    }
+    if let Some(version) = version {
+        validate_pg_tag(version)?;
+    }
+
+    let (extra_env, password_from_env) = validate_extra_env(extra_env)?;
+    let host_port = resolve_port(port)?;
+    Ok(StartPreflight {
+        host_port,
+        extra_env,
+        password_from_env,
+    })
+}
+
+/// Normalize variables managed by the Postgres definition so Docker receives
+/// each reserved key once. The first `-e POSTGRES_PASSWORD=...` wins, matching
+/// the previously advertised and implemented override behavior. Dedicated
+/// options/defaults own POSTGRES_USER and POSTGRES_DB; PGDATA is always fixed.
+fn validate_extra_env(extra_env: Vec<String>) -> Result<(Vec<String>, Option<String>)> {
+    let mut normalized = Vec::with_capacity(extra_env.len());
+    let mut password_from_env = None;
+
+    for (index, entry) in extra_env.into_iter().enumerate() {
+        let Some((key, value)) = entry.split_once('=') else {
+            return Err(Error::Exec(format!(
+                "invalid container environment variable #{}: expected KEY=VALUE",
+                index + 1
+            )));
+        };
+        if key.is_empty() {
+            return Err(Error::Exec(format!(
+                "invalid container environment variable #{}: KEY must not be empty",
+                index + 1
+            )));
+        }
+
+        match key {
+            "POSTGRES_PASSWORD" => {
+                if password_from_env.is_none() {
+                    password_from_env = Some(value.to_string());
+                }
+            }
+            "POSTGRES_USER" | "POSTGRES_DB" | "PGDATA" => {}
+            _ => normalized.push(entry),
+        }
+    }
+
+    Ok((normalized, password_from_env))
 }
 
 fn generate_password() -> String {
@@ -677,8 +750,22 @@ mod tests {
 
     #[test]
     fn resolve_port_passes_through_explicit_value() {
-        // Use a port unlikely to be bound; we just want the passthrough path.
-        assert_eq!(resolve_port(Some(54321)).unwrap(), 54321);
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        assert_eq!(resolve_port(Some(port)).unwrap(), port);
+    }
+
+    #[test]
+    fn resolve_port_rejects_bound_explicit_value() {
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let err = resolve_port(Some(port)).unwrap_err();
+        assert!(
+            matches!(err, Error::Exec(msg) if msg.contains(&port.to_string()) && msg.contains("already in use"))
+        );
     }
 
     #[test]
@@ -709,6 +796,12 @@ mod tests {
             "19",
             "14-alpine",
             "alpine",
+            "18garbage",
+            "17beta",
+            "18/invalid",
+            "18-invalid/tag",
+            "18-",
+            "18.",
             "",
         ] {
             assert!(
@@ -717,6 +810,41 @@ mod tests {
                 tag
             );
         }
+    }
+
+    #[test]
+    fn validate_pg_tag_rejects_tags_over_docker_limit() {
+        let tag = format!("18-{}", "a".repeat(126));
+        assert_eq!(tag.len(), 129);
+        assert!(validate_pg_tag(&tag).is_err());
+    }
+
+    #[test]
+    fn extra_env_requires_key_value_entries() {
+        for env in [vec!["NO_EQUALS".to_string()], vec!["=value".to_string()]] {
+            let err = validate_extra_env(env).unwrap_err();
+            assert!(matches!(err, Error::Exec(msg) if msg.contains("environment variable")));
+        }
+    }
+
+    #[test]
+    fn extra_env_normalizes_reserved_variable_precedence() {
+        let (extra_env, password) = validate_extra_env(vec![
+            "CUSTOM=first=value".to_string(),
+            "POSTGRES_USER=from-env".to_string(),
+            "POSTGRES_PASSWORD=first".to_string(),
+            "POSTGRES_PASSWORD=second".to_string(),
+            "POSTGRES_DB=from-env".to_string(),
+            "PGDATA=/tmp/pgdata".to_string(),
+            "OTHER=".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            extra_env,
+            vec!["CUSTOM=first=value".to_string(), "OTHER=".to_string()]
+        );
+        assert_eq!(password.as_deref(), Some("first"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -189,6 +189,10 @@ async fn start(
     }
 
     // Fresh create.
+    let host_port = match host_port {
+        Some(port) => port,
+        None => resolve_port(None)?,
+    };
     if !docker::image_exists(&docker, tag).await? {
         docker::pull_image(&docker, tag, json).await?;
     }
@@ -398,7 +402,7 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
 }
 
 struct StartPreflight {
-    host_port: u16,
+    host_port: Option<u16>,
     extra_env: Vec<String>,
     password_from_env: Option<String>,
 }
@@ -417,7 +421,7 @@ fn preflight_start_options(
     }
 
     let (extra_env, password_from_env) = validate_extra_env(extra_env)?;
-    let host_port = resolve_port(port)?;
+    let host_port = port.map(|port| resolve_port(Some(port))).transpose()?;
     Ok(StartPreflight {
         host_port,
         extra_env,

--- a/crates/clickhousectl/tests/local_postgres_preflight_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_preflight_test.rs
@@ -1,5 +1,6 @@
 //! Subprocess coverage that keeps invalid Postgres starts away from Docker.
 
+use serde_json::{Value, json};
 use std::io::{ErrorKind, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
@@ -13,18 +14,24 @@ fn clickhousectl_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
 }
 
-fn read_request(stream: &mut UnixStream) -> String {
+fn read_request(stream: &mut UnixStream) -> Option<String> {
     stream
         .set_read_timeout(Some(Duration::from_secs(1)))
         .expect("set fake Docker read timeout");
     let mut request = Vec::new();
     let mut buffer = [0_u8; 1024];
     while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-        let bytes = stream.read(&mut buffer).expect("read Docker request");
+        let bytes = match stream.read(&mut buffer) {
+            Ok(bytes) => bytes,
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                return None;
+            }
+            Err(error) => panic!("read Docker request: {error}"),
+        };
         assert!(bytes > 0, "Docker request ended before its headers");
         request.extend_from_slice(&buffer[..bytes]);
     }
-    String::from_utf8(request).expect("Docker request is UTF-8")
+    Some(String::from_utf8(request).expect("Docker request is UTF-8"))
 }
 
 fn write_response(stream: &mut UnixStream, content_type: &str, body: &str) {
@@ -51,18 +58,40 @@ impl FakeDocker {
             .expect("make fake Docker socket nonblocking");
         let requests = Arc::new(AtomicUsize::new(0));
         let stop = Arc::new(AtomicBool::new(false));
+        let started = Arc::new(AtomicBool::new(false));
         let daemon_requests = Arc::clone(&requests);
         let daemon_stop = Arc::clone(&stop);
+        let daemon_started = Arc::clone(&started);
         let daemon = thread::spawn(move || {
             while !daemon_stop.load(Ordering::SeqCst) {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
+                        let Some(request) = read_request(&mut stream) else {
+                            continue;
+                        };
                         daemon_requests.fetch_add(1, Ordering::SeqCst);
-                        let request = read_request(&mut stream);
                         if request.contains("/_ping ") {
                             write_response(&mut stream, "text/plain", "OK");
                         } else if request.contains("/containers/json") {
                             write_response(&mut stream, "application/json", "[]");
+                        } else if request.contains("/containers/existing-container/start") {
+                            daemon_started.store(true, Ordering::SeqCst);
+                            write_response(&mut stream, "application/json", "");
+                        } else if request.contains("/containers/existing-container/json") {
+                            let body = json!({
+                                "Id": "existing-container",
+                                "Config": {
+                                    "Env": [
+                                        "POSTGRES_USER=stored-user",
+                                        "POSTGRES_PASSWORD=stored-password",
+                                        "POSTGRES_DB=stored-database"
+                                    ]
+                                },
+                                "State": {
+                                    "Running": daemon_started.load(Ordering::SeqCst)
+                                }
+                            });
+                            write_response(&mut stream, "application/json", &body.to_string());
                         } else {
                             write_response(&mut stream, "application/json", "{}");
                         }
@@ -119,6 +148,27 @@ fn run_invalid_start(args: &[&str], expected_error: &str) -> Output {
     output
 }
 
+fn write_stopped_postgres_metadata(project: &Path, port: u16) {
+    let servers = project.join(".clickhouse/servers");
+    std::fs::create_dir_all(&servers).expect("create servers directory");
+    std::fs::write(
+        servers.join("default-pg18.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "default-pg18",
+            "pid": 0,
+            "version": "postgres:18",
+            "http_port": 0,
+            "tcp_port": port,
+            "started_at": "1700000000",
+            "cwd": project.display().to_string(),
+            "engine": "postgres",
+            "container_id": "existing-container"
+        }))
+        .unwrap(),
+    )
+    .expect("write Postgres metadata");
+}
+
 #[test]
 fn invalid_definition_options_make_zero_docker_requests() {
     for (args, expected_error) in [
@@ -139,4 +189,44 @@ fn bound_explicit_port_is_rejected_without_docker_requests() {
     let port = listener.local_addr().unwrap().port().to_string();
 
     run_invalid_start(&["--port", &port], "already in use");
+}
+
+#[test]
+fn exhausted_auto_port_range_does_not_block_resume() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let stored_port = 6543;
+    write_stopped_postgres_metadata(tempdir.path(), stored_port);
+
+    let socket_path = tempdir.path().join("docker.sock");
+    let docker = FakeDocker::spawn(&socket_path);
+    let _listeners: Vec<_> = (5432..=5532)
+        .filter_map(
+            |port| match std::net::TcpListener::bind(("127.0.0.1", port)) {
+                Ok(listener) => Some(listener),
+                Err(error) if error.kind() == ErrorKind::AddrInUse => None,
+                Err(error) => panic!("bind Postgres port {port}: {error}"),
+            },
+        )
+        .collect();
+
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", tempdir.path())
+        .env("DOCKER_HOST", format!("unix://{}", socket_path.display()))
+        .current_dir(tempdir.path())
+        .args(["local", "--json", "postgres", "start"])
+        .output()
+        .expect("run clickhousectl");
+
+    let requests = docker.finish();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(requests > 0, "resume did not contact Docker");
+    let body: Value = serde_json::from_slice(&output.stdout).expect("parse start JSON");
+    assert_eq!(body["port"], stored_port);
+    assert_eq!(body["container_id"], "existing-container");
 }

--- a/crates/clickhousectl/tests/local_postgres_preflight_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_preflight_test.rs
@@ -1,0 +1,142 @@
+//! Subprocess coverage that keeps invalid Postgres starts away from Docker.
+
+use std::io::{ErrorKind, Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn read_request(stream: &mut UnixStream) -> String {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(1)))
+        .expect("set fake Docker read timeout");
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let bytes = stream.read(&mut buffer).expect("read Docker request");
+        assert!(bytes > 0, "Docker request ended before its headers");
+        request.extend_from_slice(&buffer[..bytes]);
+    }
+    String::from_utf8(request).expect("Docker request is UTF-8")
+}
+
+fn write_response(stream: &mut UnixStream, content_type: &str, body: &str) {
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    stream
+        .write_all(response.as_bytes())
+        .expect("write fake Docker response");
+}
+
+struct FakeDocker {
+    requests: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    daemon: JoinHandle<()>,
+}
+
+impl FakeDocker {
+    fn spawn(socket_path: &Path) -> Self {
+        let listener = UnixListener::bind(socket_path).expect("bind fake Docker socket");
+        listener
+            .set_nonblocking(true)
+            .expect("make fake Docker socket nonblocking");
+        let requests = Arc::new(AtomicUsize::new(0));
+        let stop = Arc::new(AtomicBool::new(false));
+        let daemon_requests = Arc::clone(&requests);
+        let daemon_stop = Arc::clone(&stop);
+        let daemon = thread::spawn(move || {
+            while !daemon_stop.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        daemon_requests.fetch_add(1, Ordering::SeqCst);
+                        let request = read_request(&mut stream);
+                        if request.contains("/_ping ") {
+                            write_response(&mut stream, "text/plain", "OK");
+                        } else if request.contains("/containers/json") {
+                            write_response(&mut stream, "application/json", "[]");
+                        } else {
+                            write_response(&mut stream, "application/json", "{}");
+                        }
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept fake Docker connection: {error}"),
+                }
+            }
+        });
+        Self {
+            requests,
+            stop,
+            daemon,
+        }
+    }
+
+    fn finish(self) -> usize {
+        self.stop.store(true, Ordering::SeqCst);
+        self.daemon.join().expect("join fake Docker daemon");
+        self.requests.load(Ordering::SeqCst)
+    }
+}
+
+fn run_invalid_start(args: &[&str], expected_error: &str) -> Output {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let socket_path = tempdir.path().join("docker.sock");
+    let docker = FakeDocker::spawn(&socket_path);
+
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", tempdir.path())
+        .env("DOCKER_HOST", format!("unix://{}", socket_path.display()))
+        .current_dir(tempdir.path())
+        .args(["local", "postgres", "start"])
+        .args(args)
+        .output()
+        .expect("run clickhousectl");
+
+    let requests = docker.finish();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(
+        stderr.contains(expected_error),
+        "expected '{expected_error}' in stderr: {stderr}"
+    );
+    assert_eq!(requests, 0, "invalid start contacted Docker");
+    assert!(
+        !tempdir.path().join(".clickhouse/servers").exists(),
+        "invalid start created Postgres project state"
+    );
+    output
+}
+
+#[test]
+fn invalid_definition_options_make_zero_docker_requests() {
+    for (args, expected_error) in [
+        (vec!["--name", "../invalid"], "Invalid server name"),
+        (vec!["--version", "16"], "not supported"),
+        (vec!["--version", "18garbage"], "not supported"),
+        (vec!["--port", "0"], "--port 0 is not allowed"),
+        (vec!["-e", "NO_EQUALS"], "expected KEY=VALUE"),
+        (vec!["-e", "=value"], "KEY must not be empty"),
+    ] {
+        run_invalid_start(&args, expected_error);
+    }
+}
+
+#[test]
+fn bound_explicit_port_is_rejected_without_docker_requests() {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).expect("bind temporary port");
+    let port = listener.local_addr().unwrap().port().to_string();
+
+    run_invalid_start(&["--port", &port], "already in use");
+}

--- a/crates/clickhousectl/tests/local_postgres_preflight_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_preflight_test.rs
@@ -66,6 +66,9 @@ impl FakeDocker {
             while !daemon_stop.load(Ordering::SeqCst) {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("make Docker connection blocking");
                         let Some(request) = read_request(&mut stream) else {
                             continue;
                         };


### PR DESCRIPTION
## Summary
- Preflight local Postgres start names, complete 17/18 image-tag syntax, explicit port availability, and every `KEY=VALUE` entry before recovery, Docker, image pulls, or Postgres filesystem state.
- Preserve omitted-port auto-selection while rejecting port zero and occupied explicit ports with local actionable errors.
- Normalize definition-owned environment variables so Docker receives one effective reserved value, and document the result in CLI help and README.
- Add clap, unit, bound-port, malformed tag/environment, and fake Docker zero-request regression coverage.

## Environment precedence
The shipped command already advertised `-e POSTGRES_PASSWORD=...` and selected the first such entry before `--password`. This PR preserves that contract: the first `-e POSTGRES_PASSWORD=...` wins over `--password` and later password entries. Dedicated `--user` and `--database` values (or their defaults) win over same-named `-e` entries, and clickhousectl owns `PGDATA`; reserved entries are normalized before the Docker request.

## Verification
- `cargo test -p clickhousectl` (746 passed: 611 unit and 135 integration tests)
- `cargo test -p clickhousectl --test local_postgres_preflight_test` (2 passed)
- `cargo clippy -p clickhousectl --all-targets -- -D warnings` (passed)
- `cargo build -p clickhousectl` (passed)
- `cargo fmt --all -- --check` (passed)
- `git diff --check` (passed)

## Stack
Position 1 of 1, bottom and top of the stack, targeting `main`.

Closes #460