### PR TITLE
Add --name compatibility to local server stop and remove

### DIFF
--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -254,8 +254,7 @@ CONTEXT FOR AGENTS:
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
   Stops a ClickHouse server. The name defaults to \"default\"; pass it positionally to select
-  another server (e.g., `server stop dev`). The older `--name dev` form remains accepted, but
-  cannot be combined with a positional name. Use `clickhousectl local server list` to find names.
+  another server (e.g., `server stop dev`). Use `clickhousectl local server list` to find names.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data and metadata are preserved so it remains visible in `server list`.
   Restart with `clickhousectl local server start <name>`.
@@ -300,8 +299,7 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  The name defaults to \"default\"; pass it positionally to select another server. The older
-  `--name dev` form remains accepted, but cannot be combined with a positional name.
+  The name defaults to \"default\"; pass it positionally to select another server.
   Related: `clickhousectl local server stop [name]` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
         /// Name of the server to remove (default: "default")

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -253,8 +253,9 @@ CONTEXT FOR AGENTS:
     /// Stop a running server by name
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Stops a ClickHouse server. The name defaults to \"default\"; use `clickhousectl local server list`
-  to find other server names.
+  Stops a ClickHouse server. The name defaults to \"default\"; pass it positionally to select
+  another server (e.g., `server stop dev`). The older `--name dev` form remains accepted, but
+  cannot be combined with a positional name. Use `clickhousectl local server list` to find names.
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data and metadata are preserved so it remains visible in `server list`.
   Restart with `clickhousectl local server start <name>`.
@@ -263,8 +264,12 @@ CONTEXT FOR AGENTS:
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
         /// Name of the server to stop (default: "default")
-        #[arg(default_value = "default")]
-        name: String,
+        #[arg(value_name = "NAME", conflicts_with = "name_flag")]
+        name: Option<String>,
+
+        /// Compatibility form for the server name; prefer positional NAME
+        #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
+        name_flag: Option<String>,
 
         /// System-wide maintenance only: stop a server from any project. You almost certainly want the default project-scoped stop instead.
         #[arg(long)]
@@ -295,12 +300,17 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  The name defaults to \"default\".
+  The name defaults to \"default\"; pass it positionally to select another server. The older
+  `--name dev` form remains accepted, but cannot be combined with a positional name.
   Related: `clickhousectl local server stop [name]` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
         /// Name of the server to remove (default: "default")
-        #[arg(default_value = "default")]
-        name: String,
+        #[arg(value_name = "NAME", conflicts_with = "name_flag")]
+        name: Option<String>,
+
+        /// Compatibility form for the server name; prefer positional NAME
+        #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
+        name_flag: Option<String>,
     },
 
     /// Write ClickHouse connection env vars to a .env file
@@ -707,25 +717,136 @@ mod tests {
     }
 
     #[test]
