### PR TITLE
Validate local ClickHouse versions during CLI parsing

### DIFF
--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -12,6 +12,7 @@ impl FromStr for InstallVersionArg {
     type Err = String;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
         if let Some(tag) = input
             .strip_prefix("postgres@")
             .or_else(|| input.strip_prefix("postgres:"))
@@ -25,6 +26,7 @@ impl FromStr for InstallVersionArg {
     }
 }
 
+/// Kept distinct from `ServerVersionArg` so each command owns its accepted inputs and errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UseVersionArg(VersionSpec);
 
@@ -38,6 +40,7 @@ impl FromStr for UseVersionArg {
     type Err = String;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
         if input.starts_with("postgres@") || input.starts_with("postgres:") {
             return Err(
                 "Postgres image selectors are only supported by `local install`; `local use` requires a ClickHouse version"
@@ -51,6 +54,7 @@ impl FromStr for UseVersionArg {
     }
 }
 
+/// Kept distinct from `UseVersionArg` so each command owns its accepted inputs and errors.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ServerVersionArg(VersionSpec);
 
@@ -64,6 +68,7 @@ impl FromStr for ServerVersionArg {
     type Err = String;
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let input = input.trim();
         if input.starts_with("postgres@") || input.starts_with("postgres:") {
             return Err(
                 "Postgres image selectors are only supported by `local install`; `local server start --version` requires a ClickHouse version"
@@ -144,6 +149,7 @@ CONTEXT FOR AGENTS:
   Related: `clickhousectl local list` to see installed versions.")]
     Remove {
         /// Version to remove
+        // Keep this opaque: removal matches an installed directory name instead of resolving a version spec.
         version: String,
 
         /// Stop any running servers using this version, then remove it
@@ -549,6 +555,7 @@ CONTEXT FOR AGENTS:
 mod tests {
     use super::*;
     use crate::cli::{Cli, Commands};
+    use crate::version_manager::list::Channel;
     use clap::Parser;
 
     fn local_command(args: &[&str]) -> LocalCommands {
@@ -573,7 +580,14 @@ mod tests {
 
     #[test]
     fn parses_supported_clickhouse_version_forms_for_each_command() {
-        for input in ["latest", "stable", "lts", "25", "25.12", "25.12.9.61"] {
+        for (input, expected) in [
+            ("latest", VersionSpec::Latest),
+            ("stable", VersionSpec::Channel(Channel::Stable)),
+            ("lts", VersionSpec::Channel(Channel::Lts)),
+            ("25", VersionSpec::Major(25)),
+            ("25.12", VersionSpec::Minor(25, 12)),
+            ("25.12.9.61", VersionSpec::Exact("25.12.9.61".to_string())),
+        ] {
             let LocalCommands::Install {
                 version: InstallVersionArg::ClickHouse(version),
                 ..
@@ -581,12 +595,12 @@ mod tests {
             else {
                 panic!("expected ClickHouse install version for {input}");
             };
-            assert_eq!(version.to_string(), input);
+            assert_eq!(version, expected);
 
             let LocalCommands::Use { version, .. } = local_command(&["use", input]) else {
                 panic!("expected use version for {input}");
             };
-            assert_eq!(version.into_spec().to_string(), input);
+            assert_eq!(version.into_spec(), expected);
 
             let LocalCommands::Server {
                 command: ServerCommands::Start { version, .. },
@@ -595,11 +609,8 @@ mod tests {
                 panic!("expected server version for {input}");
             };
             assert_eq!(
-                version
-                    .expect("version should be present")
-                    .into_spec()
-                    .to_string(),
-                input
+                version.expect("version should be present").into_spec(),
+                expected
             );
         }
     }
@@ -630,7 +641,11 @@ mod tests {
 
     #[test]
     fn postgres_image_selectors_are_install_only() {
-        for (input, expected) in [("postgres@18", "18"), ("postgres:17-alpine", "17-alpine")] {
+        for (input, expected) in [
+            ("postgres@18", "18"),
+            ("postgres:17-alpine", "17-alpine"),
+            ("  postgres@16  ", "16"),
+        ] {
             let LocalCommands::Install {
                 version: InstallVersionArg::Postgres(tag),
                 ..
@@ -642,11 +657,11 @@ mod tests {
         }
 
         assert_version_rejected(
-            &["use", "postgres@18"],
+            &["use", "  postgres@18  "],
             "only supported by `local install`; `local use` requires a ClickHouse version",
         );
         assert_version_rejected(
-            &["server", "start", "--version", "postgres@18"],
+            &["server", "start", "--version", "  postgres@18  "],
             "only supported by `local install`; `local server start --version` requires a ClickHouse version",
         );
     }

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -1,4 +1,81 @@
+use crate::version_manager::{self, VersionSpec};
 use clap::{Args, Subcommand};
+use std::str::FromStr;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallVersionArg {
+    ClickHouse(VersionSpec),
+    Postgres(String),
+}
+
+impl FromStr for InstallVersionArg {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if let Some(tag) = input
+            .strip_prefix("postgres@")
+            .or_else(|| input.strip_prefix("postgres:"))
+        {
+            return Ok(Self::Postgres(tag.to_string()));
+        }
+
+        version_manager::parse_version_spec(input)
+            .map(Self::ClickHouse)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UseVersionArg(VersionSpec);
+
+impl UseVersionArg {
+    pub(crate) fn into_spec(self) -> VersionSpec {
+        self.0
+    }
+}
+
+impl FromStr for UseVersionArg {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.starts_with("postgres@") || input.starts_with("postgres:") {
+            return Err(
+                "Postgres image selectors are only supported by `local install`; `local use` requires a ClickHouse version"
+                    .to_string(),
+            );
+        }
+
+        version_manager::parse_version_spec(input)
+            .map(Self)
+            .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerVersionArg(VersionSpec);
+
+impl ServerVersionArg {
+    pub(crate) fn into_spec(self) -> VersionSpec {
+        self.0
+    }
+}
+
+impl FromStr for ServerVersionArg {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.starts_with("postgres@") || input.starts_with("postgres:") {
+            return Err(
+                "Postgres image selectors are only supported by `local install`; `local server start --version` requires a ClickHouse version"
+                    .to_string(),
+            );
+        }
+
+        version_manager::parse_version_spec(input)
+            .map(Self)
+            .map_err(|error| error.to_string())
+    }
+}
 
 #[derive(Args)]
 pub struct LocalArgs {
@@ -17,8 +94,8 @@ pub enum LocalCommands {
 CONTEXT FOR AGENTS:
   `clickhousectl local use <version>` will auto-install if the version is missing and set as default.")]
     Install {
-        /// Version to install. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.9.61".
-        version: String,
+        /// Version to install. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", exact like "25.12.9.61", or a Postgres image selector like "postgres@18".
+        version: InstallVersionArg,
 
         /// Force re-install even if version is already installed
         #[arg(long)]
@@ -49,7 +126,7 @@ CONTEXT FOR AGENTS:
   Related: `clickhousectl local which` to verify, `clickhousectl local server start` to start a server.")]
     Use {
         /// Version to use as default. Accepts: "latest" (recommended), "stable", "lts", partial like "25.12", or exact like "25.12.5.44".
-        version: String,
+        version: UseVersionArg,
 
         /// Do not create or update the ~/.local/bin/clickhouse symlink
         #[arg(long)]
@@ -198,7 +275,7 @@ CONTEXT FOR AGENTS:
 
         /// ClickHouse version to use (e.g. "latest" (recommended), stable, lts, 25.12). Installs if needed. Does not change the default version.
         #[arg(long, short = 'v')]
-        version: Option<String>,
+        version: Option<ServerVersionArg>,
 
         /// HTTP port (default: 8123, auto-assigns a free port if in use)
         #[arg(long)]
@@ -484,6 +561,96 @@ mod tests {
         local.command
     }
 
+    fn assert_version_rejected(args: &[&str], expected: &str) {
+        let mut argv = vec!["clickhousectl", "local"];
+        argv.extend_from_slice(args);
+        let error = Cli::try_parse_from(argv)
+            .err()
+            .expect("invalid version should fail during clap parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+        assert!(error.to_string().contains(expected), "{error}");
+    }
+
+    #[test]
+    fn parses_supported_clickhouse_version_forms_for_each_command() {
+        for input in ["latest", "stable", "lts", "25", "25.12", "25.12.9.61"] {
+            let LocalCommands::Install {
+                version: InstallVersionArg::ClickHouse(version),
+                ..
+            } = local_command(&["install", input])
+            else {
+                panic!("expected ClickHouse install version for {input}");
+            };
+            assert_eq!(version.to_string(), input);
+
+            let LocalCommands::Use { version, .. } = local_command(&["use", input]) else {
+                panic!("expected use version for {input}");
+            };
+            assert_eq!(version.into_spec().to_string(), input);
+
+            let LocalCommands::Server {
+                command: ServerCommands::Start { version, .. },
+            } = local_command(&["server", "start", "--version", input])
+            else {
+                panic!("expected server version for {input}");
+            };
+            assert_eq!(
+                version
+                    .expect("version should be present")
+                    .into_spec()
+                    .to_string(),
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_clickhouse_versions_for_each_command() {
+        let expected = "all parts must be numeric";
+        assert_version_rejected(&["install", "not.a.version"], expected);
+        assert_version_rejected(&["use", "not.a.version"], expected);
+        assert_version_rejected(&["server", "start", "--version", "not.a.version"], expected);
+    }
+
+    #[test]
+    fn rejects_three_part_clickhouse_versions_for_each_command() {
+        let expected = "3-part version '25.12.9' is not supported";
+        assert_version_rejected(&["install", "25.12.9"], expected);
+        assert_version_rejected(&["use", "25.12.9"], expected);
+        assert_version_rejected(&["server", "start", "--version", "25.12.9"], expected);
+    }
+
+    #[test]
+    fn rejects_unsupported_clickhouse_version_shapes_for_each_command() {
+        let expected = "expected 1-2 or 4 parts";
+        assert_version_rejected(&["install", "25.12.9.61.2"], expected);
+        assert_version_rejected(&["use", "25.12.9.61.2"], expected);
+        assert_version_rejected(&["server", "start", "--version", "25.12.9.61.2"], expected);
+    }
+
+    #[test]
+    fn postgres_image_selectors_are_install_only() {
+        for (input, expected) in [("postgres@18", "18"), ("postgres:17-alpine", "17-alpine")] {
+            let LocalCommands::Install {
+                version: InstallVersionArg::Postgres(tag),
+                ..
+            } = local_command(&["install", input])
+            else {
+                panic!("expected Postgres install version for {input}");
+            };
+            assert_eq!(tag, expected);
+        }
+
+        assert_version_rejected(
+            &["use", "postgres@18"],
+            "only supported by `local install`; `local use` requires a ClickHouse version",
+        );
+        assert_version_rejected(
+            &["server", "start", "--version", "postgres@18"],
+            "only supported by `local install`; `local server start --version` requires a ClickHouse version",
+        );
+    }
+
     #[test]
     fn use_help_documents_standard_clickhouse_subcommands() {
         let error = Cli::try_parse_from(["clickhousectl", "local", "use", "--help"])
@@ -577,7 +744,12 @@ mod tests {
         };
         assert_eq!(name.as_deref(), Some("existing"));
         assert_eq!(name_flag, None);
-        assert_eq!(version.as_deref(), Some("25.12.9.61"));
+        assert_eq!(
+            version
+                .map(ServerVersionArg::into_spec)
+                .map(|v| v.to_string()),
+            Some("25.12.9.61".to_string())
+        );
         assert!(args.is_empty());
     }
 
@@ -635,7 +807,12 @@ mod tests {
             panic!("expected server start");
         };
         assert_eq!(name.as_deref(), Some("existing"));
-        assert_eq!(version.as_deref(), Some("25.12.9.61"));
+        assert_eq!(
+            version
+                .map(ServerVersionArg::into_spec)
+                .map(|v| v.to_string()),
+            Some("25.12.9.61".to_string())
+        );
         assert_eq!(
             args,
             ["--logger.level=trace", "--max_server_memory_usage=1000000"]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -7,7 +7,7 @@ pub mod postgres;
 pub mod server;
 pub mod symlink;
 
-use cli::{LocalCommands, ServerCommands};
+use cli::{InstallVersionArg, LocalCommands, ServerCommands, ServerVersionArg};
 
 use crate::error::{Error, Result};
 use crate::{init, paths, version_manager};
@@ -17,7 +17,7 @@ use std::process::Command;
 
 pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
     match cmd {
-        LocalCommands::Install { version, force } => install(&version, force, json).await,
+        LocalCommands::Install { version, force } => install(version, force, json).await,
         LocalCommands::List { remote } => {
             if remote {
                 list_available(json).await
@@ -25,7 +25,9 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
                 list_installed(json)
             }
         }
-        LocalCommands::Use { version, no_global } => use_version(&version, no_global, json).await,
+        LocalCommands::Use { version, no_global } => {
+            use_version(version.into_spec(), no_global, json).await
+        }
         LocalCommands::Remove { version, force } => remove(&version, force, json),
         LocalCommands::Which => which(json),
         LocalCommands::Init => {
@@ -47,14 +49,6 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
         LocalCommands::Server { command } => run_server_commands(command, json).await,
         LocalCommands::Postgres { command } => postgres::run(command, json).await,
     }
-}
-
-/// If the version spec looks like `postgres@<tag>` or `postgres:<tag>`, extract
-/// the tag. The CLI accepts both `@` (more shell-friendly, no need to quote)
-/// and `:` (matches Docker image syntax).
-fn parse_postgres_install_spec(spec: &str) -> Option<&str> {
-    spec.strip_prefix("postgres@")
-        .or_else(|| spec.strip_prefix("postgres:"))
 }
 
 async fn install_postgres(tag: &str, force: bool, json: bool) -> Result<()> {
@@ -82,11 +76,11 @@ async fn install_postgres(tag: &str, force: bool, json: bool) -> Result<()> {
     Ok(())
 }
 
-async fn install(version_spec: &str, force: bool, json: bool) -> Result<()> {
-    if let Some(tag) = parse_postgres_install_spec(version_spec) {
-        return install_postgres(tag, force, json).await;
-    }
-    let spec = version_manager::parse_version_spec(version_spec)?;
+async fn install(version: InstallVersionArg, force: bool, json: bool) -> Result<()> {
+    let spec = match version {
+        InstallVersionArg::ClickHouse(spec) => spec,
+        InstallVersionArg::Postgres(tag) => return install_postgres(&tag, force, json).await,
+    };
     let platform = version_manager::platform::Platform::detect()?;
 
     let version = version_manager::install::install_local_first(&spec, &platform, force).await?;
@@ -163,8 +157,11 @@ async fn list_available(json: bool) -> Result<()> {
     Ok(())
 }
 
-async fn use_version(version_spec: &str, no_global: bool, json: bool) -> Result<()> {
-    let spec = version_manager::parse_version_spec(version_spec)?;
+async fn use_version(
+    spec: version_manager::VersionSpec,
+    no_global: bool,
+    json: bool,
+) -> Result<()> {
     let platform = version_manager::platform::Platform::detect()?;
 
     let version = version_manager::install::ensure_installed_local_first(&spec, &platform).await?;
@@ -316,7 +313,7 @@ fn run_client(
 #[allow(clippy::too_many_arguments)]
 async fn start_server(
     name: Option<String>,
-    version_spec: Option<String>,
+    version_spec: Option<ServerVersionArg>,
     http_port: Option<u16>,
     tcp_port: Option<u16>,
     foreground: bool,
@@ -339,8 +336,8 @@ async fn start_server(
         return Err(Error::ServerAlreadyRunning(server_name));
     }
 
-    let version = if let Some(spec_str) = &version_spec {
-        let spec = version_manager::parse_version_spec(spec_str)?;
+    let version = if let Some(spec) = version_spec {
+        let spec = spec.into_spec();
         let platform = version_manager::platform::Platform::detect()?;
         version_manager::install::ensure_installed_local_first(&spec, &platform).await?
     } else {
@@ -353,7 +350,7 @@ async fn start_server(
                 // subsequent bare start too; `ensure_installed_local_first` returns the
                 // already-installed build silently if `latest` still resolves to it,
                 // otherwise it pulls the newer master build.
-                let spec = version_manager::parse_version_spec("latest")?;
+                let spec = version_manager::VersionSpec::Latest;
                 let platform = version_manager::platform::Platform::detect()?;
                 // Says "using", not "installing": on repeat starts the build is
                 // usually already installed and nothing is downloaded. The install
@@ -1145,17 +1142,6 @@ mod tests {
         assert_eq!(output.servers[2].version.as_deref(), Some("postgres:18"));
         assert!(output.servers[2].stopped);
         assert_eq!(output.servers[2].error, None);
-    }
-
-    #[test]
-    fn parse_postgres_install_spec_recognizes_at_and_colon() {
-        assert_eq!(parse_postgres_install_spec("postgres@17"), Some("17"));
-        assert_eq!(
-            parse_postgres_install_spec("postgres:17-alpine"),
-            Some("17-alpine")
-        );
-        assert_eq!(parse_postgres_install_spec("25.12"), None);
-        assert_eq!(parse_postgres_install_spec("stable"), None);
     }
 
     #[test]

--- a/crates/clickhousectl/src/version_manager/mod.rs
+++ b/crates/clickhousectl/src/version_manager/mod.rs
@@ -10,4 +10,4 @@ pub use list::{
     get_default_version, list_available_versions_from_builds, list_installed_versions,
     set_default_version,
 };
-pub use spec::parse_version_spec;
+pub use spec::{VersionSpec, parse_version_spec};

--- a/crates/clickhousectl/tests/local_version_error_test.rs
+++ b/crates/clickhousectl/tests/local_version_error_test.rs
@@ -1,4 +1,4 @@
-//! Regression coverage for local version-spec error reporting.
+//! Subprocess coverage for clap-time local version validation.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -7,24 +7,66 @@ fn clickhousectl_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
 }
 
-#[test]
-fn local_use_reports_an_invalid_version_without_a_lookup_wrapper() {
-    let tempdir = tempfile::tempdir().expect("create tempdir");
+fn assert_rejected_before_side_effects(args: &[&str], expected_error: &str) {
+    let home = tempfile::tempdir().expect("create home");
+    let project = tempfile::tempdir().expect("create project");
     let output = Command::new(clickhousectl_binary())
+        .env_clear()
         .env("DO_NOT_TRACK", "1")
-        .env("HOME", tempdir.path())
-        .args(["local", "use", "not.a.version"])
+        .env("HOME", home.path())
+        .current_dir(project.path())
+        .args(args)
         .output()
         .expect("run clickhousectl");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert_eq!(output.status.code(), Some(2), "stderr: {stderr}");
     assert!(
-        stderr.contains("Error: invalid version 'not.a.version': all parts must be numeric"),
+        stderr.contains("error: invalid value"),
         "unexpected stderr: {stderr}"
     );
     assert!(
-        !stderr.contains("No matching version found"),
-        "parse error was wrapped as a lookup miss: {stderr}"
+        stderr.contains(expected_error),
+        "missing actionable parser error: {stderr}"
+    );
+    assert!(
+        stderr.contains("For more information, try '--help'."),
+        "missing clap help guidance: {stderr}"
+    );
+    assert!(
+        !home.path().join(".clickhouse").exists(),
+        "invalid version created home state"
+    );
+    assert!(
+        !project.path().join(".clickhouse").exists(),
+        "invalid version created project state"
+    );
+}
+
+#[test]
+fn invalid_local_versions_fail_before_dispatch_or_filesystem_setup() {
+    assert_rejected_before_side_effects(
+        &["local", "install", "not.a.version"],
+        "all parts must be numeric",
+    );
+    assert_rejected_before_side_effects(
+        &["local", "use", "25.12.9"],
+        "3-part version '25.12.9' is not supported",
+    );
+    assert_rejected_before_side_effects(
+        &["local", "server", "start", "--version", "25.12.9.61.2"],
+        "expected 1-2 or 4 parts",
+    );
+}
+
+#[test]
+fn postgres_install_selector_is_rejected_by_clickhouse_only_commands() {
+    assert_rejected_before_side_effects(
+        &["local", "use", "postgres@18"],
+        "only supported by `local install`; `local use` requires a ClickHouse version",
+    );
+    assert_rejected_before_side_effects(
+        &["local", "server", "start", "--version", "postgres@18"],
+        "only supported by `local install`; `local server start --version` requires a ClickHouse version",
     );
 }

--- a/crates/clickhousectl/tests/telemetry_test.rs
+++ b/crates/clickhousectl/tests/telemetry_test.rs
@@ -490,6 +490,55 @@ async fn failed_parse_after_positional_captures_later_flags_without_values() {
 }
 
 #[tokio::test]
+async fn invalid_local_versions_report_invalid_value_without_dispatch_side_effects() {
+    let sandbox = Sandbox::new().await;
+    sandbox.write_state(false);
+    let project = tempfile::tempdir().unwrap();
+    let cases: &[(&[&str], &str, &str)] = &[
+        (
+            &["local", "install", "not.a.version"],
+            "local install",
+            "not.a.version",
+        ),
+        (&["local", "use", "25.12.9"], "local use", "25.12.9"),
+        (
+            &["local", "server", "start", "--version", "25.12.9.61.2"],
+            "local server start",
+            "25.12.9.61.2",
+        ),
+        (&["local", "use", "postgres@18"], "local use", "postgres@18"),
+    ];
+
+    for (index, (args, command, operand)) in cases.iter().enumerate() {
+        let output = sandbox
+            .command(args)
+            .current_dir(project.path())
+            .output()
+            .unwrap();
+        assert_eq!(output.status.code(), Some(2), "{}", stderr_of(&output));
+        assert!(
+            stderr_of(&output).contains("error: invalid value"),
+            "{}",
+            stderr_of(&output)
+        );
+
+        let payloads = sandbox.wait_for_requests(index + 1).await;
+        let event = &payloads[index];
+        assert_eq!(event["command"], *command);
+        assert_eq!(event["exit_code"], 2);
+        assert_eq!(event["outcome"], "invalid_value");
+        let raw = serde_json::to_string(event).unwrap();
+        assert!(!raw.contains(operand), "version operand leaked: {raw}");
+    }
+
+    let home_state = sandbox.home.path().join(".clickhouse");
+    assert!(!home_state.join("versions").exists());
+    assert!(!home_state.join("default").exists());
+    assert!(!sandbox.home.path().join(".local").exists());
+    assert!(!project.path().join(".clickhouse").exists());
+}
+
+#[tokio::test]
 async fn typo_carries_definition_derived_suggestion() {
     let sandbox = Sandbox::new().await;
     sandbox.write_state(false);


### PR DESCRIPTION
## Summary
- parse local install, use, and server ClickHouse version operands into command-specific clap types
- reject malformed and unsupported version shapes with usage exit 2 before dispatch while preserving Postgres install selectors
- cover exact parsed variants, actionable errors, telemetry classification, whitespace-normalized selectors, and filesystem side effects

## Design notes
- `local remove <version>` intentionally remains an opaque string because removal matches exact installed directory names rather than resolving version syntax
- `UseVersionArg` and `ServerVersionArg` intentionally remain separate so each command owns its accepted inputs and diagnostics

## Tests
- `cargo test -p clickhousectl`
- `cargo test -p clickhousectl local::cli::tests`
- `cargo test -p clickhousectl --test local_version_error_test`
- `cargo test -p clickhousectl --test telemetry_test invalid_local_versions_report_invalid_value_without_dispatch_side_effects`
- `cargo check -p clickhousectl --no-default-features`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #463