### PR TITLE
Require exact-SHA Cloud integration decisions

### DIFF
--- a/.github/CLOUD_INTEGRATION.md
+++ b/.github/CLOUD_INTEGRATION.md
@@ -33,9 +33,18 @@ Use an override after a failed live run only as an explicit subsequent
 maintainer decision. Include why the failure is accepted or link the successful
 run that covers the change.
 
+An override is not sticky for the same SHA. A later admitted Cloud Integration
+run replaces it as the current decision. If that run fails, the decision stays
+failing until the run succeeds or a maintainer records a subsequent override.
+
 A PR that changes `.github/workflows/cloud-integration.yml` cannot use that
 modified workflow to attest itself. Its decision remains failing until a
 maintainer reviews the workflow change and records an exact-SHA override.
+
+A PR that changes `scripts/classify-cloud-integration.py` can select different
+suites in the PR run than the trusted default-branch controller derives. Review
+the classifier change and use an exact-SHA override when that expected mismatch
+prevents the run from satisfying the decision.
 
 ## Stacked pull requests
 

--- a/.github/CLOUD_INTEGRATION.md
+++ b/.github/CLOUD_INTEGRATION.md
@@ -1,0 +1,72 @@
+# Cloud integration decisions
+
+`Cloud Integration` remains on demand for pull requests. The required
+`Cloud integration decision` check is bound to one exact PR head SHA and passes
+only after one of these outcomes:
+
+1. Apply the `run-cloud-integration` label and all suites selected by the
+   trusted planner pass.
+2. Apply the label and the trusted planner selects no live suites. The
+   environment-bearing job stays skipped.
+3. A maintainer records a one-shot override for the current full head SHA.
+
+After a push, remove and reapply `run-cloud-integration` to start a run for the
+new SHA. Earlier live results and overrides do not carry forward. Fork PRs do
+not receive Cloud secrets; use a same-repository mirror or the explicit
+maintainer override.
+
+## Maintainer override
+
+Repository administrators and maintainers can comment on an open PR:
+
+```text
+/cloud-integration-override <full-current-head-sha> <reason-or-stack-run-url>
+```
+
+The controller verifies effective `maintain` or `admin` permission and that the
+40-character SHA is still the PR head. The command comment, controller reply,
+and check output record the actor, SHA, event timestamp, and reason. A new SHA
+requires a new command. Writers, unrelated comments, stale SHAs, and persistent
+labels cannot create an override.
+
+Use an override after a failed live run only as an explicit subsequent
+maintainer decision. Include why the failure is accepted or link the successful
+run that covers the change.
+
+A PR that changes `.github/workflows/cloud-integration.yml` cannot use that
+modified workflow to attest itself. Its decision remains failing until a
+maintainer reviews the workflow change and records an exact-SHA override.
+
+## Stacked pull requests
+
+Run affected suites independently on every PR by default. A manual `all` run on
+the top branch validates that combined snapshot only; it does not automatically
+cover lower PR head SHAs.
+
+When one successful top-stack run intentionally covers lower PRs, a maintainer
+must add a separate exact-SHA override to every lower PR and link that run in
+the reason. Repeat the run or override for any lower PR whose head changes.
+This records the coverage decision on every mergeable SHA instead of silently
+transferring a status through the stack.
+
+The manual top-stack run is evidence, not an automatic PR decision. Satisfy the
+top PR itself with its label-triggered run or an exact-SHA override that links
+the successful manual run.
+
+## Post-merge rollout
+
+Do not require the check before this workflow is on the default branch. After
+merging it to `main`:
+
+1. Open or synchronize a representative PR and confirm that GitHub Actions
+   creates `Cloud integration decision` on its current head SHA.
+2. Exercise either the `run-cloud-integration` label or an exact-SHA override
+   and confirm that the same check becomes successful.
+3. In the `main` branch protection rule or ruleset, add
+   `Cloud integration decision` from the GitHub Actions app to the required
+   status checks. Do not make the `Cloud Integration` workflow itself required.
+
+Existing open PRs with no decision check must be synchronized/reopened, run via
+the label, or given an exact-SHA override before enabling the rule. This order
+prevents branch protection from locking every PR while the controller is not
+yet available.

--- a/.github/workflows/cloud-integration-decision.yml
+++ b/.github/workflows/cloud-integration-decision.yml
@@ -1,0 +1,90 @@
+name: Cloud Integration Decision
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: [Cloud Integration]
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+env:
+  DO_NOT_TRACK: "1"
+
+concurrency:
+  group: >-
+    cloud-integration-decision-${{
+      github.event.pull_request.number ||
+      github.event.workflow_run.pull_requests[0].number ||
+      github.event.issue.number ||
+      github.run_id
+    }}
+  queue: max
+  cancel-in-progress: false
+
+jobs:
+  initialize:
+    name: Initialize Cloud integration decision
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      checks: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      # pull_request_target must never execute the PR or an unmerged stack base.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Require an exact-SHA decision
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/cloud-integration-decision.py initialize
+
+  reconcile:
+    name: Reconcile Cloud integration decision
+    if: github.event_name == 'workflow_run'
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # For workflow_run, github.sha is a trusted default-branch revision.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate the completed Cloud run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/cloud-integration-decision.py reconcile
+
+  override:
+    name: Record Cloud integration override
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null
+    permissions:
+      checks: write
+      contents: read
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      # issue_comment workflows also execute only the trusted default branch.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Validate and record a maintainer override
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/cloud-integration-decision.py override

--- a/.github/workflows/test-cloud-api.yml
+++ b/.github/workflows/test-cloud-api.yml
@@ -8,10 +8,12 @@ on:
       - "crates/clickhouse-openapi-analyzer/**"
       - "scripts/check-openapi-drift.py"
       - "scripts/classify-cloud-integration.py"
+      - "scripts/cloud-integration-decision.py"
       - "scripts/tests/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/test-cloud-api.yml"