-    fn server_stop_name_defaults_to_default() {
+    fn server_stop_omission_stays_explicit() {
         let LocalCommands::Server {
-            command: ServerCommands::Stop { name, .. },
+            command: ServerCommands::Stop {
+                name, name_flag, ..
+            },
         } = local_command(&["server", "stop"])
         else {
             panic!("expected server stop");
         };
-        assert_eq!(name, "default");
+        assert_eq!(name, None);
+        assert_eq!(name_flag, None);
     }
 
     #[test]
-    fn server_remove_name_defaults_to_default() {
+    fn server_remove_omission_stays_explicit() {
         let LocalCommands::Server {
-            command: ServerCommands::Remove { name },
+            command: ServerCommands::Remove { name, name_flag },
         } = local_command(&["server", "remove"])
         else {
             panic!("expected server remove");
         };
-        assert_eq!(name, "default");
+        assert_eq!(name, None);
+        assert_eq!(name_flag, None);
+    }
+
+    #[test]
+    fn server_stop_accepts_both_name_forms_before_trailing_options() {
+        let LocalCommands::Server {
+            command:
+                ServerCommands::Stop {
+                    name,
+                    name_flag,
+                    global,
+                    project,
+                },
+        } = local_command(&[
+            "server",
+            "stop",
+            "analytics",
+            "--global",
+            "--project",
+            "/tmp/project",
+        ])
+        else {
+            panic!("expected server stop");
+        };
+        assert_eq!(name.as_deref(), Some("analytics"));
+        assert_eq!(name_flag, None);
+        assert!(global);
+        assert_eq!(project.as_deref(), Some("/tmp/project"));
+
+        let LocalCommands::Server {
+            command:
+                ServerCommands::Stop {
+                    name,
+                    name_flag,
+                    global,
+                    project,
+                },
+        } = local_command(&[
+            "server",
+            "stop",
+            "--name",
+            "analytics",
+            "--global",
+            "--project",
+            "/tmp/project",
+        ])
+        else {
+            panic!("expected server stop");
+        };
+        assert_eq!(name, None);
+        assert_eq!(name_flag.as_deref(), Some("analytics"));
+        assert!(global);
+        assert_eq!(project.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn server_remove_accepts_both_name_forms_before_trailing_options() {
+        let LocalCommands::Server {
+            command: ServerCommands::Remove { name, name_flag },
+        } = local_command(&["server", "remove", "analytics", "--json"])
+        else {
+            panic!("expected server remove");
+        };
+        assert_eq!(name.as_deref(), Some("analytics"));
+        assert_eq!(name_flag, None);
+
+        let LocalCommands::Server {
+            command: ServerCommands::Remove { name, name_flag },
+        } = local_command(&["server", "remove", "--name", "analytics", "--json"])
+        else {
+            panic!("expected server remove");
+        };
+        assert_eq!(name, None);
+        assert_eq!(name_flag.as_deref(), Some("analytics"));
+    }
+
+    #[test]
+    fn server_stop_name_forms_conflict() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "local",
+            "server",
+            "stop",
+            "existing",
+            "--name",
+            "other",
+        ])
+        .err()
+        .expect("name forms should conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn server_remove_name_forms_conflict() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "local",
+            "server",
+            "remove",
+            "existing",
+            "--name",
+            "other",
+        ])
+        .err()
+        .expect("name forms should conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        assert!(error.to_string().contains("cannot be used with"));
     }
 
     #[test]
@@ -769,15 +890,15 @@ mod tests {
         else {
             panic!("expected server stop");
         };
-        assert_eq!(name, "analytics");
+        assert_eq!(name.as_deref(), Some("analytics"));
 
         let LocalCommands::Server {
-            command: ServerCommands::Remove { name },
+            command: ServerCommands::Remove { name, .. },
         } = local_command(&["server", "remove", "analytics"])
         else {
             panic!("expected server remove");
         };
-        assert_eq!(name, "analytics");
+        assert_eq!(name.as_deref(), Some("analytics"));
 
         let LocalCommands::Postgres {
             command: PostgresCommands::Stop { name, .. },

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -714,9 +714,11 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
         }
         ServerCommands::Stop {
             name,
+            name_flag,
             global,
             project,
         } => {
+            let name = name.or(name_flag).unwrap_or_else(|| "default".to_string());
             if global {
                 stop_server_global(&name, project.as_deref(), json)
             } else {
@@ -772,7 +774,8 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             password,
             database,
         } => dotenv_server(name.as_deref(), local, user, password, database, json),
-        ServerCommands::Remove { name } => {
+        ServerCommands::Remove { name, name_flag } => {
+            let name = name.or(name_flag).unwrap_or_else(|| "default".to_string());
             server::validate_server_name(&name)?;
 
             // Recover orphaned servers so we correctly detect a running

--- a/crates/clickhousectl/tests/local_server_stopped_test.rs
+++ b/crates/clickhousectl/tests/local_server_stopped_test.rs
@@ -31,6 +31,11 @@ fn write_server_metadata(project: &Path, pid: u32) -> PathBuf {
     metadata
 }
 
+fn create_stopped_server(project: &Path, name: &str) {
+    std::fs::create_dir_all(project.join(".clickhouse/servers").join(name).join("data"))
+        .expect("create stopped server data dir");
+}
+
 fn run(project: &Path, home: &Path, args: &[&str]) -> Output {
     Command::new(clickhousectl_binary())
         .env("DO_NOT_TRACK", "1")
@@ -94,6 +99,80 @@ impl Drop for ProcessGuard {
                 libc::kill(self.pid as i32, libc::SIGKILL);
             }
         }
+    }
+}
+
+#[test]
+fn stop_and_remove_accept_name_forms_omission_and_trailing_json() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let cases = [
+        (
+            "stop-positional",
+            ["local", "server", "stop", "stop-positional", "--json"].as_slice(),
+        ),
+        (
+            "stop-flag",
+            ["local", "server", "stop", "--name", "stop-flag", "--json"].as_slice(),
+        ),
+        ("default", ["local", "server", "stop", "--json"].as_slice()),
+        (
+            "remove-positional",
+            ["local", "server", "remove", "remove-positional", "--json"].as_slice(),
+        ),
+        (
+            "remove-flag",
+            [
+                "local",
+                "server",
+                "remove",
+                "--name",
+                "remove-flag",
+                "--json",
+            ]
+            .as_slice(),
+        ),
+        (
+            "default",
+            ["local", "server", "remove", "--json"].as_slice(),
+        ),
+    ];
+
+    for (name, args) in cases {
+        create_stopped_server(project.path(), name);
+        let output = run(project.path(), home.path(), args);
+        assert!(
+            output.status.success(),
+            "args: {args:?}\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let body: Value = serde_json::from_slice(&output.stdout).expect("parse command JSON");
+        assert_eq!(body["name"], name, "args: {args:?}");
+    }
+}
+
+#[test]
+fn stop_and_remove_reject_positional_and_name_flag_together() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+
+    for command in ["stop", "remove"] {
+        let output = run(
+            project.path(),
+            home.path(),
+            &[
+                "local",
+                "server",
+                command,
+                "positional",
+                "--name",
+                "flagged",
+            ],
+        );
+        assert_eq!(output.status.code(), Some(2));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("cannot be used with"), "{stderr}");
+        assert!(stderr.contains("--name <NAME>"), "{stderr}");
     }
 }
 


### PR DESCRIPTION
## Summary

- keep positional `NAME` canonical for `local server stop` and `local server remove`
- accept compatibility `--name NAME` while making both forms a clap conflict
- preserve omitted names through parsing and apply the existing `default` fallback during dispatch
- cover positional, compatibility, conflict, omission, and trailing-option behavior in parser and subprocess tests

Closes #474

## Verification

- `cargo test -p clickhousectl local::cli::tests::` (24 passed)
- `cargo test -p clickhousectl --test local_server_stopped_test stop_and_remove` (2 passed)
- `cargo test -p clickhousectl` (745 passed across unit and integration tests)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

## Stack

- Position: child 2 of 2
- Base: #482 (`issue-476-start-help-quotes`)
- Parent PR is unchanged and should merge first.