### PR TITLE
Require a service selector when parsing cloud service query

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -5,8 +5,8 @@ use crate::cloud::credentials;
 use crate::cloud::output::{ABSENT, or_absent, print_human};
 use crate::cloud::shared::{parse_serde_enum, parse_tags, resolve_org_id};
 use crate::cloud::types::DeleteResponse;
-use clap::Subcommand;
 use clap::builder::PossibleValuesParser;
+use clap::{ArgGroup, Subcommand};
 use clickhouse_cloud_api::models::{
     AutoscalingMode, InstancePrivateEndpointsPatch, InstanceServiceQueryApiEndpointsPostRequest,
     InstanceTagsPatch, IpAccessListEntry, IpAccessListPatch, QueryEndpointRole,
@@ -402,7 +402,9 @@ CONTEXT FOR AGENTS:
     },
 
     /// Run a SQL query against a cloud service over HTTP via the Query API
-    #[command(after_help = "\
+    #[command(
+        group(ArgGroup::new("service_selector").required(true).args(["name", "id"])),
+        after_help = "\
 CONTEXT FOR AGENTS:
   Runs SQL over HTTP — no local clickhouse binary or service password required.
   With API key auth: first uses the authenticated key directly when the query
@@ -417,7 +419,8 @@ CONTEXT FOR AGENTS:
   SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
   on a TTY, TabSeparated when piped. --json selects JSONEachRow and cannot be
   combined with --format; an explicit --format takes precedence over agent
-  auto-JSON.")]
+  auto-JSON."
+    )]
     Query {
         /// Service name to query (exactly one of --name or --id is required)
         #[arg(long, conflicts_with = "id")]
@@ -3149,7 +3152,14 @@ mod tests {
 
     #[test]
     fn parses_service_query_options() {
-        let command = parse_service(&["clickhousectl", "cloud", "service", "query"]);
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+        ]);
         let crate::cloud::cli::ServiceCommands::Query {
             name,
             id,
@@ -3164,7 +3174,7 @@ mod tests {
             panic!("expected service query");
         };
         assert!(name.is_none());
-        assert!(id.is_none());
+        assert_eq!(id.as_deref(), Some("svc-1"));
         assert!(query.is_none());
         assert!(queries_file.is_none());
         assert!(database.is_none());
@@ -3213,6 +3223,28 @@ mod tests {
         assert_eq!(format.as_deref(), Some("CSV"));
         assert_eq!(org_id.as_deref(), Some("org-1"));
         assert!(no_auto_enable);
+    }
+
+    #[test]
+    fn rejects_service_query_without_name_or_id() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--query",
+            "SELECT 1",
+        ])
+        .err()
+        .expect("service query without a selector should fail");
+
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        let message = error.to_string();
+        assert!(message.contains("--name <NAME>"), "{message}");
+        assert!(message.contains("--id <ID>"), "{message}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -840,6 +840,7 @@ async fn resolve_service(
         }
         (None, Some(id)) => Ok(client.get_service(org_id, id).await?),
         (Some(_), Some(_)) => Err(CloudError::new("specify either --name or --id, not both")),
+        // Clap rejects this state; retain the check for any future non-CLI caller.
         (None, None) => Err(CloudError::new(
             "specify --name or --id to identify the service",
         )),

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2565,6 +2565,44 @@ async fn service_query_rejects_json_with_an_explicit_format_before_network_acces
 }
 
 #[tokio::test]
+async fn service_query_requires_a_selector_before_auth_input_or_network() {
+    let control = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).unwrap();
+    let url = control.uri();
+    let missing_query_file = dir.path().join("must-not-be-read.sql");
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", &home)
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--queries-file",
+            missing_query_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--name <NAME>"), "{stderr}");
+    assert!(stderr.contains("--id <ID>"), "{stderr}");
+    assert!(
+        !stderr.contains("must-not-be-read.sql"),
+        "query input was read before selector validation: {stderr}"
+    );
+    assert!(control.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
     let control = start_mock_control_plane_with_service().await;
     let query_host = start_mock_query_host().await;

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2344,11 +2344,21 @@ async fn start_mock_control_plane_with_service() -> MockServer {
         "status": 200,
         "requestId": "stub-service-get",
     });