+      - ".github/workflows/cloud-integration-decision.yml"
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -995,6 +995,10 @@ Distribution packagers can compile telemetry out entirely (including the `teleme
 
 ## Cloud integration testing
 
+Maintainer operation, exact-SHA overrides, stacked-PR policy, and the required
+check rollout procedure are documented in
+[`.github/CLOUD_INTEGRATION.md`](.github/CLOUD_INTEGRATION.md).
+
 Cloud API integration is tested against a real ClickHouse Cloud workspace via the library crate. All changes to cloud commands must pass CI testing before merge. Tests live in three binaries, each a single `#[tokio::test]` lifecycle:
 
 - [`tests/integration_test.rs`](crates/clickhouse-cloud-api/tests/integration_test.rs) — ClickHouse service CRUD + service-scoped endpoints

--- a/scripts/cloud-integration-decision.py
+++ b/scripts/cloud-integration-decision.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""Maintain the exact-SHA Cloud integration decision check."""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CHECK_NAME = "Cloud integration decision"
+SOURCE_WORKFLOW_PATH = ".github/workflows/cloud-integration.yml"
+PLAN_JOB_NAME = "Plan Cloud integration tests"
+LIVE_JOB_NAME = "Cloud integration tests"
+OVERRIDE_COMMAND = "/cloud-integration-override"
+OVERRIDE_RE = re.compile(
+    rf"\A{re.escape(OVERRIDE_COMMAND)}\s+([0-9a-fA-F]{{40}})\s+(.+?)\s*\Z",
+    re.DOTALL,
+)
+SUITE_STEPS = {
+    "Run cloud integration suite": "service",
+    "Run cloud Postgres integration suite": "postgres",
+    "Run cloud Org integration suite": "organization",
+    "Run ClickPipe Postgres CDC integration test": "clickpipes",
+}
+
+CLASSIFIER_PATH = Path(__file__).with_name("classify-cloud-integration.py")
+CLASSIFIER_SPEC = importlib.util.spec_from_file_location(
+    "cloud_integration_classifier_for_decision", CLASSIFIER_PATH
+)
+if CLASSIFIER_SPEC is None or CLASSIFIER_SPEC.loader is None:
+    raise RuntimeError(f"cannot load classifier from {CLASSIFIER_PATH}")
+classifier = importlib.util.module_from_spec(CLASSIFIER_SPEC)
+sys.modules[CLASSIFIER_SPEC.name] = classifier
+CLASSIFIER_SPEC.loader.exec_module(classifier)
+
+
+class ControllerError(RuntimeError):
+    """The controller cannot safely update a decision."""
+
+
+class APIError(ControllerError):
+    def __init__(self, status: int, message: str):
+        super().__init__(f"GitHub API returned {status}: {message}")
+        self.status = status
+
+
+@dataclass(frozen=True)
+class Decision:
+    conclusion: str
+    title: str
+    summary: str
+    details_url: str
+
+
+@dataclass(frozen=True)
+class Override:
+    sha: str
+    reason: str
+    actor: str
+    timestamp: str
+    comment_url: str
+
+
+class GitHubAPI:
+    def __init__(self, base_url: str, repository: str, token: str):
+        self.base_url = base_url.rstrip("/")
+        self.repository = repository
+        self.token = token
+
+    def request(
+        self, method: str, path: str, payload: dict[str, Any] | None = None
+    ) -> Any:
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "clickhousectl-cloud-integration-decision",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            raise APIError(error.code, detail) from error
+        except urllib.error.URLError as error:
+            raise ControllerError(f"GitHub API request failed: {error}") from error
+        return json.loads(body) if body else None
+
+    def get_pull(self, number: int) -> dict[str, Any]:
+        return self.request("GET", f"/repos/{self.repository}/pulls/{number}")
+
+    def list_pull_files(self, number: int) -> list[dict[str, Any]]:
+        files = []
+        for page in range(1, 31):
+            batch = self.request(
+                "GET",
+                f"/repos/{self.repository}/pulls/{number}/files"
+                f"?per_page=100&page={page}",
+            )
+            files.extend(batch)
+            if len(batch) < 100:
+                return files
+        raise ControllerError("PR file list reached GitHub's 3,000-file limit")
+
+    def list_run_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        jobs = []
+        for page in range(1, 11):
+            response = self.request(
+                "GET",
+                f"/repos/{self.repository}/actions/runs/{run_id}/jobs"
+                f"?filter=latest&per_page=100&page={page}",
+            )
+            batch = response["jobs"]
+            jobs.extend(batch)
+            if len(batch) < 100:
+                return jobs
+        raise ControllerError("workflow job list exceeded 1,000 jobs")
+
+    def content_blob_sha(self, path: str, ref: str) -> str | None:
+        encoded_path = urllib.parse.quote(path, safe="/")
+        query = urllib.parse.urlencode({"ref": ref})
+        try:
+            response = self.request(
+                "GET",
+                f"/repos/{self.repository}/contents/{encoded_path}?{query}",
+            )
+        except APIError as error:
+            if error.status == 404:
+                return None
+            raise
+        return response.get("sha") if isinstance(response, dict) else None
+
+    def collaborator_permission(self, actor: str) -> dict[str, Any]:
+        encoded_actor = urllib.parse.quote(actor, safe="")
+        return self.request(
+            "GET",
+            f"/repos/{self.repository}/collaborators/{encoded_actor}/permission",
+        )
+
+    def post_comment(self, number: int, body: str) -> dict[str, Any]:
+        return self.request(
+            "POST",
+            f"/repos/{self.repository}/issues/{number}/comments",
+            {"body": body},
+        )
+
+    def find_decision_check(self, sha: str) -> dict[str, Any] | None:
+        query = urllib.parse.urlencode(
+            {"check_name": CHECK_NAME, "filter": "latest", "per_page": 100}
+        )
+        response = self.request(
+            "GET",
+            f"/repos/{self.repository}/commits/{sha}/check-runs?{query}",
+        )
+        external_id = decision_external_id(sha)
+        matches = [
+            check
+            for check in response["check_runs"]
+            if check.get("external_id") == external_id
+            and check.get("app", {}).get("slug") == "github-actions"
+        ]
+        return max(matches, key=lambda check: check["id"]) if matches else None
+
+    def upsert_decision(
+        self, sha: str, decision: Decision, *, create_only: bool = False
+    ) -> dict[str, Any]:
+        existing = self.find_decision_check(sha)
+        if existing is not None and create_only:
+            return existing
+
+        timestamp = utc_now()
+        payload = {
+            "status": "completed",
+            "conclusion": decision.conclusion,
+            "completed_at": timestamp,
+            "details_url": decision.details_url,
+            "output": {
+                "title": decision.title,
+                "summary": decision.summary,
+            },
+        }
+        if existing is not None:
+            return self.request(
+                "PATCH",
+                f"/repos/{self.repository}/check-runs/{existing['id']}",
+                payload,
+            )
+
+        payload.update(
+            {
+                "name": CHECK_NAME,
+                "head_sha": sha,
+                "external_id": decision_external_id(sha),
+                "started_at": timestamp,
+            }
+        )
+        return self.request(
+            "POST", f"/repos/{self.repository}/check-runs", payload
+        )
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def decision_external_id(sha: str) -> str:
+    return f"cloud-integration-decision:{sha}"
+
+
+def load_event() -> dict[str, Any]:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        raise ControllerError("GITHUB_EVENT_PATH is not set")
+    with open(event_path, encoding="utf-8") as event_file:
+        return json.load(event_file)
+
+
+def required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise ControllerError(f"{name} is not set")
+    return value
+
+
+def waiting_decision(pull_request: dict[str, Any], repository: str) -> Decision:
+    sha = pull_request["head"]["sha"]
+    is_fork = pull_request["head"]["repo"]["full_name"] != repository
+    fork_note = (
+        " This is a fork PR, so use a trusted same-repository mirror or a "
+        "maintainer override; Cloud secrets are not available to the fork."
+        if is_fork
+        else ""
+    )
+    summary = (
+        f"Head `{sha}` has no Cloud integration decision. Apply the "
+        "`run-cloud-integration` label to run the trusted planner and any "
+        f"selected live suites.{fork_note}\n\n"
+        "Maintainers may instead record a one-shot override by commenting:\n\n"
+        f"`{OVERRIDE_COMMAND} {sha} <reason or successful stack-run URL>`\n\n"
+        "A decision for another commit does not apply to this SHA."
+    )
+    return Decision(
+        conclusion="action_required",
+        title="Cloud integration decision required",
+        summary=summary,
+        details_url=pull_request["html_url"],
+    )
+
+
+def failed_decision(run: dict[str, Any], reason: str) -> Decision:
+    sha = run["head_sha"]
+    return Decision(
+        conclusion="failure",
+        title="Cloud integration decision failed",
+        summary=(
+            f"Cloud Integration run [{run['id']}]({run['html_url']}) did not "
+            f"produce a trusted successful decision for exact head `{sha}`.\n\n"
+            f"Reason: {reason}\n\n"
+            "Fix or rerun Cloud Integration, or have a maintainer record a "
+            "subsequent exact-SHA override."
+        ),
+        details_url=run["html_url"],
+    )
+
+
+def successful_live_decision(
+    run: dict[str, Any], suites: tuple[str, ...]
+) -> Decision:
+    suite_text = ", ".join(f"`{suite}`" for suite in suites)
+    return Decision(
+        conclusion="success",
+        title="Selected Cloud integration suites passed",
+        summary=(
+            f"Cloud Integration run [{run['id']}]({run['html_url']}) tested "
+            f"exact head `{run['head_sha']}`.\n\n"
+            f"Successful suites: {suite_text}."
+        ),
+        details_url=run["html_url"],
+    )
+
+
+def successful_no_suite_decision(run: dict[str, Any]) -> Decision:
+    return Decision(
+        conclusion="success",
+        title="No live Cloud integration suites selected",
+        summary=(
+            f"The trusted planner in Cloud Integration run "
+            f"[{run['id']}]({run['html_url']}) selected no live suites for "
+            f"exact head `{run['head_sha']}`. The environment-bearing "
+            f"`{LIVE_JOB_NAME}` job was skipped."
+        ),
+        details_url=run["html_url"],
+    )
+
+
+def parse_override_command(body: str) -> tuple[str, str] | None:
+    if not body.lstrip().startswith(OVERRIDE_COMMAND):
+        return None
+    match = OVERRIDE_RE.fullmatch(body.strip())
+    if match is None:
+        raise ControllerError(
+            f"override syntax is: {OVERRIDE_COMMAND} <full-head-sha> <reason>"
+        )
+    reason = match.group(2).strip()
+    if not reason:
+        raise ControllerError("override reason must not be empty")
+    return match.group(1).lower(), reason
+
+
+def permission_allows_override(permission: str | dict[str, Any]) -> bool:
+    if isinstance(permission, str):
+        return permission in {"admin", "maintain"}
+    effective = permission.get("permission", "none")
+    granular = permission.get("user", {}).get("permissions", {})
+    return effective in {"admin", "maintain"} or bool(
+        granular.get("admin") or granular.get("maintain")
+    )
+
+
+def validate_override(
+    event: dict[str, Any],
+    pull_request: dict[str, Any],
+    permission: str | dict[str, Any],
+    repository: str,
+) -> Override | None:
+    parsed = parse_override_command(event["comment"]["body"])
+    if parsed is None:
+        return None
+    sha, reason = parsed
+    actor = event["sender"]["login"]
+    if event["comment"]["user"]["login"] != actor:
+        raise ControllerError("comment author and event sender do not match")
+    if not permission_allows_override(permission):
+        return None
+    if event["repository"]["full_name"] != repository:
+        raise ControllerError("override event repository does not match")
+    if pull_request["state"] != "open":
+        raise ControllerError("override target PR is not open")
+    if pull_request["number"] != event["issue"]["number"]:
+        raise ControllerError("override event PR number does not match")
+    if pull_request["head"]["sha"].lower() != sha:
+        raise ControllerError(
+            "override SHA is stale or is not the PR's current full head SHA"
+        )
+    return Override(
+        sha=sha,
+        reason=reason,
+        actor=actor,
+        timestamp=event["comment"]["created_at"],
+        comment_url=event["comment"]["html_url"],
+    )
+
+
+def override_decision(override: Override) -> Decision:
+    quoted_reason = "\n".join(
+        f"> {line}" for line in override.reason.splitlines()
+    )
+    return Decision(
+        conclusion="success",
+        title="Maintainer Cloud integration override recorded",
+        summary=(
+            f"Actor: `@{override.actor}`  \n"
+            f"Exact head: `{override.sha}`  \n"
+            f"Recorded: `{override.timestamp}`  \n"
+            f"Audit comment: {override.comment_url}\n\n"
+            f"Reason:\n{quoted_reason}\n\n"
+            "This one-shot override does not apply after the PR head changes."
+        ),
+        details_url=override.comment_url,
+    )
+
+
+def selection_from_pull_files(files: list[dict[str, Any]]) -> Any:
+    records = []
+    status_map = {
+        "added": "A",
+        "modified": "M",
+        "changed": "M",
+        "removed": "D",
+    }
+    for changed_file in files:
+        status = changed_file.get("status")
+        filename = changed_file.get("filename")
+        if not isinstance(filename, str) or not filename:
+            return classifier.Selection(
+                classifier.SUITES,
+                failed_closed=True,
+                reason="GitHub returned a changed file without a filename",
+            )
+        if status in status_map:
+            records.append((status_map[status], (filename,)))
+        elif status in {"renamed", "copied"}:
+            previous = changed_file.get("previous_filename")
+            if not isinstance(previous, str) or not previous:
+                return classifier.Selection(
+                    classifier.SUITES,
+                    failed_closed=True,
+                    reason=f"GitHub omitted the previous filename for {filename}",
+                )
+            marker = "R100" if status == "renamed" else "C100"
+            records.append((marker, (previous, filename)))
+        else:
+            return classifier.Selection(
+                classifier.SUITES,
+                failed_closed=True,
+                reason=f"GitHub returned unsupported file status {status!r}",
+            )
+    return classifier.select_records(records)
+
+
+def current_run_is_safe(
+    run: dict[str, Any], pull_request: dict[str, Any], repository: str
+) -> bool:
+    source_prs = run.get("pull_requests") or []
+    if len(source_prs) != 1:
+        return False
+    source_pr = source_prs[0]
+    head_repository = run.get("head_repository") or {}
+    return all(
+        (
+            run.get("path") == SOURCE_WORKFLOW_PATH,
+            run.get("event") == "pull_request",
+            run.get("status") == "completed",
+            head_repository.get("full_name") == repository,
+            pull_request.get("state") == "open",
+            source_pr.get("number") == pull_request.get("number"),
+            source_pr.get("head", {}).get("sha") == run.get("head_sha"),
+            pull_request.get("head", {}).get("sha") == run.get("head_sha"),
+            pull_request.get("head", {}).get("ref") == run.get("head_branch"),
+            pull_request.get("head", {}).get("repo", {}).get("full_name")
+            == repository,
+            source_pr.get("base", {}).get("sha")
+            == pull_request.get("base", {}).get("sha"),
+        )
+    )
+
+
+def one_job(jobs: list[dict[str, Any]], name: str) -> dict[str, Any] | None:
+    matches = [job for job in jobs if job.get("name") == name]
+    return matches[0] if len(matches) == 1 else None
+
+
+def successful_suite_steps(
+    live_job: dict[str, Any],
+) -> tuple[tuple[str, ...], str | None]:
+    selected = set()
+    steps = live_job.get("steps") or []
+    for step_name, suite in SUITE_STEPS.items():
+        matches = [step for step in steps if step.get("name") == step_name]
+        if len(matches) != 1:
+            return (), f"live job did not contain exactly one {step_name!r} step"
+        conclusion = matches[0].get("conclusion")
+        if conclusion == "success":
+            selected.add(suite)
+        elif conclusion != "skipped":
+            return (), f"{step_name!r} concluded {conclusion!r}"
+    return tuple(suite for suite in classifier.SUITES if suite in selected), None
+
+
+def evaluate_workflow_run(
+    run: dict[str, Any],
+    pull_request: dict[str, Any],
+    jobs: list[dict[str, Any]],
+    repository: str,
+    source_workflow_unchanged: bool,
+    selection: Any | None,
+) -> Decision | None:
+    if not current_run_is_safe(run, pull_request, repository):
+        return None
+
+    plan_job = one_job(jobs, PLAN_JOB_NAME)
+    if plan_job is None or plan_job.get("conclusion") == "skipped":
+        return None
+    if not source_workflow_unchanged:
+        return failed_decision(run, "the PR changes the trusted Cloud workflow")
+    if plan_job.get("conclusion") != "success":
+        return failed_decision(
+            run, f"planner job concluded {plan_job.get('conclusion')!r}"
+        )
+    if selection is None:
+        return failed_decision(run, "trusted suite selection was unavailable")
+
+    live_job = one_job(jobs, LIVE_JOB_NAME)
+    if live_job is None:
+        return failed_decision(run, "the environment-bearing job was missing")
+
+    expected_suites = tuple(selection.suites)
+    if live_job.get("conclusion") == "skipped":
+        if expected_suites:
+            return failed_decision(
+                run,
+                "the environment-bearing job was skipped although trusted "
+                f"selection required {classifier.format_suites(expected_suites)}",
+            )
+        if run.get("conclusion") != "success":
+            return failed_decision(
+                run, f"workflow concluded {run.get('conclusion')!r}"
+            )
+        return successful_no_suite_decision(run)
+
+    if live_job.get("conclusion") != "success":
+        return failed_decision(
+            run,
+            f"environment-bearing job concluded {live_job.get('conclusion')!r}",
+        )
+    if run.get("conclusion") != "success":
+        return failed_decision(
+            run, f"workflow concluded {run.get('conclusion')!r}"
+        )
+
+    actual_suites, step_error = successful_suite_steps(live_job)
+    if step_error is not None:
+        return failed_decision(run, step_error)
+    if actual_suites != expected_suites or not actual_suites:
+        return failed_decision(
+            run,
+            "successful suite steps did not match trusted selection "
+            f"(expected {classifier.format_suites(expected_suites)}, got "
+            f"{classifier.format_suites(actual_suites)})",
+        )
+    return successful_live_decision(run, actual_suites)
+
+
+def initialize(api: GitHubAPI, event: dict[str, Any], repository: str) -> None:
+    pull_request = event["pull_request"]
+    decision = waiting_decision(pull_request, repository)
+    check = api.upsert_decision(
+        pull_request["head"]["sha"], decision, create_only=True
+    )
+    print(f"Decision check {check['id']} initialized for {pull_request['head']['sha']}")
+
+
+def reconcile(api: GitHubAPI, event: dict[str, Any], repository: str) -> None:
+    run = event["workflow_run"]
+    source_prs = run.get("pull_requests") or []
+    if len(source_prs) != 1:
+        print("Ignoring Cloud run without exactly one associated PR")
+        return
+
+    pull_request = api.get_pull(source_prs[0]["number"])
+    if not current_run_is_safe(run, pull_request, repository):
+        print("Ignoring fork, stale, non-PR, or otherwise unrelated Cloud run")
+        return
+
+    jobs = api.list_run_jobs(run["id"])
+    plan_job = one_job(jobs, PLAN_JOB_NAME)
+    if plan_job is None or plan_job.get("conclusion") == "skipped":
+        print("Ignoring Cloud run whose admission/planner job did not run")
+        return
+
+    base_sha = pull_request["base"]["sha"]
+    head_sha = pull_request["head"]["sha"]
+    base_workflow = api.content_blob_sha(SOURCE_WORKFLOW_PATH, base_sha)
+    head_workflow = api.content_blob_sha(SOURCE_WORKFLOW_PATH, head_sha)
+    source_unchanged = base_workflow is not None and head_workflow == base_workflow
+
+    selection = None
+    if source_unchanged and plan_job.get("conclusion") == "success":
+        try:
+            selection = selection_from_pull_files(
+                api.list_pull_files(pull_request["number"])
+            )
+        except ControllerError as error:
+            selection = classifier.Selection(
+                classifier.SUITES, failed_closed=True, reason=str(error)
+            )
+
+    decision = evaluate_workflow_run(
+        run,
+        pull_request,
+        jobs,
+        repository,
+        source_unchanged,
+        selection,
+    )
+    if decision is None:
+        print("Cloud run did not change the current decision")
+        return
+    check = api.upsert_decision(head_sha, decision)
+    print(
+        f"Decision check {check['id']} updated to {decision.conclusion} for {head_sha}"
+    )
+
+
+def record_override(
+    api: GitHubAPI, event: dict[str, Any], repository: str
+) -> None:
+    parsed = parse_override_command(event["comment"]["body"])
+    if parsed is None:
+        print("Ignoring unrelated PR comment")
+        return
+
+    actor = event["sender"]["login"]
+    permission = api.collaborator_permission(actor)
+    if not permission_allows_override(permission):
+        level = permission.get("permission", "none")
+        print(f"Ignoring override from @{actor} with {level!r} permission")
+        return
+
+    pull_number = event["issue"]["number"]
+    pull_request = api.get_pull(pull_number)
+    override = validate_override(event, pull_request, permission, repository)
+    if override is None:
+        return
+    decision = override_decision(override)
+    check = api.upsert_decision(override.sha, decision)
+
+    reason_quote = "\n".join(f"> {line}" for line in override.reason.splitlines())
+    api.post_comment(
+        pull_number,
+        (
+            f"Cloud integration override recorded by `@{override.actor}`.\n\n"
+            f"- Exact head: `{override.sha}`\n"
+            f"- Recorded: `{override.timestamp}`\n"
+            f"- Decision check: {check['html_url']}\n\n"
+            f"Reason:\n{reason_quote}\n\n"
+            "This override is one-shot. A new head SHA requires a new decision."
+        ),
+    )
+    print(f"Override recorded in decision check {check['id']} for {override.sha}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("initialize", "reconcile", "override"))
+    args = parser.parse_args()
+
+    repository = required_env("GITHUB_REPOSITORY")
+    api = GitHubAPI(
+        required_env("GITHUB_API_URL"), repository, required_env("GH_TOKEN")
+    )
+    event = load_event()
+
+    if args.mode == "initialize":
+        initialize(api, event, repository)
+    elif args.mode == "reconcile":
+        reconcile(api, event, repository)
+    else:
+        record_override(api, event, repository)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ControllerError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/scripts/cloud-integration-decision.py
+++ b/scripts/cloud-integration-decision.py
@@ -241,7 +241,8 @@ def required_env(name: str) -> str:
 
 def waiting_decision(pull_request: dict[str, Any], repository: str) -> Decision:
     sha = pull_request["head"]["sha"]
-    is_fork = pull_request["head"]["repo"]["full_name"] != repository
+    head_repository = pull_request["head"].get("repo") or {}
+    is_fork = head_repository.get("full_name") != repository
     fork_note = (
         " This is a fork PR, so use a trusted same-repository mirror or a "
         "maintainer override; Cloud secrets are not available to the fork."
@@ -432,7 +433,12 @@ def current_run_is_safe(
     if len(source_prs) != 1:
         return False
     source_pr = source_prs[0]
+    source_head = source_pr.get("head") or {}
+    source_base = source_pr.get("base") or {}
     head_repository = run.get("head_repository") or {}
+    pull_head = pull_request.get("head") or {}
+    pull_head_repository = pull_head.get("repo") or {}
+    pull_base = pull_request.get("base") or {}
     return all(
         (
             run.get("path") == SOURCE_WORKFLOW_PATH,
@@ -441,13 +447,11 @@ def current_run_is_safe(
             head_repository.get("full_name") == repository,
             pull_request.get("state") == "open",
             source_pr.get("number") == pull_request.get("number"),
-            source_pr.get("head", {}).get("sha") == run.get("head_sha"),
-            pull_request.get("head", {}).get("sha") == run.get("head_sha"),
-            pull_request.get("head", {}).get("ref") == run.get("head_branch"),
-            pull_request.get("head", {}).get("repo", {}).get("full_name")
-            == repository,
-            source_pr.get("base", {}).get("sha")
-            == pull_request.get("base", {}).get("sha"),
+            source_head.get("sha") == run.get("head_sha"),
+            pull_head.get("sha") == run.get("head_sha"),
+            pull_head.get("ref") == run.get("head_branch"),
+            pull_head_repository.get("full_name") == repository,
+            source_base.get("sha") == pull_base.get("sha"),
         )
     )
 
@@ -602,21 +606,35 @@ def reconcile(api: GitHubAPI, event: dict[str, Any], repository: str) -> None:
 def record_override(
     api: GitHubAPI, event: dict[str, Any], repository: str
 ) -> None:
-    parsed = parse_override_command(event["comment"]["body"])
+    actor = event["sender"]["login"]
+    pull_number = event["issue"]["number"]
+    try:
+        parsed = parse_override_command(event["comment"]["body"])
+    except ControllerError as error:
+        post_override_rejection(api, pull_number, actor, str(error))
+        return
     if parsed is None:
         print("Ignoring unrelated PR comment")
         return
 
-    actor = event["sender"]["login"]
     permission = api.collaborator_permission(actor)
     if not permission_allows_override(permission):
         level = permission.get("permission", "none")
+        post_override_rejection(
+            api,
+            pull_number,
+            actor,
+            "override commands require `maintain` or `admin` permission",
+        )
         print(f"Ignoring override from @{actor} with {level!r} permission")
         return
 
-    pull_number = event["issue"]["number"]
     pull_request = api.get_pull(pull_number)
-    override = validate_override(event, pull_request, permission, repository)
+    try:
+        override = validate_override(event, pull_request, permission, repository)
+    except ControllerError as error:
+        post_override_rejection(api, pull_number, actor, str(error))
+        return
     if override is None:
         return
     decision = override_decision(override)
@@ -635,6 +653,20 @@ def record_override(
         ),
     )
     print(f"Override recorded in decision check {check['id']} for {override.sha}")
+
+
+def post_override_rejection(
+    api: GitHubAPI, pull_number: int, actor: str, reason: str
+) -> None:
+    api.post_comment(
+        pull_number,
+        (
+            f"Cloud integration override from `@{actor}` was not recorded.\n\n"
+            f"Reason: {reason}.\n\n"
+            "No decision check was changed."
+        ),
+    )
+    print(f"Override from @{actor} was not recorded: {reason}")
 
 
 def main() -> int:

--- a/scripts/tests/test_cloud_integration_decision.py
+++ b/scripts/tests/test_cloud_integration_decision.py
@@ -1,0 +1,350 @@
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "cloud-integration-decision.py"
+SPEC = importlib.util.spec_from_file_location("cloud_integration_decision", SCRIPT)
+decision = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = decision
+SPEC.loader.exec_module(decision)
+
+REPO = "ClickHouse/clickhousectl"
+HEAD_SHA = "a" * 40
+NEW_HEAD_SHA = "b" * 40
+BASE_SHA = "c" * 40
+
+
+def pull_request(*, head_sha=HEAD_SHA, head_repo=REPO, base_sha=BASE_SHA):
+    return {
+        "number": 410,
+        "state": "open",
+        "html_url": "https://github.example/pull/410",
+        "head": {
+            "sha": head_sha,
+            "ref": "feature",
+            "repo": {"full_name": head_repo},
+        },
+        "base": {"sha": base_sha},
+    }
+
+
+def workflow_run(*, head_sha=HEAD_SHA, conclusion="success"):
+    return {
+        "id": 1234,
+        "html_url": "https://github.example/actions/runs/1234",
+        "path": decision.SOURCE_WORKFLOW_PATH,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusion": conclusion,
+        "head_sha": head_sha,
+        "head_branch": "feature",
+        "head_repository": {"full_name": REPO},
+        "pull_requests": [
+            {
+                "number": 410,
+                "head": {"sha": head_sha},
+                "base": {"sha": BASE_SHA},
+            }
+        ],
+    }
+
+
+def plan_job(conclusion="success"):
+    return {"name": decision.PLAN_JOB_NAME, "conclusion": conclusion}
+
+
+def live_job(selected=(), conclusion="success"):
+    selected = set(selected)
+    return {
+        "name": decision.LIVE_JOB_NAME,
+        "conclusion": conclusion,
+        "steps": [
+            {
+                "name": step,
+                "conclusion": "success" if suite in selected else "skipped",
+            }
+            for step, suite in decision.SUITE_STEPS.items()
+        ],
+    }
+
+
+def selection(*suites):
+    return decision.classifier.Selection(tuple(suites))
+
+
+class CloudIntegrationDecisionTests(unittest.TestCase):
+    def evaluate(self, jobs, selected, **kwargs):
+        return decision.evaluate_workflow_run(
+            kwargs.get("run", workflow_run()),
+            kwargs.get("pr", pull_request()),
+            jobs,
+            REPO,
+            kwargs.get("source_unchanged", True),
+            selected,
+        )
+
+    def test_initial_decision_is_exact_sha_and_action_required(self):
+        result = decision.waiting_decision(pull_request(), REPO)
+        self.assertEqual(result.conclusion, "action_required")
+        self.assertIn(HEAD_SHA, result.summary)
+        self.assertIn("run-cloud-integration", result.summary)
+        self.assertIn(decision.OVERRIDE_COMMAND, result.summary)
+
+    def test_successful_selected_live_suites_satisfy_decision(self):
+        suites = ("service", "clickpipes")
+        result = self.evaluate(
+            [plan_job(), live_job(suites)], selection(*suites)
+        )
+        self.assertEqual(result.conclusion, "success")
+        self.assertIn(HEAD_SHA, result.summary)
+        self.assertIn("`service`", result.summary)
+        self.assertIn("`clickpipes`", result.summary)
+
+    def test_success_requires_exact_trusted_suite_selection(self):
+        result = self.evaluate(
+            [plan_job(), live_job(("service",))],
+            selection("service", "postgres"),
+        )
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("did not match trusted selection", result.summary)
+
+    def test_failed_live_job_keeps_decision_failing(self):
+        result = self.evaluate(
+            [plan_job(), live_job(("service",), conclusion="failure")],
+            selection("service"),
+            run=workflow_run(conclusion="failure"),
+        )
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("concluded 'failure'", result.summary)
+
+    def test_no_suite_succeeds_only_when_secret_job_was_skipped(self):
+        result = self.evaluate(
+            [plan_job(), live_job((), conclusion="skipped")], selection()
+        )
+        self.assertEqual(result.conclusion, "success")
+        self.assertIn("selected no live suites", result.summary)
+        self.assertIn("was skipped", result.summary)
+
+    def test_skipped_secret_job_fails_when_a_suite_was_selected(self):
+        result = self.evaluate(
+            [plan_job(), live_job((), conclusion="skipped")],
+            selection("organization"),
+        )
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("was skipped although", result.summary)
+
+    def test_unrelated_label_with_skipped_admission_is_ignored(self):
+        result = self.evaluate(
+            [plan_job("skipped"), live_job((), conclusion="skipped")],
+            selection(),
+        )
+        self.assertIsNone(result)
+
+    def test_stale_run_is_ignored_after_new_head(self):
+        result = self.evaluate(
+            [plan_job(), live_job(("service",))],
+            selection("service"),
+            pr=pull_request(head_sha=NEW_HEAD_SHA),
+        )
+        self.assertIsNone(result)
+
+    def test_run_for_stale_base_revision_is_ignored(self):
+        result = self.evaluate(
+            [plan_job(), live_job(("service",))],
+            selection("service"),
+            pr=pull_request(base_sha="d" * 40),
+        )
+        self.assertIsNone(result)
+
+    def test_fork_run_cannot_satisfy_decision(self):
+        run = workflow_run()
+        run["head_repository"] = {"full_name": "contributor/fork"}
+        result = self.evaluate(
+            [plan_job(), live_job(("service",))],
+            selection("service"),
+            run=run,
+            pr=pull_request(head_repo="contributor/fork"),
+        )
+        self.assertIsNone(result)
+
+    def test_non_pr_and_wrong_workflow_runs_are_ignored(self):
+        for key, value in (
+            ("event", "workflow_dispatch"),
+            ("path", ".github/workflows/other.yml"),
+        ):
+            run = workflow_run()
+            run[key] = value
+            with self.subTest(key=key):
+                self.assertIsNone(
+                    self.evaluate(
+                        [plan_job(), live_job(("service",))],
+                        selection("service"),
+                        run=run,
+                    )
+                )
+
+    def test_changed_source_workflow_cannot_attest_itself(self):
+        result = self.evaluate(
+            [plan_job(), live_job(("service",))],
+            selection("service"),
+            source_unchanged=False,
+        )
+        self.assertEqual(result.conclusion, "failure")
+        self.assertIn("changes the trusted Cloud workflow", result.summary)
+
+    def test_classifier_handles_github_file_records_and_renames(self):
+        result = decision.selection_from_pull_files(
+            [
+                {
+                    "status": "renamed",
+                    "previous_filename": (
+                        "crates/clickhouse-cloud-api/src/models/activity.rs"
+                    ),
+                    "filename": (
+                        "crates/clickhouse-cloud-api/src/models/services.rs"
+                    ),
+                },
+                {"status": "modified", "filename": "README.md"},
+            ]
+        )
+        self.assertEqual(
+            result.suites, ("service", "organization", "clickpipes")
+        )
+        self.assertFalse(result.failed_closed)
+
+    def test_unknown_file_status_fails_closed_to_all_suites(self):
+        result = decision.selection_from_pull_files(
+            [{"status": "mystery", "filename": "README.md"}]
+        )
+        self.assertEqual(result.suites, decision.classifier.SUITES)
+        self.assertTrue(result.failed_closed)
+
+    def test_override_requires_full_sha_and_reason(self):
+        self.assertIsNone(decision.parse_override_command("ordinary comment"))
+        for body in (
+            decision.OVERRIDE_COMMAND,
+            f"{decision.OVERRIDE_COMMAND} abc reason",
+            f"{decision.OVERRIDE_COMMAND} {HEAD_SHA}",
+            f"{decision.OVERRIDE_COMMAND} {HEAD_SHA}   ",
+        ):
+            with self.subTest(body=body):
+                with self.assertRaises(decision.ControllerError):
+                    decision.parse_override_command(body)
+        self.assertEqual(
+            decision.parse_override_command(
+                f"{decision.OVERRIDE_COMMAND} {HEAD_SHA} covered by run 123"
+            ),
+            (HEAD_SHA, "covered by run 123"),
+        )
+
+    def test_only_maintain_and_admin_permissions_can_override(self):
+        for permission in ("admin", "maintain"):
+            self.assertTrue(decision.permission_allows_override(permission))
+        for permission in ("write", "triage", "read", "none"):
+            self.assertFalse(decision.permission_allows_override(permission))
+        self.assertTrue(
+            decision.permission_allows_override(
+                {
+                    "permission": "write",
+                    "user": {"permissions": {"maintain": True}},
+                }
+            )
+        )
+        self.assertFalse(
+            decision.permission_allows_override(
+                {
+                    "permission": "write",
+                    "user": {"permissions": {"push": True}},
+                }
+            )
+        )
+
+    def test_override_is_bound_to_current_head_and_audited(self):
+        event = {
+            "repository": {"full_name": REPO},
+            "issue": {"number": 410},
+            "sender": {"login": "maintainer"},
+            "comment": {
+                "body": (
+                    f"{decision.OVERRIDE_COMMAND} {HEAD_SHA} "
+                    "covered by stack run 123"
+                ),
+                "created_at": "2026-08-26T12:00:00Z",
+                "html_url": "https://github.example/comment/1",
+                "user": {"login": "maintainer"},
+            },
+        }
+        override = decision.validate_override(
+            event, pull_request(), "maintain", REPO
+        )
+        result = decision.override_decision(override)
+        self.assertEqual(result.conclusion, "success")
+        self.assertIn("maintainer", result.summary)
+        self.assertIn(HEAD_SHA, result.summary)
+        self.assertIn("2026-08-26T12:00:00Z", result.summary)
+        self.assertIn("covered by stack run 123", result.summary)
+
+        with self.assertRaises(decision.ControllerError):
+            decision.validate_override(
+                event, pull_request(head_sha=NEW_HEAD_SHA), "maintain", REPO
+            )
+
+    def test_unauthorized_override_is_ignored(self):
+        event = {
+            "repository": {"full_name": REPO},
+            "issue": {"number": 410},
+            "sender": {"login": "writer"},
+            "comment": {
+                "body": f"{decision.OVERRIDE_COMMAND} {HEAD_SHA} reason",
+                "created_at": "2026-08-26T12:00:00Z",
+                "html_url": "https://github.example/comment/1",
+                "user": {"login": "writer"},
+            },
+        }
+        self.assertIsNone(
+            decision.validate_override(event, pull_request(), "write", REPO)
+        )
+
+
+class CloudIntegrationDecisionWorkflowTests(unittest.TestCase):
+    def test_controller_workflow_never_checks_out_pr_code(self):
+        workflow_path = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "cloud-integration-decision.yml"
+        )
+        workflow = workflow_path.read_text(encoding="utf-8")
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", workflow)
+        self.assertNotIn("github.event.pull_request.head", workflow)
+        self.assertNotIn("github.event.pull_request.base.sha", workflow)
+        self.assertEqual(workflow.count("persist-credentials: false"), 3)
+
+        checkout_uses = re.findall(r"actions/checkout@([^\s]+)", workflow)
+        self.assertEqual(len(checkout_uses), 3)
+        self.assertTrue(
+            all(re.fullmatch(r"[0-9a-f]{40}", pin) for pin in checkout_uses)
+        )
+
+    def test_controller_has_narrow_explicit_write_permissions(self):
+        workflow_path = (
+            Path(__file__).resolve().parents[2]
+            / ".github"
+            / "workflows"
+            / "cloud-integration-decision.yml"
+        )
+        workflow = workflow_path.read_text(encoding="utf-8")
+        self.assertIn("actions: read", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertIn("checks: write", workflow)
+        self.assertIn("issues: write", workflow)
+        self.assertIn("pull-requests: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("statuses: write", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_cloud_integration_decision.py
+++ b/scripts/tests/test_cloud_integration_decision.py
@@ -3,6 +3,7 @@ import re
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 SCRIPT = Path(__file__).resolve().parents[1] / "cloud-integration-decision.py"
 SPEC = importlib.util.spec_from_file_location("cloud_integration_decision", SCRIPT)
@@ -17,6 +18,7 @@ BASE_SHA = "c" * 40
 
 
 def pull_request(*, head_sha=HEAD_SHA, head_repo=REPO, base_sha=BASE_SHA):
+    repo = None if head_repo is None else {"full_name": head_repo}
     return {
         "number": 410,
         "state": "open",
@@ -24,7 +26,7 @@ def pull_request(*, head_sha=HEAD_SHA, head_repo=REPO, base_sha=BASE_SHA):
         "head": {
             "sha": head_sha,
             "ref": "feature",
-            "repo": {"full_name": head_repo},
+            "repo": repo,
         },
         "base": {"sha": base_sha},
     }
@@ -72,6 +74,250 @@ def live_job(selected=(), conclusion="success"):
 
 def selection(*suites):
     return decision.classifier.Selection(tuple(suites))
+
+
+def override_event(*, actor="maintainer", sha=HEAD_SHA, body=None):
+    if body is None:
+        body = f"{decision.OVERRIDE_COMMAND} {sha} covered by stack run 123"
+    return {
+        "repository": {"full_name": REPO},
+        "issue": {"number": 410},
+        "sender": {"login": actor},
+        "comment": {
+            "body": body,
+            "created_at": "2026-08-26T12:00:00Z",
+            "html_url": "https://github.example/comment/1",
+            "user": {"login": actor},
+        },
+    }
+
+
+class GitHubAPITests(unittest.TestCase):
+    def setUp(self):
+        self.api = decision.GitHubAPI("https://api.github.example", REPO, "token")
+        self.result = decision.Decision(
+            conclusion="success",
+            title="Accepted",
+            summary="Exact SHA accepted",
+            details_url="https://github.example/run/1",
+        )
+
+    def test_find_decision_check_uses_external_id_app_and_latest_id(self):
+        external_id = decision.decision_external_id(HEAD_SHA)
+        response = {
+            "check_runs": [
+                {
+                    "id": 99,
+                    "external_id": "unrelated",
+                    "app": {"slug": "github-actions"},
+                },
+                {
+                    "id": 12,
+                    "external_id": external_id,
+                    "app": {"slug": "github-actions"},
+                },
+                {
+                    "id": 15,
+                    "external_id": external_id,
+                    "app": {"slug": "github-actions"},
+                },
+                {
+                    "id": 30,
+                    "external_id": external_id,
+                    "app": {"slug": "other-app"},
+                },
+            ]
+        }
+        with mock.patch.object(self.api, "request", return_value=response) as request:
+            result = self.api.find_decision_check(HEAD_SHA)
+
+        self.assertEqual(result["id"], 15)
+        method, path = request.call_args.args
+        self.assertEqual(method, "GET")
+        self.assertIn(f"/commits/{HEAD_SHA}/check-runs?", path)
+        self.assertIn("check_name=Cloud+integration+decision", path)
+
+    def test_upsert_creates_once_then_updates_the_same_check(self):
+        existing = {"id": 42}
+        with (
+            mock.patch.object(
+                self.api, "find_decision_check", side_effect=(None, existing)
+            ),
+            mock.patch.object(
+                self.api,
+                "request",
+                side_effect=({"id": 42}, {"id": 42}),
+            ) as request,
+            mock.patch.object(
+                decision, "utc_now", return_value="2026-08-26T12:00:00Z"
+            ),
+        ):
+            self.api.upsert_decision(HEAD_SHA, self.result)
+            self.api.upsert_decision(HEAD_SHA, self.result)
+
+        create_method, create_path, create_payload = request.call_args_list[0].args
+        self.assertEqual(
+            (create_method, create_path),
+            ("POST", f"/repos/{REPO}/check-runs"),
+        )
+        self.assertEqual(create_payload["name"], decision.CHECK_NAME)
+        self.assertEqual(create_payload["head_sha"], HEAD_SHA)
+        self.assertEqual(
+            create_payload["external_id"], decision.decision_external_id(HEAD_SHA)
+        )
+
+        update_method, update_path, update_payload = request.call_args_list[1].args
+        self.assertEqual(
+            (update_method, update_path),
+            ("PATCH", f"/repos/{REPO}/check-runs/42"),
+        )
+        self.assertNotIn("name", update_payload)
+        self.assertNotIn("head_sha", update_payload)
+
+    def test_create_only_returns_existing_check_without_updating(self):
+        existing = {"id": 42, "conclusion": "success"}
+        with (
+            mock.patch.object(
+                self.api, "find_decision_check", return_value=existing
+            ),
+            mock.patch.object(self.api, "request") as request,
+        ):
+            result = self.api.upsert_decision(
+                HEAD_SHA, self.result, create_only=True
+            )
+
+        self.assertIs(result, existing)
+        request.assert_not_called()
+
+
+class ControllerFlowTests(unittest.TestCase):
+    def test_initialize_uses_create_only_for_the_exact_head(self):
+        api = mock.Mock()
+        api.upsert_decision.return_value = {"id": 42}
+
+        with mock.patch("builtins.print"):
+            decision.initialize(
+                api, {"pull_request": pull_request(head_repo=None)}, REPO
+            )
+
+        sha, result = api.upsert_decision.call_args.args
+        self.assertEqual(sha, HEAD_SHA)
+        self.assertEqual(result.conclusion, "action_required")
+        self.assertIn("fork PR", result.summary)
+        self.assertTrue(api.upsert_decision.call_args.kwargs["create_only"])
+
+    def test_reconcile_ignores_run_without_one_associated_pull(self):
+        api = mock.Mock()
+        run = workflow_run()
+        run["pull_requests"] = []
+
+        with mock.patch("builtins.print"):
+            decision.reconcile(api, {"workflow_run": run}, REPO)
+
+        api.get_pull.assert_not_called()
+        api.upsert_decision.assert_not_called()
+
+    def test_reconcile_ignores_deleted_fork_before_loading_jobs(self):
+        api = mock.Mock()
+        api.get_pull.return_value = pull_request(head_repo=None)
+
+        with mock.patch("builtins.print"):
+            decision.reconcile(api, {"workflow_run": workflow_run()}, REPO)
+
+        api.list_run_jobs.assert_not_called()
+        api.upsert_decision.assert_not_called()
+
+    def test_reconcile_ignores_run_with_skipped_planner(self):
+        api = mock.Mock()
+        api.get_pull.return_value = pull_request()
+        api.list_run_jobs.return_value = [plan_job("skipped")]
+
+        with mock.patch("builtins.print"):
+            decision.reconcile(api, {"workflow_run": workflow_run()}, REPO)
+
+        api.content_blob_sha.assert_not_called()
+        api.upsert_decision.assert_not_called()
+
+    def test_reconcile_updates_decision_from_trusted_evidence(self):
+        api = mock.Mock()
+        api.get_pull.return_value = pull_request()
+        api.list_run_jobs.return_value = [plan_job(), live_job(("service",))]
+        api.content_blob_sha.side_effect = ("workflow-blob", "workflow-blob")
+        api.list_pull_files.return_value = [
+            {"status": "modified", "filename": "README.md"}
+        ]
+        api.upsert_decision.return_value = {"id": 42}
+
+        with (
+            mock.patch.object(
+                decision,
+                "selection_from_pull_files",
+                return_value=selection("service"),
+            ),
+            mock.patch("builtins.print"),
+        ):
+            decision.reconcile(api, {"workflow_run": workflow_run()}, REPO)
+
+        sha, result = api.upsert_decision.call_args.args
+        self.assertEqual(sha, HEAD_SHA)
+        self.assertEqual(result.conclusion, "success")
+        self.assertEqual(
+            api.content_blob_sha.call_args_list,
+            [
+                mock.call(decision.SOURCE_WORKFLOW_PATH, BASE_SHA),
+                mock.call(decision.SOURCE_WORKFLOW_PATH, HEAD_SHA),
+            ],
+        )
+
+    def test_record_override_updates_check_and_posts_audit_comment(self):
+        api = mock.Mock()
+        api.collaborator_permission.return_value = {"permission": "maintain"}
+        api.get_pull.return_value = pull_request()
+        api.upsert_decision.return_value = {
+            "id": 42,
+            "html_url": "https://github.example/check/42",
+        }
+
+        with mock.patch("builtins.print"):
+            decision.record_override(api, override_event(), REPO)
+
+        sha, result = api.upsert_decision.call_args.args
+        self.assertEqual(sha, HEAD_SHA)
+        self.assertEqual(result.conclusion, "success")
+        pull_number, comment = api.post_comment.call_args.args
+        self.assertEqual(pull_number, 410)
+        self.assertIn("override recorded by `@maintainer`", comment)
+        self.assertIn("https://github.example/check/42", comment)
+
+    def test_record_override_posts_feedback_when_permission_is_insufficient(self):
+        api = mock.Mock()
+        api.collaborator_permission.return_value = {"permission": "write"}
+
+        with mock.patch("builtins.print"):
+            decision.record_override(api, override_event(actor="writer"), REPO)
+
+        api.get_pull.assert_not_called()
+        api.upsert_decision.assert_not_called()
+        pull_number, comment = api.post_comment.call_args.args
+        self.assertEqual(pull_number, 410)
+        self.assertIn("was not recorded", comment)
+        self.assertIn("`maintain` or `admin`", comment)
+        self.assertIn("No decision check was changed", comment)
+
+    def test_record_override_posts_feedback_for_stale_sha(self):
+        api = mock.Mock()
+        api.collaborator_permission.return_value = {"permission": "maintain"}
+        api.get_pull.return_value = pull_request(head_sha=NEW_HEAD_SHA)
+
+        with mock.patch("builtins.print"):
+            decision.record_override(api, override_event(), REPO)
+
+        api.upsert_decision.assert_not_called()
+        pull_number, comment = api.post_comment.call_args.args
+        self.assertEqual(pull_number, 410)
+        self.assertIn("was not recorded", comment)
+        self.assertIn("SHA is stale", comment)
+        self.assertIn("No decision check was changed", comment)
 
 
 class CloudIntegrationDecisionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add a trusted controller that creates one `Cloud integration decision` check per exact PR head SHA
- accept only verified selected-suite success, trusted no-suite plans, or maintain/admin exact-SHA comment overrides with an audit trail
- reject stale, fork, skipped-admission, unrelated, and self-modified workflow evidence without executing PR code on write-capable controller paths
- document stacked-PR handling and wire controller tests into ordinary Cloud API CI

## Tests
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (65 passed)\n- `python3 -m py_compile scripts/cloud-integration-decision.py scripts/tests/test_cloud_integration_decision.py`\n- `cargo fmt --all --check`\n- Ruby YAML parse for the changed workflows\n- `git diff --check`\n\n## Rollout\nDo not require the check before this stack lands on the default branch. After merge, initialize and exercise `Cloud integration decision` on a representative current PR, then add that GitHub Actions check to the required status checks for `main`; existing open PRs must first be synchronized/reopened, label-run, or explicitly overridden. Keep the on-demand `Cloud Integration` workflow itself informational.\n\nCloses #410