### PR TITLE
Correct local Postgres diagnostics and help

### DIFF
--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -191,6 +191,9 @@ pub enum Error {
     #[error("Failed to execute ClickHouse: {0}")]
     Exec(String),
 
+    #[error("Postgres error: {0}")]
+    Postgres(String),
+
     /// A child process whose status must be returned unchanged. This is
     /// intentionally not printed as a clickhousectl error by `run_parsed`.
     #[error("child process exited with code {0}")]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -463,7 +463,6 @@ CONTEXT FOR AGENTS:
   Defaults to 18. Image is pulled if not already present locally.
   When --port is omitted, port 5432 is used if free or another free port is auto-selected.
   An explicitly requested port is rejected if it is occupied.
-  Data persists at .clickhouse/servers/<name>-pg<major>/data/ and is bind-mounted into the container.
   A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
   POSTGRES_USER, POSTGRES_DB, and PGDATA are reserved; use --user/--database for the first two.
   `-e POSTGRES_PASSWORD=...` remains a compatibility alternative to --password, but the two cannot

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -461,14 +461,16 @@ CONTEXT FOR AGENTS:
   a random name is generated (e.g. \"bold-crane\").
   --version (-v) selects a postgres image tag (17 or 18 — e.g. 17, 17-alpine, 18.1, 18-bookworm).
   Defaults to 18. Image is pulled if not already present locally.
-  --port defaults to 5432; if taken, a free port is auto-assigned.
-  Data persists at .clickhouse/servers/<name>/data/ and is bind-mounted into the container.
+  When --port is omitted, port 5432 is used if free or another free port is auto-selected.
+  An explicitly requested port is rejected if it is occupied.
+  Data persists at .clickhouse/servers/<name>-pg<major>/data/ and is bind-mounted into the container.
   A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
   POSTGRES_USER, POSTGRES_DB, and PGDATA are reserved; use --user/--database for the first two.
   `-e POSTGRES_PASSWORD=...` remains a compatibility alternative to --password, but the two cannot
   be combined. Every --env key must be unique, so generated variables are never duplicated.
   Containers are labeled `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`,
-  `clickhousectl.project=<cwd>`, `created_by=clickhousectl_<version>` for safe discovery.
+  `clickhousectl.major=<major>`, `clickhousectl.project=<cwd>`, and
+  `created_by=clickhousectl_<version>` for safe discovery.
   Requires Docker to be installed and running.")]
     Start {
         /// Server name (default: "default", or random if default is already running)
@@ -479,7 +481,7 @@ CONTEXT FOR AGENTS:
         #[arg(long, short = 'v', value_parser = crate::local::postgres::parse_pg_tag_arg)]
         version: Option<String>,
 
-        /// Host TCP port (default: 5432, auto-assigns a free port if in use)
+        /// Host TCP port (when omitted: uses 5432 if free, otherwise auto-selects; an occupied explicit port is rejected)
         #[arg(long, value_parser = crate::local::postgres::parse_pg_port_arg)]
         port: Option<u16>,
 

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -10,13 +10,16 @@
 //!
 //!  * `clickhousectl.engine=postgres`
 //!  * `clickhousectl.name=<server-name>`
+//!  * `clickhousectl.major=<major-version>`
 //!  * `clickhousectl.project=<canonical project cwd>`
 //!  * `created_by=clickhousectl_<crate-version>`
 
 use crate::error::{Error, Result};
 use bollard::Docker;
+use bollard::errors::Error as BollardError;
 use futures_util::StreamExt;
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::io::{self, IsTerminal, Write};
 
 pub const LABEL_ENGINE: &str = "clickhousectl.engine";
@@ -38,15 +41,156 @@ pub fn pg_container_name(user_name: &str, major: &str) -> String {
 
 /// Connect to the local Docker daemon and verify it's reachable.
 pub async fn connect() -> Result<Docker> {
-    let docker = Docker::connect_with_local_defaults().map_err(|e| {
-        Error::DockerNotAvailable(format!("could not initialize docker client: {e}"))
-    })?;
-    docker.ping().await.map_err(|e| {
-        Error::DockerNotAvailable(format!(
-            "Docker daemon is not reachable ({e}). Install Docker Desktop or start the daemon."
-        ))
-    })?;
+    let docker = Docker::connect_with_defaults()
+        .map_err(|error| docker_unavailable(DockerConnectStage::Constructor, &error))?;
+    docker
+        .ping()
+        .await
+        .map_err(|error| docker_unavailable(DockerConnectStage::Ping, &error))?;
     Ok(docker)
+}
+
+#[derive(Clone, Copy)]
+enum DockerConnectStage {
+    Constructor,
+    Ping,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DockerFailureKind {
+    MissingSocket,
+    PermissionDenied,
+    ConnectionRefused,
+    TimedOut,
+    InvalidHost,
+    HttpStatus(u16),
+    Other,
+}
+
+#[derive(Clone, Copy)]
+enum HostPlatform {
+    MacOs,
+    Linux,
+    Windows,
+    Other,
+}
+
+impl HostPlatform {
+    fn current() -> Self {
+        if cfg!(target_os = "macos") {
+            Self::MacOs
+        } else if cfg!(target_os = "linux") {
+            Self::Linux
+        } else if cfg!(target_os = "windows") {
+            Self::Windows
+        } else {
+            Self::Other
+        }
+    }
+}
+
+fn docker_unavailable(stage: DockerConnectStage, error: &BollardError) -> Error {
+    let kind = classify_docker_failure(error);
+    let prefix = match stage {
+        DockerConnectStage::Constructor => "could not initialize Docker client",
+        DockerConnectStage::Ping => "Docker daemon is not reachable",
+    };
+    Error::DockerNotAvailable(format!(
+        "{prefix}: {}.\n{}",
+        docker_failure_cause(stage, kind),
+        docker_guidance(HostPlatform::current())
+    ))
+}
+
+fn classify_docker_failure(error: &BollardError) -> DockerFailureKind {
+    match error {
+        BollardError::SocketNotFoundError(_) => return DockerFailureKind::MissingSocket,
+        BollardError::UnsupportedURISchemeError { .. }
+        | BollardError::URLParseError { .. }
+        | BollardError::InvalidURIError { .. }
+        | BollardError::InvalidURIPartsError { .. } => return DockerFailureKind::InvalidHost,
+        BollardError::RequestTimeoutError => return DockerFailureKind::TimedOut,
+        BollardError::IOError { err } => match err.kind() {
+            io::ErrorKind::NotFound => return DockerFailureKind::MissingSocket,
+            io::ErrorKind::PermissionDenied => return DockerFailureKind::PermissionDenied,
+            io::ErrorKind::ConnectionRefused => return DockerFailureKind::ConnectionRefused,
+            io::ErrorKind::TimedOut => return DockerFailureKind::TimedOut,
+            _ => {}
+        },
+        BollardError::DockerResponseServerError { status_code, .. } => {
+            return DockerFailureKind::HttpStatus(*status_code);
+        }
+        _ => {}
+    }
+
+    let mut descriptions = Vec::new();
+    let mut source: Option<&(dyn StdError + 'static)> = Some(error);
+    while let Some(current) = source {
+        descriptions.push(current.to_string().to_ascii_lowercase());
+        if let Some(io_error) = current.downcast_ref::<io::Error>() {
+            match io_error.kind() {
+                io::ErrorKind::NotFound => return DockerFailureKind::MissingSocket,
+                io::ErrorKind::PermissionDenied => return DockerFailureKind::PermissionDenied,
+                io::ErrorKind::ConnectionRefused => return DockerFailureKind::ConnectionRefused,
+                io::ErrorKind::TimedOut => return DockerFailureKind::TimedOut,
+                _ => {}
+            }
+        }
+        source = current.source();
+    }
+
+    // Some connector errors do not expose their underlying io::Error through
+    // Error::source. Inspect their text only for classification; never render it.
+    let chain = descriptions.join(": ");
+    if chain.contains("permission denied") {
+        DockerFailureKind::PermissionDenied
+    } else if chain.contains("connection refused") {
+        DockerFailureKind::ConnectionRefused
+    } else if chain.contains("no such file") || chain.contains("not found") {
+        DockerFailureKind::MissingSocket
+    } else if chain.contains("timed out") || chain.contains("timeout") {
+        DockerFailureKind::TimedOut
+    } else {
+        DockerFailureKind::Other
+    }
+}
+
+fn docker_failure_cause(stage: DockerConnectStage, kind: DockerFailureKind) -> String {
+    match kind {
+        DockerFailureKind::MissingSocket => "Docker socket was not found".into(),
+        DockerFailureKind::PermissionDenied => {
+            "permission denied while opening the Docker socket".into()
+        }
+        DockerFailureKind::ConnectionRefused => "the Docker daemon refused the connection".into(),
+        DockerFailureKind::TimedOut => "the Docker daemon connection timed out".into(),
+        DockerFailureKind::InvalidHost => {
+            "DOCKER_HOST is invalid or uses an unsupported scheme".into()
+        }
+        DockerFailureKind::HttpStatus(status) => {
+            format!("the Docker API returned HTTP status {status}")
+        }
+        DockerFailureKind::Other => match stage {
+            DockerConnectStage::Constructor => "Docker client initialization failed".into(),
+            DockerConnectStage::Ping => "the Docker API ping failed".into(),
+        },
+    }
+}
+
+fn docker_guidance(platform: HostPlatform) -> &'static str {
+    match platform {
+        HostPlatform::MacOs => {
+            "On macOS, start Docker Desktop and check access to its socket. Verify the active context with `docker context show`; for a non-default context, set `DOCKER_HOST` to its endpoint."
+        }
+        HostPlatform::Linux => {
+            "On Linux, start Docker Engine or Docker Desktop and check that your user can access the Docker socket. Verify `docker context show`; for rootless Docker or a non-default context, set `DOCKER_HOST` to its Unix socket (rootless Engine commonly uses `unix://$XDG_RUNTIME_DIR/docker.sock`)."
+        }
+        HostPlatform::Windows => {
+            "On Windows, start Docker Desktop or Docker Engine and check named-pipe permissions. Verify `docker context show`; for a non-default context, set `DOCKER_HOST` to its endpoint."
+        }
+        HostPlatform::Other => {
+            "Start Docker Engine and check socket permissions. Verify `docker context show`; for rootless Docker or a non-default context, set `DOCKER_HOST` to its endpoint."
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -830,6 +974,88 @@ pub fn recover_project_postgres_blocking(project_cwd: &str) {
 mod tests {
     use super::*;
     use bollard::models::{CreateImageInfo, ProgressDetail};
+
+    #[test]
+    fn docker_failures_keep_safe_causes_without_endpoint_values() {
+        let secret_path = "/tmp/docker-password-secret.sock";
+        let missing = BollardError::SocketNotFoundError(secret_path.into());
+        let Error::DockerNotAvailable(message) =
+            docker_unavailable(DockerConnectStage::Constructor, &missing)
+        else {
+            panic!("expected DockerNotAvailable");
+        };
+        assert!(
+            message
+                .starts_with("could not initialize Docker client: Docker socket was not found.\n")
+        );
+        assert!(!message.contains(secret_path));
+
+        let invalid = BollardError::UnsupportedURISchemeError {
+            uri: "tcp+secret://user:password@example.test".into(),
+        };
+        let Error::DockerNotAvailable(message) =
+            docker_unavailable(DockerConnectStage::Constructor, &invalid)
+        else {
+            panic!("expected DockerNotAvailable");
+        };
+        assert!(message.contains("DOCKER_HOST is invalid or uses an unsupported scheme"));
+        assert!(!message.contains("user:password"));
+        assert!(!message.contains("example.test"));
+    }
+
+    #[test]
+    fn docker_ping_failures_preserve_actionable_io_causes() {
+        for (kind, expected) in [
+            (
+                io::ErrorKind::PermissionDenied,
+                "permission denied while opening the Docker socket",
+            ),
+            (
+                io::ErrorKind::ConnectionRefused,
+                "the Docker daemon refused the connection",
+            ),
+            (
+                io::ErrorKind::TimedOut,
+                "the Docker daemon connection timed out",
+            ),
+        ] {
+            let error = BollardError::IOError {
+                err: io::Error::new(kind, "sensitive endpoint details"),
+            };
+            let Error::DockerNotAvailable(message) =
+                docker_unavailable(DockerConnectStage::Ping, &error)
+            else {
+                panic!("expected DockerNotAvailable");
+            };
+            assert!(
+                message.starts_with(&format!("Docker daemon is not reachable: {expected}.\n")),
+                "{message}"
+            );
+            assert!(!message.contains("sensitive endpoint details"));
+        }
+    }
+
+    #[test]
+    fn docker_guidance_is_platform_aware() {
+        let macos = docker_guidance(HostPlatform::MacOs);
+        assert!(macos.contains("Docker Desktop"));
+        assert!(macos.contains("socket"));
+        assert!(macos.contains("docker context show"));
+        assert!(macos.contains("DOCKER_HOST"));
+
+        let linux = docker_guidance(HostPlatform::Linux);
+        assert!(linux.contains("Docker Engine or Docker Desktop"));
+        assert!(linux.contains("socket"));
+        assert!(linux.contains("docker context show"));
+        assert!(linux.contains("rootless Docker"));
+        assert!(linux.contains("DOCKER_HOST"));
+
+        let windows = docker_guidance(HostPlatform::Windows);
+        assert!(windows.contains("Docker Desktop or Docker Engine"));
+        assert!(windows.contains("named-pipe permissions"));
+        assert!(windows.contains("docker context show"));
+        assert!(windows.contains("DOCKER_HOST"));
+    }
 
     #[test]
     fn pull_progress_is_interactive_only_for_human_ttys() {

--- a/crates/clickhousectl/src/local/docker.rs
+++ b/crates/clickhousectl/src/local/docker.rs
@@ -91,14 +91,15 @@ impl HostPlatform {
 
 fn docker_unavailable(stage: DockerConnectStage, error: &BollardError) -> Error {
     let kind = classify_docker_failure(error);
+    let platform = HostPlatform::current();
     let prefix = match stage {
         DockerConnectStage::Constructor => "could not initialize Docker client",
         DockerConnectStage::Ping => "Docker daemon is not reachable",
     };
     Error::DockerNotAvailable(format!(
         "{prefix}: {}.\n{}",
-        docker_failure_cause(stage, kind),
-        docker_guidance(HostPlatform::current())
+        docker_failure_cause(stage, kind, platform),
+        docker_guidance(platform)
     ))
 }
 
@@ -155,11 +156,19 @@ fn classify_docker_failure(error: &BollardError) -> DockerFailureKind {
     }
 }
 
-fn docker_failure_cause(stage: DockerConnectStage, kind: DockerFailureKind) -> String {
+fn docker_failure_cause(
+    stage: DockerConnectStage,
+    kind: DockerFailureKind,
+    platform: HostPlatform,
+) -> String {
+    let endpoint = match platform {
+        HostPlatform::Windows => "Docker named pipe",
+        _ => "Docker socket",
+    };
     match kind {
-        DockerFailureKind::MissingSocket => "Docker socket was not found".into(),
+        DockerFailureKind::MissingSocket => format!("{endpoint} was not found"),
         DockerFailureKind::PermissionDenied => {
-            "permission denied while opening the Docker socket".into()
+            format!("permission denied while opening the {endpoint}")
         }
         DockerFailureKind::ConnectionRefused => "the Docker daemon refused the connection".into(),
         DockerFailureKind::TimedOut => "the Docker daemon connection timed out".into(),
@@ -1033,6 +1042,59 @@ mod tests {
             );
             assert!(!message.contains("sensitive endpoint details"));
         }
+    }
+
+    #[test]
+    fn docker_endpoint_failure_causes_are_platform_aware() {
+        assert_eq!(
+            docker_failure_cause(
+                DockerConnectStage::Constructor,
+                DockerFailureKind::MissingSocket,
+                HostPlatform::Windows,
+            ),
+            "Docker named pipe was not found"
+        );
+        assert_eq!(
+            docker_failure_cause(
+                DockerConnectStage::Ping,
+                DockerFailureKind::PermissionDenied,
+                HostPlatform::Windows,
+            ),
+            "permission denied while opening the Docker named pipe"
+        );
+        assert_eq!(
+            docker_failure_cause(
+                DockerConnectStage::Constructor,
+                DockerFailureKind::MissingSocket,
+                HostPlatform::Linux,
+            ),
+            "Docker socket was not found"
+        );
+    }
+
+    #[test]
+    fn docker_timeout_and_http_status_failures_are_classified() {
+        let timeout = BollardError::RequestTimeoutError;
+        assert_eq!(
+            classify_docker_failure(&timeout),
+            DockerFailureKind::TimedOut
+        );
+
+        let response = BollardError::DockerResponseServerError {
+            status_code: 503,
+            message: "sensitive daemon response".into(),
+        };
+        assert_eq!(
+            classify_docker_failure(&response),
+            DockerFailureKind::HttpStatus(503)
+        );
+        let Error::DockerNotAvailable(message) =
+            docker_unavailable(DockerConnectStage::Ping, &response)
+        else {
+            panic!("expected DockerNotAvailable");
+        };
+        assert!(message.contains("the Docker API returned HTTP status 503"));
+        assert!(!message.contains("sensitive daemon response"));
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -53,7 +53,7 @@ pub(crate) fn validate_pg_tag(tag: &str) -> Result<()> {
     };
 
     if !valid {
-        return Err(Error::Exec(format!(
+        return Err(Error::Postgres(format!(
             "invalid or unsupported postgres version '{}'. Use 17 or 18, optionally followed \
              by .<minor> and -<variant> (for example: 17, 17-alpine, 18.1, 18-bookworm).",
             tag
@@ -153,7 +153,7 @@ fn validate_start_options(
         validate_pg_tag(version)?;
     }
 
-    validate_pg_start_env_args(password, &extra_env).map_err(Error::Exec)?;
+    validate_pg_start_env_args(password, &extra_env).map_err(Error::Postgres)?;
     let password_from_env = extra_env.iter().find_map(|assignment| {
         assignment
             .strip_prefix("POSTGRES_PASSWORD=")
@@ -260,7 +260,7 @@ async fn start(
                 _ => {
                     let versions: Vec<String> =
                         existing.iter().map(|i| i.version.clone()).collect();
-                    return Err(Error::Exec(format!(
+                    return Err(Error::Postgres(format!(
                         "multiple postgres instances named '{}' ({}); pass --version to select one",
                         user_name,
                         versions.join(", ")
@@ -307,7 +307,7 @@ async fn start(
         }
         // Metadata orphaned — container removed externally. Force explicit
         // cleanup to avoid silently re-initing against potentially-stale data.
-        return Err(Error::Exec(format!(
+        return Err(Error::Postgres(format!(
             "Postgres '{}' (postgres:{}) has metadata but the container is gone. \
              Run `clickhousectl local postgres remove {}` to clear the data dir \
              and start fresh.",
@@ -429,7 +429,7 @@ fn resolve_pg_target(user_name: &str, version: Option<&str>) -> Result<server::S
         1 => Ok(instances.into_iter().next().unwrap()),
         _ => {
             let versions: Vec<String> = instances.iter().map(|i| i.version.clone()).collect();
-            Err(Error::Exec(format!(
+            Err(Error::Postgres(format!(
                 "multiple postgres instances named '{}' ({}); pass --version to select one",
                 user_name,
                 versions.join(", ")
@@ -504,7 +504,7 @@ async fn wait_running(docker: &bollard::Docker, id: &str, attempts: usize) -> bo
 fn resolve_port(explicit: Option<u16>) -> Result<u16> {
     match explicit {
         Some(0) => {
-            return Err(Error::Exec(
+            return Err(Error::Postgres(
                 "--port 0 is not allowed; pick a specific port or omit the flag".into(),
             ));
         }
@@ -512,7 +512,7 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
             return Ok(port);
         }
         Some(port) => {
-            return Err(Error::Exec(format!(
+            return Err(Error::Postgres(format!(
                 "Postgres port {port} is already in use; choose another --port or omit --port to auto-select a free port"
             )));
         }
@@ -526,7 +526,7 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
             return Ok(p);
         }
     }
-    Err(Error::Exec(
+    Err(Error::Postgres(
         "could not find a free TCP port for Postgres".into(),
     ))
 }
@@ -743,7 +743,7 @@ fn exec_host_psql(
     #[cfg(feature = "telemetry")]
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
-    Err(Error::Exec(err.to_string()))
+    Err(Error::Postgres(err.to_string()))
 }
 
 fn dotenv(name: Option<&str>, version: Option<&str>, use_local: bool, json: bool) -> Result<()> {
@@ -815,7 +815,7 @@ mod tests {
     #[test]
     fn resolve_port_rejects_zero() {
         let err = resolve_port(Some(0)).unwrap_err();
-        assert!(matches!(err, Error::Exec(msg) if msg.contains("--port 0")));
+        assert!(matches!(err, Error::Postgres(msg) if msg.contains("--port 0")));
     }
 
     #[test]
@@ -842,8 +842,22 @@ mod tests {
 
         let err = resolve_port(Some(port)).unwrap_err();
         assert!(
-            matches!(err, Error::Exec(msg) if msg.contains(&format!("port {port} is already in use")) && msg.contains("omit --port"))
+            matches!(err, Error::Postgres(msg) if msg.contains(&format!("port {port} is already in use")) && msg.contains("omit --port"))
         );
+    }
+
+    #[test]
+    fn resolve_port_auto_selects_when_omitted_default_is_bound() {
+        let default_listener = match std::net::TcpListener::bind(("127.0.0.1", DEFAULT_PG_PORT)) {
+            Ok(listener) => Some(listener),
+            Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => None,
+            Err(error) => panic!("bind default Postgres port: {error}"),
+        };
+
+        let port = resolve_port(None).unwrap();
+
+        assert_ne!(port, DEFAULT_PG_PORT);
+        drop(default_listener);
     }
 
     #[test]
@@ -953,7 +967,7 @@ mod tests {
             )
             .err()
             .expect("malformed environment variable should fail");
-            assert!(matches!(error, Error::Exec(_)), "{assignment}: {error}");
+            assert!(matches!(error, Error::Postgres(_)), "{assignment}: {error}");
         }
     }
 
@@ -970,7 +984,7 @@ mod tests {
         .expect("duplicate environment variable should fail");
 
         assert!(
-            matches!(error, Error::Exec(msg) if msg.contains("APP_MODE") && msg.contains("more than once"))
+            matches!(error, Error::Postgres(msg) if msg.contains("APP_MODE") && msg.contains("more than once"))
         );
     }
 
@@ -990,7 +1004,9 @@ mod tests {
             )
             .err()
             .expect("reserved environment variable should fail");
-            assert!(matches!(error, Error::Exec(msg) if msg.contains("managed by clickhousectl")));
+            assert!(
+                matches!(error, Error::Postgres(msg) if msg.contains("managed by clickhousectl"))
+            );
         }
     }
 
@@ -1005,7 +1021,7 @@ mod tests {
         )
         .err()
         .expect("password sources should conflict");
-        assert!(matches!(error, Error::Exec(msg) if msg.contains("both --password and --env")));
+        assert!(matches!(error, Error::Postgres(msg) if msg.contains("both --password and --env")));
 
         let error = validate_start_options(
             Some("dev"),
@@ -1020,7 +1036,7 @@ mod tests {
         .err()
         .expect("duplicate password should fail");
         assert!(
-            matches!(error, Error::Exec(msg) if msg.contains("POSTGRES_PASSWORD") && msg.contains("more than once"))
+            matches!(error, Error::Postgres(msg) if msg.contains("POSTGRES_PASSWORD") && msg.contains("more than once"))
         );
     }
 }

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -308,7 +308,7 @@ async fn start(
         // Metadata orphaned — container removed externally. Force explicit
         // cleanup to avoid silently re-initing against potentially-stale data.
         return Err(Error::Postgres(format!(
-            "Postgres '{}' (postgres:{}) has metadata but the container is gone. \
+            "server '{}' (postgres:{}) has metadata but the container is gone. \
              Run `clickhousectl local postgres remove {}` to clear the data dir \
              and start fresh.",
             user_name, major, user_name
@@ -513,7 +513,7 @@ fn resolve_port(explicit: Option<u16>) -> Result<u16> {
         }
         Some(port) => {
             return Err(Error::Postgres(format!(
-                "Postgres port {port} is already in use; choose another --port or omit --port to auto-select a free port"
+                "port {port} is already in use; choose another --port or omit --port to auto-select a free port"
             )));
         }
         None => {}
@@ -743,7 +743,7 @@ fn exec_host_psql(
     #[cfg(feature = "telemetry")]
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
-    Err(Error::Postgres(err.to_string()))
+    Err(Error::Postgres(format!("could not execute psql: {err}")))
 }
 
 fn dotenv(name: Option<&str>, version: Option<&str>, use_local: bool, json: bool) -> Result<()> {
@@ -813,7 +813,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_port_rejects_zero() {
+    fn resolve_port_rejects_zero_for_non_clap_callers() {
         let err = resolve_port(Some(0)).unwrap_err();
         assert!(matches!(err, Error::Postgres(msg) if msg.contains("--port 0")));
     }

--- a/crates/clickhousectl/tests/local_docker_diagnostics_test.rs
+++ b/crates/clickhousectl/tests/local_docker_diagnostics_test.rs
@@ -1,0 +1,116 @@
+//! Subprocess coverage for Docker constructor and ping diagnostics.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixListener;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn run_postgres_start(home: &Path, project: &Path, docker_host: &str) -> Output {
+    Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("DOCKER_HOST", docker_host)
+        .current_dir(project)
+        .args(["local", "--json", "postgres", "start"])
+        .output()
+        .expect("run clickhousectl")
+}
+
+fn assert_platform_guidance(stderr: &str) {
+    #[cfg(target_os = "macos")]
+    assert!(
+        stderr.contains("On macOS, start Docker Desktop"),
+        "{stderr}"
+    );
+    #[cfg(target_os = "linux")]
+    assert!(
+        stderr.contains("On Linux, start Docker Engine or Docker Desktop"),
+        "{stderr}"
+    );
+    #[cfg(target_os = "windows")]
+    assert!(
+        stderr.contains("On Windows, start Docker Desktop or Docker Engine"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("socket"), "{stderr}");
+    assert!(stderr.contains("docker context show"), "{stderr}");
+    assert!(stderr.contains("DOCKER_HOST"), "{stderr}");
+}
+
+#[test]
+fn missing_socket_reports_constructor_guidance_without_leaking_endpoint() {
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let socket_path = home.path().join("docker-secret-token.sock");
+    let docker_host = format!("unix://{}", socket_path.display());
+
+    let output = run_postgres_start(home.path(), project.path(), &docker_host);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains(
+            "Docker is not available: could not initialize Docker client: Docker socket was not found."
+        ),
+        "{stderr}"
+    );
+    assert_platform_guidance(&stderr);
+    assert!(!stderr.contains("docker-secret-token"), "{stderr}");
+}
+
+#[test]
+fn permission_denied_socket_reports_ping_guidance_without_leaking_endpoint() {
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let socket_path = home.path().join("docker-secret-token.sock");
+    let _listener = UnixListener::bind(&socket_path).expect("bind fake Docker socket");
+    fs::set_permissions(&socket_path, fs::Permissions::from_mode(0o000))
+        .expect("deny fake Docker socket access");
+    let docker_host = format!("unix://{}", socket_path.display());
+
+    let output = run_postgres_start(home.path(), project.path(), &docker_host);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains(
+            "Docker is not available: Docker daemon is not reachable: permission denied while opening the Docker socket."
+        ),
+        "{stderr}"
+    );
+    assert_platform_guidance(&stderr);
+    assert!(!stderr.contains("docker-secret-token"), "{stderr}");
+}
+
+#[test]
+fn stale_socket_reports_daemon_down_guidance_without_leaking_endpoint() {
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let socket_path = home.path().join("docker-secret-token.sock");
+    let listener = UnixListener::bind(&socket_path).expect("bind fake Docker socket");
+    drop(listener);
+    let docker_host = format!("unix://{}", socket_path.display());
+
+    let output = run_postgres_start(home.path(), project.path(), &docker_host);
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains(
+            "Docker is not available: Docker daemon is not reachable: the Docker daemon refused the connection."
+        ),
+        "{stderr}"
+    );
+    assert_platform_guidance(&stderr);
+    assert!(!stderr.contains("docker-secret-token"), "{stderr}");
+}

--- a/crates/clickhousectl/tests/local_docker_diagnostics_test.rs
+++ b/crates/clickhousectl/tests/local_docker_diagnostics_test.rs
@@ -1,4 +1,4 @@
-//! Subprocess coverage for Docker constructor and ping diagnostics.
+//! Subprocess coverage for local Postgres and Docker diagnostics.
 
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -38,6 +38,9 @@ fn assert_platform_guidance(stderr: &str) {
         stderr.contains("On Windows, start Docker Desktop or Docker Engine"),
         "{stderr}"
     );
+    #[cfg(target_os = "windows")]
+    assert!(stderr.contains("named pipe"), "{stderr}");
+    #[cfg(not(target_os = "windows"))]
     assert!(stderr.contains("socket"), "{stderr}");
     assert!(stderr.contains("docker context show"), "{stderr}");
     assert!(stderr.contains("DOCKER_HOST"), "{stderr}");
@@ -113,4 +116,30 @@ fn stale_socket_reports_daemon_down_guidance_without_leaking_endpoint() {
     );
     assert_platform_guidance(&stderr);
     assert!(!stderr.contains("docker-secret-token"), "{stderr}");
+}
+
+#[test]
+fn missing_psql_reports_which_program_could_not_run() {
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let empty_path = home.path().join("empty-path");
+    fs::create_dir(&empty_path).expect("create empty PATH directory");
+
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home.path())
+        .env("PATH", empty_path)
+        .current_dir(project.path())
+        .args(["local", "postgres", "client", "--host", "127.0.0.1"])
+        .output()
+        .expect("run clickhousectl");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr.contains("Postgres error: could not execute psql:"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("Failed to execute ClickHouse"), "{stderr}");
 }

--- a/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
@@ -233,8 +233,11 @@ fn bound_explicit_port_fails_locally_without_docker_or_project_state() {
 
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
-    assert!(stderr.contains(&format!("Postgres port {port} is already in use")));
+    assert!(stderr.contains(&format!(
+        "Postgres error: Postgres port {port} is already in use"
+    )));
     assert!(stderr.contains("omit --port to auto-select a free port"));
+    assert!(!stderr.contains("Failed to execute ClickHouse"));
     assert_eq!(requests, 0);
     assert!(!project_state_created);
 }
@@ -293,4 +296,70 @@ fn password_env_override_reports_stored_settings_on_resume() {
     );
     let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
     assert!(stderr.contains("resuming with stored settings"), "{stderr}");
+}
+
+#[test]
+fn unsupported_version_diagnostic_is_postgres_specific() {
+    let (output, requests, project_state_created) = run_invalid_start(&["--version", "16"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
+    assert!(
+        stderr
+            .contains("Postgres error: invalid or unsupported postgres version '16'. Use 17 or 18")
+    );
+    assert!(!stderr.contains("Failed to execute ClickHouse"));
+    assert_eq!(requests, 0);
+    assert!(!project_state_created);
+}
+
+#[test]
+fn postgres_start_help_matches_managed_runtime_behavior() {
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let output = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home.path())
+        .args(["local", "postgres", "start", "--help"])
+        .output()
+        .expect("render postgres start help");
+
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("stdout is UTF-8"),
+        r#"Start a Postgres container
+
+Usage: clickhousectl local postgres start [OPTIONS]
+
+Options:
+      --json                 Output as JSON
+      --name <NAME>          Server name (default: "default", or random if default is already running)
+  -v, --version <VERSION>    Postgres image tag (17 or 18 — e.g. 17, 17-alpine, 18.1, 18-bookworm). Default: 18. Pulls if missing
+      --port <PORT>          Host TCP port (when omitted: uses 5432 if free, otherwise auto-selects; an occupied explicit port is rejected)
+      --user <USER>          POSTGRES_USER (default: postgres)
+      --password <PASSWORD>  POSTGRES_PASSWORD (default: random 24-char alphanumeric)
+      --database <DATABASE>  POSTGRES_DB (default: postgres)
+  -e, --env <KEY=VALUE>      Extra unique env vars for the container; POSTGRES_PASSWORD is the only supported reserved key
+  -h, --help                 Print help
+
+CONTEXT FOR AGENTS:
+  Starts a named Postgres server backed by a Docker container.
+  Without --name, the first server is called "default"; if "default" is running,
+  a random name is generated (e.g. "bold-crane").
+  --version (-v) selects a postgres image tag (17 or 18 — e.g. 17, 17-alpine, 18.1, 18-bookworm).
+  Defaults to 18. Image is pulled if not already present locally.
+  When --port is omitted, port 5432 is used if free or another free port is auto-selected.
+  An explicitly requested port is rejected if it is occupied.
+  Data persists at .clickhouse/servers/<name>-pg<major>/data/ and is bind-mounted into the container.
+  A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
+  POSTGRES_USER, POSTGRES_DB, and PGDATA are reserved; use --user/--database for the first two.
+  `-e POSTGRES_PASSWORD=...` remains a compatibility alternative to --password, but the two cannot
+  be combined. Every --env key must be unique, so generated variables are never duplicated.
+  Containers are labeled `clickhousectl.engine=postgres`, `clickhousectl.name=<name>`,
+  `clickhousectl.major=<major>`, `clickhousectl.project=<cwd>`, and
+  `created_by=clickhousectl_<version>` for safe discovery.
+  Requires Docker to be installed and running.
+"#
+    );
+    assert!(output.stderr.is_empty());
 }

--- a/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_start_validation_test.rs
@@ -233,9 +233,7 @@ fn bound_explicit_port_fails_locally_without_docker_or_project_state() {
 
     assert_eq!(output.status.code(), Some(1));
     let stderr = String::from_utf8(output.stderr).expect("stderr is UTF-8");
-    assert!(stderr.contains(&format!(
-        "Postgres error: Postgres port {port} is already in use"
-    )));
+    assert!(stderr.contains(&format!("Postgres error: port {port} is already in use")));
     assert!(stderr.contains("omit --port to auto-select a free port"));
     assert!(!stderr.contains("Failed to execute ClickHouse"));
     assert_eq!(requests, 0);
@@ -350,7 +348,6 @@ CONTEXT FOR AGENTS:
   Defaults to 18. Image is pulled if not already present locally.
   When --port is omitted, port 5432 is used if free or another free port is auto-selected.
   An explicitly requested port is rejected if it is occupied.
-  Data persists at .clickhouse/servers/<name>-pg<major>/data/ and is bind-mounted into the container.
   A random POSTGRES_PASSWORD is generated unless --password or `-e POSTGRES_PASSWORD=...` is given.
   POSTGRES_USER, POSTGRES_DB, and PGDATA are reserved; use --user/--database for the first two.
   `-e POSTGRES_PASSWORD=...` remains a compatibility alternative to --password, but the two cannot

--- a/scripts/test-postgres-integration.sh
+++ b/scripts/test-postgres-integration.sh
@@ -217,7 +217,7 @@ EOF
 # ── 11. --port 0 rejected ──
 case_port_zero_rejected() {
     local out; out=$("$CTL" local postgres start --name z --port 0 2>&1) || true
-    echo "$out" | grep -q -- "--port 0 is not allowed; pick a specific port or omit the flag" || { die "no rejection: $out"; return 1; }
+    echo "$out" | grep -Fq -- "invalid value '0' for '--port <PORT>': --port 0 is not allowed; pick a specific port or omit the flag" || { die "no rejection: $out"; return 1; }
 }
 
 # ── 12. Non-TTY query path returns query result ──


### PR DESCRIPTION
## Summary
- use Postgres-specific validation and runtime errors instead of ClickHouse execution errors
- provide sanitized, platform-aware Docker constructor and ping guidance for Desktop/Engine, permissions, contexts, rootless Docker, and DOCKER_HOST
- correct Postgres start help for managed labels and omitted versus explicit ports
- restore actionable psql launch context and remove redundant Postgres error prefixes
- add exact help, fake-socket, Docker classification, and missing-psql subprocess coverage

## Tests
- `cargo fmt --all --check`
- `cargo build -p clickhousectl`
- `cargo check -p clickhousectl --all-targets`
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `bash -n scripts/test-postgres-integration.sh`
- direct CLI verification of the integration-script port-zero and unsupported-version diagnostics

The full Docker-backed `scripts/test-postgres-integration.sh` was not run because the configured OrbStack socket at `~/.orbstack/run/docker.sock` is unavailable.

Closes #465