### PR TITLE
Bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,7 +957,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clickhouse-cloud-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "clickhousectl"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "bollard",

--- a/crates/clickhouse-cloud-api/Cargo.toml
+++ b/crates/clickhouse-cloud-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse-cloud-api"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Typed Rust client for the ClickHouse Cloud API"
 license = "Apache-2.0"

--- a/crates/clickhousectl/Cargo.toml
+++ b/crates/clickhousectl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhousectl"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "The CLI for ClickHouse: local and cloud."
 license = "Apache-2.0"
@@ -45,7 +45,7 @@ chrono = "0.4.44"
 open = "5.3.3"
 url = "2.5.8"
 tabled = "0.20.0"
-clickhouse-cloud-api = { version = "0.4.1", path = "../clickhouse-cloud-api" }
+clickhouse-cloud-api = { version = "0.4.2", path = "../clickhouse-cloud-api" }
 uuid = { version = "1.23.0", features = ["v4"] }
 is-ai-agent = "0.5.0"
 base64 = "0.22.1"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clickhousectl",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "The CLI for ClickHouse: local and cloud.",
   "homepage": "https://github.com/ClickHouse/clickhousectl",
   "repository": {


### PR DESCRIPTION
## Summary

- bump `clickhousectl` and `clickhouse-cloud-api` to `0.4.2`
- align the CLI API dependency, npm package, and Cargo lockfile
- leave PyPI unchanged because it derives the CLI version from Cargo

## Verification

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Stack

- Position: child 34 of 34 in gh-stack #563
- Base: #562 (`stack/479-server-state-machine-tests`)
- Parent PR should merge first.