### PR TITLE
Retry newly provisioned Query API endpoints until ready

### DIFF
--- a/crates/clickhousectl/src/cloud/client.rs
+++ b/crates/clickhousectl/src/cloud/client.rs
@@ -403,6 +403,13 @@ impl CloudClient {
         &self.lib_client
     }
 
+    /// Override the Query API host for unit tests in other cloud modules.
+    #[cfg(test)]
+    pub(crate) fn with_query_host_for_tests(mut self, host: impl Into<String>) -> Self {
+        self.lib_client = self.lib_client.with_query_host(host);
+        self
+    }
+
     /// Unwrap an `ApiResponse<T>` into `T`, returning an error if the result is empty.
     pub fn unwrap_response<T>(response: clickhouse_cloud_api::models::ApiResponse<T>) -> Result<T> {
         response

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1714,6 +1714,24 @@ const QUERY_ENDPOINT_RETRY_INITIAL_DELAY: std::time::Duration =
     std::time::Duration::from_millis(100);
 const QUERY_ENDPOINT_RETRY_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
+async fn run_query_attempt_before_deadline<T>(
+    deadline: tokio::time::Instant,
+    readiness_timeout: std::time::Duration,
+    attempt: impl std::future::Future<Output = Result<T, clickhouse_cloud_api::Error>>,
+) -> Result<T, clickhouse_cloud_api::Error> {
+    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+    tokio::time::timeout(remaining, attempt)
+        .await
+        .unwrap_or_else(|_| {
+            Err(clickhouse_cloud_api::Error::Api {
+                status: 408,
+                message: format!(
+                    "Query API endpoint did not become ready within {readiness_timeout:?}"
+                ),
+            })
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_basic_service_query(
     client: &CloudClient,
@@ -1765,15 +1783,19 @@ async fn run_newly_provisioned_service_query(
     let mut waiting = false;
 
     loop {
-        let result = run_basic_service_query(
-            client,
-            service_id,
-            key_id,
-            key_secret,
-            sql,
-            database,
-            format,
-            service_name,
+        let result = run_query_attempt_before_deadline(
+            deadline,
+            QUERY_ENDPOINT_READY_TIMEOUT,
+            run_basic_service_query(
+                client,
+                service_id,
+                key_id,
+                key_secret,
+                sql,
+                database,
+                format,
+                service_name,
+            ),
         )
         .await;
         if !result.as_ref().is_err_and(query_requires_provisioning) {
@@ -3861,6 +3883,30 @@ mod tests {
         }
         assert!(!query_requires_provisioning(
             &clickhouse_cloud_api::Error::ServiceStopped
+        ));
+    }
+
+    #[tokio::test]
+    async fn query_readiness_deadline_bounds_a_stalled_attempt() {
+        let readiness_timeout = std::time::Duration::from_millis(5);
+        let deadline = tokio::time::Instant::now() + readiness_timeout;
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            run_query_attempt_before_deadline(
+                deadline,
+                readiness_timeout,
+                std::future::pending::<Result<(), clickhouse_cloud_api::Error>>(),
+            ),
+        )
+        .await
+        .expect("stalled attempt exceeded the test guard");
+
+        assert!(matches!(
+            result,
+            Err(clickhouse_cloud_api::Error::Api {
+                status: 408,
+                ref message,
+            }) if message == "Query API endpoint did not become ready within 5ms"
         ));
     }
 

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1744,7 +1744,7 @@ async fn run_query_attempt_before_deadline<T>(
 
 #[allow(clippy::too_many_arguments)]
 async fn run_basic_service_query(
-    client: &clickhouse_cloud_api::Client,
+    client: &CloudClient,
     service_id: &str,
     key_id: &str,
     key_secret: &str,
@@ -1754,7 +1754,11 @@ async fn run_basic_service_query(
     service_name: &str,
     confirmed_idle: bool,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
-    let run = |wake| client.run_query(service_id, key_id, key_secret, sql, database, format, wake);
+    let run = |wake| {
+        client
+            .api()
+            .run_query(service_id, key_id, key_secret, sql, database, format, wake)
+    };
     if confirmed_idle {
         eprint_waking_service(service_name);
         return run(true).await;
@@ -1814,7 +1818,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 async fn run_newly_provisioned_service_query(
-    client: &clickhouse_cloud_api::Client,
+    client: &CloudClient,
     service_id: &str,
     key_id: &str,
     key_secret: &str,
@@ -1825,7 +1829,7 @@ async fn run_newly_provisioned_service_query(
     readiness: QueryEndpointReadiness,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
     let confirmed_idle = wait_for_query_endpoint_readiness(readiness, || {
-        client.run_query(
+        client.api().run_query(
             service_id,
             key_id,
             key_secret,
@@ -1901,7 +1905,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
     } else {
         let result = if let Some(key) = credentials::get_service_query_key(&service_id) {
             run_basic_service_query(
-                client.api(),
+                client,
                 &service_id,
                 &key.key_id,
                 &key.key_secret,
@@ -1917,7 +1921,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 .basic_auth_credentials()
                 .ok_or_else(|| CloudError::new("API key credentials are unavailable"))?;
             match run_basic_service_query(
-                client.api(),
+                client,
                 &service_id,
                 key_id,
                 key_secret,
@@ -1947,7 +1951,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                     )
                     .await?;
                     run_newly_provisioned_service_query(
-                        client.api(),
+                        client,
                         &service_id,
                         &key.key_id,
                         &key.key_secret,
@@ -4045,8 +4049,13 @@ mod tests {
             .expect(3)
             .mount(&query_host)
             .await;
-        let client = clickhouse_cloud_api::Client::new("key-id", "key-secret")
-            .with_query_host(query_host.uri());
+        let client = CloudClient::new(
+            Some("control-key"),
+            Some("control-secret"),
+            Some("https://api.example.com/v1"),
+        )
+        .unwrap()
+        .with_query_host_for_tests(query_host.uri());
         let started = tokio::time::Instant::now();
 
         let result = tokio::time::timeout(

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1709,6 +1709,11 @@ struct ServiceQueryOptions {
     no_auto_enable: bool,
 }
 
+const QUERY_ENDPOINT_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const QUERY_ENDPOINT_RETRY_INITIAL_DELAY: std::time::Duration =
+    std::time::Duration::from_millis(100);
+const QUERY_ENDPOINT_RETRY_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+
 #[allow(clippy::too_many_arguments)]
 async fn run_basic_service_query(
     client: &CloudClient,
@@ -1739,9 +1744,53 @@ fn query_requires_provisioning(error: &clickhouse_cloud_api::Error) -> bool {
         error,
         clickhouse_cloud_api::Error::Api {
             status: 401 | 403 | 404,
-            ..
-        }
+            message,
+        } if !message.starts_with("SQL error ")
     )
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_newly_provisioned_service_query(
+    client: &CloudClient,
+    service_id: &str,
+    key_id: &str,
+    key_secret: &str,
+    sql: &str,
+    database: Option<&str>,
+    format: &str,
+    service_name: &str,
+) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
+    let deadline = tokio::time::Instant::now() + QUERY_ENDPOINT_READY_TIMEOUT;
+    let mut delay = QUERY_ENDPOINT_RETRY_INITIAL_DELAY;
+    let mut waiting = false;
+
+    loop {
+        let result = run_basic_service_query(
+            client,
+            service_id,
+            key_id,
+            key_secret,
+            sql,
+            database,
+            format,
+            service_name,
+        )
+        .await;
+        if !result.as_ref().is_err_and(query_requires_provisioning) {
+            return result;
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return result;
+        }
+        if !waiting {
+            eprintln!("Waiting for the Query API endpoint to become ready...");
+            waiting = true;
+        }
+        tokio::time::sleep(delay.min(remaining)).await;
+        delay = (delay * 2).min(QUERY_ENDPOINT_RETRY_MAX_DELAY);
+    }
 }
 
 async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> CloudResult<()> {
@@ -1837,7 +1886,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                         &service_name,
                     )
                     .await?;
-                    run_basic_service_query(
+                    run_newly_provisioned_service_query(
                         client,
                         &service_id,
                         &key.key_id,
@@ -3796,6 +3845,12 @@ mod tests {
                 }
             ));
         }
+        assert!(!query_requires_provisioning(
+            &clickhouse_cloud_api::Error::Api {
+                status: 404,
+                message: "SQL error 60: Table does not exist".into(),
+            }
+        ));
         for status in [400, 408, 429, 500] {
             assert!(!query_requires_provisioning(
                 &clickhouse_cloud_api::Error::Api {

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1722,6 +1722,15 @@ const QUERY_ENDPOINT_READINESS: QueryEndpointReadiness = QueryEndpointReadiness 
     max_delay: std::time::Duration::from_secs(5),
 };
 
+fn query_readiness_timeout_error(
+    readiness_timeout: std::time::Duration,
+) -> clickhouse_cloud_api::Error {
+    clickhouse_cloud_api::Error::Api {
+        status: 408,
+        message: format!("Query API endpoint did not become ready within {readiness_timeout:?}"),
+    }
+}
+
 async fn run_query_attempt_before_deadline<T>(
     deadline: tokio::time::Instant,
     readiness_timeout: std::time::Duration,
@@ -1730,14 +1739,7 @@ async fn run_query_attempt_before_deadline<T>(
     let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
     tokio::time::timeout(remaining, attempt)
         .await
-        .unwrap_or_else(|_| {
-            Err(clickhouse_cloud_api::Error::Api {
-                status: 408,
-                message: format!(
-                    "Query API endpoint did not become ready within {readiness_timeout:?}"
-                ),
-            })
-        })
+        .unwrap_or_else(|_| Err(query_readiness_timeout_error(readiness_timeout)))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1777,6 +1779,39 @@ fn query_requires_provisioning(error: &clickhouse_cloud_api::Error) -> bool {
     )
 }
 
+async fn wait_for_query_endpoint_readiness<T, F, Fut>(
+    readiness: QueryEndpointReadiness,
+    mut probe: F,
+) -> Result<bool, clickhouse_cloud_api::Error>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, clickhouse_cloud_api::Error>>,
+{
+    let deadline = tokio::time::Instant::now() + readiness.timeout;
+    let mut delay = readiness.initial_delay;
+    let mut waiting = false;
+
+    loop {
+        match run_query_attempt_before_deadline(deadline, readiness.timeout, probe()).await {
+            Ok(_) => return Ok(false),
+            Err(clickhouse_cloud_api::Error::ServiceIdle) => return Ok(true),
+            Err(error) if query_requires_provisioning(&error) => {}
+            Err(error) => return Err(error),
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(query_readiness_timeout_error(readiness.timeout));
+        }
+        if !waiting {
+            eprintln!("Waiting for the Query API endpoint to become ready...");
+            waiting = true;
+        }
+        tokio::time::sleep(delay.min(remaining)).await;
+        delay = (delay * 2).min(readiness.max_delay);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_newly_provisioned_service_query(
     client: &clickhouse_cloud_api::Client,
@@ -1789,43 +1824,18 @@ async fn run_newly_provisioned_service_query(
     service_name: &str,
     readiness: QueryEndpointReadiness,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
-    let deadline = tokio::time::Instant::now() + readiness.timeout;
-    let mut delay = readiness.initial_delay;
-    let mut waiting = false;
-
-    let confirmed_idle = loop {
-        let error = match run_query_attempt_before_deadline(
-            deadline,
-            readiness.timeout,
-            client.run_query(
-                service_id,
-                key_id,
-                key_secret,
-                "SELECT 1",
-                None,
-                "TabSeparated",
-                false,
-            ),
+    let confirmed_idle = wait_for_query_endpoint_readiness(readiness, || {
+        client.run_query(
+            service_id,
+            key_id,
+            key_secret,
+            "SELECT 1",
+            None,
+            "TabSeparated",
+            false,
         )
-        .await
-        {
-            Ok(_) => break false,
-            Err(clickhouse_cloud_api::Error::ServiceIdle) => break true,
-            Err(error) if query_requires_provisioning(&error) => error,
-            Err(error) => return Err(error),
-        };
-
-        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
-        if remaining.is_zero() {
-            return Err(error);
-        }
-        if !waiting {
-            eprintln!("Waiting for the Query API endpoint to become ready...");
-            waiting = true;
-        }
-        tokio::time::sleep(delay.min(remaining)).await;
-        delay = (delay * 2).min(readiness.max_delay);
-    };
+    })
+    .await?;
 
     run_basic_service_query(
         client,
@@ -3930,13 +3940,67 @@ mod tests {
         .await
         .expect("stalled attempt exceeded the test guard");
 
-        assert!(matches!(
-            result,
-            Err(clickhouse_cloud_api::Error::Api {
-                status: 408,
-                ref message,
-            }) if message == "Query API endpoint did not become ready within 5ms"
-        ));
+        assert_query_readiness_timeout(result, readiness_timeout);
+    }
+
+    #[tokio::test]
+    async fn query_readiness_deadline_classifies_completed_retryable_probes_as_timeout() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        let readiness = QueryEndpointReadiness {
+            timeout: std::time::Duration::from_millis(50),
+            initial_delay: std::time::Duration::ZERO,
+            max_delay: std::time::Duration::ZERO,
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_for_probe = Arc::clone(&attempts);
+        let result = wait_for_query_endpoint_readiness(readiness, move || {
+            let attempt = attempts_for_probe.fetch_add(1, Ordering::SeqCst);
+            async move {
+                if attempt == 2 {
+                    // A non-yielding completed probe can cross the deadline before
+                    // the loop checks the remaining overall readiness budget.
+                    std::thread::sleep(std::time::Duration::from_millis(100));
+                }
+                Err::<(), _>(clickhouse_cloud_api::Error::Api {
+                    status: [401, 403, 404][attempt.min(2)],
+                    message: "endpoint not ready".into(),
+                })
+            }
+        })
+        .await;
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_query_readiness_timeout(result, readiness.timeout);
+    }
+
+    fn assert_query_readiness_timeout<T>(
+        result: Result<T, clickhouse_cloud_api::Error>,
+        readiness_timeout: std::time::Duration,
+    ) {
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("readiness should time out"),
+        };
+        let client = CloudClient::new(
+            Some("test-key"),
+            Some("test-secret"),
+            Some("https://api.example.com/v1"),
+        )
+        .unwrap();
+        let converted = client.convert_error(error);
+
+        assert_eq!(
+            converted.kind,
+            crate::cloud::client::CloudErrorKind::Generic
+        );
+        assert_eq!(
+            converted.message,
+            format!("Query API endpoint did not become ready within {readiness_timeout:?}")
+        );
     }
 
     #[tokio::test]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -1709,10 +1709,18 @@ struct ServiceQueryOptions {
     no_auto_enable: bool,
 }
 
-const QUERY_ENDPOINT_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
-const QUERY_ENDPOINT_RETRY_INITIAL_DELAY: std::time::Duration =
-    std::time::Duration::from_millis(100);
-const QUERY_ENDPOINT_RETRY_MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
+#[derive(Clone, Copy)]
+struct QueryEndpointReadiness {
+    timeout: std::time::Duration,
+    initial_delay: std::time::Duration,
+    max_delay: std::time::Duration,
+}
+
+const QUERY_ENDPOINT_READINESS: QueryEndpointReadiness = QueryEndpointReadiness {
+    timeout: std::time::Duration::from_secs(120),
+    initial_delay: std::time::Duration::from_millis(100),
+    max_delay: std::time::Duration::from_secs(5),
+};
 
 async fn run_query_attempt_before_deadline<T>(
     deadline: tokio::time::Instant,
@@ -1734,7 +1742,7 @@ async fn run_query_attempt_before_deadline<T>(
 
 #[allow(clippy::too_many_arguments)]
 async fn run_basic_service_query(
-    client: &CloudClient,
+    client: &clickhouse_cloud_api::Client,
     service_id: &str,
     key_id: &str,
     key_secret: &str,
@@ -1742,12 +1750,14 @@ async fn run_basic_service_query(
     database: Option<&str>,
     format: &str,
     service_name: &str,
+    confirmed_idle: bool,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
-    let run = |wake: bool| {
-        client
-            .api()
-            .run_query(service_id, key_id, key_secret, sql, database, format, wake)
-    };
+    let run = |wake| client.run_query(service_id, key_id, key_secret, sql, database, format, wake);
+    if confirmed_idle {
+        eprint_waking_service(service_name);
+        return run(true).await;
+    }
+
     match run(false).await {
         Err(clickhouse_cloud_api::Error::ServiceIdle) => {
             eprint_waking_service(service_name);
@@ -1769,7 +1779,7 @@ fn query_requires_provisioning(error: &clickhouse_cloud_api::Error) -> bool {
 
 #[allow(clippy::too_many_arguments)]
 async fn run_newly_provisioned_service_query(
-    client: &CloudClient,
+    client: &clickhouse_cloud_api::Client,
     service_id: &str,
     key_id: &str,
     key_secret: &str,
@@ -1777,42 +1787,58 @@ async fn run_newly_provisioned_service_query(
     database: Option<&str>,
     format: &str,
     service_name: &str,
+    readiness: QueryEndpointReadiness,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
-    let deadline = tokio::time::Instant::now() + QUERY_ENDPOINT_READY_TIMEOUT;
-    let mut delay = QUERY_ENDPOINT_RETRY_INITIAL_DELAY;
+    let deadline = tokio::time::Instant::now() + readiness.timeout;
+    let mut delay = readiness.initial_delay;
     let mut waiting = false;
 
-    loop {
-        let result = run_query_attempt_before_deadline(
+    let confirmed_idle = loop {
+        let error = match run_query_attempt_before_deadline(
             deadline,
-            QUERY_ENDPOINT_READY_TIMEOUT,
-            run_basic_service_query(
-                client,
+            readiness.timeout,
+            client.run_query(
                 service_id,
                 key_id,
                 key_secret,
-                sql,
-                database,
-                format,
-                service_name,
+                "SELECT 1",
+                None,
+                "TabSeparated",
+                false,
             ),
         )
-        .await;
-        if !result.as_ref().is_err_and(query_requires_provisioning) {
-            return result;
-        }
+        .await
+        {
+            Ok(_) => break false,
+            Err(clickhouse_cloud_api::Error::ServiceIdle) => break true,
+            Err(error) if query_requires_provisioning(&error) => error,
+            Err(error) => return Err(error),
+        };
 
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            return result;
+            return Err(error);
         }
         if !waiting {
             eprintln!("Waiting for the Query API endpoint to become ready...");
             waiting = true;
         }
         tokio::time::sleep(delay.min(remaining)).await;
-        delay = (delay * 2).min(QUERY_ENDPOINT_RETRY_MAX_DELAY);
-    }
+        delay = (delay * 2).min(readiness.max_delay);
+    };
+
+    run_basic_service_query(
+        client,
+        service_id,
+        key_id,
+        key_secret,
+        sql,
+        database,
+        format,
+        service_name,
+        confirmed_idle,
+    )
+    .await
 }
 
 async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> CloudResult<()> {
@@ -1865,7 +1891,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
     } else {
         let result = if let Some(key) = credentials::get_service_query_key(&service_id) {
             run_basic_service_query(
-                client,
+                client.api(),
                 &service_id,
                 &key.key_id,
                 &key.key_secret,
@@ -1873,6 +1899,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 options.database.as_deref(),
                 &format,
                 &service_name,
+                false,
             )
             .await
         } else {
@@ -1880,7 +1907,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 .basic_auth_credentials()
                 .ok_or_else(|| CloudError::new("API key credentials are unavailable"))?;
             match run_basic_service_query(
-                client,
+                client.api(),
                 &service_id,
                 key_id,
                 key_secret,
@@ -1888,6 +1915,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 options.database.as_deref(),
                 &format,
                 &service_name,
+                false,
             )
             .await
             {
@@ -1909,7 +1937,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                     )
                     .await?;
                     run_newly_provisioned_service_query(
-                        client,
+                        client.api(),
                         &service_id,
                         &key.key_id,
                         &key.key_secret,
@@ -1917,6 +1945,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                         options.database.as_deref(),
                         &format,
                         &service_name,
+                        QUERY_ENDPOINT_READINESS,
                     )
                     .await
                 }
@@ -3908,6 +3937,92 @@ mod tests {
                 ref message,
             }) if message == "Query API endpoint did not become ready within 5ms"
         ));
+    }
+
+    #[tokio::test]
+    async fn query_readiness_deadline_does_not_bound_idle_wake_or_repeat_user_query() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let readiness = QueryEndpointReadiness {
+            timeout: std::time::Duration::from_millis(300),
+            initial_delay: std::time::Duration::from_millis(10),
+            max_delay: std::time::Duration::from_millis(10),
+        };
+        let query_host = MockServer::start().await;
+        let probe_attempts = Arc::new(AtomicUsize::new(0));
+        let probe_attempts_for_response = Arc::clone(&probe_attempts);
+        Mock::given(method("POST"))
+            .and(path("/service/service-1/run"))
+            .respond_with(move |request: &wiremock::Request| {
+                let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                match body["sql"].as_str() {
+                    Some("SELECT 1") => {
+                        if probe_attempts_for_response.fetch_add(1, Ordering::SeqCst) == 0 {
+                            ResponseTemplate::new(401)
+                                .set_delay(std::time::Duration::from_millis(225))
+                                .set_body_string("new key not ready")
+                        } else {
+                            ResponseTemplate::new(206)
+                                .set_body_string(r#"{"data":"Confirm wake service"}"#)
+                        }
+                    }
+                    Some("SELECT 42") => ResponseTemplate::new(200)
+                        .set_delay(std::time::Duration::from_millis(150))
+                        .set_body_string("42\n"),
+                    sql => ResponseTemplate::new(400)
+                        .set_body_string(format!("unexpected SQL in readiness test: {sql:?}")),
+                }
+            })
+            .expect(3)
+            .mount(&query_host)
+            .await;
+        let client = clickhouse_cloud_api::Client::new("key-id", "key-secret")
+            .with_query_host(query_host.uri());
+        let started = tokio::time::Instant::now();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            run_newly_provisioned_service_query(
+                &client,
+                "service-1",
+                "key-id",
+                "key-secret",
+                "SELECT 42",
+                None,
+                "TabSeparated",
+                "demo",
+                readiness,
+            ),
+        )
+        .await
+        .expect("wake and user query exceeded the test guard");
+
+        assert_eq!(result.unwrap().text().await.unwrap(), "42\n");
+        assert_eq!(probe_attempts.load(Ordering::SeqCst), 2);
+        assert!(
+            started.elapsed() > readiness.timeout,
+            "the delayed wake/query should finish after the readiness deadline"
+        );
+
+        let requests = query_host.received_requests().await.unwrap();
+        let sql: Vec<_> = requests
+            .iter()
+            .map(|request| {
+                serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["sql"]
+                    .as_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect();
+        assert_eq!(sql, ["SELECT 1", "SELECT 1", "SELECT 42"]);
+        assert!(requests[0].headers.get("wake-service").is_none());
+        assert!(requests[1].headers.get("wake-service").is_none());
+        assert_eq!(requests[2].headers.get("wake-service").unwrap(), "true");
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3783,7 +3783,7 @@ async fn service_query_probes_new_endpoint_readiness_without_repeating_user_sql(
 
     let dir = tempfile::tempdir().unwrap();
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     let output = command
         .env("DO_NOT_TRACK", "1")
         .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3694,6 +3694,140 @@ async fn service_query_auto_provisioning_is_single_flight_across_processes() {
     );
 }
 
+#[tokio::test]
+async fn service_query_retries_new_endpoint_readiness_without_reprovisioning() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let control = start_mock_control_plane_with_service().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/organizations/org-1/keys"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": {
+                "key": { "id": QUERY_TEST_KEY_UUID },
+                "keyId": "provisioned-key-id",
+                "keySecret": "provisioned-key-secret",
+            },
+            "status": 200,
+            "requestId": "stub-key-create",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1" },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert",
+        })))
+        .expect(1)
+        .mount(&control)
+        .await;
+
+    let query_host = MockServer::start().await;
+    let basic_auth = |credentials: &str| {
+        format!(
+            "Basic {}",
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, credentials)
+        )
+    };
+    let primary_auth = basic_auth("fake-key-for-tests:fake-secret-for-tests");
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .and(header("authorization", primary_auth.as_str()))
+        .respond_with(ResponseTemplate::new(401).set_body_string("API key is not authorized"))
+        .expect(1)
+        .mount(&query_host)
+        .await;
+
+    let provisioned_auth = basic_auth("provisioned-key-id:provisioned-key-secret");
+    let attempt = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
+        .and(header("authorization", provisioned_auth.as_str()))
+        .respond_with(
+            move |_: &wiremock::Request| match attempt.fetch_add(1, Ordering::SeqCst) {
+                0 => ResponseTemplate::new(401).set_body_string("new key not ready"),
+                1 => ResponseTemplate::new(403).set_body_string("new binding not ready"),
+                2 => ResponseTemplate::new(404).set_body_string("query endpoint not found"),
+                _ => ResponseTemplate::new(200).set_body_string("1\n"),
+            },
+        )
+        .expect(4)
+        .mount(&query_host)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+        .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+        .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &control.uri(),
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--org-id",
+            "org-1",
+            "--query",
+            "SELECT 1",
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+    assert_success(&output);
+    assert_eq!(output.stdout, b"1\n");
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Waiting for the Query API endpoint to become ready")
+    );
+
+    let control_requests = control.received_requests().await.unwrap();
+    assert_eq!(
+        control_requests
+            .iter()
+            .filter(|request| {
+                request.method == wiremock::http::Method::POST
+                    && request.url.path() == "/v1/organizations/org-1/keys"
+            })
+            .count(),
+        1,
+        "readiness retries must reuse the newly created key",
+    );
+    assert_eq!(
+        control_requests
+            .iter()
+            .filter(|request| {
+                request.method == wiremock::http::Method::POST
+                    && request.url.path() == endpoint_path
+            })
+            .count(),
+        1,
+        "readiness retries must not repeat the endpoint upsert",
+    );
+}
+
 /// Mount a key-creation POST returning `result`, plus a key DELETE, on the
 /// control plane. `result` lets each test omit exactly the field under test.
 async fn mount_key_create_and_delete(control: &MockServer, result: Value) {

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3695,7 +3695,7 @@ async fn service_query_auto_provisioning_is_single_flight_across_processes() {
 }
 
 #[tokio::test]
-async fn service_query_retries_new_endpoint_readiness_without_reprovisioning() {
+async fn service_query_probes_new_endpoint_readiness_without_repeating_user_sql() {
     use std::sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -3760,15 +3760,24 @@ async fn service_query_retries_new_endpoint_readiness_without_reprovisioning() {
     Mock::given(method("POST"))
         .and(path(format!("/service/{QUERY_TEST_SERVICE_ID}/run")))
         .and(header("authorization", provisioned_auth.as_str()))
-        .respond_with(
-            move |_: &wiremock::Request| match attempt.fetch_add(1, Ordering::SeqCst) {
-                0 => ResponseTemplate::new(401).set_body_string("new key not ready"),
-                1 => ResponseTemplate::new(403).set_body_string("new binding not ready"),
-                2 => ResponseTemplate::new(404).set_body_string("query endpoint not found"),
-                _ => ResponseTemplate::new(200).set_body_string("1\n"),
-            },
-        )
-        .expect(4)
+        .respond_with(move |request: &wiremock::Request| {
+            let body: Value = serde_json::from_slice(&request.body).unwrap();
+            match body["sql"].as_str() {
+                Some("SELECT 1") => match attempt.fetch_add(1, Ordering::SeqCst) {
+                    0 => ResponseTemplate::new(401).set_body_string("new key not ready"),
+                    1 => ResponseTemplate::new(403).set_body_string("new binding not ready"),
+                    2 => ResponseTemplate::new(404).set_body_string("query endpoint not found"),
+                    _ => ResponseTemplate::new(206)
+                        .set_body_string(r#"{"data":"Confirm wake service"}"#),
+                },
+                Some("SELECT 42") => ResponseTemplate::new(200)
+                    .set_delay(std::time::Duration::from_millis(50))
+                    .set_body_string("42\n"),
+                sql => ResponseTemplate::new(400)
+                    .set_body_string(format!("unexpected SQL in readiness test: {sql:?}")),
+            }
+        })
+        .expect(5)
         .mount(&query_host)
         .await;
 
@@ -3792,16 +3801,45 @@ async fn service_query_retries_new_endpoint_readiness_without_reprovisioning() {
             "--org-id",
             "org-1",
             "--query",
-            "SELECT 1",
+            "SELECT 42",
         ])
         .output()
         .expect("failed to spawn clickhousectl");
     assert_success(&output);
-    assert_eq!(output.stdout, b"1\n");
+    assert_eq!(output.stdout, b"42\n");
     assert!(
         String::from_utf8_lossy(&output.stderr)
             .contains("Waiting for the Query API endpoint to become ready")
     );
+
+    let query_requests = query_host.received_requests().await.unwrap();
+    let provisioned_requests: Vec<_> = query_requests
+        .iter()
+        .filter(|request| {
+            request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok())
+                == Some(provisioned_auth.as_str())
+        })
+        .collect();
+    let sql: Vec<_> = provisioned_requests
+        .iter()
+        .map(|request| serde_json::from_slice::<Value>(&request.body).unwrap()["sql"].clone())
+        .collect();
+    assert_eq!(
+        sql.iter().filter(|value| **value == "SELECT 1").count(),
+        4,
+        "readiness retries must use the harmless probe",
+    );
+    let user_queries: Vec<_> = provisioned_requests
+        .iter()
+        .filter(|request| {
+            serde_json::from_slice::<Value>(&request.body).unwrap()["sql"] == "SELECT 42"
+        })
+        .collect();
+    assert_eq!(user_queries.len(), 1, "user SQL must run exactly once");
+    assert_eq!(user_queries[0].headers.get("wake-service").unwrap(), "true");
 
     let control_requests = control.received_requests().await.unwrap();
     assert_eq!(


### PR DESCRIPTION
## Summary

- retry a newly provisioned Query API endpoint for up to 120 seconds with exponential backoff capped at 5 seconds
- retry only non-SQL 401, 403, and generic 404 readiness responses; stopped services, SQL errors, rate limits, transport failures, and 5xx responses remain terminal
- reuse the single key and endpoint upsert from the inherited locked provisioning flow
- add subprocess wiremock coverage for a 401 -> 403 -> 404 -> success sequence, asserting one key creation and one endpoint upsert

Closes #453

## Tests

- `cargo test -p clickhousectl` (748 passed)
- `cargo test -p clickhousectl --test cli_request_shape_test service_query_retries_new_endpoint_readiness_without_reprovisioning -- --exact` (1 passed)
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

No live Cloud resources or credentials were used.

## Stack

This is the child of `issue-451-query-provision-singleflight` (PR #493). It targets that parent branch; PR #493 remains unchanged and should merge first.