### PR TITLE
Keep local install workflow triggers aligned

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - "crates/clickhousectl/**"
       - "Cargo.lock"
+      - ".github/workflows/test-install.yml"
+      - "scripts/classify-install-integration.py"
+      - "scripts/tests/test_classify_install_integration.py"
       - ".github/workflows/test-cli.yml"
 
 permissions:
@@ -25,6 +28,9 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+
+      - name: Check install integration path inventory
+        run: python3 -m unittest discover -s scripts/tests -p 'test_classify_install_integration.py'
 
       - name: Build
         run: cargo build -p clickhousectl

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -3,11 +3,45 @@ name: Test Install
 on:
   pull_request:
     paths:
-      - "crates/clickhousectl/src/version_manager/**"
-      - "crates/clickhousectl/src/main.rs"
-      - "crates/clickhousectl/src/cli.rs"
-      - "crates/clickhousectl/Cargo.toml"
+      # Exact entries are enforced by test_classify_install_integration.py.
+      - ".cargo/config"
+      - ".cargo/config.toml"
+      - ".github/workflows/test-cli.yml"
       - ".github/workflows/test-install.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/clickhousectl/Cargo.toml"
+      - "crates/clickhousectl/src/cli.rs"
+      - "crates/clickhousectl/src/error.rs"
+      - "crates/clickhousectl/src/http.rs"
+      - "crates/clickhousectl/src/local/cli.rs"
+      - "crates/clickhousectl/src/local/discovery.rs"
+      - "crates/clickhousectl/src/local/mod.rs"
+      - "crates/clickhousectl/src/local/output.rs"
+      - "crates/clickhousectl/src/local/server.rs"
+      - "crates/clickhousectl/src/local/symlink.rs"
+      - "crates/clickhousectl/src/main.rs"
+      - "crates/clickhousectl/src/paths.rs"
+      - "crates/clickhousectl/src/update.rs"
+      - "crates/clickhousectl/src/user_agent.rs"
+      - "crates/clickhousectl/src/version_manager/download.rs"
+      - "crates/clickhousectl/src/version_manager/install.rs"
+      - "crates/clickhousectl/src/version_manager/list.rs"
+      - "crates/clickhousectl/src/version_manager/lock.rs"
+      - "crates/clickhousectl/src/version_manager/master.rs"
+      - "crates/clickhousectl/src/version_manager/mod.rs"
+      - "crates/clickhousectl/src/version_manager/network.rs"
+      - "crates/clickhousectl/src/version_manager/platform.rs"
+      - "crates/clickhousectl/src/version_manager/resolve.rs"
+      - "crates/clickhousectl/src/version_manager/spec.rs"
+      - "crates/clickhousectl/tests/local_install_local_first_test.rs"
+      - "crates/clickhousectl/tests/local_server_start_args_test.rs"
+      - "crates/clickhousectl/tests/local_version_error_test.rs"
+      - "crates/clickhousectl/tests/telemetry_test.rs"
+      - "rust-toolchain"
+      - "rust-toolchain.toml"
+      - "scripts/classify-install-integration.py"
+      - "scripts/tests/test_classify_install_integration.py"
 
 permissions:
   contents: read
