### PR TITLE
Make Query API provisioning single-flight across processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae67d5c03ee972c101a1d8db3ddbf8a9c819ad1ea9d6fd9cd385605547b60edb"
+dependencies = [
+ "nix",
+ "rand 0.10.2",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1011,7 @@ dependencies = [
 name = "clickhousectl"
 version = "0.4.1"
 dependencies = [
+ "atomic-write-file",
  "base64",
  "bollard",
  "chrono",
@@ -1015,7 +1026,7 @@ dependencies = [
  "is-ai-agent",
  "libc",
  "open",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "rpassword",
  "serde",
@@ -2325,6 +2336,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2583,7 +2606,7 @@ dependencies = [
  "hmac 0.13.0",
  "md-5",
  "memchr",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha2 0.11.0",
  "stringprep",
 ]
@@ -2703,7 +2726,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.2",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -2764,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -3648,7 +3671,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.10.1",
+ "rand 0.10.2",
  "socket2",
  "tokio",
  "tokio-util",

--- a/README.md
+++ b/README.md
@@ -599,7 +599,9 @@ Use `clickhousectl cloud service create --help` for the complete option list. If
 
 `--query` and `--queries-file` are mutually exclusive. Omit both to read SQL from stdin; `--queries-file -` also reads stdin explicitly.
 
-Provisioning happens lazily (rather than at `service create` time) because the endpoint can only be bound once the service has finished provisioning, which can take several minutes — `service create` returns immediately instead of blocking on it.
+Provisioning happens lazily (rather than at `service create` time) because the endpoint can only be bound once the service has finished provisioning, which can take several minutes — `service create` returns immediately instead of blocking on it. Concurrent queries from the same project directory share one provisioning operation and reuse its atomically stored credential.
+
+The control-plane endpoint upsert replaces the complete `openApiKeys` list and does not support conditional updates. Provisioning the same service concurrently from different project directories can therefore still lose another project's endpoint binding; coordinate first use across projects when they share a service.
 
 Per-service scoping is enforced at the query endpoint binding, which is created with role `sql_console_admin` (read + write inside the bound service only). The API key itself has no org-level roles, so the binding is the only thing that grants it any access. After deleting a service, `cloud service delete` deletes an auto-provisioned key by its stored management and organization IDs, then removes the local record. Legacy records without that metadata remain readable, but service deletion will not guess at a cloud key by name; a partial record with a management ID is retained for manual recovery.
 

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -53,6 +53,7 @@ bollard = "0.21.0"
 crossterm = "0.29.0"
 rand = "0.10.1"
 dotenvy = "0.15.7"
+atomic-write-file = "0.3.1"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/clickhousectl/src/cloud/auth.rs
+++ b/crates/clickhousectl/src/cloud/auth.rs
@@ -93,10 +93,7 @@ pub async fn run(
                         "--api-secret is required when --api-key is provided".into(),
                     )
                 })?;
-                let mut creds = credentials::load_credentials().unwrap_or_default();
-                creds.api_key = Some(key);
-                creds.api_secret = Some(secret);
-                credentials::save_credentials(&creds)
+                credentials::set_api_credentials(key, secret)
                     .map_err(|error| Error::Cloud(error.to_string()))?;
                 println!(
                     "Credentials saved to {}",
@@ -138,12 +135,14 @@ pub async fn run(
                     println!("OAuth tokens cleared. API keys unchanged.");
                 }
                 (false, true) => {
-                    credentials::clear_credentials();
+                    credentials::clear_credentials()
+                        .map_err(|error| Error::Cloud(error.to_string()))?;
                     println!("API keys cleared. OAuth tokens unchanged.");
                 }
                 _ => {
                     clear_tokens();
-                    credentials::clear_credentials();
+                    credentials::clear_credentials()
+                        .map_err(|error| Error::Cloud(error.to_string()))?;
                     println!("Logged out. All saved credentials cleared.");
                 }
             }
@@ -303,10 +302,7 @@ fn auth_interactive() -> std::result::Result<(), Box<dyn std::error::Error>> {
         return Err("API secret cannot be empty".into());
     }
 
-    let mut creds = credentials::load_credentials().unwrap_or_default();
-    creds.api_key = Some(api_key);
-    creds.api_secret = Some(api_secret);
-    credentials::save_credentials(&creds)?;
+    credentials::set_api_credentials(api_key, api_secret)?;
 
     println!(
         "Credentials saved to {}",

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -144,7 +144,7 @@ fn save_credentials(creds: &Credentials) -> CloudResult<()> {
 
 pub fn set_api_credentials(api_key: String, api_secret: String) -> CloudResult<()> {
     let _lock = lock_credentials_mutation()?;
-    let mut creds = load_credentials().unwrap_or_default();
+    let mut creds = try_load_credentials()?;
     creds.api_key = Some(api_key);
     creds.api_secret = Some(api_secret);
     save_credentials(&creds)
@@ -172,9 +172,7 @@ pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {
         return Ok(());
     }
     let _lock = lock_credentials_mutation()?;
-    let Some(mut creds) = load_credentials() else {
-        return Ok(());
-    };
+    let mut creds = try_load_credentials()?;
     if creds.service_query_keys.remove(service_id).is_some() {
         save_credentials(&creds)?;
     }

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -1,8 +1,10 @@
 use crate::cloud::client::{CloudError, Result as CloudResult};
 use crate::init;
+use atomic_write_file::AtomicWriteFile;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::io::Write as _;
 use std::path::PathBuf;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -37,8 +39,36 @@ pub struct ServiceQueryKey {
     pub created_at: DateTime<Utc>,
 }
 
+/// Holds the project-wide provisioning lock until it is dropped.
+pub struct ServiceQueryProvisionLock {
+    _file: std::fs::File,
+}
+
 pub fn credentials_path() -> PathBuf {
     init::local_dir().join("credentials.json")
+}
+
+fn ensure_credentials_dir() -> CloudResult<PathBuf> {
+    let dir = init::local_dir();
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(dir.join(".gitignore"), "*\n")?;
+    }
+    Ok(dir)
+}
+
+/// Serialize Query API provisioning across processes in this project.
+pub fn lock_service_query_provisioning() -> CloudResult<ServiceQueryProvisionLock> {
+    let path = ensure_credentials_dir()?.join("query-provision.lock");
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(&path)
+        .map_err(|error| CloudError::new(format!("failed to open {}: {error}", path.display())))?;
+    file.lock()
+        .map_err(|error| CloudError::new(format!("failed to lock {}: {error}", path.display())))?;
+    Ok(ServiceQueryProvisionLock { _file: file })
 }
 
 pub fn load_credentials() -> Option<Credentials> {
@@ -47,27 +77,44 @@ pub fn load_credentials() -> Option<Credentials> {
     serde_json::from_str(&data).ok()
 }
 
+/// Load credentials without treating read or parse failures as an empty file.
+pub fn try_load_credentials() -> CloudResult<Credentials> {
+    let path = credentials_path();
+    let data = match std::fs::read_to_string(&path) {
+        Ok(data) => data,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Credentials::default());
+        }
+        Err(error) => {
+            return Err(CloudError::new(format!(
+                "failed to read {}: {error}",
+                path.display()
+            )));
+        }
+    };
+    serde_json::from_str(&data)
+        .map_err(|error| CloudError::new(format!("failed to parse {}: {error}", path.display())))
+}
+
 pub fn clear_credentials() {
     let path = credentials_path();
     let _ = std::fs::remove_file(path);
 }
 
 pub fn save_credentials(creds: &Credentials) -> CloudResult<()> {
-    let dir = init::local_dir();
-    if !dir.exists() {
-        std::fs::create_dir_all(&dir)?;
-        std::fs::write(dir.join(".gitignore"), "*\n")?;
-    }
-
+    ensure_credentials_dir()?;
     let path = credentials_path();
     let json = serde_json::to_string_pretty(creds)?;
-    std::fs::write(&path, &json)?;
+    let mut file = AtomicWriteFile::open(&path)?;
+    file.write_all(json.as_bytes())?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
+
+    file.commit()?;
 
     Ok(())
 }
@@ -78,26 +125,8 @@ pub fn get_service_query_key(service_id: &str) -> Option<ServiceQueryKey> {
 }
 
 pub fn try_get_service_query_key(service_id: &str) -> CloudResult<Option<ServiceQueryKey>> {
-    let path = credentials_path();
-    let data = match std::fs::read_to_string(&path) {
-        Ok(data) => data,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => {
-            return Err(CloudError::new(format!(
-                "failed to read {}: {error}",
-                path.display()
-            )));
-        }
-    };
-    let creds: Credentials = serde_json::from_str(&data)
-        .map_err(|error| CloudError::new(format!("failed to parse {}: {error}", path.display())))?;
+    let creds = try_load_credentials()?;
     Ok(creds.service_query_keys.get(service_id).cloned())
-}
-
-pub fn set_service_query_key(service_id: &str, key: ServiceQueryKey) -> CloudResult<()> {
-    let mut creds = load_credentials().unwrap_or_default();
-    creds.service_query_keys.insert(service_id.to_string(), key);
-    save_credentials(&creds)
 }
 
 pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Credentials {
@@ -113,8 +113,15 @@ pub fn clear_credentials() -> CloudResult<()> {
         return Ok(());
     }
     let _lock = lock_credentials_mutation()?;
-    let _ = std::fs::remove_file(path);
-    Ok(())
+    remove_credentials_file(&path)
+}
+
+fn remove_credentials_file(path: &Path) -> CloudResult<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
 }
 
 fn save_credentials(creds: &Credentials) -> CloudResult<()> {
@@ -177,6 +184,28 @@ pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn remove_credentials_file_removes_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+        std::fs::write(&path, "credentials").unwrap();
+
+        remove_credentials_file(&path).unwrap();
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn remove_credentials_file_tolerates_concurrent_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+        std::fs::write(&path, "credentials").unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        remove_credentials_file(&path).unwrap();
+        remove_credentials_file(&path).unwrap();
+    }
 
     #[test]
     fn legacy_credentials_round_trip() {

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -59,7 +59,17 @@ fn ensure_credentials_dir() -> CloudResult<PathBuf> {
 
 /// Serialize Query API provisioning across processes in this project.
 pub fn lock_service_query_provisioning() -> CloudResult<ServiceQueryProvisionLock> {
-    let path = ensure_credentials_dir()?.join("query-provision.lock");
+    Ok(ServiceQueryProvisionLock {
+        _file: lock_file("query-provision.lock")?,
+    })
+}
+
+fn lock_credentials_mutation() -> CloudResult<std::fs::File> {
+    lock_file("credentials.lock")
+}
+
+fn lock_file(name: &str) -> CloudResult<std::fs::File> {
+    let path = ensure_credentials_dir()?.join(name);
     let file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -69,7 +79,7 @@ pub fn lock_service_query_provisioning() -> CloudResult<ServiceQueryProvisionLoc
         .map_err(|error| CloudError::new(format!("failed to open {}: {error}", path.display())))?;
     file.lock()
         .map_err(|error| CloudError::new(format!("failed to lock {}: {error}", path.display())))?;
-    Ok(ServiceQueryProvisionLock { _file: file })
+    Ok(file)
 }
 
 pub fn load_credentials() -> Option<Credentials> {
@@ -97,12 +107,17 @@ pub fn try_load_credentials() -> CloudResult<Credentials> {
         .map_err(|error| CloudError::new(format!("failed to parse {}: {error}", path.display())))
 }
 
-pub fn clear_credentials() {
+pub fn clear_credentials() -> CloudResult<()> {
     let path = credentials_path();
+    if !path.exists() {
+        return Ok(());
+    }
+    let _lock = lock_credentials_mutation()?;
     let _ = std::fs::remove_file(path);
+    Ok(())
 }
 
-pub fn save_credentials(creds: &Credentials) -> CloudResult<()> {
+fn save_credentials(creds: &Credentials) -> CloudResult<()> {
     ensure_credentials_dir()?;
     let path = credentials_path();
     let json = serde_json::to_string_pretty(creds)?;
@@ -120,6 +135,21 @@ pub fn save_credentials(creds: &Credentials) -> CloudResult<()> {
     Ok(())
 }
 
+pub fn set_api_credentials(api_key: String, api_secret: String) -> CloudResult<()> {
+    let _lock = lock_credentials_mutation()?;
+    let mut creds = load_credentials().unwrap_or_default();
+    creds.api_key = Some(api_key);
+    creds.api_secret = Some(api_secret);
+    save_credentials(&creds)
+}
+
+pub fn set_service_query_key(service_id: &str, key: ServiceQueryKey) -> CloudResult<()> {
+    let _lock = lock_credentials_mutation()?;
+    let mut creds = try_load_credentials()?;
+    creds.service_query_keys.insert(service_id.to_string(), key);
+    save_credentials(&creds)
+}
+
 pub fn get_service_query_key(service_id: &str) -> Option<ServiceQueryKey> {
     let creds = load_credentials()?;
     creds.service_query_keys.get(service_id).cloned()
@@ -131,6 +161,10 @@ pub fn try_get_service_query_key(service_id: &str) -> CloudResult<Option<Service
 }
 
 pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {
+    if !credentials_path().exists() {
+        return Ok(());
+    }
+    let _lock = lock_credentials_mutation()?;
     let Some(mut creds) = load_credentials() else {
         return Ok(());
     };

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -64,6 +64,7 @@ pub fn lock_service_query_provisioning() -> CloudResult<ServiceQueryProvisionLoc
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(&path)
         .map_err(|error| CloudError::new(format!("failed to open {}: {error}", path.display())))?;
     file.lock()

--- a/crates/clickhousectl/src/cloud/credentials.rs
+++ b/crates/clickhousectl/src/cloud/credentials.rs
@@ -109,11 +109,18 @@ pub fn try_load_credentials() -> CloudResult<Credentials> {
 
 pub fn clear_credentials() -> CloudResult<()> {
     let path = credentials_path();
+    clear_credentials_with_lock(&path, lock_credentials_mutation)
+}
+
+fn clear_credentials_with_lock(
+    path: &Path,
+    acquire_lock: impl FnOnce() -> CloudResult<std::fs::File>,
+) -> CloudResult<()> {
+    let _lock = acquire_lock()?;
     if !path.exists() {
         return Ok(());
     }
-    let _lock = lock_credentials_mutation()?;
-    remove_credentials_file(&path)
+    remove_credentials_file(path)
 }
 
 fn remove_credentials_file(path: &Path) -> CloudResult<()> {
@@ -182,6 +189,20 @@ pub fn remove_service_query_key(service_id: &str) -> CloudResult<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clear_credentials_checks_for_file_after_acquiring_lock() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("credentials.json");
+
+        clear_credentials_with_lock(&path, || {
+            std::fs::write(&path, "credentials").unwrap();
+            Ok(tempfile::tempfile().unwrap())
+        })
+        .unwrap();
+
+        assert!(!path.exists());
+    }
 
     #[test]
     fn remove_credentials_file_removes_existing_file() {

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -22,7 +22,15 @@ const ALLOWED_ORIGINS: &str = "*";
 
 enum EndpointCompensation {
     Delete,
-    Restore(InstanceServiceQueryApiEndpointsPostRequest),
+    Restore {
+        previous: InstanceServiceQueryApiEndpointsPostRequest,
+        written: InstanceServiceQueryApiEndpointsPostRequest,
+    },
+}
+
+enum EndpointCompensationOutcome {
+    Applied,
+    EndpointAbsent,
 }
 
 struct BoundQueryEndpoint {
@@ -149,7 +157,7 @@ pub async fn ensure_service_query_setup(
         Utc::now(),
     );
     if let Err(persistence_error) = credentials::set_service_query_key(service_id, stored.clone()) {
-        if let Err(compensation_error) = compensate_endpoint_binding(
+        let compensation_outcome = match compensate_endpoint_binding(
             client,
             org_id,
             service_id,
@@ -158,20 +166,30 @@ pub async fn ensure_service_query_setup(
         )
         .await
         {
-            return Err(CloudError::new(format!(
-                "local credential persistence failed: {persistence_error}; query endpoint cleanup \
-                 failed: {compensation_error}. API key {api_key_uuid} remains bound and was \
-                 retained for recovery"
-            )));
-        }
+            Ok(outcome) => outcome,
+            Err(compensation_error) => {
+                return Err(CloudError::new(format!(
+                    "local credential persistence failed: {persistence_error}; query endpoint \
+                     cleanup failed: {compensation_error}. API key {api_key_uuid} was retained for \
+                     recovery; inspect the current endpoint before deleting it"
+                )));
+            }
+        };
 
         if let Err(cleanup_error) = client.delete_api_key(org_id, &api_key_uuid).await {
             return Err(CloudError::new(format!(
-                "local credential persistence failed: {persistence_error}; the query endpoint \
-                 binding was restored, but deleting API key {api_key_uuid} failed: {cleanup_error}"
+                "local credential persistence failed: {persistence_error}; query endpoint cleanup \
+                 succeeded, but deleting API key {api_key_uuid} failed: {cleanup_error}"
             )));
         }
-        return Err(persistence_error);
+        return match compensation_outcome {
+            EndpointCompensationOutcome::Applied => Err(persistence_error),
+            EndpointCompensationOutcome::EndpointAbsent => Err(CloudError::new(format!(
+                "local credential persistence failed: {persistence_error}; query endpoint cleanup \
+                 was skipped because the endpoint was deleted concurrently, and it was not \
+                 recreated. API key {api_key_uuid} was deleted"
+            ))),
+        };
     }
 
     Ok(stored)
@@ -214,23 +232,18 @@ async fn bind_query_endpoint(
     service_id: &str,
     api_key_uuid: &str,
 ) -> CloudResult<BoundQueryEndpoint> {
-    let (mut open_api_keys, compensation) = match client
+    let (mut open_api_keys, previous) = match client
         .api()
         .instance_query_endpoint_get(org_id, service_id)
         .await
     {
         Ok(resp) => {
             let request = existing_endpoint_request(resp.result)?;
-            (
-                request.open_api_keys.clone(),
-                EndpointCompensation::Restore(request),
-            )
+            (request.open_api_keys.clone(), Some(request))
         }
         // Only a 404 means there is no endpoint yet, so this binding is the
         // first one and starts from an empty list.
-        Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {
-            (Vec::new(), EndpointCompensation::Delete)
-        }
+        Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => (Vec::new(), None),
         Err(e) => return Err(client.convert_error_for_organization(e, org_id)),
     };
     if !open_api_keys.iter().any(|k| k == api_key_uuid) {
@@ -243,6 +256,13 @@ async fn bind_query_endpoint(
         roles: vec![QueryEndpointRole::SqlConsoleAdmin],
         open_api_keys,
         allowed_origins: ALLOWED_ORIGINS.to_string(),
+    };
+    let compensation = match previous {
+        Some(previous) => EndpointCompensation::Restore {
+            previous,
+            written: endpoint_request.clone(),
+        },
+        None => EndpointCompensation::Delete,
     };
 
     let endpoint = client
@@ -260,7 +280,7 @@ async fn compensate_endpoint_binding(
     service_id: &str,
     api_key_uuid: &str,
     compensation: &EndpointCompensation,
-) -> CloudResult<()> {
+) -> CloudResult<EndpointCompensationOutcome> {
     let current = match client
         .api()
         .instance_query_endpoint_get(org_id, service_id)
@@ -268,13 +288,7 @@ async fn compensate_endpoint_binding(
     {
         Ok(response) => response.result,
         Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {
-            return match compensation {
-                EndpointCompensation::Delete => Ok(()),
-                EndpointCompensation::Restore(request) => client
-                    .create_query_endpoint(org_id, service_id, request)
-                    .await
-                    .map(|_| ()),
-            };
+            return Ok(EndpointCompensationOutcome::EndpointAbsent);
         }
         Err(error) => return Err(client.convert_error_for_organization(error, org_id)),
     };
@@ -291,34 +305,36 @@ async fn compensate_endpoint_binding(
                 let previous_len = request.open_api_keys.len();
                 request.open_api_keys.retain(|key| key != api_key_uuid);
                 if request.open_api_keys.len() == previous_len {
-                    return Ok(());
+                    return Ok(EndpointCompensationOutcome::Applied);
                 }
                 client
                     .create_query_endpoint(org_id, service_id, &request)
                     .await?;
             }
         }
-        EndpointCompensation::Restore(previous) => {
+        EndpointCompensation::Restore { previous, written } => {
             let current = current.ok_or_else(|| {
                 CloudError::new(
-                    "the query endpoint response is missing field 'result', so the newly bound \
-                     key cannot be safely removed",
+                    "query endpoint restoration was skipped because the current state could not be \
+                     confirmed: the API response is missing field 'result'",
                 )
             })?;
-            let mut request = previous.clone();
-            request.open_api_keys = current.open_api_keys.ok_or_else(|| {
-                CloudError::new(
-                    "the query endpoint response is missing field 'openApiKeys', so the newly \
-                     bound key cannot be safely removed",
-                )
-            })?;
-            request.open_api_keys.retain(|key| key != api_key_uuid);
+            if current.allowed_origins.as_ref() != Some(&written.allowed_origins)
+                || current.open_api_keys.as_ref() != Some(&written.open_api_keys)
+                || current.roles.as_ref() != Some(&written.roles)
+            {
+                return Err(CloudError::new(
+                    "query endpoint restoration was intentionally skipped because its current \
+                     roles, allowed origins, or API key bindings no longer match the state written \
+                     by this operation",
+                ));
+            }
             client
-                .create_query_endpoint(org_id, service_id, &request)
+                .create_query_endpoint(org_id, service_id, previous)
                 .await?;
         }
     }
-    Ok(())
+    Ok(EndpointCompensationOutcome::Applied)
 }
 
 #[cfg(test)]

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -62,7 +62,8 @@ fn build_service_query_key(
 /// after taking the lock, credentials are re-read so waiters reuse the winner's
 /// key. The winner creates the API key, binds it to the query endpoint (merging
 /// into any existing endpoint configuration) with read+write scope on this
-/// service, and atomically saves the merged credentials.
+/// service, then merges the key into the latest credentials under the shared
+/// credentials mutation lock.
 pub async fn ensure_service_query_setup(
     client: &CloudClient,
     org_id: &str,
@@ -70,9 +71,8 @@ pub async fn ensure_service_query_setup(
     service_name: &str,
 ) -> CloudResult<ServiceQueryKey> {
     let _lock = credentials::lock_service_query_provisioning()?;
-    let mut creds = credentials::try_load_credentials()?;
-    if let Some(existing) = creds.service_query_keys.get(service_id) {
-        return Ok(existing.clone());
+    if let Some(existing) = credentials::try_get_service_query_key(service_id)? {
+        return Ok(existing);
     }
 
     let key_request = ApiKeyPostRequest {
@@ -138,10 +138,7 @@ pub async fn ensure_service_query_setup(
         service_name,
         Utc::now(),
     );
-    creds
-        .service_query_keys
-        .insert(service_id.to_string(), stored.clone());
-    if let Err(error) = credentials::save_credentials(&creds) {
+    if let Err(error) = credentials::set_service_query_key(service_id, stored.clone()) {
         discard_api_key(client, org_id, &api_key_uuid).await;
         return Err(error);
     }

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -13,11 +13,22 @@ use chrono::{DateTime, Utc};
 use clickhouse_cloud_api::models::{
     ApiKeyPostRequest, ApiKeyPostRequestState, ApiKeyPostResponse,
     InstanceServiceQueryApiEndpointsPostRequest, IpAccessListEntry, QueryEndpointRole,
+    ServiceQueryAPIEndpoint,
 };
 
 /// Default `allowedOrigins` for the query endpoint. The CLI is a non-browser
 /// caller so CORS doesn't apply, but the API still requires a value.
 const ALLOWED_ORIGINS: &str = "*";
+
+enum EndpointCompensation {
+    Delete,
+    Restore(InstanceServiceQueryApiEndpointsPostRequest),
+}
+
+struct BoundQueryEndpoint {
+    endpoint: ServiceQueryAPIEndpoint,
+    compensation: EndpointCompensation,
+}
 
 /// Requires a response field the provisioning flow cannot proceed without.
 fn require_field<T>(value: Option<T>, field: &str) -> CloudResult<T> {
@@ -96,9 +107,8 @@ pub async fn ensure_service_query_setup(
     // The endpoint binding's `openApiKeys` array, by contrast, references
     // API keys by their resource UUID — the same value the management
     // endpoints (GET/DELETE /v1/.../keys/{keyId}) accept. Resolve the UUID
-    // first: every failure past this point deletes the key it identifies, so
-    // an absent `key.id` is the only one with no cleanup available — we
-    // cannot name the key we just created.
+    // first so every later failure can either delete the key safely or report
+    // the exact retained key for recovery.
     let api_key_uuid =
         require_field(key_response.key.as_ref().and_then(|key| key.id), "key.id")?.to_string();
 
@@ -115,8 +125,8 @@ pub async fn ensure_service_query_setup(
         }
     };
 
-    let endpoint = match bind_query_endpoint(client, org_id, service_id, &api_key_uuid).await {
-        Ok(endpoint) => endpoint,
+    let binding = match bind_query_endpoint(client, org_id, service_id, &api_key_uuid).await {
+        Ok(binding) => binding,
         Err(e) => {
             // The key was created but never bound or persisted, so nothing
             // can use it.
@@ -134,36 +144,64 @@ pub async fn ensure_service_query_setup(
         api_key_uuid.clone(),
         key_id,
         key_secret,
-        endpoint.id,
+        binding.endpoint.id,
         service_name,
         Utc::now(),
     );
-    if let Err(error) = credentials::set_service_query_key(service_id, stored.clone()) {
-        discard_api_key(client, org_id, &api_key_uuid).await;
-        return Err(error);
+    if let Err(persistence_error) = credentials::set_service_query_key(service_id, stored.clone()) {
+        if let Err(compensation_error) = compensate_endpoint_binding(
+            client,
+            org_id,
+            service_id,
+            &api_key_uuid,
+            &binding.compensation,
+        )
+        .await
+        {
+            return Err(CloudError::new(format!(
+                "local credential persistence failed: {persistence_error}; query endpoint cleanup \
+                 failed: {compensation_error}. API key {api_key_uuid} remains bound and was \
+                 retained for recovery"
+            )));
+        }
+
+        if let Err(cleanup_error) = client.delete_api_key(org_id, &api_key_uuid).await {
+            return Err(CloudError::new(format!(
+                "local credential persistence failed: {persistence_error}; the query endpoint \
+                 binding was restored, but deleting API key {api_key_uuid} failed: {cleanup_error}"
+            )));
+        }
+        return Err(persistence_error);
     }
 
     Ok(stored)
 }
 
-/// The keys already bound to an existing query endpoint, taken from a
-/// successful GET. The upsert replaces `openApiKeys` wholesale, so an absent
-/// `result` or absent `openApiKeys` cannot be read as "no keys bound": merging
-/// into an empty list would revoke every binding the response failed to
-/// report. An explicitly empty list is a real answer and merges normally.
-fn existing_open_api_keys(
-    endpoint: Option<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint>,
-) -> CloudResult<Vec<String>> {
+/// Capture an existing endpoint exactly enough to restore it if local
+/// persistence fails after binding. Every request field is replaced by an
+/// upsert, so binding is unsafe when the GET omits any of them.
+fn existing_endpoint_request(
+    endpoint: Option<ServiceQueryAPIEndpoint>,
+) -> CloudResult<InstanceServiceQueryApiEndpointsPostRequest> {
     let incomplete = |field: &str| {
         CloudError::new(format!(
-            "the query endpoint response is missing field '{field}', so the keys currently bound \
-             to the endpoint are unknown; binding a new key would revoke them"
+            "the query endpoint response is missing field '{field}', so its pre-bind state cannot \
+             be safely restored; refusing to bind a new key"
         ))
     };
-    endpoint
-        .ok_or_else(|| incomplete("result"))?
+    let endpoint = endpoint.ok_or_else(|| incomplete("result"))?;
+    let open_api_keys = endpoint
         .open_api_keys
-        .ok_or_else(|| incomplete("openApiKeys"))
+        .ok_or_else(|| incomplete("openApiKeys"))?;
+    let allowed_origins = endpoint
+        .allowed_origins
+        .ok_or_else(|| incomplete("allowedOrigins"))?;
+    let roles = endpoint.roles.ok_or_else(|| incomplete("roles"))?;
+    Ok(InstanceServiceQueryApiEndpointsPostRequest {
+        allowed_origins,
+        open_api_keys,
+        roles,
+    })
 }
 
 /// Bind `api_key_uuid` to the service's query endpoint, merging into the
@@ -175,16 +213,24 @@ async fn bind_query_endpoint(
     org_id: &str,
     service_id: &str,
     api_key_uuid: &str,
-) -> CloudResult<clickhouse_cloud_api::models::ServiceQueryAPIEndpoint> {
-    let mut open_api_keys = match client
+) -> CloudResult<BoundQueryEndpoint> {
+    let (mut open_api_keys, compensation) = match client
         .api()
         .instance_query_endpoint_get(org_id, service_id)
         .await
     {
-        Ok(resp) => existing_open_api_keys(resp.result)?,
+        Ok(resp) => {
+            let request = existing_endpoint_request(resp.result)?;
+            (
+                request.open_api_keys.clone(),
+                EndpointCompensation::Restore(request),
+            )
+        }
         // Only a 404 means there is no endpoint yet, so this binding is the
         // first one and starts from an empty list.
-        Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => Vec::new(),
+        Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {
+            (Vec::new(), EndpointCompensation::Delete)
+        }
         Err(e) => return Err(client.convert_error_for_organization(e, org_id)),
     };
     if !open_api_keys.iter().any(|k| k == api_key_uuid) {
@@ -199,9 +245,80 @@ async fn bind_query_endpoint(
         allowed_origins: ALLOWED_ORIGINS.to_string(),
     };
 
-    client
+    let endpoint = client
         .create_query_endpoint(org_id, service_id, &endpoint_request)
+        .await?;
+    Ok(BoundQueryEndpoint {
+        endpoint,
+        compensation,
+    })
+}
+
+async fn compensate_endpoint_binding(
+    client: &CloudClient,
+    org_id: &str,
+    service_id: &str,
+    api_key_uuid: &str,
+    compensation: &EndpointCompensation,
+) -> CloudResult<()> {
+    let current = match client
+        .api()
+        .instance_query_endpoint_get(org_id, service_id)
         .await
+    {
+        Ok(response) => response.result,
+        Err(clickhouse_cloud_api::Error::Api { status: 404, .. }) => {
+            return match compensation {
+                EndpointCompensation::Delete => Ok(()),
+                EndpointCompensation::Restore(request) => client
+                    .create_query_endpoint(org_id, service_id, request)
+                    .await
+                    .map(|_| ()),
+            };
+        }
+        Err(error) => return Err(client.convert_error_for_organization(error, org_id)),
+    };
+
+    match compensation {
+        EndpointCompensation::Delete => {
+            let mut request = existing_endpoint_request(current)?;
+            if request.allowed_origins == ALLOWED_ORIGINS
+                && request.roles == [QueryEndpointRole::SqlConsoleAdmin]
+                && request.open_api_keys == [api_key_uuid]
+            {
+                client.delete_query_endpoint(org_id, service_id).await?;
+            } else {
+                let previous_len = request.open_api_keys.len();
+                request.open_api_keys.retain(|key| key != api_key_uuid);
+                if request.open_api_keys.len() == previous_len {
+                    return Ok(());
+                }
+                client
+                    .create_query_endpoint(org_id, service_id, &request)
+                    .await?;
+            }
+        }
+        EndpointCompensation::Restore(previous) => {
+            let current = current.ok_or_else(|| {
+                CloudError::new(
+                    "the query endpoint response is missing field 'result', so the newly bound \
+                     key cannot be safely removed",
+                )
+            })?;
+            let mut request = previous.clone();
+            request.open_api_keys = current.open_api_keys.ok_or_else(|| {
+                CloudError::new(
+                    "the query endpoint response is missing field 'openApiKeys', so the newly \
+                     bound key cannot be safely removed",
+                )
+            })?;
+            request.open_api_keys.retain(|key| key != api_key_uuid);
+            client
+                .create_query_endpoint(org_id, service_id, &request)
+                .await?;
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -266,46 +383,47 @@ mod tests {
         assert_eq!(key.created_at, created_at);
     }
 
-    fn endpoint(
-        open_api_keys: Option<Vec<&str>>,
-    ) -> clickhouse_cloud_api::models::ServiceQueryAPIEndpoint {
-        clickhouse_cloud_api::models::ServiceQueryAPIEndpoint {
-            allowed_origins: None,
+    fn endpoint(open_api_keys: Option<Vec<&str>>) -> ServiceQueryAPIEndpoint {
+        ServiceQueryAPIEndpoint {
+            allowed_origins: Some("https://example.com".to_string()),
             id: Some("ep-1".to_string()),
             open_api_keys: open_api_keys.map(|keys| keys.into_iter().map(str::to_string).collect()),
-            roles: None,
+            roles: Some(vec![QueryEndpointRole::SqlConsoleReadOnly]),
         }
     }
 
     #[test]
     fn existing_keys_are_returned_when_the_endpoint_reports_them() {
         assert_eq!(
-            existing_open_api_keys(Some(endpoint(Some(vec!["uuid-a", "uuid-b"])))).unwrap(),
-            vec!["uuid-a".to_string(), "uuid-b".to_string()],
+            existing_endpoint_request(Some(endpoint(Some(vec!["uuid-a", "uuid-b"]))))
+                .unwrap()
+                .open_api_keys,
+            vec!["uuid-a".to_string(), "uuid-b".to_string()]
         );
     }
 
     #[test]
     fn an_explicitly_empty_key_list_is_a_real_answer() {
         assert!(
-            existing_open_api_keys(Some(endpoint(Some(vec![]))))
+            existing_endpoint_request(Some(endpoint(Some(vec![]))))
                 .unwrap()
+                .open_api_keys
                 .is_empty()
         );
     }
 
     #[test]
     fn absent_open_api_keys_is_refused_rather_than_treated_as_empty() {
-        let err = existing_open_api_keys(Some(endpoint(None))).unwrap_err();
+        let err = existing_endpoint_request(Some(endpoint(None))).unwrap_err();
         assert!(
-            err.to_string().contains("'openApiKeys'") && err.to_string().contains("revoke"),
-            "error should name the field and the consequence: {err}",
+            err.to_string().contains("'openApiKeys'") && err.to_string().contains("restored"),
+            "error should name the field and the rollback consequence: {err}",
         );
     }
 
     #[test]
     fn absent_result_is_refused_rather_than_treated_as_empty() {
-        let err = existing_open_api_keys(None).unwrap_err();
+        let err = existing_endpoint_request(None).unwrap_err();
         assert!(
             err.to_string().contains("'result'"),
             "error should name the field: {err}",

--- a/crates/clickhousectl/src/cloud/service_query.rs
+++ b/crates/clickhousectl/src/cloud/service_query.rs
@@ -58,18 +58,21 @@ fn build_service_query_key(
 }
 
 /// Ensure a query endpoint is provisioned for `service_id` and return the
-/// persisted key. If a key is already cached locally, returns it unchanged;
-/// otherwise creates the API key, binds it to the query endpoint (merging
+/// persisted key. Provisioning is serialized across processes in this project;
+/// after taking the lock, credentials are re-read so waiters reuse the winner's
+/// key. The winner creates the API key, binds it to the query endpoint (merging
 /// into any existing endpoint configuration) with read+write scope on this
-/// service, and saves it to `.clickhouse/credentials.json`.
+/// service, and atomically saves the merged credentials.
 pub async fn ensure_service_query_setup(
     client: &CloudClient,
     org_id: &str,
     service_id: &str,
     service_name: &str,
 ) -> CloudResult<ServiceQueryKey> {
-    if let Some(existing) = credentials::get_service_query_key(service_id) {
-        return Ok(existing);
+    let _lock = credentials::lock_service_query_provisioning()?;
+    let mut creds = credentials::try_load_credentials()?;
+    if let Some(existing) = creds.service_query_keys.get(service_id) {
+        return Ok(existing.clone());
     }
 
     let key_request = ApiKeyPostRequest {
@@ -128,14 +131,20 @@ pub async fn ensure_service_query_setup(
     // dangling UUID in the endpoint's `openApiKeys`.
     let stored = build_service_query_key(
         org_id,
-        api_key_uuid,
+        api_key_uuid.clone(),
         key_id,
         key_secret,
         endpoint.id,
         service_name,
         Utc::now(),
     );
-    credentials::set_service_query_key(service_id, stored.clone())?;
+    creds
+        .service_query_keys
+        .insert(service_id.to_string(), stored.clone());
+    if let Err(error) = credentials::save_credentials(&creds) {
+        discard_api_key(client, org_id, &api_key_uuid).await;
+        return Err(error);
+    }
 
     Ok(stored)
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -212,6 +212,28 @@ fn write_project_api_credentials(root: &Path, key: &str, secret: &str) {
     .unwrap();
 }
 
+#[test]
+fn logout_does_not_report_success_when_credentials_removal_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir(&home).unwrap();
+    std::fs::create_dir(&credentials_dir).unwrap();
+    std::fs::create_dir(credentials_dir.join("credentials.json")).unwrap();
+
+    let output = Command::new(clickhousectl_binary())
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .current_dir(dir.path())
+        .args(["cloud", "auth", "logout", "--api-keys"])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("API keys cleared"));
+    assert!(credentials_dir.join("credentials.json").is_dir());
+}
+
 // ── Backup configuration validation (issue #425) ────────────────────────────
 
 #[tokio::test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3017,6 +3017,234 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
 
 const QUERY_TEST_KEY_UUID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
+#[tokio::test]
+async fn service_query_auto_provisioning_is_single_flight_across_processes() {
+    const PROCESS_COUNT: usize = 6;
+
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "key": { "id": QUERY_TEST_KEY_UUID },
+                "keyId": "provisioned-key-id",
+                "keySecret": "provisioned-key-secret",
+            },
+            "status": 200,
+            "requestId": "stub-key-create",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1" },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    let credentials_path = credentials_dir.join("credentials.json");
+    let initial_credentials = serde_json::json!({
+        "api_key": "fake-key-for-tests",
+        "api_secret": "fake-secret-for-tests",
+        "service_query_keys": {
+            "existing-service": {
+                "key_id": "existing-key-id",
+                "key_secret": "existing-key-secret",
+                "endpoint_id": "existing-endpoint",
+                "service_name": "existing",
+                "created_at": "2026-05-11T12:00:00Z",
+            }
+        }
+    });
+    std::fs::write(
+        &credentials_path,
+        serde_json::to_vec(&initial_credentials).unwrap(),
+    )
+    .unwrap();
+    let initial_metadata = std::fs::metadata(&credentials_path).unwrap();
+
+    // Hold the same project lock as the CLI until every process has reached
+    // provisioning. This makes the contention deterministic rather than
+    // relying on process startup timing.
+    let provision_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(credentials_dir.join("query-provision.lock"))
+        .unwrap();
+    provision_lock.lock().unwrap();
+
+    let control_url = control.uri();
+    let query_host_url = query_host.uri();
+    let mut children = Vec::with_capacity(PROCESS_COUNT);
+    for _ in 0..PROCESS_COUNT {
+        let mut command = Command::new(clickhousectl_binary());
+        clear_agent_env(&mut command);
+        children.push(
+            command
+                .env("DO_NOT_TRACK", "1")
+                .env("HOME", &home_dir)
+                .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+                .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+                .env("CLICKHOUSE_CLOUD_QUERY_HOST", &query_host_url)
+                .current_dir(dir.path())
+                .args([
+                    "cloud",
+                    "--url",
+                    control_url.as_str(),
+                    "service",
+                    "query",
+                    "--id",
+                    QUERY_TEST_SERVICE_ID,
+                    "--org-id",
+                    "org-1",
+                    "--query",
+                    "SELECT 1",
+                ])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("failed to spawn concurrent clickhousectl"),
+        );
+    }
+
+    let primary_auth = format!(
+        "Basic {}",
+        base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            "fake-key-for-tests:fake-secret-for-tests",
+        )
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            let started = query_host
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .filter(|request| {
+                    request
+                        .headers
+                        .get("authorization")
+                        .and_then(|value| value.to_str().ok())
+                        == Some(primary_auth.as_str())
+                })
+                .count();
+            if started == PROCESS_COUNT {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("concurrent queries did not all reach provisioning");
+
+    provision_lock.unlock().unwrap();
+    drop(provision_lock);
+    let outputs = futures_util::future::join_all(
+        children
+            .into_iter()
+            .map(|child| tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())),
+    )
+    .await;
+    for output in outputs {
+        let output = output.unwrap();
+        assert_success(&output);
+        assert_eq!(output.stdout, b"1\n");
+    }
+
+    let control_requests = control.received_requests().await.unwrap();
+    assert_eq!(
+        control_requests
+            .iter()
+            .filter(|request| {
+                request.method == wiremock::http::Method::POST
+                    && request.url.path() == "/v1/organizations/org-1/keys"
+            })
+            .count(),
+        1,
+        "only the lock winner may create a key",
+    );
+    let endpoint_upserts: Vec<_> = control_requests
+        .iter()
+        .filter(|request| {
+            request.method == wiremock::http::Method::POST && request.url.path() == endpoint_path
+        })
+        .collect();
+    assert_eq!(endpoint_upserts.len(), 1, "the key must be bound once");
+    let upsert_body: Value = serde_json::from_slice(&endpoint_upserts[0].body).unwrap();
+    assert_eq!(
+        upsert_body["openApiKeys"],
+        serde_json::json!([QUERY_TEST_KEY_UUID])
+    );
+    assert!(
+        control_requests
+            .iter()
+            .all(|request| request.method != wiremock::http::Method::DELETE),
+        "a successfully shared key must not be deleted",
+    );
+
+    let stored: Value = serde_json::from_slice(&std::fs::read(&credentials_path).unwrap()).unwrap();
+    assert_eq!(stored["api_key"], "fake-key-for-tests");
+    assert_eq!(stored["api_secret"], "fake-secret-for-tests");
+    assert_eq!(
+        stored["service_query_keys"]["existing-service"]["key_id"], "existing-key-id",
+        "the lock winner must merge the credentials it re-read",
+    );
+    let new_key = &stored["service_query_keys"][QUERY_TEST_SERVICE_ID];
+    assert_eq!(new_key["api_key_id"], QUERY_TEST_KEY_UUID);
+    assert_eq!(new_key["key_id"], "provisioned-key-id");
+    assert_eq!(new_key["key_secret"], "provisioned-key-secret");
+    assert_eq!(stored["service_query_keys"].as_object().unwrap().len(), 2);
+
+    let final_metadata = std::fs::metadata(&credentials_path).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        assert_ne!(
+            initial_metadata.ino(),
+            final_metadata.ino(),
+            "credentials must be replaced atomically, not truncated in place",
+        );
+        assert_eq!(final_metadata.permissions().mode() & 0o777, 0o600);
+    }
+    let mut entries: Vec<_> = std::fs::read_dir(&credentials_dir)
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    entries.sort();
+    assert_eq!(
+        entries,
+        [".gitignore", "credentials.json", "query-provision.lock"],
+        "atomic persistence must not leave a temporary file",
+    );
+}
+
 /// Mount a key-creation POST returning `result`, plus a key DELETE, on the
 /// control plane. `result` lets each test omit exactly the field under test.
 async fn mount_key_create_and_delete(control: &MockServer, result: Value) {
@@ -3274,6 +3502,88 @@ async fn service_query_deletes_the_key_when_the_endpoint_get_omits_open_api_keys
         stderr.contains("'openApiKeys'"),
         "stderr should name the omitted field:\n{stderr}",
     );
+}
+
+#[tokio::test]
+async fn service_query_deletes_the_exact_key_when_atomic_persistence_fails() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    let credentials_path = credentials_dir.join("credentials.json");
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get",
+        })))
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path))
+        .respond_with(move |_: &wiremock::Request| {
+            // The child has already re-read credentials by the time it binds
+            // the endpoint. A directory at the destination makes the atomic
+            // commit fail after key creation and binding have succeeded.
+            std::fs::create_dir(&credentials_path).unwrap();
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": { "id": "ep-1" },
+                "status": 200,
+                "requestId": "stub-endpoint-upsert",
+            }))
+        })
+        .expect(1)
+        .mount(&control)
+        .await;
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &control.uri(),
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert!(!output.status.success());
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+        "persistence failure must delete the exact key it created",
+    );
+    assert!(credentials_dir.join("credentials.json").is_dir());
 }
 
 /// Provision against an endpoint GET that reports `existing_keys`, and return

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -212,6 +212,86 @@ fn write_project_api_credentials(root: &Path, key: &str, secret: &str) {
     .unwrap();
 }
 
+fn invoke_api_key_login(project_dir: &Path) -> std::process::Output {
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", project_dir.join("home"))
+        .current_dir(project_dir)
+        .args([
+            "cloud",
+            "auth",
+            "login",
+            "--api-key",
+            "new-key",
+            "--api-secret",
+            "new-secret",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
+#[test]
+fn api_key_login_preserves_malformed_credentials() {
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    let credentials_path = credentials_dir.join("credentials.json");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    let original = b"{malformed credentials\n";
+    std::fs::write(&credentials_path, original).unwrap();
+
+    let output = invoke_api_key_login(dir.path());
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("Error: failed to parse ")
+            && stderr.contains(".clickhouse/credentials.json")
+    );
+    assert_eq!(std::fs::read(credentials_path).unwrap(), original);
+}
+
+#[cfg(unix)]
+#[test]
+fn api_key_login_preserves_unreadable_credentials() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    let credentials_path = credentials_dir.join("credentials.json");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    let original = br#"{"api_key":"old-key","api_secret":"old-secret"}"#;
+    std::fs::write(&credentials_path, original).unwrap();
+    std::fs::set_permissions(&credentials_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let output = invoke_api_key_login(dir.path());
+
+    std::fs::set_permissions(&credentials_path, std::fs::Permissions::from_mode(0o600)).unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("Error: failed to read ")
+            && stderr.contains(".clickhouse/credentials.json")
+    );
+    assert_eq!(std::fs::read(credentials_path).unwrap(), original);
+}
+
+#[test]
+fn api_key_login_initializes_missing_credentials() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let output = invoke_api_key_login(dir.path());
+
+    assert_success(&output);
+    let credentials: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join(".clickhouse/credentials.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(credentials["api_key"], "new-key");
+    assert_eq!(credentials["api_secret"], "new-secret");
+}
+
 #[test]
 fn logout_does_not_report_success_when_credentials_removal_fails() {
     let dir = tempfile::tempdir().unwrap();
@@ -720,6 +800,96 @@ async fn service_query_key_removal_merges_changes_made_under_the_credentials_loc
     assert_eq!(stored["api_key"], "concurrent-key");
     assert_eq!(stored["api_secret"], "concurrent-secret");
     assert!(stored.get("service_query_keys").is_none());
+}
+
+#[tokio::test]
+async fn service_query_key_removal_preserves_credentials_corrupted_while_waiting_for_lock() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/keys/{DELETE_TEST_API_KEY_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-key-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-service-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_service_query_key(dir.path(), Some("org-1"), Some(DELETE_TEST_API_KEY_ID));
+    let credentials_dir = dir.path().join(".clickhouse");
+    let credentials_path = credentials_dir.join("credentials.json");
+    let credentials_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(credentials_dir.join("credentials.lock"))
+        .unwrap();
+    credentials_lock.lock().unwrap();
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let mut child = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "service",
+            "delete",
+            DELETE_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            if mock.received_requests().await.unwrap().len() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("service deletion did not reach local credential cleanup");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "service-key removal did not wait for the credentials lock",
+    );
+
+    let corrupted = b"{corrupted while locked\n";
+    std::fs::write(&credentials_path, corrupted).unwrap();
+    credentials_lock.unlock().unwrap();
+    drop(credentials_lock);
+
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.starts_with("Error: failed to parse ")
+            && stderr.contains(".clickhouse/credentials.json")
+    );
+    assert_eq!(std::fs::read(credentials_path).unwrap(), corrupted);
 }
 
 #[tokio::test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -610,6 +610,97 @@ async fn service_delete_removes_the_exact_stored_query_key_after_the_service() {
 }
 
 #[tokio::test]
+async fn service_query_key_removal_merges_changes_made_under_the_credentials_lock() {
+    let mock = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/keys/{DELETE_TEST_API_KEY_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-key-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "/v1/organizations/org-1/services/{DELETE_TEST_SERVICE_ID}"
+        )))
+        .respond_with(successful_delete_response("stub-service-delete"))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    write_service_query_key(dir.path(), Some("org-1"), Some(DELETE_TEST_API_KEY_ID));
+    let credentials_dir = dir.path().join(".clickhouse");
+    let credentials_path = credentials_dir.join("credentials.json");
+    let credentials_lock = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(credentials_dir.join("credentials.lock"))
+        .unwrap();
+    credentials_lock.lock().unwrap();
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let mut child = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", dir.path().join("home"))
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &mock.uri(),
+            "--json",
+            "service",
+            "delete",
+            DELETE_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn clickhousectl");
+
+    tokio::time::timeout(std::time::Duration::from_secs(15), async {
+        loop {
+            if mock.received_requests().await.unwrap().len() == 2 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("service deletion did not reach local credential cleanup");
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "service-key removal did not wait for the credentials lock",
+    );
+
+    let mut latest: Value = serde_json::from_slice(&std::fs::read(&credentials_path).unwrap())
+        .expect("credentials were not valid JSON");
+    latest["api_key"] = Value::String("concurrent-key".to_string());
+    latest["api_secret"] = Value::String("concurrent-secret".to_string());
+    std::fs::write(&credentials_path, serde_json::to_vec(&latest).unwrap()).unwrap();
+    credentials_lock.unlock().unwrap();
+    drop(credentials_lock);
+
+    let output = tokio::task::spawn_blocking(move || child.wait_with_output().unwrap())
+        .await
+        .unwrap();
+    assert_success(&output);
+    let stored: Value = serde_json::from_slice(&std::fs::read(&credentials_path).unwrap()).unwrap();
+    assert_eq!(stored["api_key"], "concurrent-key");
+    assert_eq!(stored["api_secret"], "concurrent-secret");
+    assert!(stored.get("service_query_keys").is_none());
+}
+
+#[tokio::test]
 async fn service_delete_without_a_stored_query_key_only_deletes_the_service() {
     let mock = MockServer::start().await;
     Mock::given(method("DELETE"))
@@ -3017,6 +3108,167 @@ async fn service_query_with_stored_key_sends_basic_auth_with_that_key() {
 
 const QUERY_TEST_KEY_UUID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
 
+async fn provision_while_project_auth_changes(auth_args: &[&str]) -> tempfile::TempDir {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "key": { "id": QUERY_TEST_KEY_UUID },
+                "keyId": "provisioned-key-id",
+                "keySecret": "provisioned-key-secret",
+            },
+            "status": 200,
+            "requestId": "stub-key-create",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let home_dir = dir.path().join("home");
+    std::fs::create_dir_all(&home_dir).unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    std::fs::write(
+        credentials_dir.join("credentials.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "api_key": "fake-key-for-tests",
+            "api_secret": "fake-secret-for-tests",
+            "service_query_keys": {
+                "existing-service": {
+                    "key_id": "existing-key-id",
+                    "key_secret": "existing-key-secret",
+                    "service_name": "existing",
+                    "created_at": "2026-05-11T12:00:00Z",
+                }
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let auth_args: Vec<String> = auth_args.iter().map(|arg| (*arg).to_string()).collect();
+    let auth_project_dir = dir.path().to_path_buf();
+    let auth_home_dir = home_dir.clone();
+    Mock::given(method("POST"))
+        .and(path(endpoint_path))
+        .respond_with(move |_: &wiremock::Request| {
+            let mut command = Command::new(clickhousectl_binary());
+            clear_agent_env(&mut command);
+            let output = command
+                .env("DO_NOT_TRACK", "1")
+                .env("HOME", &auth_home_dir)
+                .env_remove("CLICKHOUSE_CLOUD_API_KEY")
+                .env_remove("CLICKHOUSE_CLOUD_API_SECRET")
+                .current_dir(&auth_project_dir)
+                .args(&auth_args)
+                .output()
+                .expect("failed to spawn concurrent auth command");
+            assert_success(&output);
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": { "id": "ep-1" },
+                "status": 200,
+                "requestId": "stub-endpoint-upsert",
+            }))
+        })
+        .expect(1)
+        .mount(&control)
+        .await;
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", &home_dir)
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &control.uri(),
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_success(&output);
+    assert_eq!(output.stdout, b"1\n");
+    dir
+}
+
+#[tokio::test]
+async fn provisioning_merges_a_concurrent_api_key_login() {
+    let dir = provision_while_project_auth_changes(&[
+        "cloud",
+        "auth",
+        "login",
+        "--api-key",
+        "concurrent-key",
+        "--api-secret",
+        "concurrent-secret",
+    ])
+    .await;
+
+    let stored: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join(".clickhouse/credentials.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(stored["api_key"], "concurrent-key");
+    assert_eq!(stored["api_secret"], "concurrent-secret");
+    assert_eq!(
+        stored["service_query_keys"]["existing-service"]["key_id"],
+        "existing-key-id"
+    );
+    assert_eq!(
+        stored["service_query_keys"][QUERY_TEST_SERVICE_ID]["key_id"],
+        "provisioned-key-id"
+    );
+}
+
+#[tokio::test]
+async fn provisioning_does_not_restore_credentials_cleared_by_concurrent_logout() {
+    let dir =
+        provision_while_project_auth_changes(&["cloud", "auth", "logout", "--api-keys"]).await;
+
+    let stored: Value = serde_json::from_slice(
+        &std::fs::read(dir.path().join(".clickhouse/credentials.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(stored.get("api_key").is_none());
+    assert!(stored.get("api_secret").is_none());
+    assert!(
+        stored["service_query_keys"]
+            .get("existing-service")
+            .is_none()
+    );
+    assert_eq!(
+        stored["service_query_keys"][QUERY_TEST_SERVICE_ID]["key_id"],
+        "provisioned-key-id"
+    );
+    assert_eq!(stored["service_query_keys"].as_object().unwrap().len(), 1);
+}
+
 #[tokio::test]
 async fn service_query_auto_provisioning_is_single_flight_across_processes() {
     const PROCESS_COUNT: usize = 6;
@@ -3240,7 +3492,12 @@ async fn service_query_auto_provisioning_is_single_flight_across_processes() {
     entries.sort();
     assert_eq!(
         entries,
-        [".gitignore", "credentials.json", "query-provision.lock"],
+        [
+            ".gitignore",
+            "credentials.json",
+            "credentials.lock",
+            "query-provision.lock",
+        ],
         "atomic persistence must not leave a temporary file",
     );
 }

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -4113,7 +4113,6 @@ async fn service_query_restores_existing_endpoint_before_deleting_key_on_persist
     let endpoint_path =
         format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
     let existing_key = "99999999-8888-7777-6666-555555555555";
-    let concurrent_key = "11111111-2222-3333-4444-555555555555";
     let get_count = std::sync::atomic::AtomicUsize::new(0);
     Mock::given(method("GET"))
         .and(path(endpoint_path.clone()))
@@ -4129,7 +4128,7 @@ async fn service_query_restores_existing_endpoint_before_deleting_key_on_persist
                 serde_json::json!({
                     "id": "ep-1",
                     "allowedOrigins": "*",
-                    "openApiKeys": [existing_key, concurrent_key, QUERY_TEST_KEY_UUID],
+                    "openApiKeys": [existing_key, QUERY_TEST_KEY_UUID],
                     "roles": ["sql_console_admin"],
                 })
             };
@@ -4187,10 +4186,10 @@ async fn service_query_restores_existing_endpoint_before_deleting_key_on_persist
         restore_body,
         serde_json::json!({
             "allowedOrigins": "https://before.example",
-            "openApiKeys": [existing_key, concurrent_key],
+            "openApiKeys": [existing_key],
             "roles": ["sql_console_read_only"],
         }),
-        "compensation must restore pre-bind settings without removing concurrent keys",
+        "compensation must restore the snapshot when the endpoint still matches the bind",
     );
     let key_delete = requests
         .iter()
@@ -4203,6 +4202,155 @@ async fn service_query_restores_existing_endpoint_before_deleting_key_on_persist
     assert!(
         endpoint_upserts[1].0 < key_delete,
         "the key must be deleted only after it is unbound",
+    );
+}
+
+async fn invoke_persistence_failure_with_current_endpoint(
+    current_endpoint: Option<Value>,
+) -> (MockServer, std::process::Output, String) {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    let credentials_path = credentials_dir.join("credentials.json");
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    let existing_key = "99999999-8888-7777-6666-555555555555";
+    let get_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            if get_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": {
+                        "id": "ep-1",
+                        "allowedOrigins": "https://before.example",
+                        "openApiKeys": [existing_key],
+                        "roles": ["sql_console_read_only"],
+                    },
+                    "status": 200,
+                    "requestId": "stub-endpoint-get-before-bind",
+                }))
+            } else if let Some(result) = &current_endpoint {
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": result,
+                    "status": 200,
+                    "requestId": "stub-endpoint-get-before-compensation",
+                }))
+            } else {
+                ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "error": "not found",
+                    "status": 404,
+                    "requestId": "stub-endpoint-get-before-compensation",
+                }))
+            }
+        })
+        .expect(2)
+        .mount(&control)
+        .await;
+    let upsert_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            if upsert_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                std::fs::create_dir(&credentials_path).unwrap();
+            }
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": { "id": "ep-1" },
+                "status": 200,
+                "requestId": "stub-endpoint-upsert",
+            }))
+        })
+        .mount(&control)
+        .await;
+
+    let output = invoke_service_query_provisioning_in(&control, &query_host, dir.path());
+    (control, output, endpoint_path)
+}
+
+#[tokio::test]
+async fn service_query_does_not_restore_over_concurrently_changed_endpoint() {
+    let concurrent_key = "11111111-2222-3333-4444-555555555555";
+    let (control, output, endpoint_path) =
+        invoke_persistence_failure_with_current_endpoint(Some(serde_json::json!({
+            "id": "ep-1",
+            "allowedOrigins": "https://new.example",
+            "openApiKeys": [concurrent_key, QUERY_TEST_KEY_UUID],
+            "roles": ["sql_console_read_only"],
+        })))
+        .await;
+
+    assert!(!output.status.success());
+    let requests = control.received_requests().await.unwrap();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| {
+                request.method == wiremock::http::Method::POST
+                    && request.url.path() == endpoint_path
+            })
+            .count(),
+        1,
+        "compensation must not overwrite the concurrently changed endpoint",
+    );
+    assert!(
+        recorded_key_deletes(&control).await.is_empty(),
+        "the possibly still-bound key must be retained for recovery",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("restoration was intentionally skipped")
+            && stderr.contains("no longer match the state written by this operation")
+            && stderr.contains(QUERY_TEST_KEY_UUID)
+            && stderr.contains("inspect the current endpoint before deleting it"),
+        "the error must explain the guarded skip and recovery action:\n{stderr}",
+    );
+}
+
+#[tokio::test]
+async fn service_query_does_not_recreate_concurrently_deleted_endpoint() {
+    let (control, output, endpoint_path) =
+        invoke_persistence_failure_with_current_endpoint(None).await;
+
+    assert!(!output.status.success());
+    let requests = control.received_requests().await.unwrap();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| {
+                request.method == wiremock::http::Method::POST
+                    && request.url.path() == endpoint_path
+            })
+            .count(),
+        1,
+        "compensation must not recreate a concurrently deleted endpoint",
+    );
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+        "the unbound API key should still be cleaned up",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cleanup was skipped because the endpoint was deleted concurrently")
+            && stderr.contains("it was not recreated")
+            && stderr.contains(QUERY_TEST_KEY_UUID)
+            && stderr.contains("was deleted"),
+        "the error must explain that deletion was preserved and cleanup completed:\n{stderr}",
     );
 }
 

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3569,7 +3569,10 @@ async fn recorded_key_deletes(control: &MockServer) -> Vec<String> {
         .await
         .unwrap()
         .iter()
-        .filter(|r| r.method == wiremock::http::Method::DELETE)
+        .filter(|r| {
+            r.method == wiremock::http::Method::DELETE
+                && r.url.path().starts_with("/v1/organizations/org-1/keys/")
+        })
         .map(|r| r.url.path().to_string())
         .collect()
 }