+    let stub_services = serde_json::json!({
+        "result": [{ "id": QUERY_TEST_SERVICE_ID, "name": "demo" }],
+        "status": 200,
+        "requestId": "stub-service-list",
+    });
     Mock::given(method("GET"))
         .and(path(format!(
             "/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}"
         )))
         .respond_with(ResponseTemplate::new(200).set_body_json(stub_service))
+        .mount(&mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/organizations/org-1/services"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(stub_services))
         .mount(&mock)
         .await;
     mock
@@ -2565,41 +2575,79 @@ async fn service_query_rejects_json_with_an_explicit_format_before_network_acces
 }
 
 #[tokio::test]
-async fn service_query_requires_a_selector_before_auth_input_or_network() {
-    let control = MockServer::start().await;
+async fn service_query_requires_exactly_one_selector_before_network_access() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
     let dir = tempfile::tempdir().unwrap();
-    let home = dir.path().join("home");
-    std::fs::create_dir(&home).unwrap();
+    let home_dir = dir.path().join("home");
+    std::fs::create_dir(&home_dir).unwrap();
     let url = control.uri();
     let missing_query_file = dir.path().join("must-not-be-read.sql");
 
-    let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
-    let output = command
-        .env("DO_NOT_TRACK", "1")
-        .env("HOME", &home)
-        .current_dir(dir.path())
-        .args([
+    let invoke = |selector: &[&str], query_input: &[&str], authenticated: bool| {
+        let mut args = vec![
             "cloud",
             "--url",
-            &url,
+            url.as_str(),
             "service",
             "query",
-            "--queries-file",
-            missing_query_file.to_str().unwrap(),
-        ])
-        .output()
-        .expect("failed to spawn clickhousectl");
+            "--org-id",
+            "org-1",
+        ];
+        args.extend_from_slice(query_input);
+        args.extend_from_slice(selector);
 
-    assert_eq!(output.status.code(), Some(2));
-    let stderr = String::from_utf8_lossy(&output.stderr);
+        let mut command = Command::new(clickhousectl_binary());
+        clear_inherited_env(&mut command);
+        command
+            .env("DO_NOT_TRACK", "1")
+            .env("HOME", &home_dir)
+            .env("CLICKHOUSE_CLOUD_QUERY_HOST", query_host.uri())
+            .current_dir(dir.path())
+            .args(args);
+        if authenticated {
+            command
+                .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+                .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests");
+        }
+        command.output().expect("failed to spawn clickhousectl")
+    };
+
+    let missing = invoke(
+        &[],
+        &["--queries-file", missing_query_file.to_str().unwrap()],
+        false,
+    );
+    assert_eq!(missing.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&missing.stderr);
     assert!(stderr.contains("--name <NAME>"), "{stderr}");
     assert!(stderr.contains("--id <ID>"), "{stderr}");
     assert!(
         !stderr.contains("must-not-be-read.sql"),
         "query input was read before selector validation: {stderr}"
     );
+
+    let both = invoke(
+        &["--name", "demo", "--id", QUERY_TEST_SERVICE_ID],
+        &["--query", "SELECT 1"],
+        false,
+    );
+    assert_eq!(both.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&both.stderr);
+    assert!(stderr.contains("--name <NAME>"), "{stderr}");
+    assert!(stderr.contains("--id <ID>"), "{stderr}");
+
     assert!(control.received_requests().await.unwrap().is_empty());
+    assert!(query_host.received_requests().await.unwrap().is_empty());
+
+    for selector in [["--name", "demo"], ["--id", QUERY_TEST_SERVICE_ID]] {
+        let output = invoke(&selector, &["--query", "SELECT 1"], true);
+        assert_success(&output);
+        assert_eq!(output.stdout, b"1\n");
+    }
+
+    assert_eq!(control.received_requests().await.unwrap().len(), 2);
+    assert_eq!(query_host.received_requests().await.unwrap().len(), 2);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- require exactly one of `--name` or `--id` for `cloud service query` during Clap parsing
- preserve either selector and reject both selectors
- verify missing selectors exit 2 before authentication, query-file input, or control-plane requests

## Tests
- `cargo test -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #452