### PR TITLE
Make local install failures and prerequisites actionable

### DIFF
--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -48,8 +48,12 @@ pub enum Error {
     #[error("Unsupported platform: {os}/{arch}")]
     UnsupportedPlatform { os: String, arch: String },
 
-    #[error("Failed to create directory: {0}")]
-    CreateDir(PathBuf),
+    #[error("Failed to create directory {}: {source}", path.display())]
+    CreateDir {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("Download failed: {0}")]
     Download(String),
@@ -97,6 +101,18 @@ pub enum Error {
 
     #[error("Extraction failed: {0}")]
     Extract(String),
+
+    #[error(
+        "Failed to extract archive {} to {}: {source}",
+        archive.display(),
+        destination.display()
+    )]
+    ExtractArchive {
+        archive: PathBuf,
+        destination: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 
     #[error("Server '{0}' is not running")]
     ServerNotRunning(String),

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -36,6 +36,22 @@ pub struct LocalArgs {
 pub enum LocalCommands {
     /// Install a ClickHouse version
     #[command(after_help = "\
+EXAMPLES:
+  clickhousectl local install latest
+  clickhousectl local install stable
+  clickhousectl local install 26.8
+  clickhousectl local install 26.8.1.1760
+
+DOWNLOAD:
+  Expect an approximately 150 MB download. Binaries are installed at
+  ~/.clickhouse/versions/<version>/clickhouse.
+  Downloads use builds.clickhouse.com, with fallbacks to packages.clickhouse.com
+  on Linux and github.com/ClickHouse/ClickHouse releases on macOS.
+
+START A SERVER DIRECTLY:
+  `clickhousectl local server start` installs `latest` when needed and starts a
+  local server, so a separate install command is optional.
+
 CONTEXT FOR AGENTS:
   `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
     Install {
@@ -639,6 +655,37 @@ mod tests {
                 assert_eq!(port, expected_port, "selectors: {selectors:?}");
             }
         }
+    }
+
+    #[test]
+    fn install_help_documents_examples_destination_downloads_and_server_route() {
+        let error = Cli::try_parse_from(["clickhousectl", "local", "install", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+
+        assert!(
+            help.contains("clickhousectl local install latest"),
+            "{help}"
+        );
+        assert!(
+            help.contains("clickhousectl local install stable"),
+            "{help}"
+        );
+        assert!(help.contains("clickhousectl local install 26.8"), "{help}");
+        assert!(
+            help.contains("~/.clickhouse/versions/<version>/clickhouse"),
+            "{help}"
+        );
+        assert!(help.contains("approximately 150 MB"), "{help}");
+        assert!(help.contains("builds.clickhouse.com"), "{help}");
+        assert!(help.contains("packages.clickhouse.com"), "{help}");
+        assert!(help.contains("github.com/ClickHouse/ClickHouse"), "{help}");
+        assert!(
+            help.contains("`clickhousectl local server start` installs `latest`"),
+            "{help}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -36,24 +36,13 @@ pub struct LocalArgs {
 pub enum LocalCommands {
     /// Install a ClickHouse version
     #[command(after_help = "\
+CONTEXT FOR AGENTS:
+  `clickhousectl local use <version>` will auto-install if the version is missing and set as default.
+
 EXAMPLES:
   clickhousectl local install latest
-  clickhousectl local install stable
   clickhousectl local install 26.8
-  clickhousectl local install 26.8.1.1760
-
-DOWNLOAD:
-  Expect an approximately 150 MB download. Binaries are installed at
-  ~/.clickhouse/versions/<version>/clickhouse.
-  Downloads use builds.clickhouse.com, with fallbacks to packages.clickhouse.com
-  on Linux and github.com/ClickHouse/ClickHouse releases on macOS.
-
-START A SERVER DIRECTLY:
-  `clickhousectl local server start` installs `latest` when needed and starts a
-  local server, so a separate install command is optional.
-
-CONTEXT FOR AGENTS:
-  `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
+  clickhousectl local install 26.8.1.1760")]
     Install {
         /// Version to install. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.9.61".
         #[arg(value_parser = parse_install_version_operand)]
@@ -655,37 +644,6 @@ mod tests {
                 assert_eq!(port, expected_port, "selectors: {selectors:?}");
             }
         }
-    }
-
-    #[test]
-    fn install_help_documents_examples_destination_downloads_and_server_route() {
-        let error = Cli::try_parse_from(["clickhousectl", "local", "install", "--help"])
-            .err()
-            .expect("--help should stop parsing");
-        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
-        let help = error.to_string();
-
-        assert!(
-            help.contains("clickhousectl local install latest"),
-            "{help}"
-        );
-        assert!(
-            help.contains("clickhousectl local install stable"),
-            "{help}"
-        );
-        assert!(help.contains("clickhousectl local install 26.8"), "{help}");
-        assert!(
-            help.contains("~/.clickhouse/versions/<version>/clickhouse"),
-            "{help}"
-        );
-        assert!(help.contains("approximately 150 MB"), "{help}");
-        assert!(help.contains("builds.clickhouse.com"), "{help}");
-        assert!(help.contains("packages.clickhouse.com"), "{help}");
-        assert!(help.contains("github.com/ClickHouse/ClickHouse"), "{help}");
-        assert!(
-            help.contains("`clickhousectl local server start` installs `latest`"),
-            "{help}"
-        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/paths.rs
+++ b/crates/clickhousectl/src/paths.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Returns the base directory for ClickHouse CLI (~/.clickhouse/)
 pub fn base_dir() -> Result<PathBuf> {
@@ -40,8 +40,14 @@ pub fn configs_dir() -> Result<PathBuf> {
 /// Ensures all necessary directories exist
 pub fn ensure_dirs() -> Result<()> {
     let versions = versions_dir()?;
-    std::fs::create_dir_all(&versions).map_err(|_| Error::CreateDir(versions))?;
-    Ok(())
+    create_dir_all(&versions)
+}
+
+pub(crate) fn create_dir_all(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path).map_err(|source| Error::CreateDir {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 /// Returns the user-local PATH-style bin directory (~/.local/bin/)
@@ -58,4 +64,50 @@ pub fn global_bin_dir() -> Result<PathBuf> {
 /// Returns the path to the global `clickhouse` symlink (~/.local/bin/clickhouse)
 pub fn global_clickhouse_symlink() -> Result<PathBuf> {
     Ok(global_bin_dir()?.join("clickhouse"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_directory_error_preserves_not_a_directory_path_and_cause() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("not-a-directory");
+        std::fs::write(&file, b"file").unwrap();
+        let requested = file.join("versions");
+
+        let error = create_dir_all(&requested).unwrap_err();
+        let Error::CreateDir { path, source } = &error else {
+            panic!("expected create directory error: {error}");
+        };
+
+        assert_eq!(path, &requested);
+        assert_eq!(source.kind(), std::io::ErrorKind::NotADirectory);
+        assert!(error.to_string().contains(&requested.display().to_string()));
+        assert!(error.to_string().contains(&source.to_string()));
+    }
+
+    #[test]
+    fn create_directory_error_preserves_permission_denied_cause() {
+        let path = PathBuf::from("/restricted/.clickhouse/versions");
+        let error = Error::CreateDir {
+            path: path.clone(),
+            source: std::io::Error::from(std::io::ErrorKind::PermissionDenied),
+        };
+        let Error::CreateDir {
+            source: permission_error,
+            ..
+        } = &error
+        else {
+            unreachable!();
+        };
+
+        assert_eq!(
+            permission_error.kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert!(error.to_string().contains(&path.display().to_string()));
+        assert!(error.to_string().contains(&permission_error.to_string()));
+    }
 }

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -17,13 +17,13 @@ struct StagingDir {
 impl StagingDir {
     fn create(versions_dir: &Path) -> Result<Self> {
         let staging_root = versions_dir.join(".staging");
-        std::fs::create_dir_all(&staging_root)?;
+        paths::create_dir_all(&staging_root)?;
         loop {
             let path = staging_root.join(uuid::Uuid::new_v4().simple().to_string());
             match std::fs::create_dir(&path) {
                 Ok(()) => return Ok(Self { path }),
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error.into()),
+                Err(source) => return Err(Error::CreateDir { path, source }),
             }
         }
     }
@@ -225,7 +225,10 @@ fn commit_staged_binary(
                 .parent()
                 .expect("staged binary has a parent")
                 .join("install");
-            std::fs::create_dir(&commit_dir)?;
+            std::fs::create_dir(&commit_dir).map_err(|source| Error::CreateDir {
+                path: commit_dir.clone(),
+                source,
+            })?;
             std::fs::rename(staged_binary, commit_dir.join("clickhouse"))?;
             std::fs::rename(commit_dir, &version_dir)?;
         }
@@ -343,50 +346,51 @@ fn parse_version_output(output: &str) -> Result<String> {
 /// Handles both packages.clickhouse.com layout (usr/bin/clickhouse inside subdir)
 /// and GitHub releases layout (same structure).
 fn extract_tarball_auto(tarball_path: &std::path::Path, dest_dir: &std::path::Path) -> Result<()> {
-    let status = std::process::Command::new("tar")
-        .args(["xzf", &tarball_path.to_string_lossy()])
-        .current_dir(dest_dir)
-        .status()
-        .map_err(|e| Error::Extract(format!("Failed to run tar: {}", e)))?;
-
-    if !status.success() {
-        let _ = std::fs::remove_file(tarball_path);
-        return Err(Error::Extract("tar extraction failed".to_string()));
-    }
-
     let final_binary = dest_dir.join("clickhouse");
+    let extraction_error = |source| Error::ExtractArchive {
+        archive: tarball_path.to_path_buf(),
+        destination: final_binary.clone(),
+        source,
+    };
+    let archive_file = std::fs::File::open(tarball_path).map_err(extraction_error)?;
+    let decoder = flate2::read::GzDecoder::new(archive_file);
+    let mut archive = tar::Archive::new(decoder);
 
-    // Search extracted directories for the binary
-    for entry in std::fs::read_dir(dest_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_dir() {
-            let candidate = path.join("usr/bin/clickhouse");
-            if candidate.exists() {
-                std::fs::rename(&candidate, &final_binary)?;
-                let _ = std::fs::remove_file(tarball_path);
-                let _ = std::fs::remove_dir_all(&path);
-                return Ok(());
-            }
+    for entry in archive.entries().map_err(extraction_error)? {
+        let mut entry = entry.map_err(extraction_error)?;
+        if !entry.header().entry_type().is_file() {
+            continue;
         }
-    }
+        let path = entry.path().map_err(extraction_error)?;
+        if path.as_ref() != Path::new("clickhouse")
+            && path.as_ref() != Path::new("./clickhouse")
+            && !path.as_ref().ends_with(Path::new("usr/bin/clickhouse"))
+        {
+            continue;
+        }
 
-    // Binary might already be at top level
-    if final_binary.exists() {
+        let mut output = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&final_binary)
+            .map_err(extraction_error)?;
+        std::io::copy(&mut entry, &mut output).map_err(extraction_error)?;
         let _ = std::fs::remove_file(tarball_path);
         return Ok(());
     }
 
-    let _ = std::fs::remove_file(tarball_path);
-    Err(Error::Extract(
-        "Could not find clickhouse binary in extracted tarball".to_string(),
-    ))
+    Err(Error::Extract(format!(
+        "Archive {} did not contain the expected clickhouse or usr/bin/clickhouse binary",
+        tarball_path.display()
+    )))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::version_manager::platform::{Arch, Os};
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
     use std::process::{Child, Command, Stdio};
     use std::time::{Duration, Instant};
 
@@ -465,6 +469,20 @@ mod tests {
         let bytes =
             std::fs::read(versions_dir.join(".master-builds.json")).expect("read master sidecar");
         serde_json::from_slice(&bytes).expect("parse master sidecar")
+    }
+
+    fn write_tarball(path: &Path, entry_path: &str, contents: &[u8]) {
+        let file = std::fs::File::create(path).unwrap();
+        let encoder = GzEncoder::new(file, Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        archive
+            .append_data(&mut header, entry_path, contents)
+            .unwrap();
+        archive.into_inner().unwrap().finish().unwrap();
     }
 
     #[test]
@@ -694,6 +712,80 @@ mod tests {
         let sidecar = sidecar(&versions);
         assert_eq!(sidecar["builds"]["amd64"]["etag"], "new-etag");
         assert_eq!(sidecar["builds"]["amd64"]["version"], version);
+    }
+
+    #[test]
+    fn extracts_packaged_binary_in_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let tarball = temp.path().join("clickhouse.tgz");
+        write_tarball(
+            &tarball,
+            "clickhouse-common-static/usr/bin/clickhouse",
+            b"clickhouse-binary",
+        );
+
+        extract_tarball_auto(&tarball, temp.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read(temp.path().join("clickhouse")).unwrap(),
+            b"clickhouse-binary"
+        );
+        assert!(!tarball.exists());
+    }
+
+    #[test]
+    fn extracts_top_level_binary_in_process() {
+        let temp = tempfile::tempdir().unwrap();
+        let tarball = temp.path().join("clickhouse.tgz");
+        write_tarball(&tarball, "./clickhouse", b"clickhouse-binary");
+
+        extract_tarball_auto(&tarball, temp.path()).unwrap();
+
+        assert_eq!(
+            std::fs::read(temp.path().join("clickhouse")).unwrap(),
+            b"clickhouse-binary"
+        );
+    }
+
+    #[test]
+    fn malformed_archive_error_preserves_archive_destination_and_cause() {
+        let temp = tempfile::tempdir().unwrap();
+        let tarball = temp.path().join("malformed.tgz");
+        std::fs::write(&tarball, b"not a gzip archive").unwrap();
+        let destination = temp.path().join("clickhouse");
+
+        let error = extract_tarball_auto(&tarball, temp.path()).unwrap_err();
+        let Error::ExtractArchive {
+            archive,
+            destination: error_destination,
+            source,
+        } = &error
+        else {
+            panic!("expected contextual archive error: {error}");
+        };
+
+        assert_eq!(archive, &tarball);
+        assert_eq!(error_destination, &destination);
+        assert!(error.to_string().contains(&tarball.display().to_string()));
+        assert!(
+            error
+                .to_string()
+                .contains(&destination.display().to_string())
+        );
+        assert!(error.to_string().contains(&source.to_string()));
+    }
+
+    #[test]
+    fn missing_binary_error_names_archive_and_expected_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let tarball = temp.path().join("missing-clickhouse.tgz");
+        write_tarball(&tarball, "package/README.md", b"no binary");
+
+        let error = extract_tarball_auto(&tarball, temp.path()).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains(&tarball.display().to_string()));
+        assert!(message.contains("clickhouse or usr/bin/clickhouse"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -355,6 +355,7 @@ fn extract_tarball_auto(tarball_path: &std::path::Path, dest_dir: &std::path::Pa
     let archive_file = std::fs::File::open(tarball_path).map_err(extraction_error)?;
     let decoder = flate2::read::GzDecoder::new(archive_file);
     let mut archive = tar::Archive::new(decoder);
+    let mut found_binary = false;
 
     for entry in archive.entries().map_err(extraction_error)? {
         let mut entry = entry.map_err(extraction_error)?;
@@ -375,14 +376,21 @@ fn extract_tarball_auto(tarball_path: &std::path::Path, dest_dir: &std::path::Pa
             .open(&final_binary)
             .map_err(extraction_error)?;
         std::io::copy(&mut entry, &mut output).map_err(extraction_error)?;
-        let _ = std::fs::remove_file(tarball_path);
-        return Ok(());
+        found_binary = true;
+        break;
     }
 
-    Err(Error::Extract(format!(
-        "Archive {} did not contain the expected clickhouse or usr/bin/clickhouse binary",
-        tarball_path.display()
-    )))
+    if !found_binary {
+        return Err(Error::Extract(format!(
+            "Archive {} did not contain the expected clickhouse or usr/bin/clickhouse binary",
+            tarball_path.display()
+        )));
+    }
+
+    let mut decoder = archive.into_inner();
+    std::io::copy(&mut decoder, &mut std::io::sink()).map_err(extraction_error)?;
+    let _ = std::fs::remove_file(tarball_path);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -483,6 +491,35 @@ mod tests {
             .append_data(&mut header, entry_path, contents)
             .unwrap();
         archive.into_inner().unwrap().finish().unwrap();
+    }
+
+    fn assert_invalid_gzip_is_not_committed(mutate: impl FnOnce(&Path)) {
+        let temp = tempfile::tempdir().unwrap();
+        let versions = temp.path().join("versions");
+        let staging = StagingDir::create(&versions).unwrap();
+        let staging_path = staging.path().to_path_buf();
+        let tarball = staging.path().join("clickhouse.tgz");
+        let version = "25.12.9.61";
+        write_tarball(&tarball, "./clickhouse", b"clickhouse-binary");
+        mutate(&tarball);
+
+        let result = extract_tarball_auto(&tarball, staging.path()).and_then(|()| {
+            commit_staged_binary(
+                &versions,
+                &staging.path().join("clickhouse"),
+                version,
+                false,
+                false,
+                &test_platform("amd64"),
+                None,
+            )
+            .map(|_| ())
+        });
+
+        assert!(matches!(result, Err(Error::ExtractArchive { .. })));
+        assert!(!versions.join(version).exists());
+        drop(staging);
+        assert!(!staging_path.exists());
     }
 
     #[test]
@@ -745,6 +782,27 @@ mod tests {
             std::fs::read(temp.path().join("clickhouse")).unwrap(),
             b"clickhouse-binary"
         );
+    }
+
+    #[test]
+    fn corrupted_gzip_crc_is_not_committed() {
+        assert_invalid_gzip_is_not_committed(|tarball| {
+            let mut bytes = std::fs::read(tarball).unwrap();
+            let crc_offset = bytes.len() - 8;
+            bytes[crc_offset] ^= 0xff;
+            std::fs::write(tarball, bytes).unwrap();
+        });
+    }
+
+    #[test]
+    fn truncated_gzip_trailer_is_not_committed() {
+        assert_invalid_gzip_is_not_committed(|tarball| {
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .open(tarball)
+                .unwrap();
+            file.set_len(file.metadata().unwrap().len() - 4).unwrap();
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve the requested path and underlying OS cause when install and atomic staging directories cannot be created.
- Replace the Linux host `tar` subprocess with selective in-process extraction using the existing `flate2` and `tar` dependencies, while retaining archive, destination, malformed-input, and missing-binary context.
- Expand `local install --help` with version examples, the binary destination, source hosts, the approximate download size, and the bare `local server start` bootstrap route.

## Tests

- `cargo test -p clickhousectl`
- `cargo test -p clickhousectl --no-default-features`
- `cargo test -p clickhousectl version_manager::install::tests`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

## Stack

- Position: 4 of 4
- Base: `issue-456-atomic-installs` (#502)
- GitHub stack: #497

Closes #462

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>