@@ -3761,8 +3764,38 @@ async fn service_query_deletes_the_key_when_the_endpoint_get_omits_open_api_keys
     );
 }
 
+fn invoke_service_query_provisioning_in(
+    control: &MockServer,
+    query_host: &MockServer,
+    project_dir: &Path,
+) -> std::process::Output {
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    command
+        .env("DO_NOT_TRACK", "1")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .current_dir(project_dir)
+        .args([
+            "cloud",
+            "--url",
+            &control.uri(),
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl")
+}
+
 #[tokio::test]
-async fn service_query_deletes_the_exact_key_when_atomic_persistence_fails() {
+async fn service_query_removes_a_new_endpoint_before_deleting_the_key_on_persistence_failure() {
     let control = start_mock_control_plane_with_service().await;
     let query_host = start_mock_query_host_for_provisioning().await;
     mount_key_create_and_delete(
@@ -3782,17 +3815,34 @@ async fn service_query_deletes_the_exact_key_when_atomic_persistence_fails() {
     let credentials_path = credentials_dir.join("credentials.json");
     let endpoint_path =
         format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    let get_count = std::sync::atomic::AtomicUsize::new(0);
     Mock::given(method("GET"))
         .and(path(endpoint_path.clone()))
-        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
-            "error": "not found",
-            "status": 404,
-            "requestId": "stub-endpoint-get",
-        })))
+        .respond_with(move |_: &wiremock::Request| {
+            if get_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "error": "not found",
+                    "status": 404,
+                    "requestId": "stub-endpoint-get",
+                }))
+            } else {
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": {
+                        "id": "ep-1",
+                        "allowedOrigins": "*",
+                        "openApiKeys": [QUERY_TEST_KEY_UUID],
+                        "roles": ["sql_console_admin"],
+                    },
+                    "status": 200,
+                    "requestId": "stub-endpoint-get-after-bind",
+                }))
+            }
+        })
+        .expect(2)
         .mount(&control)
         .await;
     Mock::given(method("POST"))
-        .and(path(endpoint_path))
+        .and(path(endpoint_path.clone()))
         .respond_with(move |_: &wiremock::Request| {
             // The child has already re-read credentials by the time it binds
             // the endpoint. A directory at the destination makes the atomic
@@ -3807,30 +3857,17 @@ async fn service_query_deletes_the_exact_key_when_atomic_persistence_fails() {
         .expect(1)
         .mount(&control)
         .await;
+    Mock::given(method("DELETE"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": 200,
+            "requestId": "stub-endpoint-delete",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
 
-    let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
-    let output = command
-        .env("DO_NOT_TRACK", "1")
-        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
-        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
-        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
-        .current_dir(dir.path())
-        .args([
-            "cloud",
-            "--url",
-            &control.uri(),
-            "service",
-            "query",
-            "--id",
-            QUERY_TEST_SERVICE_ID,
-            "--org-id",
-            "org-1",
-            "--query",
-            "SELECT 1",
-        ])
-        .output()
-        .expect("failed to spawn clickhousectl");
+    let output = invoke_service_query_provisioning_in(&control, &query_host, dir.path());
 
     assert!(!output.status.success());
     assert_eq!(
@@ -3840,7 +3877,230 @@ async fn service_query_deletes_the_exact_key_when_atomic_persistence_fails() {
         )],
         "persistence failure must delete the exact key it created",
     );
+    let requests = control.received_requests().await.unwrap();
+    let endpoint_delete = requests
+        .iter()
+        .position(|request| {
+            request.method == wiremock::http::Method::DELETE && request.url.path() == endpoint_path
+        })
+        .expect("the newly created endpoint must be removed");
+    let key_delete = requests
+        .iter()
+        .position(|request| {
+            request.method == wiremock::http::Method::DELETE
+                && request.url.path()
+                    == format!("/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}")
+        })
+        .expect("the newly created key must be deleted");
+    assert!(
+        endpoint_delete < key_delete,
+        "the key must remain valid until its endpoint binding is removed",
+    );
     assert!(credentials_dir.join("credentials.json").is_dir());
+}
+
+#[tokio::test]
+async fn service_query_restores_existing_endpoint_before_deleting_key_on_persistence_failure() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    let credentials_path = credentials_dir.join("credentials.json");
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    let existing_key = "99999999-8888-7777-6666-555555555555";
+    let concurrent_key = "11111111-2222-3333-4444-555555555555";
+    let get_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            let result = if get_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                serde_json::json!({
+                    "id": "ep-1",
+                    "allowedOrigins": "https://before.example",
+                    "openApiKeys": [existing_key],
+                    "roles": ["sql_console_read_only"],
+                })
+            } else {
+                serde_json::json!({
+                    "id": "ep-1",
+                    "allowedOrigins": "*",
+                    "openApiKeys": [existing_key, concurrent_key, QUERY_TEST_KEY_UUID],
+                    "roles": ["sql_console_admin"],
+                })
+            };
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": result,
+                "status": 200,
+                "requestId": "stub-endpoint-get",
+            }))
+        })
+        .expect(2)
+        .mount(&control)
+        .await;
+    let upsert_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            if upsert_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                std::fs::create_dir(&credentials_path).unwrap();
+            }
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": { "id": "ep-1" },
+                "status": 200,
+                "requestId": "stub-endpoint-upsert",
+            }))
+        })
+        .expect(2)
+        .mount(&control)
+        .await;
+
+    let output = invoke_service_query_provisioning_in(&control, &query_host, dir.path());
+    assert!(!output.status.success());
+    assert_eq!(
+        recorded_key_deletes(&control).await,
+        vec![format!(
+            "/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}"
+        )],
+    );
+
+    let requests = control.received_requests().await.unwrap();
+    let endpoint_upserts: Vec<_> = requests
+        .iter()
+        .enumerate()
+        .filter(|(_, request)| {
+            request.method == wiremock::http::Method::POST && request.url.path() == endpoint_path
+        })
+        .collect();
+    assert_eq!(endpoint_upserts.len(), 2);
+    let bind_body: Value = serde_json::from_slice(&endpoint_upserts[0].1.body).unwrap();
+    assert_eq!(
+        bind_body["openApiKeys"],
+        serde_json::json!([existing_key, QUERY_TEST_KEY_UUID])
+    );
+    let restore_body: Value = serde_json::from_slice(&endpoint_upserts[1].1.body).unwrap();
+    assert_eq!(
+        restore_body,
+        serde_json::json!({
+            "allowedOrigins": "https://before.example",
+            "openApiKeys": [existing_key, concurrent_key],
+            "roles": ["sql_console_read_only"],
+        }),
+        "compensation must restore pre-bind settings without removing concurrent keys",
+    );
+    let key_delete = requests
+        .iter()
+        .position(|request| {
+            request.method == wiremock::http::Method::DELETE
+                && request.url.path()
+                    == format!("/v1/organizations/org-1/keys/{QUERY_TEST_KEY_UUID}")
+        })
+        .unwrap();
+    assert!(
+        endpoint_upserts[1].0 < key_delete,
+        "the key must be deleted only after it is unbound",
+    );
+}
+
+#[tokio::test]
+async fn service_query_retains_bound_key_when_endpoint_compensation_fails() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host_for_provisioning().await;
+    mount_key_create_and_delete(
+        &control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret",
+        }),
+    )
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let credentials_dir = dir.path().join(".clickhouse");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join(".gitignore"), "*\n").unwrap();
+    let credentials_path = credentials_dir.join("credentials.json");
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    let get_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            let result = if get_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                serde_json::json!({
+                    "id": "ep-1",
+                    "allowedOrigins": "https://before.example",
+                    "openApiKeys": [],
+                    "roles": ["sql_console_read_only"],
+                })
+            } else {
+                serde_json::json!({
+                    "id": "ep-1",
+                    "allowedOrigins": "*",
+                    "openApiKeys": [QUERY_TEST_KEY_UUID],
+                    "roles": ["sql_console_admin"],
+                })
+            };
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "result": result,
+                "status": 200,
+                "requestId": "stub-endpoint-get",
+            }))
+        })
+        .expect(2)
+        .mount(&control)
+        .await;
+    let upsert_count = std::sync::atomic::AtomicUsize::new(0);
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(move |_: &wiremock::Request| {
+            if upsert_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst) == 0 {
+                std::fs::create_dir(&credentials_path).unwrap();
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "result": { "id": "ep-1" },
+                    "status": 200,
+                    "requestId": "stub-endpoint-bind",
+                }))
+            } else {
+                ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                    "error": "endpoint restore rejected",
+                    "status": 500,
+                    "requestId": "stub-endpoint-restore",
+                }))
+            }
+        })
+        .expect(2)
+        .mount(&control)
+        .await;
+
+    let output = invoke_service_query_provisioning_in(&control, &query_host, dir.path());
+    assert!(!output.status.success());
+    assert!(
+        recorded_key_deletes(&control).await.is_empty(),
+        "a still-bound key must be retained",
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("local credential persistence failed")
+            && stderr.contains("query endpoint cleanup failed")
+            && stderr.contains("endpoint restore rejected")
+            && stderr.contains(QUERY_TEST_KEY_UUID)
+            && stderr.contains("retained for recovery"),
+        "the error must report both failures and the recoverable key ID:\n{stderr}",
+    );
 }
 
 /// Provision against an endpoint GET that reports `existing_keys`, and return
@@ -3862,7 +4122,12 @@ async fn provision_against_endpoint_with_keys(existing_keys: Value) -> (tempfile
     Mock::given(method("GET"))
         .and(path(endpoint_path.clone()))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "result": { "id": "ep-1", "openApiKeys": existing_keys },
+            "result": {
+                "id": "ep-1",
+                "allowedOrigins": "https://existing.example",
+                "openApiKeys": existing_keys,
+                "roles": ["sql_console_read_only"],
+            },
             "status": 200,
             "requestId": "stub-endpoint-get",
         })))

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -214,7 +214,7 @@ fn write_project_api_credentials(root: &Path, key: &str, secret: &str) {
 
 fn invoke_api_key_login(project_dir: &Path) -> std::process::Output {
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     command
         .env("DO_NOT_TRACK", "1")
         .env("HOME", project_dir.join("home"))
@@ -745,7 +745,7 @@ async fn service_query_key_removal_merges_changes_made_under_the_credentials_loc
     credentials_lock.lock().unwrap();
 
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     let mut child = command
         .env("DO_NOT_TRACK", "1")
         .env("HOME", dir.path().join("home"))
@@ -836,7 +836,7 @@ async fn service_query_key_removal_preserves_credentials_corrupted_while_waiting
     credentials_lock.lock().unwrap();
 
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     let mut child = command
         .env("DO_NOT_TRACK", "1")
         .env("HOME", dir.path().join("home"))
@@ -3361,7 +3361,7 @@ async fn provision_while_project_auth_changes(auth_args: &[&str]) -> tempfile::T
         .and(path(endpoint_path))
         .respond_with(move |_: &wiremock::Request| {
             let mut command = Command::new(clickhousectl_binary());
-            clear_agent_env(&mut command);
+            clear_inherited_env(&mut command);
             let output = command
                 .env("DO_NOT_TRACK", "1")
                 .env("HOME", &auth_home_dir)
@@ -3383,7 +3383,7 @@ async fn provision_while_project_auth_changes(auth_args: &[&str]) -> tempfile::T
         .await;
 
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     let output = command
         .env("DO_NOT_TRACK", "1")
         .env("HOME", &home_dir)
@@ -3548,7 +3548,7 @@ async fn service_query_auto_provisioning_is_single_flight_across_processes() {
     let mut children = Vec::with_capacity(PROCESS_COUNT);
     for _ in 0..PROCESS_COUNT {
         let mut command = Command::new(clickhousectl_binary());
-        clear_agent_env(&mut command);
+        clear_inherited_env(&mut command);
         children.push(
             command
                 .env("DO_NOT_TRACK", "1")
@@ -3962,7 +3962,7 @@ fn invoke_service_query_provisioning_in(
     project_dir: &Path,
 ) -> std::process::Output {
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     command
         .env("DO_NOT_TRACK", "1")
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")


### PR DESCRIPTION
## Summary

- serialize Query API auto-provisioning with a project-local cross-process lock
- re-read and merge credentials under the lock, then atomically replace `credentials.json`; waiting processes reuse the persisted service credential
- delete the exact management API key when post-create binding or persistence fails
- add deterministic six-process wiremock coverage for one key creation, one endpoint binding, valid merged credentials, and atomic replacement
- document the residual cross-project lost-update risk because endpoint upsert replaces the complete `openApiKeys` list without conditional updates

Closes #451

## Tests

- `cargo test -p clickhousectl --test cli_request_shape_test service_query_auto_provisioning_is_single_flight_across_processes -- --exact` (1 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test service_query_deletes_the_exact_key_when_atomic_persistence_fails -- --exact` (1 passed)
- `cargo test -p clickhousectl --bin clickhousectl service_query` (21 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test service_query` (24 passed)
- `cargo test -p clickhousectl --bin clickhousectl` (609 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test` (104 passed)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

No live Cloud resources or credentials were used.

## Stack

This is child 3 of the Cloud-query stack. It targets `issue-455-query-input-conflict` (PR #490), above `issue-452-service-query-selector` (PR #483). Both parent PRs remain unchanged and should merge first.