### PR TITLE
Reject simultaneous --query and --queries-file inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,8 @@ clickhousectl cloud service delete <service-id> --force
 
 Use `clickhousectl cloud service create --help` for the complete option list. If omitted, `--provider` defaults to `aws`, `--region` defaults to `us-east-1`, and the IP allowlist defaults to `0.0.0.0/0`; production workflows should normally set all three explicitly. When the create response includes an initial password, it is shown only once.
 
+`--query` and `--queries-file` are mutually exclusive. If neither is supplied, `cloud service query` reads SQL from stdin; `--queries-file -` also reads stdin explicitly.
+
 #### Query API auth modes
 
 `cloud service query` is the canonical way to run SQL against a cloud service — over HTTP, with no `clickhouse` binary and no service password required. It works with both credential modes:

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -416,10 +416,10 @@ CONTEXT FOR AGENTS:
   For queries that may exceed Query API timeouts, `clickhousectl local use latest`
   puts the standard `clickhouse` binary on PATH; use `clickhouse client` to connect
   to the service instead.
-  SQL precedence: --query > --queries-file > stdin. Default format: PrettyCompact
-  on a TTY, TabSeparated when piped. --json selects JSONEachRow and cannot be
-  combined with --format; an explicit --format takes precedence over agent
-  auto-JSON."
+  SQL sources: --query and --queries-file are mutually exclusive. When neither
+  is supplied, SQL is read from stdin. Default format: PrettyCompact on a TTY,
+  TabSeparated when piped. --json selects JSONEachRow and cannot be combined
+  with --format; an explicit --format takes precedence over agent auto-JSON."
     )]
     Query {
         /// Service name to query (exactly one of --name or --id is required)
@@ -431,11 +431,11 @@ CONTEXT FOR AGENTS:
         id: Option<String>,
 
         /// Execute a SQL query
-        #[arg(long, short)]
+        #[arg(long, short, conflicts_with = "queries_file")]
         query: Option<String>,
 
         /// Execute queries from a SQL file (use "-" for stdin)
-        #[arg(long)]
+        #[arg(long, conflicts_with = "query")]
         queries_file: Option<String>,
 
         /// Target database
@@ -2292,7 +2292,7 @@ mod tests {
     }
 
     #[test]
-    fn service_query_help_documents_native_client_for_long_queries() {
+    fn service_query_help_documents_query_behavior() {
         let error = Cli::try_parse_from(["clickhousectl", "cloud", "service", "query", "--help"])
             .err()
             .expect("--help should stop parsing");
@@ -2302,6 +2302,11 @@ mod tests {
         assert!(help.contains("Query API timeouts"), "{help}");
         assert!(help.contains("`clickhousectl local use latest`"), "{help}");
         assert!(help.contains("`clickhouse client`"), "{help}");
+        assert!(
+            help.contains("--query and --queries-file are mutually exclusive"),
+            "{help}"
+        );
+        assert!(help.contains("SQL is read from stdin"), "{help}");
     }
 
     #[test]
@@ -3192,8 +3197,6 @@ mod tests {
             "analytics",
             "--query",
             "SELECT 1",
-            "--queries-file",
-            "queries.sql",
             "--database",
             "default",
             "--format",
@@ -3219,11 +3222,62 @@ mod tests {
         assert_eq!(name.as_deref(), Some("analytics"));
         assert!(id.is_none());
         assert_eq!(query.as_deref(), Some("SELECT 1"));
-        assert_eq!(queries_file.as_deref(), Some("queries.sql"));
+        assert!(queries_file.is_none());
         assert_eq!(database.as_deref(), Some("default"));
         assert_eq!(format.as_deref(), Some("CSV"));
         assert_eq!(org_id.as_deref(), Some("org-1"));
         assert!(no_auto_enable);
+    }
+
+    #[test]
+    fn parses_service_query_file_source() {
+        let command = parse_service(&[
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--name",
+            "analytics",
+            "--queries-file",
+            "queries.sql",
+        ]);
+        let ServiceCommands::Query {
+            query,
+            queries_file,
+            ..
+        } = command
+        else {
+            panic!("expected service query");
+        };
+
+        assert!(query.is_none());
+        assert_eq!(queries_file.as_deref(), Some("queries.sql"));
+    }
+
+    #[test]
+    fn rejects_service_query_with_inline_and_file_sources() {
+        let error = Cli::try_parse_from([
+            "clickhousectl",
+            "cloud",
+            "service",
+            "query",
+            "--id",
+            "svc-1",
+            "--query",
+            "SELECT 1",
+            "--queries-file",
+            "queries.sql",
+        ])
+        .err()
+        .expect("service query with conflicting SQL sources should fail");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+        let message = error.to_string();
+        assert!(message.contains("--query <QUERY>"), "{message}");
+        assert!(
+            message.contains("--queries-file <QUERIES_FILE>"),
+            "{message}"
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -2651,6 +2651,42 @@ async fn service_query_requires_exactly_one_selector_before_network_access() {
 }
 
 #[tokio::test]
+async fn service_query_rejects_conflicting_sql_sources_before_file_or_network_access() {
+    let control = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    let missing_query_file = dir.path().join("must-not-be-read.sql");
+    let url = control.uri();
+
+    let mut command = Command::new(clickhousectl_binary());
+    clear_agent_env(&mut command);
+    let output = command
+        .env("DO_NOT_TRACK", "1")
+        .current_dir(dir.path())
+        .args([
+            "cloud",
+            "--url",
+            &url,
+            "service",
+            "query",
+            "--id",
+            QUERY_TEST_SERVICE_ID,
+            "--query",
+            "SELECT 1",
+            "--queries-file",
+            missing_query_file.to_str().unwrap(),
+        ])
+        .output()
+        .expect("failed to spawn clickhousectl");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("--query <QUERY>"), "{stderr}");
+    assert!(stderr.contains("--queries-file <QUERIES_FILE>"), "{stderr}");
+    assert!(!stderr.contains("No such file or directory"), "{stderr}");
+    assert!(control.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn service_query_with_oauth_sends_bearer_and_never_provisions() {
     let control = start_mock_control_plane_with_service().await;
     let query_host = start_mock_query_host().await;

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -14,8 +14,9 @@
 //! Tests run as cargo integration tests:
 //!     cargo test -p clickhousectl --test cli_request_shape_test
 
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use serde_json::Value;
 use wiremock::matchers::{header, method, path, path_regex};
@@ -2651,6 +2652,80 @@ async fn service_query_requires_exactly_one_selector_before_network_access() {
 }
 
 #[tokio::test]
+async fn service_query_accepts_independent_sql_sources_and_stdin_fallback() {
+    let control = start_mock_control_plane_with_service().await;
+    let query_host = start_mock_query_host().await;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("query.sql"), "SELECT 2\n").unwrap();
+    let control_url = control.uri();
+    let query_host_url = query_host.uri();
+
+    let command = || {
+        let mut command = Command::new(clickhousectl_binary());
+        clear_inherited_env(&mut command);
+        command
+            .env("DO_NOT_TRACK", "1")
+            .env("CLICKHOUSE_CLOUD_API_KEY", "fake-key-for-tests")
+            .env("CLICKHOUSE_CLOUD_API_SECRET", "fake-secret-for-tests")
+            .env("CLICKHOUSE_CLOUD_QUERY_HOST", &query_host_url)
+            .current_dir(dir.path())
+            .args([
+                "cloud",
+                "--url",
+                control_url.as_str(),
+                "service",
+                "query",
+                "--id",
+                QUERY_TEST_SERVICE_ID,
+                "--org-id",
+                "org-1",
+            ]);
+        command
+    };
+
+    let inline = command()
+        .args(["--query", "SELECT 1"])
+        .output()
+        .expect("failed to run inline query");
+    assert_success(&inline);
+
+    let file = command()
+        .args(["--queries-file", "query.sql"])
+        .output()
+        .expect("failed to run query file");
+    assert_success(&file);
+
+    let mut child = command()
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to run stdin query");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"SELECT 3\n")
+        .unwrap();
+    let stdin = child.wait_with_output().unwrap();
+    assert_success(&stdin);
+
+    let sql: Vec<String> = query_host
+        .received_requests()
+        .await
+        .unwrap()
+        .iter()
+        .map(|request| {
+            serde_json::from_slice::<Value>(&request.body).unwrap()["sql"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        })
+        .collect();
+    assert_eq!(sql, ["SELECT 1", "SELECT 2\n", "SELECT 3\n"]);
+}
+
+#[tokio::test]
 async fn service_query_rejects_conflicting_sql_sources_before_file_or_network_access() {
     let control = MockServer::start().await;
     let dir = tempfile::tempdir().unwrap();
@@ -2658,7 +2733,7 @@ async fn service_query_rejects_conflicting_sql_sources_before_file_or_network_ac
     let url = control.uri();
 
     let mut command = Command::new(clickhousectl_binary());
-    clear_agent_env(&mut command);
+    clear_inherited_env(&mut command);
     let output = command
         .env("DO_NOT_TRACK", "1")
         .current_dir(dir.path())


### PR DESCRIPTION
## Summary

- reject simultaneous `--query` and `--queries-file` inputs at Clap parsing time with usage exit 2
- preserve inline SQL, file SQL, and stdin fallback as independent query sources
- document the source conflict and stdin behavior in command help and README release-facing documentation
- cover every parser source combination and prove a conflicting nonexistent file is neither ignored nor read before exit

## Tests

- `cargo test -p clickhousectl service_query_`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo fmt --all --check`

Closes #455