@@ -23,6 +57,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Check install integration path inventory
+        run: python3 -m unittest discover -s scripts/tests -p 'test_classify_install_integration.py'
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
       - run: cargo test
 

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Classify paths that require the live local install integration workflow."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL = True
+NO_INSTALL = False
+
+# Retain mappings when files are deleted or renamed so old diff paths remain
+# classified. The inventory test requires every current non-Cloud CLI Rust file
+# to have an explicit decision.
+SOURCE_PATH_INSTALL = {
+    "crates/clickhousectl/src/cli.rs": INSTALL,
+    "crates/clickhousectl/src/dotenv.rs": NO_INSTALL,
+    "crates/clickhousectl/src/error.rs": INSTALL,
+    "crates/clickhousectl/src/http.rs": INSTALL,
+    "crates/clickhousectl/src/init.rs": NO_INSTALL,
+    "crates/clickhousectl/src/local/cli.rs": INSTALL,
+    "crates/clickhousectl/src/local/config.rs": NO_INSTALL,
+    "crates/clickhousectl/src/local/discovery.rs": INSTALL,
+    "crates/clickhousectl/src/local/docker.rs": NO_INSTALL,
+    "crates/clickhousectl/src/local/mod.rs": INSTALL,
+    "crates/clickhousectl/src/local/output.rs": INSTALL,
+    "crates/clickhousectl/src/local/postgres.rs": NO_INSTALL,
+    "crates/clickhousectl/src/local/server.rs": INSTALL,
+    "crates/clickhousectl/src/local/symlink.rs": INSTALL,
+    "crates/clickhousectl/src/main.rs": INSTALL,
+    "crates/clickhousectl/src/paths.rs": INSTALL,
+    "crates/clickhousectl/src/skills.rs": NO_INSTALL,
+    "crates/clickhousectl/src/telemetry.rs": NO_INSTALL,
+    "crates/clickhousectl/src/update.rs": INSTALL,
+    "crates/clickhousectl/src/user_agent.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/download.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/install.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/list.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/lock.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/master.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/mod.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/network.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/platform.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/resolve.rs": INSTALL,
+    "crates/clickhousectl/src/version_manager/spec.rs": INSTALL,
+}
+
+TEST_PATH_INSTALL = {
+    "crates/clickhousectl/tests/cli_request_shape_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_docker_pull_progress_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_install_local_first_test.rs": INSTALL,
+    "crates/clickhousectl/tests/local_server_readiness_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_server_start_args_test.rs": INSTALL,
+    "crates/clickhousectl/tests/local_server_stopped_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_version_error_test.rs": INSTALL,
+    "crates/clickhousectl/tests/telemetry_test.rs": INSTALL,
+}
+
+ALWAYS_INSTALL_PATHS = {
+    ".cargo/config",
+    ".cargo/config.toml",
+    ".github/workflows/test-cli.yml",
+    ".github/workflows/test-install.yml",
+    "Cargo.lock",
+    "Cargo.toml",
+    "crates/clickhousectl/Cargo.toml",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+    "scripts/classify-install-integration.py",
+    "scripts/tests/test_classify_install_integration.py",
+}
+
+INSTALL_PATHS = (
+    frozenset(path for path, selected in SOURCE_PATH_INSTALL.items() if selected)
+    | frozenset(path for path, selected in TEST_PATH_INSTALL.items() if selected)
+    | frozenset(ALWAYS_INSTALL_PATHS)
+)
+
+CLI_CRATE_PREFIX = "crates/clickhousectl/"
+CLI_TEST_PREFIX = f"{CLI_CRATE_PREFIX}tests/"
+CLOUD_SOURCE_PREFIX = f"{CLI_CRATE_PREFIX}src/cloud/"
+
+
+def classify_path(path: str) -> bool | None:
+    """Return a decision, or None for an unclassified local CLI source/test path."""
+    if path in SOURCE_PATH_INSTALL:
+        return SOURCE_PATH_INSTALL[path]
+    if path in TEST_PATH_INSTALL:
+        return TEST_PATH_INSTALL[path]
+    if path in ALWAYS_INSTALL_PATHS:
+        return INSTALL
+    if path.startswith(CLI_TEST_PREFIX):
+        return None
+    if (
+        path.startswith(CLI_CRATE_PREFIX)
+        and path.endswith(".rs")
+        and not path.startswith(CLOUD_SOURCE_PREFIX)
+    ):
+        return None
+    return NO_INSTALL

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -45,12 +45,26 @@ SOURCE_PATH_INSTALL = {
 
 TEST_PATH_INSTALL = {
     "crates/clickhousectl/tests/cli_request_shape_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_client_project_scope_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_client_selectors_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_docker_pull_progress_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_install_local_first_test.rs": INSTALL,
+    "crates/clickhousectl/tests/local_postgres_diagnostics_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_postgres_help_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_postgres_preflight_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_postgres_readiness_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_postgres_start_lock_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_server_metadata_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_server_project_scope_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_server_readiness_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_server_selection_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_server_start_args_test.rs": INSTALL,
+    "crates/clickhousectl/tests/local_server_state_machine_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_server_stopped_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_structured_errors_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_version_error_test.rs": INSTALL,
+    "crates/clickhousectl/tests/snapshots/local_postgres_help.txt": NO_INSTALL,
+    "crates/clickhousectl/tests/snapshots/local_postgres_start_help.txt": NO_INSTALL,
     "crates/clickhousectl/tests/telemetry_test.rs": INSTALL,
 }
 

--- a/scripts/classify-install-integration.py
+++ b/scripts/classify-install-integration.py
@@ -50,6 +50,7 @@ TEST_PATH_INSTALL = {
     "crates/clickhousectl/tests/local_docker_pull_progress_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_install_local_first_test.rs": INSTALL,
     "crates/clickhousectl/tests/local_postgres_diagnostics_test.rs": NO_INSTALL,
+    "crates/clickhousectl/tests/local_postgres_dotenv_lock_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_postgres_help_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_postgres_preflight_test.rs": NO_INSTALL,
     "crates/clickhousectl/tests/local_postgres_readiness_test.rs": NO_INSTALL,

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -103,9 +103,23 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
         }
         expected_no_install = {
             "crates/clickhousectl/tests/cli_request_shape_test.rs",
+            "crates/clickhousectl/tests/local_client_project_scope_test.rs",
+            "crates/clickhousectl/tests/local_client_selectors_test.rs",
             "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
+            "crates/clickhousectl/tests/local_postgres_diagnostics_test.rs",
+            "crates/clickhousectl/tests/local_postgres_help_test.rs",
+            "crates/clickhousectl/tests/local_postgres_preflight_test.rs",
+            "crates/clickhousectl/tests/local_postgres_readiness_test.rs",
+            "crates/clickhousectl/tests/local_postgres_start_lock_test.rs",
+            "crates/clickhousectl/tests/local_server_metadata_test.rs",
+            "crates/clickhousectl/tests/local_server_project_scope_test.rs",
             "crates/clickhousectl/tests/local_server_readiness_test.rs",
+            "crates/clickhousectl/tests/local_server_selection_test.rs",
+            "crates/clickhousectl/tests/local_server_state_machine_test.rs",
             "crates/clickhousectl/tests/local_server_stopped_test.rs",
+            "crates/clickhousectl/tests/local_structured_errors_test.rs",
+            "crates/clickhousectl/tests/snapshots/local_postgres_help.txt",
+            "crates/clickhousectl/tests/snapshots/local_postgres_start_help.txt",
         }
         self.assertEqual(
             {path for path, selected in classifier.TEST_PATH_INSTALL.items() if selected},

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -107,6 +107,7 @@ class InstallIntegrationClassifierTests(unittest.TestCase):
             "crates/clickhousectl/tests/local_client_selectors_test.rs",
             "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
             "crates/clickhousectl/tests/local_postgres_diagnostics_test.rs",
+            "crates/clickhousectl/tests/local_postgres_dotenv_lock_test.rs",
             "crates/clickhousectl/tests/local_postgres_help_test.rs",
             "crates/clickhousectl/tests/local_postgres_preflight_test.rs",
             "crates/clickhousectl/tests/local_postgres_readiness_test.rs",

--- a/scripts/tests/test_classify_install_integration.py
+++ b/scripts/tests/test_classify_install_integration.py
@@ -1,0 +1,155 @@
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "classify-install-integration.py"
+SPEC = importlib.util.spec_from_file_location("classify_install_integration", SCRIPT)
+classifier = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = classifier
+SPEC.loader.exec_module(classifier)
+
+
+class InstallIntegrationClassifierTests(unittest.TestCase):
+    def test_path_mapping(self):
+        cases = {
+            "crates/clickhousectl/src/version_manager/lock.rs": classifier.INSTALL,
+            "crates/clickhousectl/src/version_manager/network.rs": classifier.INSTALL,
+            "crates/clickhousectl/src/local/mod.rs": classifier.INSTALL,
+            "crates/clickhousectl/src/local/postgres.rs": classifier.NO_INSTALL,
+            "crates/clickhousectl/src/cloud/client.rs": classifier.NO_INSTALL,
+            "crates/clickhousectl/tests/local_version_error_test.rs": classifier.INSTALL,
+            "crates/clickhousectl/tests/local_docker_pull_progress_test.rs": classifier.NO_INSTALL,
+            "Cargo.lock": classifier.INSTALL,
+            "crates/clickhousectl/src/version_manager/new_source.rs": None,
+            "crates/clickhousectl/src/local/new_postgres_helper.rs": None,
+            "crates/clickhousectl/tests/new_install_test.rs": None,
+            "crates/clickhousectl/build.rs": None,
+        }
+        for path, expected in cases.items():
+            with self.subTest(path=path):
+                self.assertEqual(classifier.classify_path(path), expected)
+
+    def test_every_non_cloud_cli_source_has_an_explicit_mapping(self):
+        crate_root = classifier.REPO_ROOT / "crates" / "clickhousectl"
+        actual = {
+            path.relative_to(classifier.REPO_ROOT).as_posix()
+            for path in crate_root.rglob("*.rs")
+            if path.relative_to(crate_root).parts[0] != "tests"
+            and not path.relative_to(crate_root).as_posix().startswith("src/cloud/")
+        }
+        self.assertFalse(actual - set(classifier.SOURCE_PATH_INSTALL))
+
+    def test_current_source_mapping_values(self):
+        expected_install = {
+            "crates/clickhousectl/src/cli.rs",
+            "crates/clickhousectl/src/error.rs",
+            "crates/clickhousectl/src/http.rs",
+            "crates/clickhousectl/src/local/cli.rs",
+            "crates/clickhousectl/src/local/discovery.rs",
+            "crates/clickhousectl/src/local/mod.rs",
+            "crates/clickhousectl/src/local/output.rs",
+            "crates/clickhousectl/src/local/server.rs",
+            "crates/clickhousectl/src/local/symlink.rs",
+            "crates/clickhousectl/src/main.rs",
+            "crates/clickhousectl/src/paths.rs",
+            "crates/clickhousectl/src/update.rs",
+            "crates/clickhousectl/src/user_agent.rs",
+            "crates/clickhousectl/src/version_manager/download.rs",
+            "crates/clickhousectl/src/version_manager/install.rs",
+            "crates/clickhousectl/src/version_manager/list.rs",
+            "crates/clickhousectl/src/version_manager/lock.rs",
+            "crates/clickhousectl/src/version_manager/master.rs",
+            "crates/clickhousectl/src/version_manager/mod.rs",
+            "crates/clickhousectl/src/version_manager/network.rs",
+            "crates/clickhousectl/src/version_manager/platform.rs",
+            "crates/clickhousectl/src/version_manager/resolve.rs",
+            "crates/clickhousectl/src/version_manager/spec.rs",
+        }
+        expected_no_install = {
+            "crates/clickhousectl/src/dotenv.rs",
+            "crates/clickhousectl/src/init.rs",
+            "crates/clickhousectl/src/local/config.rs",
+            "crates/clickhousectl/src/local/docker.rs",
+            "crates/clickhousectl/src/local/postgres.rs",
+            "crates/clickhousectl/src/skills.rs",
+            "crates/clickhousectl/src/telemetry.rs",
+        }
+        self.assertEqual(
+            {path for path, selected in classifier.SOURCE_PATH_INSTALL.items() if selected},
+            expected_install,
+        )
+        self.assertEqual(
+            {path for path, selected in classifier.SOURCE_PATH_INSTALL.items() if not selected},
+            expected_no_install,
+        )
+
+    def test_every_cli_subprocess_test_has_an_explicit_mapping(self):
+        test_root = classifier.REPO_ROOT / "crates" / "clickhousectl" / "tests"
+        actual = {
+            path.relative_to(classifier.REPO_ROOT).as_posix()
+            for path in test_root.rglob("*")
+            if path.is_file()
+        }
+        self.assertFalse(actual - set(classifier.TEST_PATH_INSTALL))
+
+    def test_current_test_mapping_values(self):
+        expected_install = {
+            "crates/clickhousectl/tests/local_install_local_first_test.rs",
+            "crates/clickhousectl/tests/local_server_start_args_test.rs",
+            "crates/clickhousectl/tests/local_version_error_test.rs",
+            "crates/clickhousectl/tests/telemetry_test.rs",
+        }
+        expected_no_install = {
+            "crates/clickhousectl/tests/cli_request_shape_test.rs",
+            "crates/clickhousectl/tests/local_docker_pull_progress_test.rs",
+            "crates/clickhousectl/tests/local_server_readiness_test.rs",
+            "crates/clickhousectl/tests/local_server_stopped_test.rs",
+        }
+        self.assertEqual(
+            {path for path, selected in classifier.TEST_PATH_INSTALL.items() if selected},
+            expected_install,
+        )
+        self.assertEqual(
+            {path for path, selected in classifier.TEST_PATH_INSTALL.items() if not selected},
+            expected_no_install,
+        )
+
+    def test_workflow_filter_matches_exact_install_mapping(self):
+        workflow = classifier.REPO_ROOT / ".github" / "workflows" / "test-install.yml"
+        paths = []
+        in_paths = False
+        for line in workflow.read_text().splitlines():
+            if line == "    paths:":
+                in_paths = True
+                continue
+            if in_paths and line.startswith("      - "):
+                paths.append(json.loads(line.removeprefix("      - ")))
+            elif in_paths and not paths and line.lstrip().startswith("#"):
+                continue
+            elif in_paths:
+                break
+
+        self.assertEqual(len(paths), len(set(paths)), "workflow path filter has duplicates")
+        self.assertFalse(
+            {path for path in paths if "*" in path},
+            "install workflow paths must be exact",
+        )
+        self.assertEqual(set(paths), set(classifier.INSTALL_PATHS))
+
+    def test_broad_cli_workflow_runs_fail_closed_inventory(self):
+        command = (
+            "python3 -m unittest discover -s scripts/tests "
+            "-p 'test_classify_install_integration.py'"
+        )
+        for workflow_name in ("test-cli.yml", "test-install.yml"):
+            workflow = (
+                classifier.REPO_ROOT / ".github" / "workflows" / workflow_name
+            ).read_text()
+            with self.subTest(workflow=workflow_name):
+                self.assertIn(command, workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replace the broad local install workflow filter with an exact mapping of installer-affecting source, subprocess test, manifest, lockfile, toolchain, and workflow paths.
- Keep unrelated local and Postgres-only files explicitly classified out while covering shared dispatch, output, HTTP, path, server-discovery, and inherited version-manager dependencies.
- Add a fail-closed inventory test, run by both the broad CLI workflow and install workflow, so new or renamed non-Cloud CLI Rust and subprocess test files require an explicit mapping decision.

## Tests

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`
- `cargo test -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- Ruby YAML parsing for `.github/workflows/test-cli.yml` and `.github/workflows/test-install.yml`

## Stack

- Position: 5 of 5
- Base: `issue-462-install-errors-help` (#507)
- GitHub stack: #497

Closes #461

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback</a></sub>