### PR TITLE
Retry newly provisioned Query API endpoints until ready

### DIFF
--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -20,9 +20,18 @@ use clickhouse_cloud_api::models::{
 use std::{io::IsTerminal, time::Duration};
 use tabled::{Table, Tabled, settings::Style};
 
-const QUERY_ENDPOINT_READINESS_TIMEOUT: Duration = Duration::from_secs(120);
-const QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
-const QUERY_ENDPOINT_READINESS_MAX_BACKOFF: Duration = Duration::from_secs(5);
+#[derive(Clone, Copy)]
+struct QueryEndpointReadiness {
+    timeout: Duration,
+    initial_backoff: Duration,
+    max_backoff: Duration,
+}
+
+const QUERY_ENDPOINT_READINESS: QueryEndpointReadiness = QueryEndpointReadiness {
+    timeout: Duration::from_secs(120),
+    initial_backoff: Duration::from_millis(200),
+    max_backoff: Duration::from_secs(5),
+};
 
 #[derive(Subcommand)]
 pub enum ServiceCommands {
@@ -1724,18 +1733,70 @@ async fn run_basic_service_query(
     database: Option<&str>,
     format: &str,
     service_name: &str,
+    confirmed_idle: bool,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
     let run = |wake: bool| {
         client
             .api()
             .run_query(service_id, key_id, key_secret, sql, database, format, wake)
     };
+    if confirmed_idle {
+        eprint_waking_service(service_name);
+        return run(true).await;
+    }
+
     match run(false).await {
         Err(clickhouse_cloud_api::Error::ServiceIdle) => {
             eprint_waking_service(service_name);
             run(true).await
         }
         other => other,
+    }
+}
+
+fn query_readiness_timeout_error(timeout: Duration) -> clickhouse_cloud_api::Error {
+    clickhouse_cloud_api::Error::Api {
+        status: 408,
+        message: format!("Query API endpoint did not become ready within {timeout:?}"),
+    }
+}
+
+async fn wait_for_query_endpoint_readiness<T, F, Fut>(
+    readiness: QueryEndpointReadiness,
+    mut probe: F,
+) -> Result<bool, clickhouse_cloud_api::Error>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, clickhouse_cloud_api::Error>>,
+{
+    let deadline = tokio::time::Instant::now() + readiness.timeout;
+    let mut backoff = readiness.initial_backoff;
+    let mut waiting = false;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(query_readiness_timeout_error(readiness.timeout));
+        }
+
+        match tokio::time::timeout(remaining, probe()).await {
+            Ok(Ok(_)) => return Ok(false),
+            Ok(Err(clickhouse_cloud_api::Error::ServiceIdle)) => return Ok(true),
+            Ok(Err(error)) if query_endpoint_readiness_error(&error) => {}
+            Ok(Err(error)) => return Err(error),
+            Err(_) => return Err(query_readiness_timeout_error(readiness.timeout)),
+        }
+
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(query_readiness_timeout_error(readiness.timeout));
+        }
+        if !waiting {
+            eprintln!("Waiting for the Query API endpoint to become ready...");
+            waiting = true;
+        }
+        tokio::time::sleep(backoff.min(remaining)).await;
+        backoff = backoff.saturating_mul(2).min(readiness.max_backoff);
     }
 }
 
@@ -1749,35 +1810,33 @@ async fn run_just_provisioned_service_query(
     database: Option<&str>,
     format: &str,
     service_name: &str,
+    readiness: QueryEndpointReadiness,
 ) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
-    let deadline = tokio::time::Instant::now() + QUERY_ENDPOINT_READINESS_TIMEOUT;
-    let mut backoff = QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF;
-
-    loop {
-        match run_basic_service_query(
-            client,
+    let confirmed_idle = wait_for_query_endpoint_readiness(readiness, || {
+        client.api().run_query(
             service_id,
             key_id,
             key_secret,
-            sql,
-            database,
-            format,
-            service_name,
+            "SELECT 1",
+            None,
+            "TabSeparated",
+            false,
         )
-        .await
-        {
-            Err(error) if query_endpoint_readiness_error(&error) => {
-                if tokio::time::Instant::now() + backoff > deadline {
-                    return Err(error);
-                }
-                tokio::time::sleep(backoff).await;
-                backoff = backoff
-                    .saturating_mul(2)
-                    .min(QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
-            }
-            result => return result,
-        }
-    }
+    })
+    .await?;
+
+    run_basic_service_query(
+        client,
+        service_id,
+        key_id,
+        key_secret,
+        sql,
+        database,
+        format,
+        service_name,
+        confirmed_idle,
+    )
+    .await
 }
 
 fn query_endpoint_readiness_error(error: &clickhouse_cloud_api::Error) -> bool {
@@ -1851,6 +1910,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 options.database.as_deref(),
                 &format,
                 &service_name,
+                false,
             )
             .await
         } else {
@@ -1866,6 +1926,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                 options.database.as_deref(),
                 &format,
                 &service_name,
+                false,
             )
             .await
             {
@@ -1895,6 +1956,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                         options.database.as_deref(),
                         &format,
                         &service_name,
+                        QUERY_ENDPOINT_READINESS,
                     )
                     .await
                 }
@@ -3871,24 +3933,80 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn query_endpoint_readiness_backoff_is_bounded() {
-        let mut elapsed = Duration::ZERO;
-        let mut backoff = QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF;
-        let mut retry_count = 0;
+    #[tokio::test]
+    async fn query_readiness_deadline_bounds_a_stalled_attempt() {
+        let readiness = QueryEndpointReadiness {
+            timeout: Duration::from_millis(10),
+            initial_backoff: Duration::ZERO,
+            max_backoff: Duration::ZERO,
+        };
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            wait_for_query_endpoint_readiness(readiness, || {
+                std::future::pending::<Result<(), clickhouse_cloud_api::Error>>()
+            }),
+        )
+        .await
+        .expect("stalled attempt exceeded the test guard");
 
-        while elapsed + backoff <= QUERY_ENDPOINT_READINESS_TIMEOUT {
-            elapsed += backoff;
-            backoff = backoff
-                .saturating_mul(2)
-                .min(QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
-            retry_count += 1;
-        }
+        assert_query_readiness_timeout(result, readiness.timeout);
+    }
 
-        assert!(retry_count > 1);
-        assert!(elapsed <= QUERY_ENDPOINT_READINESS_TIMEOUT);
-        assert!(QUERY_ENDPOINT_READINESS_TIMEOUT - elapsed < backoff);
-        assert!(backoff <= QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
+    #[tokio::test]
+    async fn query_readiness_exhaustion_is_not_an_auth_error() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        let readiness = QueryEndpointReadiness {
+            timeout: Duration::from_millis(20),
+            initial_backoff: Duration::from_millis(20),
+            max_backoff: Duration::from_millis(20),
+        };
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let probe_attempts = Arc::clone(&attempts);
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            wait_for_query_endpoint_readiness(readiness, move || {
+                probe_attempts.fetch_add(1, Ordering::SeqCst);
+                std::future::ready(Err::<(), _>(clickhouse_cloud_api::Error::Api {
+                    status: 401,
+                    message: "query endpoint is not ready".into(),
+                }))
+            }),
+        )
+        .await
+        .expect("readiness retries exceeded the test guard");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert_query_readiness_timeout(result, readiness.timeout);
+    }
+
+    fn assert_query_readiness_timeout<T>(
+        result: Result<T, clickhouse_cloud_api::Error>,
+        timeout: Duration,
+    ) {
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("readiness should time out"),
+        };
+        let client = CloudClient::new(
+            Some("test-key"),
+            Some("test-secret"),
+            Some("https://api.example.com/v1"),
+        )
+        .unwrap();
+        let converted = client.convert_error(error);
+
+        assert_eq!(
+            converted.kind,
+            crate::cloud::client::CloudErrorKind::Generic
+        );
+        assert_eq!(
+            converted.message,
+            format!("Query API endpoint did not become ready within {timeout:?}")
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/cloud/services.rs
+++ b/crates/clickhousectl/src/cloud/services.rs
@@ -17,8 +17,12 @@ use clickhouse_cloud_api::models::{
     ServicePostRequestReleasechannel, ServiceReplicaScalingPatchRequest, ServiceState,
     ServiceStatePatchRequest, ServiceStatePatchRequestCommand,
 };
-use std::io::IsTerminal;
+use std::{io::IsTerminal, time::Duration};
 use tabled::{Table, Tabled, settings::Style};
+
+const QUERY_ENDPOINT_READINESS_TIMEOUT: Duration = Duration::from_secs(120);
+const QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
+const QUERY_ENDPOINT_READINESS_MAX_BACKOFF: Duration = Duration::from_secs(5);
 
 #[derive(Subcommand)]
 pub enum ServiceCommands {
@@ -1735,14 +1739,58 @@ async fn run_basic_service_query(
     }
 }
 
-fn query_requires_provisioning(error: &clickhouse_cloud_api::Error) -> bool {
-    matches!(
-        error,
-        clickhouse_cloud_api::Error::Api {
-            status: 401 | 403 | 404,
-            ..
+#[allow(clippy::too_many_arguments)]
+async fn run_just_provisioned_service_query(
+    client: &CloudClient,
+    service_id: &str,
+    key_id: &str,
+    key_secret: &str,
+    sql: &str,
+    database: Option<&str>,
+    format: &str,
+    service_name: &str,
+) -> Result<reqwest::Response, clickhouse_cloud_api::Error> {
+    let deadline = tokio::time::Instant::now() + QUERY_ENDPOINT_READINESS_TIMEOUT;
+    let mut backoff = QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF;
+
+    loop {
+        match run_basic_service_query(
+            client,
+            service_id,
+            key_id,
+            key_secret,
+            sql,
+            database,
+            format,
+            service_name,
+        )
+        .await
+        {
+            Err(error) if query_endpoint_readiness_error(&error) => {
+                if tokio::time::Instant::now() + backoff > deadline {
+                    return Err(error);
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = backoff
+                    .saturating_mul(2)
+                    .min(QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
+            }
+            result => return result,
         }
-    )
+    }
+}
+
+fn query_endpoint_readiness_error(error: &clickhouse_cloud_api::Error) -> bool {
+    match error {
+        clickhouse_cloud_api::Error::Api {
+            status: 401 | 403, ..
+        } => true,
+        clickhouse_cloud_api::Error::Api {
+            status: 404,
+            message,
+        } => !message.starts_with("SQL error "),
+        _ => false,
+    }
 }
 
 async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> CloudResult<()> {
@@ -1821,7 +1869,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
             )
             .await
             {
-                Err(error) if query_requires_provisioning(&error) => {
+                Err(error) if query_endpoint_readiness_error(&error) => {
                     if options.no_auto_enable {
                         return Err(CloudError::new(format!(
                             "the authenticated API key cannot use the Query API endpoint for service {service_id}, and --no-auto-enable prevents provisioning"
@@ -1838,7 +1886,7 @@ async fn service_query(client: &CloudClient, options: ServiceQueryOptions) -> Cl
                         &service_name,
                     )
                     .await?;
-                    run_basic_service_query(
+                    run_just_provisioned_service_query(
                         client,
                         &service_id,
                         &key.key_id,
@@ -3783,9 +3831,9 @@ mod tests {
     }
 
     #[test]
-    fn query_provisions_only_for_endpoint_or_auth_rejections() {
+    fn query_readiness_is_only_auth_or_generic_not_found() {
         for status in [401, 403, 404] {
-            assert!(query_requires_provisioning(
+            assert!(query_endpoint_readiness_error(
                 &clickhouse_cloud_api::Error::Api {
                     status,
                     message: "rejected".into(),
@@ -3793,16 +3841,54 @@ mod tests {
             ));
         }
         for status in [400, 408, 429, 500] {
-            assert!(!query_requires_provisioning(
+            assert!(!query_endpoint_readiness_error(
                 &clickhouse_cloud_api::Error::Api {
                     status,
                     message: "query failed".into(),
                 }
             ));
         }
-        assert!(!query_requires_provisioning(
+        assert!(!query_endpoint_readiness_error(
+            &clickhouse_cloud_api::Error::Api {
+                status: 404,
+                message: "SQL error 60: Unknown table".into(),
+            }
+        ));
+        assert!(!query_endpoint_readiness_error(
             &clickhouse_cloud_api::Error::ServiceStopped
         ));
+    }
+
+    #[tokio::test]
+    async fn query_does_not_provision_or_retry_transport_errors() {
+        let transport_error = reqwest::Client::new()
+            .get("not a url")
+            .send()
+            .await
+            .unwrap_err();
+        assert!(!query_endpoint_readiness_error(
+            &clickhouse_cloud_api::Error::Http(transport_error)
+        ));
+    }
+
+    #[test]
+    fn query_endpoint_readiness_backoff_is_bounded() {
+        let mut elapsed = Duration::ZERO;
+        let mut backoff = QUERY_ENDPOINT_READINESS_INITIAL_BACKOFF;
+        let mut retry_count = 0;
+
+        while elapsed + backoff <= QUERY_ENDPOINT_READINESS_TIMEOUT {
+            elapsed += backoff;
+            backoff = backoff
+                .saturating_mul(2)
+                .min(QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
+            retry_count += 1;
+        }
+
+        assert!(retry_count > 1);
+        assert!(elapsed <= QUERY_ENDPOINT_READINESS_TIMEOUT);
+        assert!(QUERY_ENDPOINT_READINESS_TIMEOUT - elapsed < backoff);
+        assert!(backoff <= QUERY_ENDPOINT_READINESS_MAX_BACKOFF);
     }
 
     #[test]

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3550,6 +3550,200 @@ async fn concurrent_service_queries_provision_once_and_reuse_atomically_saved_cr
     }
 }
 
+async fn mount_successful_query_provisioning(control: &MockServer) -> String {
+    mount_key_create_and_delete(
+        control,
+        serde_json::json!({
+            "key": { "id": QUERY_TEST_KEY_UUID },
+            "keyId": "provisioned-key-id",
+            "keySecret": "provisioned-key-secret"
+        }),
+    )
+    .await;
+    let endpoint_path =
+        format!("/v1/organizations/org-1/services/{QUERY_TEST_SERVICE_ID}/serviceQueryEndpoint");
+    Mock::given(method("GET"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "not found",
+            "status": 404,
+            "requestId": "stub-endpoint-get"
+        })))
+        .expect(1)
+        .mount(control)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(endpoint_path.clone()))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": { "id": "ep-1", "openApiKeys": [QUERY_TEST_KEY_UUID] },
+            "status": 200,
+            "requestId": "stub-endpoint-upsert"
+        })))
+        .expect(1)
+        .mount(control)
+        .await;
+    endpoint_path
+}
+
+fn query_test_basic_auth(credentials: &str) -> String {
+    format!(
+        "Basic {}",
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, credentials)
+    )
+}
+
+#[tokio::test]
+async fn just_provisioned_service_query_retries_readiness_errors_with_the_same_key() {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
+    use std::time::{Duration, Instant};
+
+    let control = start_mock_control_plane_with_service().await;
+    let endpoint_path = mount_successful_query_provisioning(&control).await;
+    let query_host = MockServer::start().await;
+    let query_path = format!("/service/{QUERY_TEST_SERVICE_ID}/run");
+    let primary_auth = query_test_basic_auth("fake-key-for-tests:fake-secret-for-tests");
+    Mock::given(method("POST"))
+        .and(path(query_path.clone()))
+        .and(header("authorization", primary_auth.as_str()))
+        .respond_with(ResponseTemplate::new(401).set_body_string("API key is not authorized"))
+        .expect(1)
+        .mount(&query_host)
+        .await;
+
+    let provisioned_auth = query_test_basic_auth("provisioned-key-id:provisioned-key-secret");
+    let response_index = Arc::new(AtomicUsize::new(0));
+    let delivered_statuses = Arc::new(Mutex::new(Vec::new()));
+    let responder_index = Arc::clone(&response_index);
+    let responder_statuses = Arc::clone(&delivered_statuses);
+    Mock::given(method("POST"))
+        .and(path(query_path))
+        .and(header("authorization", provisioned_auth.as_str()))
+        .respond_with(move |_: &wiremock::Request| {
+            let index = responder_index.fetch_add(1, Ordering::SeqCst);
+            let status = [401, 403, 404, 200].get(index).copied().unwrap_or(500);
+            responder_statuses.lock().unwrap().push(status);
+            if status == 200 {
+                ResponseTemplate::new(status).set_body_string("1\n")
+            } else {
+                ResponseTemplate::new(status).set_body_string("query endpoint is not ready")
+            }
+        })
+        .expect(4)
+        .mount(&query_host)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::create_dir(project.path().join("home")).unwrap();
+    let started = Instant::now();
+    let output = service_query_process(project.path(), &control, &query_host)
+        .output()
+        .await
+        .expect("failed to spawn clickhousectl");
+    let elapsed = started.elapsed();
+
+    assert_success(&output);
+    assert_eq!(output.stdout, b"1\n");
+    assert_eq!(*delivered_statuses.lock().unwrap(), [401, 403, 404, 200]);
+    assert!(
+        elapsed >= Duration::from_millis(1_200),
+        "readiness retries did not back off: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(10),
+        "readiness retries exceeded their expected timing bound: {elapsed:?}"
+    );
+
+    let query_requests = query_host.received_requests().await.unwrap();
+    assert_eq!(query_requests.len(), 5);
+    let provisioned_requests = query_requests
+        .iter()
+        .filter(|request| {
+            request
+                .headers
+                .get("authorization")
+                .is_some_and(|value| value == provisioned_auth.as_str())
+        })
+        .count();
+    assert_eq!(
+        provisioned_requests, 4,
+        "every retry must reuse the new key"
+    );
+
+    let control_requests = control.received_requests().await.unwrap();
+    let request_count = |request_method: wiremock::http::Method, request_path: &str| {
+        control_requests
+            .iter()
+            .filter(|request| {
+                request.method == request_method && request.url.path() == request_path
+            })
+            .count()
+    };
+    assert_eq!(
+        request_count(wiremock::http::Method::POST, "/v1/organizations/org-1/keys"),
+        1,
+        "readiness retries must not reprovision the key"
+    );
+    assert_eq!(
+        request_count(wiremock::http::Method::POST, &endpoint_path),
+        1,
+        "readiness retries must not upsert the endpoint again"
+    );
+}
+
+#[tokio::test]
+async fn just_provisioned_service_query_fails_immediately_when_the_service_is_stopped() {
+    use std::time::{Duration, Instant};
+
+    let control = start_mock_control_plane_with_service().await;
+    mount_successful_query_provisioning(&control).await;
+    let query_host = MockServer::start().await;
+    let query_path = format!("/service/{QUERY_TEST_SERVICE_ID}/run");
+    let primary_auth = query_test_basic_auth("fake-key-for-tests:fake-secret-for-tests");
+    Mock::given(method("POST"))
+        .and(path(query_path.clone()))
+        .and(header("authorization", primary_auth.as_str()))
+        .respond_with(ResponseTemplate::new(401).set_body_string("API key is not authorized"))
+        .expect(1)
+        .mount(&query_host)
+        .await;
+    let provisioned_auth = query_test_basic_auth("provisioned-key-id:provisioned-key-secret");
+    Mock::given(method("POST"))
+        .and(path(query_path))
+        .and(header("authorization", provisioned_auth.as_str()))
+        .respond_with(ResponseTemplate::new(404).set_body_string(
+            r#"{"error":"ClickHouse service is currently unavailable. Please try again later."}"#,
+        ))
+        .expect(1)
+        .mount(&query_host)
+        .await;
+
+    let project = tempfile::tempdir().unwrap();
+    std::fs::create_dir(project.path().join("home")).unwrap();
+    let started = Instant::now();
+    let output = service_query_process(project.path(), &control, &query_host)
+        .output()
+        .await
+        .expect("failed to spawn clickhousectl");
+    let elapsed = started.elapsed();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stdout.is_empty());
+    assert_eq!(query_host.received_requests().await.unwrap().len(), 2);
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "stopped-service recognition unexpectedly waited: {elapsed:?}"
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        format!(
+            "Provisioning Query API endpoint + key for service 'demo'...\nError: service 'demo' is stopped; start it with `clickhousectl cloud service start {QUERY_TEST_SERVICE_ID} --org-id org-1` and retry\n"
+        )
+    );
+}
+
 #[tokio::test]
 async fn concurrent_failed_provisioners_delete_only_their_exact_created_key() {
     const PROCESS_COUNT: usize = 3;

--- a/crates/clickhousectl/tests/cli_request_shape_test.rs
+++ b/crates/clickhousectl/tests/cli_request_shape_test.rs
@@ -3160,6 +3160,15 @@ fn service_query_process(
     control: &MockServer,
     query_host: &MockServer,
 ) -> tokio::process::Command {
+    service_query_process_with_sql(project_dir, control, query_host, "SELECT 1")
+}
+
+fn service_query_process_with_sql(
+    project_dir: &Path,
+    control: &MockServer,
+    query_host: &MockServer,
+    sql: &str,
+) -> tokio::process::Command {
     let mut command = tokio::process::Command::new(clickhousectl_binary());
     command
         .env_clear()
@@ -3180,7 +3189,7 @@ fn service_query_process(
             "--org-id",
             "org-1",
             "--query",
-            "SELECT 1",
+            sql,
         ]);
     command
 }
@@ -3621,32 +3630,45 @@ async fn just_provisioned_service_query_retries_readiness_errors_with_the_same_k
     Mock::given(method("POST"))
         .and(path(query_path))
         .and(header("authorization", provisioned_auth.as_str()))
-        .respond_with(move |_: &wiremock::Request| {
-            let index = responder_index.fetch_add(1, Ordering::SeqCst);
-            let status = [401, 403, 404, 200].get(index).copied().unwrap_or(500);
-            responder_statuses.lock().unwrap().push(status);
-            if status == 200 {
-                ResponseTemplate::new(status).set_body_string("1\n")
-            } else {
-                ResponseTemplate::new(status).set_body_string("query endpoint is not ready")
+        .respond_with(move |request: &wiremock::Request| {
+            let body: Value = serde_json::from_slice(&request.body).unwrap();
+            match body["sql"].as_str() {
+                Some("SELECT 1") => {
+                    let index = responder_index.fetch_add(1, Ordering::SeqCst);
+                    let status = [401, 403, 404, 206].get(index).copied().unwrap_or(500);
+                    responder_statuses.lock().unwrap().push(status);
+                    if status == 206 {
+                        ResponseTemplate::new(status)
+                            .set_body_string(r#"{"data":"Confirm wake service"}"#)
+                    } else {
+                        ResponseTemplate::new(status).set_body_string("query endpoint is not ready")
+                    }
+                }
+                Some("SELECT 42") => ResponseTemplate::new(200).set_body_string("42\n"),
+                sql => ResponseTemplate::new(400)
+                    .set_body_string(format!("unexpected SQL in readiness test: {sql:?}")),
             }
         })
-        .expect(4)
+        .expect(5)
         .mount(&query_host)
         .await;
 
     let project = tempfile::tempdir().unwrap();
     std::fs::create_dir(project.path().join("home")).unwrap();
     let started = Instant::now();
-    let output = service_query_process(project.path(), &control, &query_host)
+    let output = service_query_process_with_sql(project.path(), &control, &query_host, "SELECT 42")
         .output()
         .await
         .expect("failed to spawn clickhousectl");
     let elapsed = started.elapsed();
 
     assert_success(&output);
-    assert_eq!(output.stdout, b"1\n");
-    assert_eq!(*delivered_statuses.lock().unwrap(), [401, 403, 404, 200]);
+    assert_eq!(output.stdout, b"42\n");
+    assert_eq!(*delivered_statuses.lock().unwrap(), [401, 403, 404, 206]);
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("Waiting for the Query API endpoint to become ready")
+    );
     assert!(
         elapsed >= Duration::from_millis(1_200),
         "readiness retries did not back off: {elapsed:?}"
@@ -3657,8 +3679,8 @@ async fn just_provisioned_service_query_retries_readiness_errors_with_the_same_k
     );
 
     let query_requests = query_host.received_requests().await.unwrap();
-    assert_eq!(query_requests.len(), 5);
-    let provisioned_requests = query_requests
+    assert_eq!(query_requests.len(), 6);
+    let provisioned_requests: Vec<_> = query_requests
         .iter()
         .filter(|request| {
             request
@@ -3666,11 +3688,29 @@ async fn just_provisioned_service_query_retries_readiness_errors_with_the_same_k
                 .get("authorization")
                 .is_some_and(|value| value == provisioned_auth.as_str())
         })
-        .count();
+        .collect();
     assert_eq!(
-        provisioned_requests, 4,
+        provisioned_requests.len(),
+        5,
         "every retry must reuse the new key"
     );
+    let sql: Vec<_> = provisioned_requests
+        .iter()
+        .map(|request| serde_json::from_slice::<Value>(&request.body).unwrap()["sql"].clone())
+        .collect();
+    assert_eq!(
+        sql.iter().filter(|value| **value == "SELECT 1").count(),
+        4,
+        "readiness retries must use the harmless probe"
+    );
+    let user_queries: Vec<_> = provisioned_requests
+        .iter()
+        .filter(|request| {
+            serde_json::from_slice::<Value>(&request.body).unwrap()["sql"] == "SELECT 42"
+        })
+        .collect();
+    assert_eq!(user_queries.len(), 1, "user SQL must run exactly once");
+    assert_eq!(user_queries[0].headers.get("wake-service").unwrap(), "true");
 
     let control_requests = control.received_requests().await.unwrap();
     let request_count = |request_method: wiremock::http::Method, request_path: &str| {


### PR DESCRIPTION
## Summary
- wait for newly provisioned Query API endpoints with a harmless `SELECT 1` probe, bounded exponential backoff, and a user-visible status message
- apply the remaining 120-second readiness deadline to every probe and report a generic readiness timeout on exhaustion
- run user SQL once after readiness while preserving idle wake handling and immediate stopped-service failures

## Tests
- `cargo test -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #453