### PR TITLE
Bound and classify local version-manager network operations

### DIFF
--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -1,5 +1,123 @@
 use std::path::PathBuf;
+use std::{fmt, str::FromStr};
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkStage {
+    BuildProbe,
+    VersionFallback,
+    VersionList,
+    MasterCheck,
+    DownloadHeaders,
+    DownloadBody,
+    Download,
+}
+
+impl fmt::Display for NetworkStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let stage = match self {
+            Self::BuildProbe => "build probe",
+            Self::VersionFallback => "version fallback",
+            Self::VersionList => "version list",
+            Self::MasterCheck => "master check",
+            Self::DownloadHeaders => "download headers",
+            Self::DownloadBody => "download body",
+            Self::Download => "download",
+        };
+        f.write_str(stage)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NetworkCategory {
+    Timeout,
+    Connection,
+    Transport,
+    InvalidResponse,
+    Forbidden,
+    NotFound,
+    RateLimited,
+    ClientError,
+    ServerError,
+    UnexpectedStatus,
+}
+
+impl NetworkCategory {
+    pub(crate) const fn priority(self) -> u8 {
+        match self {
+            Self::RateLimited => 7,
+            Self::ServerError => 6,
+            Self::Timeout => 5,
+            Self::Connection => 4,
+            Self::Transport => 3,
+            Self::InvalidResponse => 2,
+            Self::ClientError | Self::UnexpectedStatus => 1,
+            Self::Forbidden | Self::NotFound => 0,
+        }
+    }
+}
+
+impl fmt::Display for NetworkCategory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let category = match self {
+            Self::Timeout => "timeout",
+            Self::Connection => "connection",
+            Self::Transport => "transport",
+            Self::InvalidResponse => "invalid-response",
+            Self::Forbidden => "forbidden",
+            Self::NotFound => "not-found",
+            Self::RateLimited => "rate-limited",
+            Self::ClientError => "client-error",
+            Self::ServerError => "server-error",
+            Self::UnexpectedStatus => "unexpected-status",
+        };
+        f.write_str(category)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkFailure {
+    pub stage: NetworkStage,
+    pub host: String,
+    pub category: NetworkCategory,
+    pub attempts: Option<usize>,
+}
+
+impl NetworkFailure {
+    pub(crate) fn new(stage: NetworkStage, url: &str, category: NetworkCategory) -> Self {
+        let host = url::Url::from_str(url)
+            .ok()
+            .and_then(|url| url.host_str().map(ToOwned::to_owned))
+            .unwrap_or_else(|| "unknown-host".to_string());
+        Self {
+            stage,
+            host,
+            category,
+            attempts: None,
+        }
+    }
+
+    pub(crate) fn after_attempts(mut self, attempts: usize) -> Self {
+        self.attempts = Some(attempts);
+        self
+    }
+}
+
+impl fmt::Display for NetworkFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} request to {} failed ({})",
+            self.stage, self.host, self.category
+        )?;
+        if let Some(attempts) = self.attempts {
+            write!(f, " after {attempts} attempts")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for NetworkFailure {}
 
 #[derive(Error, Debug)]
 #[allow(dead_code)]
@@ -42,6 +160,15 @@ pub enum Error {
 
     #[error("Download failed: {0}")]
     Download(String),
+
+    #[error("{0}")]
+    Network(#[from] NetworkFailure),
+
+    #[error("{probe}; fallback also failed: {fallback}")]
+    VersionResolutionFallback {
+        probe: NetworkFailure,
+        fallback: Box<Error>,
+    },
 
     #[error("No matching version found for: {0}")]
     NoMatchingVersion(String),

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, NetworkFailure, NetworkStage, Result};
 use crate::version_manager::network;
 use crate::version_manager::platform::{DownloadSource, Platform};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use reqwest::StatusCode;
@@ -137,7 +137,9 @@ async fn download_once(
             .and_then(|value| parse_retry_after(value, Utc::now()));
         return Err(DownloadAttemptError::Network(DownloadAttemptFailure {
             failure: network::failure_from_status(NetworkStage::DownloadHeaders, url, status),
-            retryable: status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error(),
+            retryable: status == StatusCode::REQUEST_TIMEOUT
+                || status == StatusCode::TOO_MANY_REQUESTS
+                || status.is_server_error(),
             retry_after,
         }));
     }
@@ -195,8 +197,15 @@ fn parse_retry_after(value: &str, now: DateTime<Utc>) -> Option<Duration> {
         return Some(Duration::from_secs(seconds));
     }
     let deadline = DateTime::parse_from_rfc2822(value)
-        .ok()?
-        .with_timezone(&Utc);
+        .map(|date| date.with_timezone(&Utc))
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(value, "%A, %d-%b-%y %H:%M:%S GMT")
+                .map(|date| date.and_utc())
+        })
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(value, "%a %b %e %H:%M:%S %Y").map(|date| date.and_utc())
+        })
+        .ok()?;
     (deadline - now).to_std().ok()
 }
 
@@ -254,15 +263,36 @@ mod tests {
     }
 
     #[test]
-    fn retry_after_supports_seconds_and_http_dates() {
+    fn retry_after_supports_seconds_and_all_http_date_forms() {
         let now = DateTime::parse_from_rfc2822("Wed, 21 Oct 2015 07:28:00 GMT")
             .unwrap()
             .with_timezone(&Utc);
         assert_eq!(parse_retry_after("7", now), Some(Duration::from_secs(7)));
-        assert_eq!(
-            parse_retry_after("Wed, 21 Oct 2015 07:28:05 GMT", now),
-            Some(Duration::from_secs(5))
-        );
+        for value in [
+            "Wed, 21 Oct 2015 07:28:05 GMT",
+            "Wednesday, 21-Oct-15 07:28:05 GMT",
+            "Wed Oct 21 07:28:05 2015",
+        ] {
+            assert_eq!(
+                parse_retry_after(value, now),
+                Some(Duration::from_secs(5)),
+                "{value}"
+            );
+        }
+    }
+
+    #[test]
+    fn expired_retry_after_dates_are_ignored() {
+        let now = DateTime::parse_from_rfc2822("Wed, 21 Oct 2015 07:28:00 GMT")
+            .unwrap()
+            .with_timezone(&Utc);
+        for value in [
+            "Wed, 21 Oct 2015 07:27:59 GMT",
+            "Wednesday, 21-Oct-15 07:27:59 GMT",
+            "Wed Oct 21 07:27:59 2015",
+        ] {
+            assert_eq!(parse_retry_after(value, now), None, "{value}");
+        }
     }
 
     #[tokio::test]
@@ -313,6 +343,35 @@ mod tests {
         };
         assert_eq!(failure.stage, NetworkStage::DownloadHeaders);
         assert_eq!(failure.category, NetworkCategory::ServerError);
+        assert_eq!(failure.attempts, Some(3));
+        assert_eq!(requests.load(Ordering::SeqCst), 3);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn request_timeout_responses_stop_after_three_attempts() {
+        let (url, requests, server) = scripted_status_server(vec![
+            ("408 Request Timeout", None),
+            ("408 Request Timeout", None),
+            ("408 Request Timeout", None),
+        ])
+        .await;
+        let temp = tempfile::tempdir().unwrap();
+
+        let error = download_url_with_policy(
+            &url,
+            &temp.path().join("artifact"),
+            test_request_policy(),
+            test_retry_policy(3),
+        )
+        .await
+        .unwrap_err();
+
+        let Error::Network(failure) = error else {
+            panic!("expected network failure");
+        };
+        assert_eq!(failure.stage, NetworkStage::DownloadHeaders);
+        assert_eq!(failure.category, NetworkCategory::Timeout);
         assert_eq!(failure.attempts, Some(3));
         assert_eq!(requests.load(Ordering::SeqCst), 3);
         server.await.unwrap();

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -1,11 +1,43 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, NetworkFailure, NetworkStage, Result};
+use crate::version_manager::network;
 use crate::version_manager::platform::{DownloadSource, Platform};
+use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use indicatif::{ProgressBar, ProgressStyle};
+use reqwest::StatusCode;
+use reqwest::header::RETRY_AFTER;
 use std::path::Path;
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 
-/// Downloads from a DownloadSource to the specified path
+const DOWNLOAD_OPERATION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+const INSTALL_RETRY_POLICY: RetryPolicy = RetryPolicy {
+    max_attempts: 3,
+    base_delay: Duration::from_millis(500),
+    max_delay: Duration::from_secs(5),
+    operation_timeout: DOWNLOAD_OPERATION_TIMEOUT,
+};
+
+#[derive(Debug, Clone, Copy)]
+struct RetryPolicy {
+    max_attempts: usize,
+    base_delay: Duration,
+    max_delay: Duration,
+    operation_timeout: Duration,
+}
+
+struct DownloadAttemptFailure {
+    failure: NetworkFailure,
+    retryable: bool,
+    retry_after: Option<Duration>,
+}
+
+enum DownloadAttemptError {
+    Network(DownloadAttemptFailure),
+    Io(std::io::Error),
+}
+
+/// Downloads from a DownloadSource to the specified path.
 pub async fn download_from_source(
     source: &DownloadSource,
     platform: &Platform,
@@ -15,19 +47,102 @@ pub async fn download_from_source(
     download_url(&url, dest_path).await
 }
 
-/// Downloads a file from a URL to the specified path, with progress bar
+/// Downloads a file with bounded connect, idle-read and total deadlines.
+/// Only the idempotent GET is retried, and every attempt truncates the partial
+/// destination before writing so bytes from failed streams cannot be mixed.
 pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
-    let client = crate::http::client_builder().build()?;
+    download_url_with_policy(
+        url,
+        dest_path,
+        network::DOWNLOAD_POLICY,
+        INSTALL_RETRY_POLICY,
+    )
+    .await
+}
 
-    let response = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("Failed to download {}: {}", url, e)))?;
+async fn download_url_with_policy(
+    url: &str,
+    dest_path: &Path,
+    request_policy: network::RequestPolicy,
+    retry_policy: RetryPolicy,
+) -> Result<()> {
+    let download = download_with_retries(url, dest_path, request_policy, retry_policy);
+    match network::with_operation_timeout(
+        retry_policy.operation_timeout,
+        NetworkStage::Download,
+        url,
+        download,
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(failure) => {
+            let _ = tokio::fs::remove_file(dest_path).await;
+            Err(failure.into())
+        }
+    }
+}
+
+async fn download_with_retries(
+    url: &str,
+    dest_path: &Path,
+    request_policy: network::RequestPolicy,
+    retry_policy: RetryPolicy,
+) -> Result<()> {
+    let client = network::client(request_policy, NetworkStage::DownloadHeaders, url)?;
+    for attempt in 1..=retry_policy.max_attempts {
+        match download_once(&client, url, dest_path).await {
+            Ok(()) => return Ok(()),
+            Err(DownloadAttemptError::Io(error)) => return Err(Error::Io(error)),
+            Err(DownloadAttemptError::Network(error))
+                if error.retryable && attempt < retry_policy.max_attempts =>
+            {
+                let delay = retry_delay(&retry_policy, attempt, error.retry_after);
+                tokio::time::sleep(delay).await;
+            }
+            Err(DownloadAttemptError::Network(error)) => {
+                let _ = tokio::fs::remove_file(dest_path).await;
+                let failure = if error.retryable {
+                    error.failure.after_attempts(attempt)
+                } else {
+                    error.failure
+                };
+                return Err(failure.into());
+            }
+        }
+    }
+    unreachable!("retry policy always executes at least one attempt")
+}
+
+async fn download_once(
+    client: &reqwest::Client,
+    url: &str,
+    dest_path: &Path,
+) -> std::result::Result<(), DownloadAttemptError> {
+    let response = network::send(client.get(url), NetworkStage::DownloadHeaders, url)
+        .await
+        .map_err(|failure| {
+            DownloadAttemptError::Network(DownloadAttemptFailure {
+                failure,
+                retryable: true,
+                retry_after: None,
+            })
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| parse_retry_after(value, Utc::now()));
+        return Err(DownloadAttemptError::Network(DownloadAttemptFailure {
+            failure: network::failure_from_status(NetworkStage::DownloadHeaders, url, status),
+            retryable: status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error(),
+            retry_after,
+        }));
+    }
 
     let total_size = response.content_length().unwrap_or(0);
-
     let pb = ProgressBar::new(total_size);
     pb.set_style(
         ProgressStyle::default_bar()
@@ -36,19 +151,222 @@ pub async fn download_url(url: &str, dest_path: &Path) -> Result<()> {
             .progress_chars("#>-"),
     );
 
-    let mut file = tokio::fs::File::create(dest_path).await?;
+    let mut file = tokio::fs::File::create(dest_path)
+        .await
+        .map_err(DownloadAttemptError::Io)?;
     let mut downloaded: u64 = 0;
     let mut stream = response.bytes_stream();
-
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
-        file.write_all(&chunk).await?;
+        let chunk = match chunk {
+            Ok(chunk) => chunk,
+            Err(error) => {
+                pb.abandon();
+                return Err(DownloadAttemptError::Network(DownloadAttemptFailure {
+                    failure: network::failure_from_reqwest(NetworkStage::DownloadBody, url, &error),
+                    retryable: true,
+                    retry_after: None,
+                }));
+            }
+        };
+        file.write_all(&chunk)
+            .await
+            .map_err(DownloadAttemptError::Io)?;
         downloaded += chunk.len() as u64;
         pb.set_position(downloaded);
     }
 
-    file.flush().await?;
-    file.shutdown().await?;
+    file.flush().await.map_err(DownloadAttemptError::Io)?;
+    file.shutdown().await.map_err(DownloadAttemptError::Io)?;
     pb.finish_with_message("Download complete");
     Ok(())
+}
+
+fn retry_delay(policy: &RetryPolicy, attempt: usize, retry_after: Option<Duration>) -> Duration {
+    let exponent = u32::try_from(attempt.saturating_sub(1)).unwrap_or(u32::MAX);
+    let multiplier = 2_u32.checked_pow(exponent).unwrap_or(u32::MAX);
+    let backoff = policy.base_delay.saturating_mul(multiplier);
+    backoff
+        .max(retry_after.unwrap_or_default())
+        .min(policy.max_delay)
+}
+
+fn parse_retry_after(value: &str, now: DateTime<Utc>) -> Option<Duration> {
+    if let Ok(seconds) = value.trim().parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+    let deadline = DateTime::parse_from_rfc2822(value)
+        .ok()?
+        .with_timezone(&Utc);
+    (deadline - now).to_std().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::{NetworkCategory, NetworkStage};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    fn test_request_policy() -> network::RequestPolicy {
+        network::RequestPolicy {
+            connect_timeout: Duration::from_millis(50),
+            read_timeout: Duration::from_millis(40),
+            request_timeout: Duration::from_millis(100),
+        }
+    }
+
+    fn test_retry_policy(max_attempts: usize) -> RetryPolicy {
+        RetryPolicy {
+            max_attempts,
+            base_delay: Duration::from_millis(2),
+            max_delay: Duration::from_millis(40),
+            operation_timeout: Duration::from_millis(500),
+        }
+    }
+
+    async fn scripted_status_server(
+        statuses: Vec<(&'static str, Option<&'static str>)>,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let server = tokio::spawn(async move {
+            for (status, retry_after) in statuses {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut request = [0_u8; 1024];
+                let _ = socket.read(&mut request).await;
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                let retry_header = retry_after
+                    .map(|value| format!("Retry-After: {value}\r\n"))
+                    .unwrap_or_default();
+                let body = if status.starts_with("200") { "ok" } else { "" };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: {}\r\n{retry_header}Connection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                socket.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        (format!("http://{address}/artifact"), requests, server)
+    }
+
+    #[test]
+    fn retry_after_supports_seconds_and_http_dates() {
+        let now = DateTime::parse_from_rfc2822("Wed, 21 Oct 2015 07:28:00 GMT")
+            .unwrap()
+            .with_timezone(&Utc);
+        assert_eq!(parse_retry_after("7", now), Some(Duration::from_secs(7)));
+        assert_eq!(
+            parse_retry_after("Wed, 21 Oct 2015 07:28:05 GMT", now),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_retry_respects_capped_retry_after_then_succeeds() {
+        let (url, requests, server) =
+            scripted_status_server(vec![("429 Too Many Requests", Some("1")), ("200 OK", None)])
+                .await;
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("artifact");
+        let started = tokio::time::Instant::now();
+
+        download_url_with_policy(
+            &url,
+            &destination,
+            test_request_policy(),
+            test_retry_policy(2),
+        )
+        .await
+        .unwrap();
+
+        assert!(started.elapsed() >= Duration::from_millis(40));
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        assert_eq!(tokio::fs::read(destination).await.unwrap(), b"ok");
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn server_errors_stop_after_retry_exhaustion() {
+        let (url, requests, server) = scripted_status_server(vec![
+            ("503 Service Unavailable", None),
+            ("503 Service Unavailable", None),
+            ("503 Service Unavailable", None),
+        ])
+        .await;
+        let temp = tempfile::tempdir().unwrap();
+
+        let error = download_url_with_policy(
+            &url,
+            &temp.path().join("artifact"),
+            test_request_policy(),
+            test_retry_policy(3),
+        )
+        .await
+        .unwrap_err();
+
+        let Error::Network(failure) = error else {
+            panic!("expected network failure");
+        };
+        assert_eq!(failure.stage, NetworkStage::DownloadHeaders);
+        assert_eq!(failure.category, NetworkCategory::ServerError);
+        assert_eq!(failure.attempts, Some(3));
+        assert_eq!(requests.load(Ordering::SeqCst), 3);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stalled_body_retries_then_reports_body_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let requests = Arc::new(AtomicUsize::new(0));
+        let server_requests = requests.clone();
+        let server = tokio::spawn(async move {
+            let mut connections = Vec::new();
+            for _ in 0..2 {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                server_requests.fetch_add(1, Ordering::SeqCst);
+                connections.push(tokio::spawn(async move {
+                    let mut request = [0_u8; 1024];
+                    let _ = socket.read(&mut request).await;
+                    socket
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 10\r\nConnection: close\r\n\r\nx",
+                        )
+                        .await
+                        .unwrap();
+                    tokio::time::sleep(Duration::from_millis(150)).await;
+                }));
+            }
+            for connection in connections {
+                connection.await.unwrap();
+            }
+        });
+        let url = format!("http://{address}/artifact?token=secret");
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("artifact");
+
+        let error = download_url_with_policy(
+            &url,
+            &destination,
+            test_request_policy(),
+            test_retry_policy(2),
+        )
+        .await
+        .unwrap_err();
+
+        let Error::Network(failure) = error else {
+            panic!("expected network failure");
+        };
+        assert_eq!(failure.stage, NetworkStage::DownloadBody);
+        assert_eq!(failure.category, NetworkCategory::Timeout);
+        assert_eq!(failure.attempts, Some(2));
+        assert!(!failure.to_string().contains("secret"));
+        assert!(!destination.exists());
+        assert_eq!(requests.load(Ordering::SeqCst), 2);
+        server.await.unwrap();
+    }
 }

--- a/crates/clickhousectl/src/version_manager/download.rs
+++ b/crates/clickhousectl/src/version_manager/download.rs
@@ -217,6 +217,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+    use tokio::sync::Semaphore;
 
     fn test_request_policy() -> network::RequestPolicy {
         network::RequestPolicy {
@@ -383,11 +384,14 @@ mod tests {
         let address = listener.local_addr().unwrap();
         let requests = Arc::new(AtomicUsize::new(0));
         let server_requests = requests.clone();
+        let held_connections = Arc::new(Semaphore::new(0));
+        let server_held_connections = held_connections.clone();
         let server = tokio::spawn(async move {
             let mut connections = Vec::new();
             for _ in 0..2 {
                 let (mut socket, _) = listener.accept().await.unwrap();
                 server_requests.fetch_add(1, Ordering::SeqCst);
+                let held_connections = server_held_connections.clone();
                 connections.push(tokio::spawn(async move {
                     let mut request = [0_u8; 1024];
                     let _ = socket.read(&mut request).await;
@@ -397,7 +401,7 @@ mod tests {
                         )
                         .await
                         .unwrap();
-                    tokio::time::sleep(Duration::from_millis(150)).await;
+                    let _permit = held_connections.acquire().await.unwrap();
                 }));
             }
             for connection in connections {
@@ -407,15 +411,20 @@ mod tests {
         let url = format!("http://{address}/artifact?token=secret");
         let temp = tempfile::tempdir().unwrap();
         let destination = temp.path().join("artifact");
+        // Keep the enclosing deadlines well clear of the idle-read timeout under test.
+        let request_policy = network::RequestPolicy {
+            request_timeout: Duration::from_secs(5),
+            ..test_request_policy()
+        };
+        let retry_policy = RetryPolicy {
+            operation_timeout: Duration::from_secs(30),
+            ..test_retry_policy(2)
+        };
 
-        let error = download_url_with_policy(
-            &url,
-            &destination,
-            test_request_policy(),
-            test_retry_policy(2),
-        )
-        .await
-        .unwrap_err();
+        let error = download_url_with_policy(&url, &destination, request_policy, retry_policy)
+            .await
+            .unwrap_err();
+        held_connections.add_permits(2);
 
         let Error::Network(failure) = error else {
             panic!("expected network failure");

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -66,7 +66,10 @@ pub async fn install_resolved(
     );
     let mut master_head = None;
     if is_master {
-        master_head = master::head_info(platform).await;
+        match master::head_info(platform).await {
+            Ok(head) => master_head = head,
+            Err(error) => eprintln!("Master freshness check skipped: {error}"),
+        }
         if !force && let Some(version) = master::reuse_if_unchanged(platform, master_head.as_ref())
         {
             eprintln!(

--- a/crates/clickhousectl/src/version_manager/list.rs
+++ b/crates/clickhousectl/src/version_manager/list.rs
@@ -1,8 +1,11 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, NetworkStage, Result};
 use crate::paths;
+use crate::version_manager::network::{self, ProbeOutcome};
 use chrono::Datelike;
+use futures_util::{StreamExt, stream};
 use serde::Deserialize;
 use std::fmt;
+use std::time::Duration;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Channel {
@@ -72,15 +75,11 @@ pub struct VersionEntry {
 /// Fetches available versions from GitHub releases
 pub async fn list_available_versions() -> Result<Vec<VersionEntry>> {
     let url = "https://api.github.com/repos/ClickHouse/ClickHouse/releases?per_page=100";
-    let client = crate::http::client_builder().build()?;
-
-    let response = client
-        .get(url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
-    let releases: Vec<GitHubRelease> = response.json().await?;
+    let client = network::client(network::METADATA_POLICY, NetworkStage::VersionList, url)?;
+    let response = network::send(client.get(url), NetworkStage::VersionList, url).await?;
+    let response = network::ensure_success(response, NetworkStage::VersionList, url)?;
+    let releases: Vec<GitHubRelease> =
+        network::json(response, NetworkStage::VersionList, url).await?;
 
     let mut versions = Vec::new();
     for release in releases {
@@ -112,30 +111,68 @@ pub async fn list_available_versions_from_builds() -> Result<Vec<String>> {
     use crate::version_manager::platform::{Platform, builds_probe_url};
 
     let platform = Platform::detect()?;
-    let client = crate::http::client_builder()
-        .build()
-        .map_err(|e| Error::Download(e.to_string()))?;
-
     let current_year = chrono::Utc::now().year() as u32;
     // ClickHouse uses YY.MM versioning — scan from current year down to 20 (2020)
     // Use two-digit year format
     let start_yy = current_year % 100;
 
-    let mut available = Vec::new();
-
+    let mut candidates = Vec::new();
     for yy in (20..=start_yy).rev() {
         for mm in (1..=12).rev() {
             let version_path = format!("{}.{}", yy, mm);
             let url = builds_probe_url(&version_path, &platform);
-            match client.head(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    available.push(version_path);
-                }
-                _ => {}
+            candidates.push((version_path, url));
+        }
+    }
+    scan_build_candidates(candidates, network::LIST_OPERATION_TIMEOUT).await
+}
+
+async fn scan_build_candidates(
+    candidates: Vec<(String, String)>,
+    operation_timeout: Duration,
+) -> Result<Vec<String>> {
+    let Some((_, first_url)) = candidates.first() else {
+        return Ok(Vec::new());
+    };
+    let first_url = first_url.clone();
+    let client = network::client(
+        network::METADATA_POLICY,
+        NetworkStage::VersionList,
+        &first_url,
+    )?;
+    let scan = stream::iter(candidates)
+        .map(|(version, url)| {
+            let client = client.clone();
+            async move {
+                let outcome = network::probe(&client, &url, NetworkStage::VersionList).await;
+                (version, outcome)
+            }
+        })
+        .buffer_unordered(8)
+        .collect::<Vec<_>>();
+    let outcomes = network::with_operation_timeout(
+        operation_timeout,
+        NetworkStage::VersionList,
+        &first_url,
+        scan,
+    )
+    .await?;
+
+    let mut available = Vec::new();
+    let mut failure = None;
+    for (version, outcome) in outcomes {
+        match outcome {
+            ProbeOutcome::Available => available.push(version),
+            ProbeOutcome::Missing => {}
+            ProbeOutcome::Failed(candidate) => {
+                failure = network::preferred_failure(failure, candidate);
             }
         }
     }
-
+    if let Some(failure) = failure {
+        return Err(failure.into());
+    }
+    available.sort_by(|a, b| compare_versions(b, a));
     Ok(available)
 }
 
@@ -206,7 +243,94 @@ pub(crate) fn compare_versions(a: &str, b: &str) -> std::cmp::Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::{NetworkCategory, NetworkFailure};
     use std::cmp::Ordering;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    async fn mount_head(server: &MockServer, endpoint: &str, status: u16) {
+        Mock::given(method("HEAD"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(status))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn build_list_treats_404_as_absent_and_keeps_successes_sorted() {
+        let server = MockServer::start().await;
+        mount_head(&server, "/new", 200).await;
+        mount_head(&server, "/old", 200).await;
+        mount_head(&server, "/missing", 404).await;
+        let candidates = vec![
+            ("25.2".to_string(), format!("{}/old", server.uri())),
+            ("25.12".to_string(), format!("{}/new", server.uri())),
+            ("25.11".to_string(), format!("{}/missing", server.uri())),
+        ];
+
+        let versions = scan_build_candidates(candidates, Duration::from_secs(1))
+            .await
+            .unwrap();
+
+        assert_eq!(versions, ["25.12", "25.2"]);
+    }
+
+    #[tokio::test]
+    async fn build_list_reports_rate_limit_instead_of_partial_results() {
+        let server = MockServer::start().await;
+        mount_head(&server, "/available", 200).await;
+        mount_head(&server, "/server-error", 500).await;
+        mount_head(&server, "/rate-limit", 429).await;
+        let candidates = vec![
+            ("25.12".to_string(), format!("{}/available", server.uri())),
+            (
+                "25.11".to_string(),
+                format!("{}/server-error", server.uri()),
+            ),
+            ("25.10".to_string(), format!("{}/rate-limit", server.uri())),
+        ];
+
+        let error = scan_build_candidates(candidates, Duration::from_secs(1))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Network(NetworkFailure {
+                stage: NetworkStage::VersionList,
+                category: NetworkCategory::RateLimited,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn build_list_scan_has_a_total_operation_deadline() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/slow"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(500)))
+            .mount(&server)
+            .await;
+        let candidates = (1..=20)
+            .map(|minor| (format!("25.{minor}"), format!("{}/slow", server.uri())))
+            .collect();
+        let started = tokio::time::Instant::now();
+
+        let error = scan_build_candidates(candidates, Duration::from_millis(60))
+            .await
+            .unwrap_err();
+
+        assert!(started.elapsed() < Duration::from_millis(250));
+        assert!(matches!(
+            error,
+            Error::Network(NetworkFailure {
+                stage: NetworkStage::VersionList,
+                category: NetworkCategory::Timeout,
+                ..
+            })
+        ));
+    }
 
     #[test]
     fn test_equal_versions() {

--- a/crates/clickhousectl/src/version_manager/master.rs
+++ b/crates/clickhousectl/src/version_manager/master.rs
@@ -12,8 +12,9 @@
 //! *and* the post-download version detection; changed (or no record, or the
 //! recorded binary is missing) -> download afresh and re-record.
 
-use crate::error::Result;
+use crate::error::{NetworkCategory, NetworkFailure, NetworkStage, Result};
 use crate::paths;
+use crate::version_manager::network;
 use crate::version_manager::platform::{DownloadSource, Platform};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -115,35 +116,46 @@ pub fn record(platform: &Platform, head: &HeadInfo, version: &str) -> Result<()>
 }
 
 /// HEAD the master URL and pull the change-detection headers.
-/// Best-effort: returns `None` on any network/build error, so callers fall
-/// back to an unconditional download rather than failing.
-pub async fn head_info(platform: &Platform) -> Option<HeadInfo> {
+/// Callers treat failure as best-effort and continue with a download, but the
+/// classified error is returned so it can be reported without leaking the URL.
+pub async fn head_info(platform: &Platform) -> Result<Option<HeadInfo>> {
     let url = DownloadSource::Builds {
         version_path: "master".to_string(),
     }
     .url(platform);
+    head_info_url(&url).await
+}
 
-    let client = reqwest::Client::builder()
-        .user_agent(crate::user_agent::user_agent())
-        .build()
-        .ok()?;
+async fn head_info_url(url: &str) -> Result<Option<HeadInfo>> {
+    head_info_url_with_policy(url, network::METADATA_POLICY).await
+}
 
-    let resp = client.head(&url).send().await.ok()?;
-    if !resp.status().is_success() {
-        return None;
-    }
+async fn head_info_url_with_policy(
+    url: &str,
+    policy: network::RequestPolicy,
+) -> Result<Option<HeadInfo>> {
+    let client = network::client(policy, NetworkStage::MasterCheck, url)?;
+    let resp = network::send(client.head(url), NetworkStage::MasterCheck, url).await?;
+    let resp = network::ensure_success(resp, NetworkStage::MasterCheck, url)?;
     let header = |name: reqwest::header::HeaderName| {
         resp.headers()
             .get(name)
             .and_then(|v| v.to_str().ok())
             .map(|s| s.to_string())
     };
-    let etag = header(reqwest::header::ETAG)?;
+    let Some(etag) = header(reqwest::header::ETAG) else {
+        return Err(NetworkFailure::new(
+            NetworkStage::MasterCheck,
+            url,
+            NetworkCategory::InvalidResponse,
+        )
+        .into());
+    };
     let last_modified = header(reqwest::header::LAST_MODIFIED);
-    Some(HeadInfo {
+    Ok(Some(HeadInfo {
         etag,
         last_modified,
-    })
+    }))
 }
 
 /// Pure reuse decision: reuse the recorded build only when we have a record,
@@ -179,6 +191,10 @@ pub fn reuse_if_unchanged(platform: &Platform, head: Option<&HeadInfo>) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::{Error, NetworkCategory};
+    use std::time::Duration;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn rec(etag: &str, version: &str) -> MasterRecord {
         MasterRecord {
@@ -186,6 +202,81 @@ mod tests {
             last_modified: None,
             version: version.to_string(),
         }
+    }
+
+    #[tokio::test]
+    async fn master_check_reads_change_headers() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/master"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"abc-1\"")
+                    .insert_header("last-modified", "Wed, 21 Oct 2015 07:28:00 GMT"),
+            )
+            .mount(&server)
+            .await;
+
+        let head = head_info_url(&format!("{}/master", server.uri()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(head.etag, "\"abc-1\"");
+        assert_eq!(
+            head.last_modified.as_deref(),
+            Some("Wed, 21 Oct 2015 07:28:00 GMT")
+        );
+    }
+
+    #[tokio::test]
+    async fn stalled_master_headers_are_bounded_and_classified() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/master"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(300)))
+            .mount(&server)
+            .await;
+        let policy = network::RequestPolicy {
+            connect_timeout: Duration::from_millis(30),
+            read_timeout: Duration::from_millis(40),
+            request_timeout: Duration::from_millis(60),
+        };
+
+        let error =
+            head_info_url_with_policy(&format!("{}/master?token=secret", server.uri()), policy)
+                .await
+                .unwrap_err();
+
+        let Error::Network(failure) = error else {
+            panic!("expected network failure");
+        };
+        assert_eq!(failure.stage, NetworkStage::MasterCheck);
+        assert_eq!(failure.category, NetworkCategory::Timeout);
+        assert!(!failure.to_string().contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn master_server_status_is_not_treated_as_unchanged() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/master"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let error = head_info_url(&format!("{}/master", server.uri()))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            Error::Network(NetworkFailure {
+                stage: NetworkStage::MasterCheck,
+                category: NetworkCategory::ServerError,
+                ..
+            })
+        ));
     }
 
     #[test]

--- a/crates/clickhousectl/src/version_manager/mod.rs
+++ b/crates/clickhousectl/src/version_manager/mod.rs
@@ -2,6 +2,7 @@ pub mod download;
 pub mod install;
 pub mod list;
 pub mod master;
+pub(crate) mod network;
 pub mod platform;
 pub mod resolve;
 pub mod spec;

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -1,0 +1,269 @@
+use crate::error::{NetworkCategory, NetworkFailure, NetworkStage};
+use reqwest::{Client, ClientBuilder, RequestBuilder, Response, StatusCode};
+use serde::de::DeserializeOwned;
+use std::future::Future;
+use std::time::Duration;
+
+pub(crate) const METADATA_POLICY: RequestPolicy = RequestPolicy {
+    connect_timeout: Duration::from_secs(3),
+    read_timeout: Duration::from_secs(5),
+    request_timeout: Duration::from_secs(8),
+};
+pub(crate) const RESOLUTION_OPERATION_TIMEOUT: Duration = Duration::from_secs(15);
+pub(crate) const LIST_OPERATION_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const DOWNLOAD_POLICY: RequestPolicy = RequestPolicy {
+    connect_timeout: Duration::from_secs(10),
+    read_timeout: Duration::from_secs(30),
+    request_timeout: Duration::from_secs(30 * 60),
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RequestPolicy {
+    pub connect_timeout: Duration,
+    pub read_timeout: Duration,
+    pub request_timeout: Duration,
+}
+
+#[derive(Debug)]
+pub(crate) enum ProbeOutcome {
+    Available,
+    Missing,
+    Failed(NetworkFailure),
+}
+
+pub(crate) fn configure_builder(builder: ClientBuilder, policy: RequestPolicy) -> ClientBuilder {
+    builder
+        .connect_timeout(policy.connect_timeout)
+        .read_timeout(policy.read_timeout)
+        .timeout(policy.request_timeout)
+}
+
+pub(crate) fn client(
+    policy: RequestPolicy,
+    stage: NetworkStage,
+    url: &str,
+) -> Result<Client, NetworkFailure> {
+    configure_builder(crate::http::client_builder(), policy)
+        .build()
+        .map_err(|_| NetworkFailure::new(stage, url, NetworkCategory::Transport))
+}
+
+pub(crate) async fn send(
+    request: RequestBuilder,
+    stage: NetworkStage,
+    url: &str,
+) -> Result<Response, NetworkFailure> {
+    request
+        .send()
+        .await
+        .map_err(|error| failure_from_reqwest(stage, url, &error))
+}
+
+pub(crate) fn ensure_success(
+    response: Response,
+    stage: NetworkStage,
+    url: &str,
+) -> Result<Response, NetworkFailure> {
+    if response.status().is_success() {
+        Ok(response)
+    } else {
+        Err(failure_from_status(stage, url, response.status()))
+    }
+}
+
+pub(crate) async fn json<T: DeserializeOwned>(
+    response: Response,
+    stage: NetworkStage,
+    url: &str,
+) -> Result<T, NetworkFailure> {
+    response
+        .json()
+        .await
+        .map_err(|error| failure_from_reqwest(stage, url, &error))
+}
+
+pub(crate) async fn probe(client: &Client, url: &str, stage: NetworkStage) -> ProbeOutcome {
+    let response = match send(client.head(url), stage, url).await {
+        Ok(response) => response,
+        Err(error) => return ProbeOutcome::Failed(error),
+    };
+    match response.status() {
+        status if status.is_success() => ProbeOutcome::Available,
+        StatusCode::FORBIDDEN | StatusCode::NOT_FOUND => ProbeOutcome::Missing,
+        status => ProbeOutcome::Failed(failure_from_status(stage, url, status)),
+    }
+}
+
+pub(crate) async fn with_operation_timeout<T>(
+    duration: Duration,
+    stage: NetworkStage,
+    url: &str,
+    future: impl Future<Output = T>,
+) -> Result<T, NetworkFailure> {
+    tokio::time::timeout(duration, future)
+        .await
+        .map_err(|_| NetworkFailure::new(stage, url, NetworkCategory::Timeout))
+}
+
+pub(crate) fn failure_from_reqwest(
+    stage: NetworkStage,
+    url: &str,
+    error: &reqwest::Error,
+) -> NetworkFailure {
+    let category = if error.is_timeout() {
+        NetworkCategory::Timeout
+    } else if error.is_connect() {
+        NetworkCategory::Connection
+    } else if error.is_decode() {
+        NetworkCategory::InvalidResponse
+    } else {
+        NetworkCategory::Transport
+    };
+    NetworkFailure::new(stage, url, category)
+}
+
+pub(crate) fn failure_from_status(
+    stage: NetworkStage,
+    url: &str,
+    status: StatusCode,
+) -> NetworkFailure {
+    let category = match status {
+        StatusCode::FORBIDDEN => NetworkCategory::Forbidden,
+        StatusCode::NOT_FOUND => NetworkCategory::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => NetworkCategory::RateLimited,
+        status if status.is_client_error() => NetworkCategory::ClientError,
+        status if status.is_server_error() => NetworkCategory::ServerError,
+        _ => NetworkCategory::UnexpectedStatus,
+    };
+    NetworkFailure::new(stage, url, category)
+}
+
+pub(crate) fn preferred_failure(
+    current: Option<NetworkFailure>,
+    candidate: NetworkFailure,
+) -> Option<NetworkFailure> {
+    match current {
+        Some(current) if current.category.priority() >= candidate.category.priority() => {
+            Some(current)
+        }
+        _ => Some(candidate),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::Notify;
+
+    fn short_policy() -> RequestPolicy {
+        RequestPolicy {
+            connect_timeout: Duration::from_millis(50),
+            read_timeout: Duration::from_millis(60),
+            request_timeout: Duration::from_millis(100),
+        }
+    }
+
+    #[test]
+    fn status_categories_are_stable_and_urls_are_redacted() {
+        let cases = [
+            (StatusCode::FORBIDDEN, NetworkCategory::Forbidden),
+            (StatusCode::NOT_FOUND, NetworkCategory::NotFound),
+            (StatusCode::TOO_MANY_REQUESTS, NetworkCategory::RateLimited),
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                NetworkCategory::ServerError,
+            ),
+        ];
+        for (status, expected) in cases {
+            let failure = failure_from_status(
+                NetworkStage::BuildProbe,
+                "https://user:password@builds.example.test/private?token=secret",
+                status,
+            );
+            let message = failure.to_string();
+            assert_eq!(failure.host, "builds.example.test");
+            assert_eq!(failure.category, expected);
+            assert!(!message.contains("user"));
+            assert!(!message.contains("password"));
+            assert!(!message.contains("private"));
+            assert!(!message.contains("secret"));
+        }
+    }
+
+    #[test]
+    fn rate_limit_is_preferred_over_less_actionable_probe_failures() {
+        let server = NetworkFailure::new(
+            NetworkStage::BuildProbe,
+            "https://builds.example.test",
+            NetworkCategory::ServerError,
+        );
+        let rate_limit = NetworkFailure::new(
+            NetworkStage::BuildProbe,
+            "https://builds.example.test",
+            NetworkCategory::RateLimited,
+        );
+        let selected = preferred_failure(Some(server), rate_limit.clone()).unwrap();
+        assert_eq!(selected, rate_limit);
+    }
+
+    #[tokio::test]
+    async fn stalled_response_headers_hit_the_read_deadline() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let hold = Arc::new(Notify::new());
+        let server_hold = hold.clone();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await;
+            server_hold.notified().await;
+        });
+        let url = format!("http://{address}/headers?token=secret");
+        let client = client(short_policy(), NetworkStage::VersionList, &url).unwrap();
+
+        let failure = send(client.get(&url), NetworkStage::VersionList, &url)
+            .await
+            .unwrap_err();
+
+        assert_eq!(failure.stage, NetworkStage::VersionList);
+        assert_eq!(failure.host, "127.0.0.1");
+        assert_eq!(failure.category, NetworkCategory::Timeout);
+        assert!(!failure.to_string().contains("secret"));
+        hold.notify_one();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stalled_connect_proxy_is_bounded_and_redacted() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let proxy_address = listener.local_addr().unwrap();
+        let hold = Arc::new(Notify::new());
+        let server_hold = hold.clone();
+        let proxy = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = socket.read(&mut request).await;
+            server_hold.notified().await;
+        });
+        let target = "https://user:password@example.test/private?token=secret";
+        let builder = crate::http::client_builder()
+            .proxy(reqwest::Proxy::all(format!("http://{proxy_address}")).unwrap());
+        let client = configure_builder(builder, short_policy()).build().unwrap();
+
+        let failure = send(client.head(target), NetworkStage::BuildProbe, target)
+            .await
+            .unwrap_err();
+
+        assert_eq!(failure.host, "example.test");
+        assert_eq!(failure.category, NetworkCategory::Timeout);
+        let message = failure.to_string();
+        assert!(!message.contains("user"));
+        assert!(!message.contains("password"));
+        assert!(!message.contains("secret"));
+        hold.notify_one();
+        proxy.await.unwrap();
+    }
+}

--- a/crates/clickhousectl/src/version_manager/network.rs
+++ b/crates/clickhousectl/src/version_manager/network.rs
@@ -130,6 +130,7 @@ pub(crate) fn failure_from_status(
     let category = match status {
         StatusCode::FORBIDDEN => NetworkCategory::Forbidden,
         StatusCode::NOT_FOUND => NetworkCategory::NotFound,
+        StatusCode::REQUEST_TIMEOUT => NetworkCategory::Timeout,
         StatusCode::TOO_MANY_REQUESTS => NetworkCategory::RateLimited,
         status if status.is_client_error() => NetworkCategory::ClientError,
         status if status.is_server_error() => NetworkCategory::ServerError,
@@ -171,6 +172,7 @@ mod tests {
         let cases = [
             (StatusCode::FORBIDDEN, NetworkCategory::Forbidden),
             (StatusCode::NOT_FOUND, NetworkCategory::NotFound),
+            (StatusCode::REQUEST_TIMEOUT, NetworkCategory::Timeout),
             (StatusCode::TOO_MANY_REQUESTS, NetworkCategory::RateLimited),
             (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -1,10 +1,13 @@
-use crate::error::{Error, Result};
+use crate::error::{Error, NetworkFailure, NetworkStage, Result};
 use crate::version_manager::list::{
     Channel, VersionEntry, list_available_versions, list_installed_versions,
 };
+use crate::version_manager::network::{self, ProbeOutcome};
 use crate::version_manager::platform::{DownloadSource, Platform, builds_probe_url};
 use crate::version_manager::spec::VersionSpec;
+use futures_util::{StreamExt, stream};
 use serde::Deserialize;
+use std::time::Duration;
 
 /// Result of resolving a version spec — contains everything needed to download
 #[derive(Debug, Clone)]
@@ -92,7 +95,10 @@ async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<Resolv
     let minor = extract_minor(&entry.version)?;
 
     // Try builds first
-    if probe_builds(&minor, platform).await {
+    if matches!(
+        probe_builds(&minor, platform).await,
+        ProbeOutcome::Available
+    ) {
         return Ok(ResolvedVersion {
             source: DownloadSource::Builds {
                 version_path: minor.clone(),
@@ -110,23 +116,25 @@ async fn resolve_channel(channel: Channel, platform: &Platform) -> Result<Resolv
 
 /// `install 25` — probe builds for highest 25.x minor
 async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersion> {
-    // Probe builds.clickhouse.com for all possible minors in this major (1..12)
-    let mut highest_available: Option<u32> = None;
-    let client = crate::http::client_builder()
-        .build()
-        .map_err(|e| Error::Download(e.to_string()))?;
+    // Probe all possible minors concurrently. The concurrency cap and outer
+    // deadline prevent a major lookup from becoming 12 serial timeouts.
+    let candidates = (1..=12)
+        .rev()
+        .map(|minor| {
+            (
+                minor,
+                builds_probe_url(&format!("{}.{}", major, minor), platform),
+            )
+        })
+        .collect::<Vec<_>>();
+    let probe_summary = probe_candidates(
+        candidates,
+        network::RESOLUTION_OPERATION_TIMEOUT,
+        NetworkStage::BuildProbe,
+    )
+    .await;
 
-    for minor in 1..=12 {
-        let url = builds_probe_url(&format!("{}.{}", major, minor), platform);
-        match client.head(&url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                highest_available = Some(minor);
-            }
-            _ => {}
-        }
-    }
-
-    if let Some(minor) = highest_available {
+    if let Some(minor) = probe_summary.highest_available {
         let version_path = format!("{}.{}", major, minor);
         return Ok(ResolvedVersion {
             source: DownloadSource::Builds {
@@ -139,38 +147,131 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
         });
     }
 
-    // Fallback: try GH matching-refs API for each minor, highest first
-    for minor in (1..=12).rev() {
-        let prefix = format!("{}.{}", major, minor);
-        if let Ok(entry) = find_version_by_refs(&prefix).await {
-            return Ok(fallback_source(&entry.version, entry.channel, platform));
-        }
-    }
-
-    Err(Error::NoMatchingVersion(major.to_string()))
+    // One major-prefix lookup replaces the previous sequence of up to 12
+    // GitHub calls. The parser selects the highest matching tagged version.
+    let fallback = find_version_by_refs(&major.to_string())
+        .await
+        .map(|entry| fallback_source(&entry.version, entry.channel, platform));
+    preserve_probe_failure(probe_summary.failure, fallback)
 }
 
 /// `install 25.12` — try builds, fallback to packages/GH
 async fn resolve_minor(major: u32, minor: u32, platform: &Platform) -> Result<ResolvedVersion> {
     let version_path = format!("{}.{}", major, minor);
+    let probe_url = builds_probe_url(&version_path, platform);
+    let fallback_url = matching_refs_url(&version_path);
+    resolve_minor_with_urls(&version_path, platform, &probe_url, &fallback_url).await
+}
 
-    // Try builds first
-    if probe_builds(&version_path, platform).await {
-        return Ok(ResolvedVersion {
-            source: DownloadSource::Builds {
-                version_path: version_path.clone(),
-            },
-            display_version: version_path,
-            exact_version_known: false,
-            exact_version: None,
-            channel: None,
-        });
+async fn resolve_minor_with_urls(
+    version_path: &str,
+    platform: &Platform,
+    probe_url: &str,
+    fallback_url: &str,
+) -> Result<ResolvedVersion> {
+    let probe_failure = match probe_url_once(probe_url).await {
+        ProbeOutcome::Available => {
+            return Ok(ResolvedVersion {
+                source: DownloadSource::Builds {
+                    version_path: version_path.to_string(),
+                },
+                display_version: version_path.to_string(),
+                exact_version_known: false,
+                exact_version: None,
+                channel: None,
+            });
+        }
+        ProbeOutcome::Missing => None,
+        ProbeOutcome::Failed(failure) => Some(failure),
+    };
+
+    let fallback = find_version_by_refs_url(version_path, fallback_url)
+        .await
+        .map(|entry| fallback_source(&entry.version, entry.channel, platform));
+    preserve_probe_failure(probe_failure, fallback)
+}
+
+fn preserve_probe_failure<T>(probe: Option<NetworkFailure>, fallback: Result<T>) -> Result<T> {
+    match (probe, fallback) {
+        (_, Ok(value)) => Ok(value),
+        (Some(probe), Err(fallback)) => Err(Error::VersionResolutionFallback {
+            probe,
+            fallback: Box::new(fallback),
+        }),
+        (None, Err(fallback)) => Err(fallback),
     }
+}
 
-    // Fallback: targeted GH API call to find exact version for this minor
-    let entry = find_version_by_refs(&version_path).await?;
+#[derive(Debug, Default)]
+struct ProbeSummary {
+    highest_available: Option<u32>,
+    failure: Option<NetworkFailure>,
+}
 
-    Ok(fallback_source(&entry.version, entry.channel, platform))
+async fn probe_candidates(
+    candidates: Vec<(u32, String)>,
+    operation_timeout: Duration,
+    stage: NetworkStage,
+) -> ProbeSummary {
+    let Some((_, first_url)) = candidates.first() else {
+        return ProbeSummary::default();
+    };
+    let first_url = first_url.clone();
+    let client = match network::client(network::METADATA_POLICY, stage, &first_url) {
+        Ok(client) => client,
+        Err(failure) => {
+            return ProbeSummary {
+                highest_available: None,
+                failure: Some(failure),
+            };
+        }
+    };
+    let scan = stream::iter(candidates)
+        .map(|(minor, url)| {
+            let client = client.clone();
+            async move {
+                let outcome = network::probe(&client, &url, stage).await;
+                (minor, outcome)
+            }
+        })
+        .buffer_unordered(6)
+        .collect::<Vec<_>>();
+    let outcomes =
+        match network::with_operation_timeout(operation_timeout, stage, &first_url, scan).await {
+            Ok(outcomes) => outcomes,
+            Err(failure) => {
+                return ProbeSummary {
+                    highest_available: None,
+                    failure: Some(failure),
+                };
+            }
+        };
+
+    let mut summary = ProbeSummary::default();
+    for (minor, outcome) in outcomes {
+        match outcome {
+            ProbeOutcome::Available => {
+                summary.highest_available = Some(
+                    summary
+                        .highest_available
+                        .map_or(minor, |current| current.max(minor)),
+                );
+            }
+            ProbeOutcome::Missing => {}
+            ProbeOutcome::Failed(failure) => {
+                summary.failure = network::preferred_failure(summary.failure, failure);
+            }
+        }
+    }
+    summary
+}
+
+async fn probe_url_once(url: &str) -> ProbeOutcome {
+    let client = match network::client(network::METADATA_POLICY, NetworkStage::BuildProbe, url) {
+        Ok(client) => client,
+        Err(failure) => return ProbeOutcome::Failed(failure),
+    };
+    network::probe(&client, url, NetworkStage::BuildProbe).await
 }
 
 /// `install 25.12.9.61` — exact version, needs channel from GH API
@@ -209,16 +310,14 @@ async fn find_exact_channel(version: &str) -> Result<Channel> {
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}-",
         version
     );
-    let client = crate::http::client_builder().build()?;
-
-    let response = client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
-
-    let refs: Vec<GitRef> = response.json().await?;
+    let client = network::client(
+        network::METADATA_POLICY,
+        NetworkStage::VersionFallback,
+        &url,
+    )?;
+    let response = network::send(client.get(&url), NetworkStage::VersionFallback, &url).await?;
+    let response = network::ensure_success(response, NetworkStage::VersionFallback, &url)?;
+    let refs: Vec<GitRef> = network::json(response, NetworkStage::VersionFallback, &url).await?;
     parse_exact_channel(&refs, version)
 }
 
@@ -277,18 +376,12 @@ fn fallback_source(version: &str, channel: Channel, platform: &Platform) -> Reso
     }
 }
 
-/// Probe builds.clickhouse.com with a HEAD request to check if a version exists
-async fn probe_builds(version_path: &str, platform: &Platform) -> bool {
+/// Probe builds.clickhouse.com with a HEAD request to check if a version exists.
+/// A 403/404 means the build is absent; transport, rate-limit and server
+/// failures remain classified so fallback cannot erase them.
+async fn probe_builds(version_path: &str, platform: &Platform) -> ProbeOutcome {
     let url = builds_probe_url(version_path, platform);
-    let client = match crate::http::client_builder().build() {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-
-    match client.head(&url).send().await {
-        Ok(resp) => resp.status().is_success(),
-        Err(_) => false,
-    }
+    probe_url_once(&url).await
 }
 
 #[derive(Deserialize)]
@@ -301,20 +394,22 @@ struct GitRef {
 /// This is a single targeted API call that works regardless of how old the version is.
 /// prefix should be like "25.2" or "24.8" — we search for tags matching `v{prefix}.`
 async fn find_version_by_refs(prefix: &str) -> Result<VersionEntry> {
-    let url = format!(
+    let url = matching_refs_url(prefix);
+    find_version_by_refs_url(prefix, &url).await
+}
+
+fn matching_refs_url(prefix: &str) -> String {
+    format!(
         "https://api.github.com/repos/ClickHouse/ClickHouse/git/matching-refs/tags/v{}.",
         prefix
-    );
-    let client = crate::http::client_builder().build()?;
+    )
+}
 
-    let response = client
-        .get(&url)
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| Error::Download(format!("GitHub API request failed: {}", e)))?;
-
-    let refs: Vec<GitRef> = response.json().await?;
+async fn find_version_by_refs_url(prefix: &str, url: &str) -> Result<VersionEntry> {
+    let client = network::client(network::METADATA_POLICY, NetworkStage::VersionFallback, url)?;
+    let response = network::send(client.get(url), NetworkStage::VersionFallback, url).await?;
+    let response = network::ensure_success(response, NetworkStage::VersionFallback, url)?;
+    let refs: Vec<GitRef> = network::json(response, NetworkStage::VersionFallback, url).await?;
     parse_version_refs(&refs, prefix)
 }
 
@@ -374,12 +469,171 @@ fn extract_minor(version: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::NetworkCategory;
     use crate::version_manager::platform::Os;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn make_ref(name: &str) -> GitRef {
         GitRef {
             ref_name: name.to_string(),
         }
+    }
+
+    async fn mount_status(server: &MockServer, endpoint: &str, method_name: &str, status: u16) {
+        Mock::given(method(method_name))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(status))
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn build_probe_distinguishes_misses_rate_limits_and_server_errors() {
+        let cases = [
+            (403, None),
+            (404, None),
+            (429, Some(NetworkCategory::RateLimited)),
+            (500, Some(NetworkCategory::ServerError)),
+        ];
+        for (status, category) in cases {
+            let server = MockServer::start().await;
+            mount_status(&server, "/probe", "HEAD", status).await;
+
+            let outcome = probe_url_once(&format!("{}/probe", server.uri())).await;
+
+            match (outcome, category) {
+                (ProbeOutcome::Missing, None) => {}
+                (ProbeOutcome::Failed(failure), Some(expected)) => {
+                    assert_eq!(failure.stage, NetworkStage::BuildProbe);
+                    assert_eq!(failure.category, expected);
+                }
+                (outcome, expected) => panic!("unexpected outcome {outcome:?} for {expected:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn forbidden_and_not_found_probes_use_the_release_fallback() {
+        let platform = Platform {
+            os: Os::Linux,
+            arch: crate::version_manager::platform::Arch::X86_64,
+        };
+        for status in [403, 404] {
+            let server = MockServer::start().await;
+            mount_status(&server, "/probe", "HEAD", status).await;
+            Mock::given(method("GET"))
+                .and(path("/refs"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+                    {"ref": "refs/tags/v25.12.9.61-stable"}
+                ])))
+                .mount(&server)
+                .await;
+
+            let resolved = resolve_minor_with_urls(
+                "25.12",
+                &platform,
+                &format!("{}/probe", server.uri()),
+                &format!("{}/refs", server.uri()),
+            )
+            .await
+            .unwrap();
+
+            assert!(matches!(resolved.source, DownloadSource::Packages { .. }));
+            assert_eq!(resolved.exact_version.as_deref(), Some("25.12.9.61"));
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_fallback_keeps_the_original_rate_limit_failure_primary() {
+        let server = MockServer::start().await;
+        mount_status(&server, "/probe", "HEAD", 429).await;
+        mount_status(&server, "/refs", "GET", 500).await;
+        let platform = Platform {
+            os: Os::Linux,
+            arch: crate::version_manager::platform::Arch::X86_64,
+        };
+
+        let error = resolve_minor_with_urls(
+            "25.12",
+            &platform,
+            &format!("{}/probe?probe_token=secret", server.uri()),
+            &format!("{}/refs?fallback_token=secret", server.uri()),
+        )
+        .await
+        .unwrap_err();
+
+        let message = error.to_string();
+        let Error::VersionResolutionFallback { probe, fallback } = error else {
+            panic!("expected probe and fallback failure, got {message}");
+        };
+        assert_eq!(probe.category, NetworkCategory::RateLimited);
+        assert!(matches!(
+            *fallback,
+            Error::Network(NetworkFailure {
+                category: NetworkCategory::ServerError,
+                ..
+            })
+        ));
+        assert!(message.starts_with("build probe request"), "{message}");
+        assert!(message.contains("rate-limited"), "{message}");
+        assert!(message.contains("server-error"), "{message}");
+        assert!(!message.contains("secret"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn no_match_fallback_does_not_replace_a_server_probe_failure() {
+        let server = MockServer::start().await;
+        mount_status(&server, "/probe", "HEAD", 500).await;
+        Mock::given(method("GET"))
+            .and(path("/refs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+        let platform = Platform {
+            os: Os::Linux,
+            arch: crate::version_manager::platform::Arch::X86_64,
+        };
+
+        let error = resolve_minor_with_urls(
+            "25.12",
+            &platform,
+            &format!("{}/probe", server.uri()),
+            &format!("{}/refs", server.uri()),
+        )
+        .await
+        .unwrap_err();
+
+        let Error::VersionResolutionFallback { probe, fallback } = error else {
+            panic!("expected probe and fallback failure");
+        };
+        assert_eq!(probe.category, NetworkCategory::ServerError);
+        assert!(matches!(*fallback, Error::NoMatchingVersion(_)));
+    }
+
+    #[tokio::test]
+    async fn candidate_probe_set_has_one_bounded_operation_deadline() {
+        let server = MockServer::start().await;
+        Mock::given(method("HEAD"))
+            .and(path("/probe"))
+            .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_millis(500)))
+            .mount(&server)
+            .await;
+        let candidates = (1..=12)
+            .map(|minor| (minor, format!("{}/probe", server.uri())))
+            .collect();
+        let started = tokio::time::Instant::now();
+
+        let summary = probe_candidates(
+            candidates,
+            Duration::from_millis(60),
+            NetworkStage::BuildProbe,
+        )
+        .await;
+
+        assert!(started.elapsed() < Duration::from_millis(250));
+        assert_eq!(summary.highest_available, None);
+        assert_eq!(summary.failure.unwrap().category, NetworkCategory::Timeout);
     }
 
     #[test]

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -134,7 +134,9 @@ async fn resolve_major(major: u32, platform: &Platform) -> Result<ResolvedVersio
     )
     .await;
 
-    if let Some(minor) = probe_summary.highest_available {
+    // A failed candidate leaves the highest minor unknown, so do not silently
+    // install a confirmed lower build from a partial probe set.
+    if let Some(minor) = probe_summary.highest_available_if_complete() {
         let version_path = format!("{}.{}", major, minor);
         return Ok(ResolvedVersion {
             source: DownloadSource::Builds {
@@ -206,6 +208,16 @@ fn preserve_probe_failure<T>(probe: Option<NetworkFailure>, fallback: Result<T>)
 struct ProbeSummary {
     highest_available: Option<u32>,
     failure: Option<NetworkFailure>,
+}
+
+impl ProbeSummary {
+    fn highest_available_if_complete(&self) -> Option<u32> {
+        if self.failure.is_none() {
+            self.highest_available
+        } else {
+            None
+        }
+    }
 }
 
 async fn probe_candidates(
@@ -634,6 +646,20 @@ mod tests {
         assert!(started.elapsed() < Duration::from_millis(250));
         assert_eq!(summary.highest_available, None);
         assert_eq!(summary.failure.unwrap().category, NetworkCategory::Timeout);
+    }
+
+    #[test]
+    fn major_resolution_discards_partial_probe_results() {
+        let summary = ProbeSummary {
+            highest_available: Some(11),
+            failure: Some(NetworkFailure::new(
+                NetworkStage::BuildProbe,
+                "https://builds.example.test/25.12/clickhouse",
+                NetworkCategory::ServerError,
+            )),
+        };
+
+        assert_eq!(summary.highest_available_if_complete(), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- bound version resolution, remote listing, master checks, and streamed downloads with explicit connect, read, request, and operation deadlines
- classify failures by stage, sanitized host, and stable category while preserving build-probe failures across fallback errors
- probe versions concurrently and add conservative artifact retries with Retry-After-aware bounded backoff

## Tests
- `cargo test -p clickhousectl version_manager`
- `cargo test -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #459