### PR TITLE
Bound and classify local version-manager network operations

### DIFF
--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -54,6 +54,21 @@ pub enum Error {
     #[error("Download failed: {0}")]
     Download(String),
 
+    #[error("{0}")]
+    VersionNetwork(#[from] crate::version_manager::network::NetworkFailure),
+
+    #[error("{fallback}; initial probe failure: {probe}")]
+    VersionFallback {
+        probe: crate::version_manager::network::NetworkFailure,
+        fallback: Box<Error>,
+    },
+
+    #[error("{failure} after {attempts} attempts")]
+    VersionNetworkRetryExhausted {
+        failure: crate::version_manager::network::NetworkFailure,
+        attempts: usize,
+    },
+
     #[error("No matching version found for: {0}")]
     NoMatchingVersion(String),
 

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -1,9 +1,37 @@
 use crate::error::{Error, Result};
+use crate::version_manager::network::{NetworkFailure, NetworkStage, OperationClient};
 use crate::version_manager::platform::{DownloadSource, Platform};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use std::path::Path;
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
+
+#[derive(Debug, Clone, Copy)]
+struct RetryPolicy {
+    max_attempts: usize,
+    initial_delay: Duration,
+    max_delay: Duration,
+}
+
+impl RetryPolicy {
+    const INSTALLER: Self = Self {
+        max_attempts: 3,
+        initial_delay: Duration::from_millis(250),
+        max_delay: Duration::from_secs(5),
+    };
+
+    fn delay(self, failure: &NetworkFailure, attempt: usize) -> Duration {
+        failure
+            .retry_after
+            .unwrap_or_else(|| {
+                let exponent = u32::try_from(attempt.saturating_sub(1)).unwrap_or(u32::MAX);
+                self.initial_delay
+                    .saturating_mul(2_u32.saturating_pow(exponent))
+            })
+            .min(self.max_delay)
+    }
+}
 
 /// Downloads from a DownloadSource to the specified path
 pub async fn download_from_source(
@@ -17,14 +45,39 @@ pub async fn download_from_source(
 
 /// Downloads a file from a URL to the specified path, with progress bar
 pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
-    let client = crate::http::client_builder().build()?;
+    let client = OperationClient::download(url)?;
+    download_url_with(&client, url, dest_path, RetryPolicy::INSTALLER).await
+}
 
-    let response = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("Failed to download {}: {}", url, e)))?;
+async fn download_url_with(
+    client: &OperationClient,
+    url: &str,
+    dest_path: &Path,
+    policy: RetryPolicy,
+) -> Result<()> {
+    for attempt in 1..=policy.max_attempts {
+        match download_once(client, url, dest_path).await {
+            Ok(()) => return Ok(()),
+            Err(Error::VersionNetwork(failure)) if failure.is_retryable() => {
+                if attempt == policy.max_attempts {
+                    return Err(Error::VersionNetworkRetryExhausted {
+                        failure,
+                        attempts: attempt,
+                    });
+                }
+                client.sleep(policy.delay(&failure, attempt)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("download retry policy always has at least one attempt")
+}
+
+async fn download_once(client: &OperationClient, url: &str, dest_path: &Path) -> Result<()> {
+    let response = client.get(url, NetworkStage::Download).await?;
+    if !response.status().is_success() {
+        return Err(NetworkFailure::from_response(NetworkStage::Download, url, &response).into());
+    }
 
     let total_size = response.content_length().unwrap_or(0);
 
@@ -41,7 +94,15 @@ pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                pb.abandon();
+                return Err(
+                    NetworkFailure::from_request(NetworkStage::Download, url, &error).into(),
+                );
+            }
+        };
         file.write_all(&chunk).await?;
         downloaded += chunk.len() as u64;
         pb.set_position(downloaded);
@@ -51,4 +112,154 @@ pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
     file.shutdown().await?;
     pb.finish_with_message("Download complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::version_manager::network::{NetworkCategory, Timeouts};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+    fn test_client(read: Duration, total: Duration) -> OperationClient {
+        OperationClient::with_timeouts(Timeouts::new(Duration::from_millis(100), read, total))
+            .unwrap()
+    }
+
+    fn test_policy(max_attempts: usize, max_delay: Duration) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            initial_delay: Duration::ZERO,
+            max_delay,
+        }
+    }
+
+    #[tokio::test]
+    async fn stalled_body_hits_read_deadline_and_exhausts_retries() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = Arc::clone(&requests);
+        tokio::spawn(async move {
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let mut request = [0; 1024];
+                    let _ = socket.read(&mut request).await;
+                    socket
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nabc",
+                        )
+                        .await
+                        .unwrap();
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                });
+            }
+        });
+        let url = format!("http://{address}/binary");
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("clickhouse");
+
+        let error = download_url_with(
+            &test_client(Duration::from_millis(40), Duration::from_millis(500)),
+            &url,
+            &destination,
+            test_policy(2, Duration::ZERO),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::VersionNetworkRetryExhausted {
+                failure: NetworkFailure {
+                    stage: NetworkStage::Download,
+                    category: NetworkCategory::Timeout,
+                    ..
+                },
+                attempts: 2,
+            }
+        ));
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn retryable_server_errors_stop_after_three_attempts() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(3)
+            .mount(&server)
+            .await;
+        let temp = tempfile::tempdir().unwrap();
+
+        let error = download_url_with(
+            &test_client(Duration::from_millis(100), Duration::from_secs(2)),
+            &server.uri(),
+            &temp.path().join("clickhouse"),
+            test_policy(3, Duration::ZERO),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::VersionNetworkRetryExhausted {
+                failure: NetworkFailure {
+                    category: NetworkCategory::Server,
+                    ..
+                },
+                attempts: 3,
+            }
+        ));
+    }
+
+    #[derive(Clone)]
+    struct RateLimitThenSuccess {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Respond for RateLimitThenSuccess {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                ResponseTemplate::new(429).insert_header("Retry-After", "60")
+            } else {
+                ResponseTemplate::new(200).set_body_bytes(b"complete".to_vec())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_after_is_honored_but_capped() {
+        let server = MockServer::start().await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        Mock::given(method("GET"))
+            .respond_with(RateLimitThenSuccess {
+                calls: Arc::clone(&calls),
+            })
+            .mount(&server)
+            .await;
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("clickhouse");
+        let max_delay = Duration::from_millis(30);
+        let started = tokio::time::Instant::now();
+
+        download_url_with(
+            &test_client(Duration::from_millis(100), Duration::from_secs(2)),
+            &server.uri(),
+            &destination,
+            test_policy(2, max_delay),
+        )
+        .await
+        .unwrap();
+
+        assert!(started.elapsed() >= max_delay);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(tokio::fs::read(destination).await.unwrap(), b"complete");
+    }
 }

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -219,6 +219,37 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn request_timeout_responses_are_classified_and_retried() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(408))
+            .expect(3)
+            .mount(&server)
+            .await;
+        let temp = tempfile::tempdir().unwrap();
+
+        let error = download_url_with(
+            &test_client(Duration::from_millis(100), Duration::from_secs(2)),
+            &server.uri(),
+            &temp.path().join("clickhouse"),
+            test_policy(3, Duration::ZERO),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::VersionNetworkRetryExhausted {
+                failure: NetworkFailure {
+                    category: NetworkCategory::Timeout,
+                    ..
+                },
+                attempts: 3,
+            }
+        ));
+    }
+
     #[derive(Clone)]
     struct RateLimitThenSuccess {
         calls: Arc<AtomicUsize>,

--- a/crates/clickhousectl/src/version_manager/list.rs
+++ b/crates/clickhousectl/src/version_manager/list.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::paths;
+use crate::version_manager::network::{NetworkFailure, NetworkStage, OperationClient};
 use chrono::Datelike;
 use serde::Deserialize;
 use std::fmt;
@@ -69,18 +70,20 @@ pub struct VersionEntry {
     pub channel: Channel,
 }
 
-/// Fetches available versions from GitHub releases
-pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
-    let url = "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
-    let client = crate::http::client_builder().build()?;
-
-    let response = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
-    let releases: Vec<GitHubRelease> = response.json().await?;
+pub(crate) async fn list_available_versions_with(
+    client: &OperationClient,
+    url: &str,
+) -> Result<Vec<VersionEntry>> {
+    let response = client.get(url, NetworkStage::VersionList).await?;
+    if !response.status().is_success() {
+        return Err(
+            NetworkFailure::from_response(NetworkStage::VersionList, url, &response).into(),
+        );
+    }
+    let releases: Vec<GitHubRelease> = response
+        .json()
+        .await
+        .map_err(|error| NetworkFailure::from_request(NetworkStage::VersionList, url, &error))?;
 
     let mut versions = Vec::new();
     for release in releases {
@@ -112,9 +115,8 @@ pub async fn list_available_versions_from_builds() -> Result<Vec<String>> {
     use crate::version_manager::platform::{Platform, builds_probe_url};
 
     let platform = Platform::detect()?;
-    let client = crate::http::client_builder()
-        .build()
-        .map_err(|e| Error::Download(e.to_string()))?;
+    let first_url = builds_probe_url("20.1", &platform);
+    let client = OperationClient::metadata(NetworkStage::BuildsList, &first_url)?;
 
     let current_year = chrono::Utc::now().year() as u32;
     // ClickHouse uses YY.MM versioning — scan from current year down to 20 (2020)
@@ -127,11 +129,20 @@ pub async fn list_available_versions_from_builds() -> Result<Vec<String>> {
         for mm in (1..=12).rev() {
             let version_path = format!("{}.{}", yy, mm);
             let url = builds_probe_url(&version_path, &platform);
-            match client.head(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
+            match client.head(&url, NetworkStage::BuildsList).await {
+                Ok(response) if response.status().is_success() => {
                     available.push(version_path);
                 }
-                _ => {}
+                Ok(response) if matches!(response.status().as_u16(), 403 | 404) => {}
+                Ok(response) => {
+                    return Err(NetworkFailure::from_response(
+                        NetworkStage::BuildsList,
+                        &url,
+                        &response,
+                    )
+                    .into());
+                }
+                Err(error) => return Err(error.into()),
             }
         }
     }

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -14,6 +14,7 @@
 
 use crate::error::Result;
 use crate::paths;
+use crate::version_manager::network::{NetworkFailure, NetworkStage, OperationClient};
 use crate::version_manager::platform::{DownloadSource, Platform};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -123,14 +124,21 @@ pub async fn head_info(platform: &Platform) -> Option<HeadInfo> {
     }
     .url(platform);
 
-    let client = reqwest::Client::builder()
-        .user_agent(crate::user_agent::user_agent())
-        .build()
-        .ok()?;
+    let client = OperationClient::metadata(NetworkStage::MasterCheck, &url).ok()?;
+    head_info_from_url(&client, &url).await.ok().flatten()
+}
 
-    let resp = client.head(&url).send().await.ok()?;
+async fn head_info_from_url(
+    client: &OperationClient,
+    url: &str,
+) -> std::result::Result<Option<HeadInfo>, NetworkFailure> {
+    let resp = client.head(url, NetworkStage::MasterCheck).await?;
     if !resp.status().is_success() {
-        return None;
+        return Err(NetworkFailure::from_response(
+            NetworkStage::MasterCheck,
+            url,
+            &resp,
+        ));
     }
     let header = |name: reqwest::header::HeaderName| {
         resp.headers()
@@ -138,12 +146,14 @@ pub async fn head_info(platform: &Platform) -> Option<HeadInfo> {
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string())
     };
-    let etag = header(reqwest::header::ETAG)?;
+    let Some(etag) = header(reqwest::header::ETAG) else {
+        return Ok(None);
+    };
     let last_modified = header(reqwest::header::LAST_MODIFIED);
-    Some(HeadInfo {
+    Ok(Some(HeadInfo {
         etag,
         last_modified,
-    })
+    }))
 }
 
 /// Pure reuse decision: reuse the recorded build only when we have a record,

--- a/crates/clickhousectl/src/version_manager/mod.rs
+++ b/crates/clickhousectl/src/version_manager/mod.rs
@@ -2,6 +2,7 @@ pub mod download;
 pub mod install;
 pub mod list;
 pub mod master;
+pub(crate) mod network;
 pub mod platform;
 pub mod resolve;
 pub mod spec;

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -279,15 +279,12 @@ mod tests {
 
     #[test]
     fn retry_after_http_date_forms_are_parsed() {
-        use chrono::Datelike;
-
-        let future = (Utc::now() + chrono::Months::new(1)).with_day(6).unwrap();
         for value in [
-            future.format("%a, %d %b %Y %H:%M:%S GMT").to_string(),
-            future.format("%A, %d-%b-%y %H:%M:%S GMT").to_string(),
-            future.format("%a %b %e %H:%M:%S %Y").to_string(),
+            "Sat, 06 Nov 2060 08:49:37 GMT",
+            "Saturday, 06-Nov-60 08:49:37 GMT",
+            "Sat Nov  6 08:49:37 2060",
         ] {
-            assert!(parse_retry_after(&value).is_some(), "{value}");
+            assert!(parse_retry_after(value).is_some(), "{value}");
         }
     }
 

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -1,0 +1,319 @@
+use chrono::{DateTime, Utc};
+use reqwest::header::RETRY_AFTER;
+use std::fmt;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::time::Instant;
+
+const METADATA_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const METADATA_READ_TIMEOUT: Duration = Duration::from_secs(10);
+const METADATA_TOTAL_TIMEOUT: Duration = Duration::from_secs(30);
+const DOWNLOAD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DOWNLOAD_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const DOWNLOAD_TOTAL_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkStage {
+    BuildProbe,
+    BuildsList,
+    GithubLookup,
+    VersionList,
+    MasterCheck,
+    Download,
+}
+
+impl fmt::Display for NetworkStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Self::BuildProbe => "build probe",
+            Self::BuildsList => "builds list",
+            Self::GithubLookup => "GitHub version lookup",
+            Self::VersionList => "GitHub version list",
+            Self::MasterCheck => "master check",
+            Self::Download => "download",
+        };
+        f.write_str(name)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NetworkCategory {
+    Timeout,
+    Connect,
+    Transport,
+    InvalidResponse,
+    Forbidden,
+    NotFound,
+    RateLimited,
+    Server,
+    Client,
+    UnexpectedStatus,
+}
+
+impl fmt::Display for NetworkCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::Timeout => "timeout",
+            Self::Connect => "connection error",
+            Self::Transport => "transport error",
+            Self::InvalidResponse => "invalid response",
+            Self::Forbidden => "forbidden (HTTP 403)",
+            Self::NotFound => "not found (HTTP 404)",
+            Self::RateLimited => "rate limited (HTTP 429)",
+            Self::Server => "server error (HTTP 5xx)",
+            Self::Client => "client error (HTTP 4xx)",
+            Self::UnexpectedStatus => "unexpected HTTP status",
+        };
+        f.write_str(category)
+    }
+}
+
+#[derive(Debug, Clone, Error)]
+#[error("{stage} request to {host} failed: {category}")]
+pub(crate) struct NetworkFailure {
+    pub(crate) stage: NetworkStage,
+    pub(crate) host: String,
+    pub(crate) category: NetworkCategory,
+    pub(crate) retry_after: Option<Duration>,
+}
+
+impl NetworkFailure {
+    pub(crate) fn from_request(stage: NetworkStage, url: &str, error: &reqwest::Error) -> Self {
+        let category = if error.is_timeout() {
+            NetworkCategory::Timeout
+        } else if error.is_connect() {
+            NetworkCategory::Connect
+        } else if error.is_decode() {
+            NetworkCategory::InvalidResponse
+        } else {
+            NetworkCategory::Transport
+        };
+        Self::new(stage, url, category, None)
+    }
+
+    pub(crate) fn from_response(
+        stage: NetworkStage,
+        url: &str,
+        response: &reqwest::Response,
+    ) -> Self {
+        let status = response.status();
+        let category = match status.as_u16() {
+            403 => NetworkCategory::Forbidden,
+            404 => NetworkCategory::NotFound,
+            429 => NetworkCategory::RateLimited,
+            _ if status.is_server_error() => NetworkCategory::Server,
+            _ if status.is_client_error() => NetworkCategory::Client,
+            _ => NetworkCategory::UnexpectedStatus,
+        };
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(parse_retry_after);
+        Self::new(stage, url, category, retry_after)
+    }
+
+    pub(crate) fn timeout(stage: NetworkStage, url: &str) -> Self {
+        Self::new(stage, url, NetworkCategory::Timeout, None)
+    }
+
+    pub(crate) fn is_retryable(&self) -> bool {
+        matches!(
+            self.category,
+            NetworkCategory::Timeout
+                | NetworkCategory::Connect
+                | NetworkCategory::Transport
+                | NetworkCategory::RateLimited
+                | NetworkCategory::Server
+        )
+    }
+
+    fn new(
+        stage: NetworkStage,
+        url: &str,
+        category: NetworkCategory,
+        retry_after: Option<Duration>,
+    ) -> Self {
+        Self {
+            stage,
+            host: reqwest::Url::parse(url)
+                .ok()
+                .and_then(|url| url.host_str().map(str::to_owned))
+                .unwrap_or_else(|| "unknown host".to_string()),
+            category,
+            retry_after,
+        }
+    }
+}
+
+fn parse_retry_after(value: &str) -> Option<Duration> {
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+
+    let retry_at = DateTime::parse_from_rfc2822(value)
+        .ok()?
+        .with_timezone(&Utc);
+    retry_at.signed_duration_since(Utc::now()).to_std().ok()
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Timeouts {
+    connect: Duration,
+    read: Duration,
+    total: Duration,
+}
+
+impl Timeouts {
+    const METADATA: Self = Self {
+        connect: METADATA_CONNECT_TIMEOUT,
+        read: METADATA_READ_TIMEOUT,
+        total: METADATA_TOTAL_TIMEOUT,
+    };
+    const DOWNLOAD: Self = Self {
+        connect: DOWNLOAD_CONNECT_TIMEOUT,
+        read: DOWNLOAD_READ_TIMEOUT,
+        total: DOWNLOAD_TOTAL_TIMEOUT,
+    };
+
+    #[cfg(test)]
+    pub(crate) const fn new(connect: Duration, read: Duration, total: Duration) -> Self {
+        Self {
+            connect,
+            read,
+            total,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct OperationClient {
+    inner: reqwest::Client,
+    deadline: Instant,
+}
+
+impl OperationClient {
+    pub(crate) fn metadata(stage: NetworkStage, url: &str) -> Result<Self, NetworkFailure> {
+        Self::build(Timeouts::METADATA)
+            .map_err(|error| NetworkFailure::from_request(stage, url, &error))
+    }
+
+    pub(crate) fn download(url: &str) -> Result<Self, NetworkFailure> {
+        Self::build(Timeouts::DOWNLOAD)
+            .map_err(|error| NetworkFailure::from_request(NetworkStage::Download, url, &error))
+    }
+
+    fn build(timeouts: Timeouts) -> reqwest::Result<Self> {
+        let inner = crate::http::client_builder()
+            .connect_timeout(timeouts.connect)
+            .read_timeout(timeouts.read)
+            .timeout(timeouts.total)
+            .build()?;
+        Ok(Self {
+            inner,
+            deadline: Instant::now() + timeouts.total,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_timeouts(timeouts: Timeouts) -> reqwest::Result<Self> {
+        Self::build(timeouts)
+    }
+
+    pub(crate) async fn get(
+        &self,
+        url: &str,
+        stage: NetworkStage,
+    ) -> Result<reqwest::Response, NetworkFailure> {
+        self.send(self.inner.get(url), url, stage).await
+    }
+
+    pub(crate) async fn head(
+        &self,
+        url: &str,
+        stage: NetworkStage,
+    ) -> Result<reqwest::Response, NetworkFailure> {
+        self.send(self.inner.head(url), url, stage).await
+    }
+
+    async fn send(
+        &self,
+        request: reqwest::RequestBuilder,
+        url: &str,
+        stage: NetworkStage,
+    ) -> Result<reqwest::Response, NetworkFailure> {
+        let remaining = self
+            .deadline
+            .checked_duration_since(Instant::now())
+            .ok_or_else(|| NetworkFailure::timeout(stage, url))?;
+        request
+            .timeout(remaining)
+            .send()
+            .await
+            .map_err(|error| NetworkFailure::from_request(stage, url, &error))
+    }
+
+    pub(crate) async fn sleep(&self, duration: Duration) {
+        let wake_at = (Instant::now() + duration).min(self.deadline);
+        tokio::time::sleep_until(wake_at).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn retry_after_seconds_and_date_are_parsed() {
+        assert_eq!(parse_retry_after("7"), Some(Duration::from_secs(7)));
+
+        let future = Utc::now() + chrono::Duration::seconds(30);
+        let parsed = parse_retry_after(&future.to_rfc2822()).unwrap();
+        assert!(parsed >= Duration::from_secs(28));
+        assert!(parsed <= Duration::from_secs(30));
+    }
+
+    #[test]
+    fn errors_expose_only_stage_host_and_category() {
+        let failure = NetworkFailure::new(
+            NetworkStage::Download,
+            "https://user:secret@example.com/private?token=secret",
+            NetworkCategory::RateLimited,
+            None,
+        );
+
+        assert_eq!(failure.host, "example.com");
+        assert_eq!(
+            failure.to_string(),
+            "download request to example.com failed: rate limited (HTTP 429)"
+        );
+        assert!(!failure.to_string().contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn total_deadline_bounds_stalled_headers() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        });
+        let url = format!("http://{address}/stalled");
+        let client = OperationClient::with_timeouts(Timeouts::new(
+            Duration::from_millis(100),
+            Duration::from_secs(1),
+            Duration::from_millis(50),
+        ))
+        .unwrap();
+
+        let error = client
+            .get(&url, NetworkStage::GithubLookup)
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.stage, NetworkStage::GithubLookup);
+        assert_eq!(error.host, "127.0.0.1");
+        assert_eq!(error.category, NetworkCategory::Timeout);
+    }
+}

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use reqwest::header::RETRY_AFTER;
 use std::fmt;
 use std::time::Duration;
@@ -153,8 +153,15 @@ fn parse_retry_after(value: &str) -> Option<Duration> {
     }
 
     let retry_at = DateTime::parse_from_rfc2822(value)
-        .ok()?
-        .with_timezone(&Utc);
+        .map(|date| date.with_timezone(&Utc))
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(value, "%A, %d-%b-%y %H:%M:%S GMT")
+                .map(|date| date.and_utc())
+        })
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(value, "%a %b %e %H:%M:%S %Y").map(|date| date.and_utc())
+        })
+        .ok()?;
     retry_at.signed_duration_since(Utc::now()).to_std().ok()
 }
 
@@ -266,13 +273,34 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[test]
-    fn retry_after_seconds_and_date_are_parsed() {
+    fn retry_after_seconds_are_parsed() {
         assert_eq!(parse_retry_after("7"), Some(Duration::from_secs(7)));
+    }
 
-        let future = Utc::now() + chrono::Duration::seconds(30);
-        let parsed = parse_retry_after(&future.to_rfc2822()).unwrap();
-        assert!(parsed >= Duration::from_secs(28));
-        assert!(parsed <= Duration::from_secs(30));
+    #[test]
+    fn retry_after_http_date_forms_are_parsed() {
+        use chrono::Datelike;
+
+        let future = (Utc::now() + chrono::Months::new(1)).with_day(6).unwrap();
+        for value in [
+            future.format("%a, %d %b %Y %H:%M:%S GMT").to_string(),
+            future.format("%A, %d-%b-%y %H:%M:%S GMT").to_string(),
+            future.format("%a %b %e %H:%M:%S %Y").to_string(),
+        ] {
+            assert!(parse_retry_after(&value).is_some(), "{value}");
+        }
+    }
+
+    #[test]
+    fn expired_retry_after_dates_are_ignored() {
+        let past = Utc::now() - chrono::Duration::seconds(30);
+        for value in [
+            past.format("%a, %d %b %Y %H:%M:%S GMT").to_string(),
+            past.format("%A, %d-%b-%y %H:%M:%S GMT").to_string(),
+            past.format("%a %b %e %H:%M:%S %Y").to_string(),
+        ] {
+            assert_eq!(parse_retry_after(&value), None, "{value}");
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -100,6 +100,7 @@ impl NetworkFailure {
         let category = match status.as_u16() {
             403 => NetworkCategory::Forbidden,
             404 => NetworkCategory::NotFound,
+            408 => NetworkCategory::Timeout,
             429 => NetworkCategory::RateLimited,
             _ if status.is_server_error() => NetworkCategory::Server,
             _ if status.is_client_error() => NetworkCategory::Client,

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -161,7 +161,9 @@ async fn resolve_major(
         }
     }
 
-    if let Some(minor) = highest_available {
+    if first_probe_failure.is_none()
+        && let Some(minor) = highest_available
+    {
         let version_path = format!("{}.{}", major, minor);
         return Ok(ResolvedVersion {
             source: DownloadSource::Builds {

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -1,10 +1,14 @@
 use crate::error::{Error, Result};
 use crate::version_manager::list::{
-    Channel, VersionEntry, list_available_versions, list_installed_versions,
+    Channel, VersionEntry, list_available_versions_with, list_installed_versions,
 };
+use crate::version_manager::network::{NetworkFailure, NetworkStage, OperationClient};
 use crate::version_manager::platform::{DownloadSource, Platform, builds_probe_url};
 use crate::version_manager::spec::VersionSpec;
 use serde::Deserialize;
+
+const GITHUB_RELEASES_URL: &str =
+    "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
 
 /// Result of resolving a version spec — contains everything needed to download
 #[derive(Debug, Clone)]
@@ -58,12 +62,32 @@ fn find_local_match(spec: &VersionSpec, installed: &[String]) -> Option<String> 
 
 /// Resolve a VersionSpec into a concrete download source
 pub async fn resolve(spec: &VersionSpec, platform: &Platform) -> Result<ResolvedVersion> {
+    if matches!(spec, VersionSpec::Latest) {
+        return resolve_latest(platform).await;
+    }
+
+    let (stage, initial_url) = match spec {
+        VersionSpec::Channel(_) | VersionSpec::Exact(_) => {
+            (NetworkStage::GithubLookup, GITHUB_RELEASES_URL.to_string())
+        }
+        VersionSpec::Major(major) => (
+            NetworkStage::BuildProbe,
+            builds_probe_url(&format!("{}.1", major), platform),
+        ),
+        VersionSpec::Minor(major, minor) => (
+            NetworkStage::BuildProbe,
+            builds_probe_url(&format!("{}.{}", major, minor), platform),
+        ),
+        VersionSpec::Latest => unreachable!(),
+    };
+    let client = OperationClient::metadata(stage, &initial_url)?;
+
     match spec {
-        VersionSpec::Latest => resolve_latest(platform).await,
-        VersionSpec::Channel(channel) => resolve_channel(*channel, platform).await,
-        VersionSpec::Major(major) => resolve_major(*major, platform).await,
-        VersionSpec::Minor(major, minor) => resolve_minor(*major, *minor, platform).await,
-        VersionSpec::Exact(version) => resolve_exact(version, platform).await,
+        VersionSpec::Latest => unreachable!(),
+        VersionSpec::Channel(channel) => resolve_channel(*channel, platform, &client).await,
+        VersionSpec::Major(major) => resolve_major(*major, platform, &client).await,
+        VersionSpec::Minor(major, minor) => resolve_minor(*major, *minor, platform, &client).await,
+        VersionSpec::Exact(version) => resolve_exact(version, platform, &client).await,
     }
 }
 
@@ -81,8 +105,12 @@ async fn resolve_latest(_platform: &Platform) -> Result<ResolvedVersion> {
 }
 
 /// `install stable` / `install lts` — GH API to find minor, then builds
-async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<ResolvedVersion> {
-    let available = list_available_versions().await?;
+async fn resolve_channel(
+    channel: Channel,
+    platform: &Platform,
+    client: &OperationClient,
+) -> Result<ResolvedVersion> {
+    let available = list_available_versions_with(client, GITHUB_RELEASES_URL).await?;
     let entry = available
         .iter()
         .find(|e| e.channel == channel)
@@ -92,7 +120,10 @@ async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<Resolv
     let minor = extract_minor(&entry.version)?;
 
     // Try builds first
-    if probe_builds(&minor, platform).await {
+    if matches!(
+        probe_builds(client, &builds_probe_url(&minor, platform)).await,
+        Ok(ProbeOutcome::Available)
+    ) {
         return Ok(ResolvedVersion {
             source: DownloadSource::Builds {
                 version_path: minor.clone(),
@@ -109,20 +140,23 @@ async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<Resolv
 }
 
 /// `install 25` — probe builds for highest 25.x minor
-async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersion> {
+async fn resolve_major(
+    major: u32,
+    platform: &Platform,
+    client: &OperationClient,
+) -> Result<ResolvedVersion> {
     // Probe builds.clickhouse.com for all possible minors in this major (1..12)
     let mut highest_available: Option<u32> = None;
-    let client = crate::http::client_builder()
-        .build()
-        .map_err(|e| Error::Download(e.to_string()))?;
+    let mut first_probe_failure = None;
 
     for minor in 1..=12 {
         let url = builds_probe_url(&format!("{}.{}", major, minor), platform);
-        match client.head(&url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                highest_available = Some(minor);
+        match probe_builds(client, &url).await {
+            Ok(ProbeOutcome::Available) => highest_available = Some(minor),
+            Ok(ProbeOutcome::Unavailable(_)) => {}
+            Err(error) => {
+                first_probe_failure.get_or_insert(error);
             }
-            _ => {}
         }
     }
 
@@ -142,49 +176,82 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
     // Fallback: try GH matching-refs API for each minor, highest first
     for minor in (1..=12).rev() {
         let prefix = format!("{}.{}", major, minor);
-        if let Ok(entry) = find_version_by_refs(&prefix).await {
-            return Ok(fallback_source(&entry.version, entry.channel, platform));
+        let url = version_refs_url(&prefix);
+        match find_version_by_refs(client, &prefix, &url).await {
+            Ok(entry) => return Ok(fallback_source(&entry.version, entry.channel, platform)),
+            Err(Error::NoMatchingVersion(_)) => {}
+            Err(error) => return Err(preserve_probe_failure(first_probe_failure, error)),
         }
     }
 
-    Err(Error::NoMatchingVersion(major.to_string()))
+    Err(preserve_probe_failure(
+        first_probe_failure,
+        Error::NoMatchingVersion(major.to_string()),
+    ))
 }
 
 /// `install 25.12` — try builds, fallback to packages/GH
-async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<ResolvedVersion> {
+async fn resolve_minor(
+    major: u32,
+    minor: u32,
+    platform: &Platform,
+    client: &OperationClient,
+) -> Result<ResolvedVersion> {
     let version_path = format!("{}.{}", major, minor);
+    let build_url = builds_probe_url(&version_path, platform);
+    let refs_url = version_refs_url(&version_path);
+    resolve_minor_from_urls(client, &version_path, platform, &build_url, &refs_url).await
+}
 
+async fn resolve_minor_from_urls(
+    client: &OperationClient,
+    version_path: &str,
+    platform: &Platform,
+    build_url: &str,
+    refs_url: &str,
+) -> Result<ResolvedVersion> {
     // Try builds first
-    if probe_builds(&version_path, platform).await {
-        return Ok(ResolvedVersion {
-            source: DownloadSource::Builds {
-                version_path: version_path.clone(),
-            },
-            display_version: version_path,
-            exact_version_known: false,
-            exact_version: None,
-            channel: None,
-        });
-    }
+    let probe_failure = match probe_builds(client, build_url).await {
+        Ok(ProbeOutcome::Available) => {
+            return Ok(ResolvedVersion {
+                source: DownloadSource::Builds {
+                    version_path: version_path.to_string(),
+                },
+                display_version: version_path.to_string(),
+                exact_version_known: false,
+                exact_version: None,
+                channel: None,
+            });
+        }
+        Ok(ProbeOutcome::Unavailable(_)) => None,
+        Err(error) => Some(error),
+    };
 
     // Fallback: targeted GH API call to find exact version for this minor
-    let entry = find_version_by_refs(&version_path).await?;
+    let entry = find_version_by_refs(client, version_path, refs_url)
+        .await
+        .map_err(|error| preserve_probe_failure(probe_failure, error))?;
 
     Ok(fallback_source(&entry.version, entry.channel, platform))
 }
 
 /// `install 25.12.9.61` — exact version, needs channel from GH API
-async fn resolve_exact(version: &str, platform: &Platform) -> Result<ResolvedVersion> {
+async fn resolve_exact(
+    version: &str,
+    platform: &Platform,
+    client: &OperationClient,
+) -> Result<ResolvedVersion> {
     // Use matching-refs to find the exact tag and its channel.
     // For "25.12.9.61", search refs matching "v25.12.9.61" — should return the exact tag.
     // Fail fast if the lookup fails: a wrong channel produces a broken download URL,
     // and silently guessing Stable could fetch the wrong artifact.
-    match find_exact_channel(version).await {
+    match find_exact_channel(client, version).await {
         Ok(channel) => Ok(fallback_source(version, channel, platform)),
         Err(Error::NoMatchingVersion(_)) => {
             let series = extract_minor(version)?;
             // The exact miss is definitive; fetching a retry hint is best-effort.
-            let available = find_version_by_refs(&series).await.ok();
+            let url = version_refs_url(&series);
+            let available = find_version_by_refs(client, &series, &url).await.ok();
 
             Err(exact_version_no_match(version, &series, available.as_ref()))
         }
@@ -204,21 +271,22 @@ fn exact_version_no_match(version: &str, series: &str, available: Option<&Versio
 }
 
 /// Look up the channel for an exact version via GitHub's matching-refs API
-async fn find_exact_channel(version: &str) -> Result<Channel> {
+async fn find_exact_channel(client: &OperationClient, version: &str) -> Result<Channel> {
     let url = format!(
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
         version
     );
-    let client = crate::http::client_builder().build()?;
+    let response = client.get(&url, NetworkStage::GithubLookup).await?;
+    if !response.status().is_success() {
+        return Err(
+            NetworkFailure::from_response(NetworkStage::GithubLookup, &url, &response).into(),
+        );
+    }
 
-    let response = client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
-
-    let refs: Vec<GitRef> = response.json().await?;
+    let refs: Vec<GitRef> = response
+        .json()
+        .await
+        .map_err(|error| NetworkFailure::from_request(NetworkStage::GithubLookup, &url, &error))?;
     parse_exact_channel(&refs, version)
 }
 
@@ -277,17 +345,34 @@ fn fallback_source(version: &str, channel: Channel, platform: &Platform) -> Reso
     }
 }
 
-/// Probe builds.clickhouse.com with a HEAD request to check if a version exists
-async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
-    let url = builds_probe_url(version_path, platform);
-    let client = match crate::http::client_builder().build() {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeMiss {
+    Forbidden,
+    NotFound,
+}
 
-    match client.head(&url).send().await {
-        Ok(resp) => resp.status().is_success(),
-        Err(_) => false,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeOutcome {
+    Available,
+    Unavailable(ProbeMiss),
+}
+
+/// Probe builds.clickhouse.com with a HEAD request to check if a version exists.
+/// Only 403/404 mean that fallback is expected; outages remain errors.
+async fn probe_builds(
+    client: &OperationClient,
+    url: &str,
+) -> std::result::Result<ProbeOutcome, NetworkFailure> {
+    let response = client.head(url, NetworkStage::BuildProbe).await?;
+    match response.status().as_u16() {
+        _ if response.status().is_success() => Ok(ProbeOutcome::Available),
+        403 => Ok(ProbeOutcome::Unavailable(ProbeMiss::Forbidden)),
+        404 => Ok(ProbeOutcome::Unavailable(ProbeMiss::NotFound)),
+        _ => Err(NetworkFailure::from_response(
+            NetworkStage::BuildProbe,
+            url,
+            &response,
+        )),
     }
 }
 
@@ -300,22 +385,40 @@ struct GitRef {
 /// Find the latest release version matching a prefix using GitHub's matching-refs API.
 /// This is a single targeted API call that works regardless of how old the version is.
 /// prefix should be like "25.2" or "24.8" — we search for tags matching `v{prefix}.`
-async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
-    let url = format!(
+fn version_refs_url(prefix: &str) -> String {
+    format!(
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix
-    );
-    let client = crate::http::client_builder().build()?;
+    )
+}
 
-    let response = client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
+async fn find_version_by_refs(
+    client: &OperationClient,
+    prefix: &str,
+    url: &str,
+) -> Result<VersionEntry> {
+    let response = client.get(url, NetworkStage::GithubLookup).await?;
+    if !response.status().is_success() {
+        return Err(
+            NetworkFailure::from_response(NetworkStage::GithubLookup, url, &response).into(),
+        );
+    }
 
-    let refs: Vec<GitRef> = response.json().await?;
+    let refs: Vec<GitRef> = response
+        .json()
+        .await
+        .map_err(|error| NetworkFailure::from_request(NetworkStage::GithubLookup, url, &error))?;
     parse_version_refs(&refs, prefix)
+}
+
+fn preserve_probe_failure(probe: Option<NetworkFailure>, fallback: Error) -> Error {
+    match probe {
+        Some(probe) => Error::VersionFallback {
+            probe,
+            fallback: Box::new(fallback),
+        },
+        None => fallback,
+    }
 }
 
 /// Parse a list of git refs into the best matching VersionEntry.
@@ -374,11 +477,141 @@ fn extract_minor(version: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::version_manager::network::{NetworkCategory, Timeouts};
     use crate::version_manager::platform::Os;
+    use std::time::Duration;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn make_ref(name: &str) -> GitRef {
         GitRef {
             ref_name: name.to_string(),
+        }
+    }
+
+    fn test_client() -> OperationClient {
+        OperationClient::with_timeouts(Timeouts::new(
+            Duration::from_millis(100),
+            Duration::from_millis(100),
+            Duration::from_secs(2),
+        ))
+        .unwrap()
+    }
+
+    fn macos_platform() -> Platform {
+        Platform {
+            os: Os::MacOS,
+            arch: crate::version_manager::platform::Arch::Aarch64,
+        }
+    }
+
+    #[tokio::test]
+    async fn build_probe_distinguishes_403_and_404_as_expected_misses() {
+        for (status, expected) in [(403, ProbeMiss::Forbidden), (404, ProbeMiss::NotFound)] {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .respond_with(ResponseTemplate::new(status))
+                .mount(&server)
+                .await;
+
+            let outcome = probe_builds(&test_client(), &server.uri()).await.unwrap();
+            assert_eq!(outcome, ProbeOutcome::Unavailable(expected));
+        }
+    }
+
+    #[tokio::test]
+    async fn build_probe_classifies_429_and_5xx_as_failures() {
+        for (status, expected) in [
+            (429, NetworkCategory::RateLimited),
+            (503, NetworkCategory::Server),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("HEAD"))
+                .respond_with(ResponseTemplate::new(status))
+                .mount(&server)
+                .await;
+
+            let error = probe_builds(&test_client(), &server.uri())
+                .await
+                .unwrap_err();
+            assert_eq!(error.stage, NetworkStage::BuildProbe);
+            assert_eq!(error.category, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn expected_probe_miss_falls_back_to_github() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/build"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/refs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                {"ref": "refs/tags/v25.12.9.61-stable"}
+            ])))
+            .mount(&server)
+            .await;
+
+        let resolved = resolve_minor_from_urls(
+            &test_client(),
+            "25.12",
+            &macos_platform(),
+            &format!("{}/build", server.uri()),
+            &format!("{}/refs", server.uri()),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            resolved.source,
+            DownloadSource::GitHub {
+                ref version,
+                channel: Channel::Stable,
+            } if version == "25.12.9.61"
+        ));
+    }
+
+    #[tokio::test]
+    async fn fallback_failure_preserves_original_probe_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/build"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/refs"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let error = resolve_minor_from_urls(
+            &test_client(),
+            "25.12",
+            &macos_platform(),
+            &format!("{}/build", server.uri()),
+            &format!("{}/refs", server.uri()),
+        )
+        .await
+        .unwrap_err();
+
+        match error {
+            Error::VersionFallback { probe, fallback } => {
+                assert_eq!(probe.stage, NetworkStage::BuildProbe);
+                assert_eq!(probe.category, NetworkCategory::Server);
+                assert!(matches!(
+                    *fallback,
+                    Error::VersionNetwork(NetworkFailure {
+                        stage: NetworkStage::GithubLookup,
+                        category: NetworkCategory::RateLimited,
+                        ..
+                    })
+                ));
+            }
+            other => panic!("expected preserved fallback error, got {other:?}"),
         }
     }
 

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -155,7 +155,8 @@ async fn resolve_major(
             Ok(ProbeOutcome::Available) => highest_available = Some(minor),
             Ok(ProbeOutcome::Unavailable(_)) => {}
             Err(error) => {
-                first_probe_failure.get_or_insert(error);
+                first_probe_failure = Some(error);
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary

- Bound version resolution, build listing, master checks, and streamed downloads with explicit connect, read, and total operation deadlines through the shared HTTP client.
- Classify failures by stage, host, and stable status category; treat only build-probe 403/404 as expected fallback and preserve the original unexpected probe failure when fallback also fails.
- Retry installer downloads at most three times for transport, timeout, 429, and 5xx failures, honoring `Retry-After` within a five-second backoff cap.

## Tests

- `cargo test -p clickhousectl version_manager` (95 passed)
- `cargo test -p clickhousectl` (all passed)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

## Stack

- Position: 2 of 2
- Base: `issue-463-parse-version-operands` (#485)

Closes #459