### PR TITLE
Make local ClickHouse installs atomic and concurrency-safe

### DIFF
--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -2,11 +2,42 @@ use crate::error::{Error, Result};
 use crate::paths;
 use crate::version_manager::download::download_from_source;
 use crate::version_manager::list::list_installed_versions;
+use crate::version_manager::lock::FileLock;
 use crate::version_manager::master;
 use crate::version_manager::platform::{DownloadSource, Platform};
 use crate::version_manager::resolve::{ResolvedVersion, resolve, try_resolve_local};
 use crate::version_manager::spec::VersionSpec;
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+struct StagingDir {
+    path: PathBuf,
+}
+
+impl StagingDir {
+    fn create(versions_dir: &Path) -> Result<Self> {
+        let staging_root = versions_dir.join(".staging");
+        std::fs::create_dir_all(&staging_root)?;
+        loop {
+            let path = staging_root.join(uuid::Uuid::new_v4().simple().to_string());
+            match std::fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error.into()),
+            }
+        }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for StagingDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
 
 /// Install a version spec, trying installed versions first before any remote call.
 /// An installed match is a successful no-op regardless of whether the spec is
@@ -50,6 +81,7 @@ pub async fn install_resolved(
     force: bool,
 ) -> Result<String> {
     paths::ensure_dirs()?;
+    let versions_dir = paths::versions_dir()?;
 
     // The floating `latest`/master build has no version upfront and a stable
     // URL whose content moves. Use the HTTP etag to skip the ~153MB download
@@ -73,8 +105,8 @@ pub async fn install_resolved(
 
     // If we know the exact version upfront, check if already installed
     if let Some(ref version) = resolved.exact_version {
-        let version_dir = paths::version_dir(version)?;
-        if version_dir.exists() && !force {
+        let binary = paths::binary_path(version)?;
+        if binary.exists() && !force {
             return Err(Error::VersionAlreadyInstalled(version.to_string()));
         }
     }
@@ -98,12 +130,10 @@ pub async fn install_resolved(
         }
     }
 
-    // Download to a temp directory first
-    let temp_dir = paths::versions_dir()?.join(".download-temp");
-    if temp_dir.exists() {
-        std::fs::remove_dir_all(&temp_dir)?;
-    }
-    std::fs::create_dir_all(&temp_dir)?;
+    // Keep every download isolated. A killed process may leave its own staging
+    // directory behind, but no later invocation reuses or removes it.
+    let staging = StagingDir::create(&versions_dir)?;
+    let temp_dir = staging.path();
 
     let binary_path = temp_dir.join("clickhouse");
 
@@ -113,7 +143,7 @@ pub async fn install_resolved(
         let tarball_path = temp_dir.join("clickhouse.tgz");
         download_from_source(&resolved.source, platform, &tarball_path).await?;
         eprintln!("Extracting...");
-        extract_tarball_auto(&tarball_path, &temp_dir)?;
+        extract_tarball_auto(&tarball_path, temp_dir)?;
     } else {
         download_from_source(&resolved.source, platform, &binary_path).await?;
     }
@@ -131,24 +161,15 @@ pub async fn install_resolved(
         detect_binary_version(&binary_path)?
     };
 
-    // Check if this exact version is already installed (post-detection check for builds source).
-    // Skipped for master: a master build's version string is shared across commits, so an
-    // existing dir doesn't mean the content matches — we got here because the etag changed
-    // (or there was no record), so overwrite the existing binary in place and adopt the dir
-    // as the master install (the record write below re-points the master record at it).
-    let version_dir = paths::version_dir(&exact_version)?;
-    if version_dir.exists() && !force && !is_master {
-        let _ = std::fs::remove_dir_all(&temp_dir);
-        return Err(Error::VersionAlreadyInstalled(exact_version));
-    }
-
-    // Move to final location
-    let replaced_existing = version_dir.exists();
-    if replaced_existing {
-        std::fs::remove_dir_all(&version_dir)?;
-    }
-    std::fs::create_dir_all(&version_dir)?;
-    std::fs::rename(&binary_path, version_dir.join("clickhouse"))?;
+    let replaced_existing = commit_staged_binary(
+        &versions_dir,
+        &binary_path,
+        &exact_version,
+        force,
+        is_master,
+        platform,
+        master_head.as_ref(),
+    )?;
 
     // Replacing a build on disk never affects already-running servers (they keep
     // executing the old binary) — just say so, so the swap isn't silent.
@@ -157,24 +178,6 @@ pub async fn install_resolved(
             "Note: running servers keep using the previous {} build until restarted",
             exact_version
         );
-    }
-
-    // Clean up temp dir
-    let _ = std::fs::remove_dir_all(&temp_dir);
-
-    // Record the master etag so a later `latest` resolve can skip the download
-    // when master is unchanged. Best-effort: a sidecar write failure must not
-    // fail an otherwise-successful install.
-    if is_master {
-        if let Some(head) = &master_head {
-            let _ = master::record(platform, head, &exact_version);
-        }
-    } else {
-        // A non-master install just wrote versions/<exact_version>/. If the
-        // sidecar recorded that dir as the installed master build, the record
-        // is now stale and would make a later `latest` resolve reuse this
-        // binary as if it were master. Best-effort, like `record`.
-        let _ = master::clear_record_for_version(platform, &exact_version);
     }
 
     let channel_suffix = match resolved.channel {
@@ -186,14 +189,83 @@ pub async fn install_resolved(
     Ok(exact_version)
 }
 
+#[allow(clippy::too_many_arguments)]
+fn commit_staged_binary(
+    versions_dir: &Path,
+    staged_binary: &Path,
+    exact_version: &str,
+    force: bool,
+    is_master: bool,
+    platform: &Platform,
+    master_head: Option<&master::HeadInfo>,
+) -> Result<bool> {
+    let lock_path = versions_dir
+        .join(".locks")
+        .join(format!("version-{exact_version}.lock"));
+    let _lock = FileLock::acquire(&lock_path)?;
+    pause_after_target_lock_for_test();
+
+    let version_dir = versions_dir.join(exact_version);
+    let target_binary = version_dir.join("clickhouse");
+    if target_binary.exists() && !force && !is_master {
+        return Err(Error::VersionAlreadyInstalled(exact_version.to_string()));
+    }
+
+    let replaced_existing = target_binary.exists();
+    let new_head = if is_master { master_head } else { None };
+    master::commit_install_in(versions_dir, platform, exact_version, new_head, || {
+        if version_dir.exists() {
+            // Both paths are under versions_dir, so rename atomically replaces
+            // an old complete binary without exposing staged contents.
+            std::fs::rename(staged_binary, &target_binary)?;
+        } else {
+            // Rename a complete directory into place for a first install;
+            // interruption cannot leave an empty target version behind.
+            let commit_dir = staged_binary
+                .parent()
+                .expect("staged binary has a parent")
+                .join("install");
+            std::fs::create_dir(&commit_dir)?;
+            std::fs::rename(staged_binary, commit_dir.join("clickhouse"))?;
+            std::fs::rename(commit_dir, &version_dir)?;
+        }
+        Ok(())
+    })?;
+
+    Ok(replaced_existing)
+}
+
+#[cfg(test)]
+fn pause_after_target_lock_for_test() {
+    let (Ok(marker), Ok(release)) = (
+        std::env::var("CHCTL_TEST_TARGET_LOCKED"),
+        std::env::var("CHCTL_TEST_TARGET_RELEASE"),
+    ) else {
+        return;
+    };
+    std::fs::write(marker, b"locked").expect("write target lock marker");
+    let release = PathBuf::from(release);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !release.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting to release target lock"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+#[cfg(not(test))]
+fn pause_after_target_lock_for_test() {}
+
 /// Like `install_resolved`, but returns the existing version instead of erroring
 /// when already installed. Intended for cases like `server start --version` where
 /// the goal is "make sure this version is available" rather than "install this".
 pub async fn ensure_installed(resolved: &ResolvedVersion, platform: &Platform) -> Result<String> {
     // If we know the exact version upfront, return it if already installed
     if let Some(ref version) = resolved.exact_version {
-        let version_dir = paths::version_dir(version)?;
-        if version_dir.exists() {
+        let binary = paths::binary_path(version)?;
+        if binary.exists() {
             return Ok(version.clone());
         }
     }
@@ -314,6 +386,315 @@ fn extract_tarball_auto(tarball_path: &std::path::Path, dest_dir: &std::path::Pa
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::version_manager::platform::{Arch, Os};
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    const COMMIT_HELPER: &str = "version_manager::install::tests::commit_install_subprocess";
+
+    struct ChildInstall<'a> {
+        versions_dir: &'a Path,
+        version: &'a str,
+        contents: &'a str,
+        etag: &'a str,
+        platform: &'a str,
+        ready: &'a Path,
+        target_pause: Option<(&'a Path, &'a Path)>,
+        sidecar_pause: Option<(&'a Path, &'a Path)>,
+        binary_pause: Option<(&'a Path, &'a Path)>,
+    }
+
+    fn spawn_install(config: ChildInstall<'_>) -> Child {
+        let mut command = Command::new(std::env::current_exe().expect("locate test binary"));
+        command
+            .args(["--exact", COMMIT_HELPER, "--nocapture"])
+            .env("CHCTL_TEST_COMMIT_ROOT", config.versions_dir)
+            .env("CHCTL_TEST_COMMIT_VERSION", config.version)
+            .env("CHCTL_TEST_COMMIT_CONTENTS", config.contents)
+            .env("CHCTL_TEST_COMMIT_ETAG", config.etag)
+            .env("CHCTL_TEST_COMMIT_PLATFORM", config.platform)
+            .env("CHCTL_TEST_COMMIT_READY", config.ready)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        if let Some((marker, release)) = config.target_pause {
+            command
+                .env("CHCTL_TEST_TARGET_LOCKED", marker)
+                .env("CHCTL_TEST_TARGET_RELEASE", release);
+        }
+        if let Some((marker, release)) = config.sidecar_pause {
+            command
+                .env("CHCTL_TEST_SIDECAR_LOCKED", marker)
+                .env("CHCTL_TEST_SIDECAR_RELEASE", release);
+        }
+        if let Some((marker, release)) = config.binary_pause {
+            command
+                .env("CHCTL_TEST_BINARY_COMMIT_PAUSED", marker)
+                .env("CHCTL_TEST_BINARY_COMMIT_RELEASE", release);
+        }
+        command.spawn().expect("spawn install helper")
+    }
+
+    fn wait_for_path(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !path.exists() {
+            assert!(Instant::now() < deadline, "timed out waiting for {path:?}");
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn wait_success(child: &mut Child) {
+        let status = child.wait().expect("wait for install helper");
+        assert!(status.success(), "install helper failed with {status}");
+    }
+
+    fn test_platform(name: &str) -> Platform {
+        match name {
+            "amd64" => Platform {
+                os: Os::Linux,
+                arch: Arch::X86_64,
+            },
+            "macos-aarch64" => Platform {
+                os: Os::MacOS,
+                arch: Arch::Aarch64,
+            },
+            other => panic!("unknown test platform {other}"),
+        }
+    }
+
+    fn sidecar(versions_dir: &Path) -> serde_json::Value {
+        let bytes =
+            std::fs::read(versions_dir.join(".master-builds.json")).expect("read master sidecar");
+        serde_json::from_slice(&bytes).expect("parse master sidecar")
+    }
+
+    #[test]
+    fn commit_install_subprocess() {
+        let Ok(versions_dir) = std::env::var("CHCTL_TEST_COMMIT_ROOT") else {
+            return;
+        };
+        let versions_dir = PathBuf::from(versions_dir);
+        std::fs::create_dir_all(&versions_dir).unwrap();
+        let version = std::env::var("CHCTL_TEST_COMMIT_VERSION").unwrap();
+        let contents = std::env::var("CHCTL_TEST_COMMIT_CONTENTS").unwrap();
+        let etag = std::env::var("CHCTL_TEST_COMMIT_ETAG").unwrap();
+        let platform = test_platform(&std::env::var("CHCTL_TEST_COMMIT_PLATFORM").unwrap());
+        let staging = StagingDir::create(&versions_dir).unwrap();
+        let binary = staging.path().join("clickhouse");
+        std::fs::write(&binary, contents).unwrap();
+        std::fs::write(
+            std::env::var("CHCTL_TEST_COMMIT_READY").unwrap(),
+            staging.path().to_string_lossy().as_bytes(),
+        )
+        .unwrap();
+        commit_staged_binary(
+            &versions_dir,
+            &binary,
+            &version,
+            true,
+            true,
+            &platform,
+            Some(&master::HeadInfo {
+                etag,
+                last_modified: None,
+            }),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn same_version_processes_commit_binary_and_sidecar_together() {
+        let temp = tempfile::tempdir().unwrap();
+        let versions = temp.path().join("versions");
+        std::fs::create_dir(&versions).unwrap();
+        let ready_a = temp.path().join("ready-a");
+        let ready_b = temp.path().join("ready-b");
+        let locked_a = temp.path().join("locked-a");
+        let release_a = temp.path().join("release-a");
+        let mut first = spawn_install(ChildInstall {
+            versions_dir: &versions,
+            version: "26.8.1.1",
+            contents: "first-complete-binary",
+            etag: "first-etag",
+            platform: "amd64",
+            ready: &ready_a,
+            target_pause: Some((&locked_a, &release_a)),
+            sidecar_pause: None,
+            binary_pause: None,
+        });
+        wait_for_path(&locked_a);
+
+        let mut second = spawn_install(ChildInstall {
+            versions_dir: &versions,
+            version: "26.8.1.1",
+            contents: "second-complete-binary",
+            etag: "second-etag",
+            platform: "amd64",
+            ready: &ready_b,
+            target_pause: None,
+            sidecar_pause: None,
+            binary_pause: None,
+        });
+        wait_for_path(&ready_b);
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(second.try_wait().unwrap().is_none());
+        assert_ne!(
+            std::fs::read_to_string(&ready_a).unwrap(),
+            std::fs::read_to_string(&ready_b).unwrap()
+        );
+
+        std::fs::write(&release_a, b"release").unwrap();
+        wait_success(&mut first);
+        wait_success(&mut second);
+
+        assert_eq!(
+            std::fs::read_to_string(versions.join("26.8.1.1/clickhouse")).unwrap(),
+            "second-complete-binary"
+        );
+        let sidecar = sidecar(&versions);
+        assert_eq!(sidecar["builds"]["amd64"]["etag"], "second-etag");
+        assert_eq!(sidecar["builds"]["amd64"]["version"], "26.8.1.1");
+    }
+
+    #[test]
+    fn different_version_processes_preserve_binaries_and_sidecar_records() {
+        let temp = tempfile::tempdir().unwrap();
+        let versions = temp.path().join("versions");
+        std::fs::create_dir(&versions).unwrap();
+        let ready_a = temp.path().join("ready-a");
+        let ready_b = temp.path().join("ready-b");
+        let locked_a = temp.path().join("sidecar-locked-a");
+        let release_a = temp.path().join("sidecar-release-a");
+        let mut first = spawn_install(ChildInstall {
+            versions_dir: &versions,
+            version: "26.8.1.1",
+            contents: "linux-binary",
+            etag: "linux-etag",
+            platform: "amd64",
+            ready: &ready_a,
+            target_pause: None,
+            sidecar_pause: Some((&locked_a, &release_a)),
+            binary_pause: None,
+        });
+        wait_for_path(&locked_a);
+
+        let mut second = spawn_install(ChildInstall {
+            versions_dir: &versions,
+            version: "26.8.2.2",
+            contents: "macos-binary",
+            etag: "macos-etag",
+            platform: "macos-aarch64",
+            ready: &ready_b,
+            target_pause: None,
+            sidecar_pause: None,
+            binary_pause: None,
+        });
+        wait_for_path(&ready_b);
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(second.try_wait().unwrap().is_none());
+
+        std::fs::write(&release_a, b"release").unwrap();
+        wait_success(&mut first);
+        wait_success(&mut second);
+
+        assert_eq!(
+            std::fs::read_to_string(versions.join("26.8.1.1/clickhouse")).unwrap(),
+            "linux-binary"
+        );
+        assert_eq!(
+            std::fs::read_to_string(versions.join("26.8.2.2/clickhouse")).unwrap(),
+            "macos-binary"
+        );
+        let sidecar = sidecar(&versions);
+        assert_eq!(sidecar["builds"]["amd64"]["etag"], "linux-etag");
+        assert_eq!(sidecar["builds"]["macos-aarch64"]["etag"], "macos-etag");
+    }
+
+    #[test]
+    fn interrupted_install_keeps_valid_binary_and_sidecar() {
+        let temp = tempfile::tempdir().unwrap();
+        let versions = temp.path().join("versions");
+        let version = "26.8.1.1";
+        std::fs::create_dir_all(versions.join(version)).unwrap();
+        std::fs::write(versions.join(version).join("clickhouse"), b"valid-binary").unwrap();
+        std::fs::write(
+            versions.join(".master-builds.json"),
+            format!(r#"{{"builds":{{"amd64":{{"etag":"valid-etag","version":"{version}"}}}}}}"#),
+        )
+        .unwrap();
+
+        let ready = temp.path().join("ready");
+        let locked = temp.path().join("binary-commit-paused");
+        let release = temp.path().join("never-release");
+        let mut child = spawn_install(ChildInstall {
+            versions_dir: &versions,
+            version,
+            contents: "partial-replacement",
+            etag: "partial-etag",
+            platform: "amd64",
+            ready: &ready,
+            target_pause: None,
+            sidecar_pause: None,
+            binary_pause: Some((&locked, &release)),
+        });
+        wait_for_path(&locked);
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        let abandoned_staging = PathBuf::from(std::fs::read_to_string(&ready).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(versions.join(version).join("clickhouse")).unwrap(),
+            "valid-binary"
+        );
+        assert_eq!(
+            std::fs::read_to_string(abandoned_staging.join("clickhouse")).unwrap(),
+            "partial-replacement"
+        );
+        let sidecar = sidecar(&versions);
+        assert!(sidecar["builds"].get("amd64").is_none());
+    }
+
+    #[test]
+    fn stale_staging_is_ignored_during_atomic_commit() {
+        let temp = tempfile::tempdir().unwrap();
+        let versions = temp.path().join("versions");
+        let stale = versions.join(".staging/stale-install");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(stale.join("clickhouse"), b"stale-binary").unwrap();
+        let version = "26.8.1.1";
+        std::fs::create_dir(versions.join(version)).unwrap();
+        std::fs::write(versions.join(version).join("clickhouse"), b"old-binary").unwrap();
+
+        let staging = StagingDir::create(&versions).unwrap();
+        let staged_binary = staging.path().join("clickhouse");
+        std::fs::write(&staged_binary, b"new-complete-binary").unwrap();
+        let platform = test_platform("amd64");
+        commit_staged_binary(
+            &versions,
+            &staged_binary,
+            version,
+            true,
+            true,
+            &platform,
+            Some(&master::HeadInfo {
+                etag: "new-etag".to_string(),
+                last_modified: None,
+            }),
+        )
+        .unwrap();
+        drop(staging);
+
+        assert_eq!(
+            std::fs::read_to_string(stale.join("clickhouse")).unwrap(),
+            "stale-binary"
+        );
+        assert_eq!(
+            std::fs::read_to_string(versions.join(version).join("clickhouse")).unwrap(),
+            "new-complete-binary"
+        );
+        let sidecar = sidecar(&versions);
+        assert_eq!(sidecar["builds"]["amd64"]["etag"], "new-etag");
+        assert_eq!(sidecar["builds"]["amd64"]["version"], version);
+    }
 
     #[test]
     fn test_parse_version_output_client() {

--- a/crates/clickhousectl/src/version_manager/lock.rs
+++ b/crates/clickhousectl/src/version_manager/lock.rs
@@ -1,0 +1,43 @@
+use std::fs::{File, OpenOptions};
+use std::io;
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+pub(crate) struct FileLock {
+    file: File,
+}
+
+impl FileLock {
+    pub(crate) fn acquire(path: &Path) -> io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(path)?;
+
+        loop {
+            // SAFETY: `file` owns this valid descriptor for the lifetime of the lock.
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+            if result == 0 {
+                return Ok(Self { file });
+            }
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::Interrupted {
+                return Err(error);
+            }
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        // SAFETY: `self.file` remains open until after `drop` returns.
+        unsafe {
+            libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -14,10 +14,13 @@
 
 use crate::error::Result;
 use crate::paths;
+use crate::version_manager::lock::FileLock;
 use crate::version_manager::network::{NetworkFailure, NetworkStage, OperationClient};
 use crate::version_manager::platform::{DownloadSource, Platform};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 /// One installed master build's change-detection state, per platform.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,21 +51,31 @@ struct Sidecar {
     builds: BTreeMap<String, MasterRecord>,
 }
 
+const SIDECAR_NAME: &str = ".master-builds.json";
+
 /// Path to the sidecar file (`~/.clickhouse/versions/.master-builds.json`).
-fn sidecar_path() -> Result<std::path::PathBuf> {
-    Ok(paths::versions_dir()?.join(".master-builds.json"))
+fn sidecar_path() -> Result<PathBuf> {
+    Ok(sidecar_path_in(&paths::versions_dir()?))
+}
+
+fn sidecar_path_in(versions_dir: &Path) -> PathBuf {
+    versions_dir.join(SIDECAR_NAME)
+}
+
+fn load_sidecar_from(path: &Path) -> Sidecar {
+    let Ok(bytes) = std::fs::read(path) else {
+        return Sidecar::default();
+    };
+    // A corrupt/old-format sidecar is treated as absent -- worst case is one
+    // extra download that rewrites it.
+    serde_json::from_slice(&bytes).unwrap_or_default()
 }
 
 fn load_sidecar() -> Sidecar {
     let Ok(path) = sidecar_path() else {
         return Sidecar::default();
     };
-    let Ok(bytes) = std::fs::read(&path) else {
-        return Sidecar::default();
-    };
-    // A corrupt/old-format sidecar is treated as absent -- worst case is one
-    // extra download that rewrites it.
-    serde_json::from_slice(&bytes).unwrap_or_default()
+    load_sidecar_from(&path)
 }
 
 /// Load the recorded master state for this platform, if any.
@@ -89,31 +102,134 @@ fn clear_version_from(sidecar: &mut Sidecar, platform_key: &str, version: &str) 
 /// the recorded etag no longer describes the binary on disk, and a stale match
 /// would make a later `latest` resolve silently reuse the wrong build.
 pub fn clear_record_for_version(platform: &Platform, version: &str) -> Result<()> {
-    let mut sidecar = load_sidecar();
+    clear_record_for_version_in(&paths::versions_dir()?, platform, version)
+}
+
+pub(crate) fn clear_record_for_version_in(
+    versions_dir: &Path,
+    platform: &Platform,
+    version: &str,
+) -> Result<()> {
+    let _lock = FileLock::acquire(&versions_dir.join(".locks/master-sidecar.lock"))?;
+    let path = sidecar_path_in(versions_dir);
+    let mut sidecar = load_sidecar_from(&path);
+    pause_after_sidecar_load_for_test();
     if clear_version_from(&mut sidecar, platform.builds_path(), version) {
-        let json = serde_json::to_vec_pretty(&sidecar)?;
-        std::fs::write(sidecar_path()?, json)?;
+        write_sidecar_atomically(&path, &sidecar)?;
     }
     Ok(())
 }
 
-/// Persist the master state for this platform, merging into any existing
-/// sidecar so other platforms' records are preserved.
-pub fn record(platform: &Platform, head: &HeadInfo, version: &str) -> Result<()> {
-    let mut sidecar = load_sidecar();
-    sidecar.builds.insert(
-        platform.builds_path().to_string(),
-        MasterRecord {
-            etag: head.etag.clone(),
-            last_modified: head.last_modified.clone(),
-            version: version.to_string(),
-        },
-    );
-    let path = sidecar_path()?;
-    let json = serde_json::to_vec_pretty(&sidecar)?;
-    std::fs::write(&path, json)?;
+/// Commit a staged binary while keeping a matching master record safe across
+/// process interruption. The old record is invalidated before the binary swap;
+/// after that point an interruption can only cause a later redundant download.
+pub(crate) fn commit_install_in<F>(
+    versions_dir: &Path,
+    platform: &Platform,
+    version: &str,
+    new_head: Option<&HeadInfo>,
+    commit_binary: F,
+) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let _lock = FileLock::acquire(&versions_dir.join(".locks/master-sidecar.lock"))?;
+    let path = sidecar_path_in(versions_dir);
+    let mut sidecar = load_sidecar_from(&path);
+    pause_after_sidecar_load_for_test();
+
+    if clear_version_from(&mut sidecar, platform.builds_path(), version) {
+        write_sidecar_atomically(&path, &sidecar)?;
+    }
+
+    pause_before_binary_commit_for_test();
+    commit_binary()?;
+
+    if let Some(head) = new_head {
+        sidecar.builds.insert(
+            platform.builds_path().to_string(),
+            MasterRecord {
+                etag: head.etag.clone(),
+                last_modified: head.last_modified.clone(),
+                version: version.to_string(),
+            },
+        );
+        // The binary is already safely committed. Failure to restore the
+        // optional cache record only forces a later download.
+        let _ = write_sidecar_atomically(&path, &sidecar);
+    }
+
     Ok(())
 }
+
+fn write_sidecar_atomically(path: &Path, sidecar: &Sidecar) -> Result<()> {
+    let json = serde_json::to_vec_pretty(sidecar)?;
+    let parent = path.parent().expect("sidecar path has a parent");
+    let temp_path = parent.join(format!(
+        ".master-builds-{}.tmp",
+        uuid::Uuid::new_v4().simple()
+    ));
+    let result = (|| -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temp_path)?;
+        file.write_all(&json)?;
+        file.sync_all()?;
+        std::fs::rename(&temp_path, path)?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp_path);
+    }
+    result
+}
+
+#[cfg(test)]
+fn pause_after_sidecar_load_for_test() {
+    let (Ok(marker), Ok(release)) = (
+        std::env::var("CHCTL_TEST_SIDECAR_LOCKED"),
+        std::env::var("CHCTL_TEST_SIDECAR_RELEASE"),
+    ) else {
+        return;
+    };
+    std::fs::write(marker, b"locked").expect("write sidecar lock marker");
+    let release = PathBuf::from(release);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !release.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting to release sidecar lock"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+#[cfg(not(test))]
+fn pause_after_sidecar_load_for_test() {}
+
+#[cfg(test)]
+fn pause_before_binary_commit_for_test() {
+    let (Ok(marker), Ok(release)) = (
+        std::env::var("CHCTL_TEST_BINARY_COMMIT_PAUSED"),
+        std::env::var("CHCTL_TEST_BINARY_COMMIT_RELEASE"),
+    ) else {
+        return;
+    };
+    std::fs::write(marker, b"paused").expect("write binary commit marker");
+    let release = PathBuf::from(release);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !release.exists() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting to commit binary"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+#[cfg(not(test))]
+fn pause_before_binary_commit_for_test() {}
 
 /// HEAD the master URL and pull the change-detection headers.
 /// Best-effort: returns `None` on any network/build error, so callers fall
@@ -173,7 +289,7 @@ fn should_reuse(
 /// version to reuse (download can be skipped). Otherwise `None`.
 ///
 /// `head` is the result of [`head_info`]; pass it through so the same HEAD
-/// result drives both the reuse check and the post-download [`record`].
+/// result drives both the reuse check and the post-download master record.
 pub fn reuse_if_unchanged(platform: &Platform, head: Option<&HeadInfo>) -> Option<String> {
     let record = load_record(platform)?;
     let binary_exists = paths::binary_path(&record.version)

--- a/crates/clickhousectl/src/version_manager/mod.rs
+++ b/crates/clickhousectl/src/version_manager/mod.rs
@@ -1,6 +1,7 @@
 pub mod download;
 pub mod install;
 pub mod list;
+mod lock;
 pub mod master;
 pub(crate) mod network;
 pub mod platform;


### PR DESCRIPTION
## Summary

- Give every install a UUID-named staging directory that only its owning process cleans up.
- Serialize target-version and master-sidecar commits with cross-process file locks, then atomically rename complete binaries and sidecar files into place.
- Invalidate matching master metadata before the binary swap so interruption preserves a complete binary without a stale ETag.
- Add deterministic subprocess coverage for same-version and different-version races, interruption, and stale staging, asserting final binary contents and sidecar state.

## Tests

- `cargo test -p clickhousectl version_manager::install::tests -- --nocapture` (10 passed)
- `cargo test -p clickhousectl` (all passed)
- `cargo test -p clickhousectl --no-default-features` (all passed)
- `cargo build -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

## Stack

- Position: 3 of 3
- Base: `issue-459-version-network-bounds-v2` (#496)

Closes #456

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>