### PR TITLE
Allow direct local client connections to select a binary version

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,14 @@ clickhousectl local client --queries-file schema.sql # Run queries from a file
 clickhousectl local client --host remote-host --port 9000  # Connect to a specific host/port
 clickhousectl local client --host remote-host         # Direct mode; port defaults to 9000
 clickhousectl local client --port 19000               # Direct mode; host defaults to localhost
+clickhousectl local client --host remote-host --version 26.8.1.1760  # Use an installed client binary
 ```
 
-`--name` selects a managed server and cannot be combined with direct `--host` or `--port` selectors.
+`--name` selects the connection and local client binary from managed server metadata, so named mode does not need a global default. It cannot be combined with direct `--host` or `--port` selectors, and named mode does not accept `--version`.
+
+In direct mode, `--host` and `--port` select the server connection while `--version` independently selects an already installed local client binary. Numeric selectors such as `26`, `26.8`, and `26.8.1.1760` select the newest installed match. This does not install a binary or change `~/.clickhouse/default`.
+
+Without `--version`, direct mode uses the valid default. If no default exists, zero installed versions is an error, one installed version is used without creating a default, and multiple installed versions require either `--version` or `local use`. A default that names a missing binary is an error; repair it with `local use`, or bypass it for one direct connection with `--version`.
 
 ### Creating and managing ClickHouse servers
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -140,6 +140,26 @@ pub enum Error {
     #[error("No default version set. Run: clickhousectl local use <version>")]
     NoDefaultVersion,
 
+    #[error(
+        "No ClickHouse client versions are installed. Run `clickhousectl local install <version>` before making a direct connection."
+    )]
+    NoClientVersionInstalled,
+
+    #[error(
+        "Multiple ClickHouse client versions are installed, but no default is set. Pass `--version <version>` (see `clickhousectl local list`) or run `clickhousectl local use <version>`."
+    )]
+    AmbiguousClientVersion,
+
+    #[error(
+        "Default ClickHouse version '{0}' is not installed. Repair it with `clickhousectl local use <version>`, or bypass it for this direct connection with `--version <installed-version>`."
+    )]
+    StaleDefaultVersion(String),
+
+    #[error(
+        "ClickHouse client version '{0}' is not installed. Run `clickhousectl local install {0}`, or choose an installed version with `clickhousectl local list`."
+    )]
+    ClientVersionNotInstalled(String),
+
     #[error("Version {0} is already installed")]
     VersionAlreadyInstalled(String),
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -1,5 +1,5 @@
 use crate::version_manager::{self, VersionSpec};
-use clap::{Args, Subcommand};
+use clap::{ArgGroup, Args, Subcommand};
 use std::str::FromStr;
 
 fn parse_server_name_arg(name: &str) -> Result<String, String> {
@@ -101,6 +101,37 @@ impl FromStr for ServerVersionArg {
         version_manager::parse_version_spec(input)
             .map(Self)
             .map_err(|error| error.to_string())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientVersionArg(VersionSpec);
+
+impl ClientVersionArg {
+    pub(crate) fn into_spec(self) -> VersionSpec {
+        self.0
+    }
+}
+
+impl FromStr for ClientVersionArg {
+    type Err = String;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.starts_with("postgres@") || input.starts_with("postgres:") {
+            return Err(
+                "Postgres image selectors are only supported by `local install`; `local client --version` requires an installed ClickHouse version"
+                    .to_string(),
+            );
+        }
+
+        let spec = version_manager::parse_version_spec(input).map_err(|error| error.to_string())?;
+        if matches!(spec, VersionSpec::Latest | VersionSpec::Channel(_)) {
+            return Err(
+                "`local client --version` selects an installed numeric version (for example, 25.12 or 25.12.9.61); floating selectors latest, stable, and lts are not supported"
+                    .to_string(),
+            );
+        }
+        Ok(Self(spec))
     }
 }
 
@@ -208,17 +239,27 @@ CONTEXT FOR AGENTS:
     Init,
 
     /// Connect to a running ClickHouse server with clickhouse-client
-    #[command(after_help = "\
+    #[command(
+        group(ArgGroup::new("direct").args(["host", "port"]).multiple(true)),
+        after_help = "\
 CONTEXT FOR AGENTS:
   Two connection modes:
   1. Named server: `clickhousectl local client --name dev` — looks up port and version from a
      locally managed server started via `clickhousectl local server start`. Defaults to \"default\".
+     Its recorded server version selects the local client binary; --version is not accepted.
   2. Explicit host/port: `clickhousectl local client --host myhost --port 9000` — connects to any
      ClickHouse server directly, bypassing local server lookup. Host-only uses port 9000; port-only
-     connects to localhost. Direct selectors cannot be combined with --name.
+     connects to localhost. --host/--port select the connection; --version selects an already
+     installed local client binary and never changes the default. Direct selectors cannot be
+     combined with --name.
+  Direct mode without --version uses a valid default. With no default, it uses the sole installed
+  version without setting a default; zero installed versions and multiple installed versions are
+  errors. A stale default must be repaired with `local use` or bypassed with --version.
   --query and --queries-file execute SQL inline or from a file.
   Additional clickhouse-client args can be passed after --.
-  Related: `clickhousectl local server start` to start a local server, `clickhousectl local server list` to see servers.")]
+  Related: `clickhousectl local list` to see installed versions, `clickhousectl local use` to set a
+  default, `clickhousectl local server list` to see managed servers."
+    )]
     Client {
         /// Server name to connect to (default: "default")
         #[arg(long, short, conflicts_with_all = ["host", "port"])]
@@ -235,6 +276,10 @@ CONTEXT FOR AGENTS:
             value_parser = clap::value_parser!(u16).range(1..=65535)
         )]
         port: Option<u16>,
+
+        /// Installed local client version for direct host/port mode (e.g. 25, 25.12, or 25.12.9.61). Does not change the default.
+        #[arg(long, short = 'v', requires = "direct", conflicts_with = "name")]
+        version: Option<ClientVersionArg>,
 
         /// Execute a SQL query
         #[arg(long, short)]
@@ -699,6 +744,10 @@ mod tests {
         assert_version_rejected(&["install", "not.a.version"], expected);
         assert_version_rejected(&["use", "not.a.version"], expected);
         assert_version_rejected(&["server", "start", "--version", "not.a.version"], expected);
+        assert_version_rejected(
+            &["client", "--host", "remote", "--version", "not.a.version"],
+            expected,
+        );
     }
 
     #[test]
@@ -707,6 +756,10 @@ mod tests {
         assert_version_rejected(&["install", "25.12.9"], expected);
         assert_version_rejected(&["use", "25.12.9"], expected);
         assert_version_rejected(&["server", "start", "--version", "25.12.9"], expected);
+        assert_version_rejected(
+            &["client", "--host", "remote", "--version", "25.12.9"],
+            expected,
+        );
     }
 
     #[test]
@@ -715,6 +768,10 @@ mod tests {
         assert_version_rejected(&["install", "25.12.9.61.2"], expected);
         assert_version_rejected(&["use", "25.12.9.61.2"], expected);
         assert_version_rejected(&["server", "start", "--version", "25.12.9.61.2"], expected);
+        assert_version_rejected(
+            &["client", "--host", "remote", "--version", "25.12.9.61.2"],
+            expected,
+        );
     }
 
     #[test]
@@ -742,6 +799,41 @@ mod tests {
             &["server", "start", "--version", "  postgres@18  "],
             "only supported by `local install`; `local server start --version` requires a ClickHouse version",
         );
+        assert_version_rejected(
+            &["client", "--host", "remote", "--version", "postgres@18"],
+            "only supported by `local install`; `local client --version` requires an installed ClickHouse version",
+        );
+    }
+
+    #[test]
+    fn clickhouse_client_parses_numeric_installed_version_selectors() {
+        for input in ["25", "25.12", "25.12.9.61"] {
+            for selectors in [
+                vec!["--host", "remote", "--version", input],
+                vec!["--version", input, "--port", "9000"],
+            ] {
+                let mut args = vec!["client"];
+                args.extend(selectors);
+                let LocalCommands::Client {
+                    version: Some(version),
+                    ..
+                } = local_command(&args)
+                else {
+                    panic!("expected ClickHouse client version {input}");
+                };
+                assert_eq!(version.into_spec().to_string(), input);
+            }
+        }
+    }
+
+    #[test]
+    fn clickhouse_client_rejects_floating_binary_versions() {
+        for input in ["latest", "stable", "lts"] {
+            assert_version_rejected(
+                &["client", "--host", "remote", "--version", input],
+                "selects an installed numeric version",
+            );
+        }
     }
 
     #[test]
@@ -819,6 +911,34 @@ mod tests {
     }
 
     #[test]
+    fn clickhouse_client_version_requires_direct_mode_and_conflicts_with_named_mode() {
+        let missing_direct = local_parse_error(&["client", "--version", "25.12.9.61"]);
+        assert_eq!(
+            missing_direct.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+        assert!(
+            missing_direct.to_string().contains("--host"),
+            "{missing_direct}"
+        );
+        assert!(
+            missing_direct.to_string().contains("--port"),
+            "{missing_direct}"
+        );
+
+        for selectors in [
+            ["--name", "dev", "--version", "25.12.9.61"],
+            ["--version", "25.12.9.61", "--name", "dev"],
+        ] {
+            let args: Vec<&str> = ["client"].into_iter().chain(selectors).collect();
+            let error = local_parse_error(&args);
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            assert!(error.to_string().contains("--version"), "{error}");
+            assert!(error.to_string().contains("--name"), "{error}");
+        }
+    }
+
+    #[test]
     fn clickhouse_client_rejects_zero_and_nonnumeric_ports() {
         for port in ["0", "not-a-port"] {
             let error = local_parse_error(&["client", "--port", port]);
@@ -838,12 +958,44 @@ mod tests {
             "child-host",
             "--port",
             "0",
+            "--version",
+            "child-version",
         ]) else {
             panic!("expected ClickHouse client");
         };
 
         assert_eq!(name.as_deref(), Some("dev"));
-        assert_eq!(args, ["--host", "child-host", "--port", "0"]);
+        assert_eq!(
+            args,
+            [
+                "--host",
+                "child-host",
+                "--port",
+                "0",
+                "--version",
+                "child-version"
+            ]
+        );
+    }
+
+    #[test]
+    fn clickhouse_client_help_distinguishes_connection_and_binary_selection() {
+        let error = Cli::try_parse_from(["clickhousectl", "local", "client", "--help"])
+            .err()
+            .expect("--help should stop parsing");
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let help = error.to_string();
+
+        for text in [
+            "--host/--port select the connection",
+            "--version selects an already",
+            "installed local client binary",
+            "never changes the default",
+            "uses the sole installed",
+            "A stale default must be repaired",
+        ] {
+            assert!(help.contains(text), "missing {text:?} in:\n{help}");
+        }
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -246,19 +246,12 @@ CONTEXT FOR AGENTS:
   Two connection modes:
   1. Named server: `clickhousectl local client --name dev` — looks up port and version from a
      locally managed server started via `clickhousectl local server start`. Defaults to \"default\".
-     Its recorded server version selects the local client binary; --version is not accepted.
   2. Explicit host/port: `clickhousectl local client --host myhost --port 9000` — connects to any
      ClickHouse server directly, bypassing local server lookup. Host-only uses port 9000; port-only
-     connects to localhost. --host/--port select the connection; --version selects an already
-     installed local client binary and never changes the default. Direct selectors cannot be
-     combined with --name.
-  Direct mode without --version uses a valid default. With no default, it uses the sole installed
-  version without setting a default; zero installed versions and multiple installed versions are
-  errors. A stale default must be repaired with `local use` or bypassed with --version.
+     connects to localhost. Direct selectors cannot be combined with --name.
   --query and --queries-file execute SQL inline or from a file.
   Additional clickhouse-client args can be passed after --.
-  Related: `clickhousectl local list` to see installed versions, `clickhousectl local use` to set a
-  default, `clickhousectl local server list` to see managed servers."
+  Related: `clickhousectl local server start` to start a local server, `clickhousectl local server list` to see servers."
     )]
     Client {
         /// Server name to connect to (default: "default")
@@ -979,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn clickhouse_client_help_distinguishes_connection_and_binary_selection() {
+    fn clickhouse_client_help_describes_binary_version_selection() {
         let error = Cli::try_parse_from(["clickhousectl", "local", "client", "--help"])
             .err()
             .expect("--help should stop parsing");
@@ -987,12 +980,8 @@ mod tests {
         let help = error.to_string();
 
         for text in [
-            "--host/--port select the connection",
-            "--version selects an already",
-            "installed local client binary",
-            "never changes the default",
-            "uses the sole installed",
-            "A stale default must be repaired",
+            "Installed local client version for direct host/port mode",
+            "Does not change the default",
         ] {
             assert!(help.contains(text), "missing {text:?} in:\n{help}");
         }

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -7,7 +7,7 @@ pub mod postgres;
 pub mod server;
 pub mod symlink;
 
-use cli::{InstallVersionArg, LocalCommands, ServerCommands, ServerVersionArg};
+use cli::{ClientVersionArg, InstallVersionArg, LocalCommands, ServerCommands, ServerVersionArg};
 
 use crate::error::{Error, Result};
 use crate::{init, paths, version_manager};
@@ -42,10 +42,11 @@ pub async fn run(cmd: LocalCommands, json: bool) -> Result<()> {
             name,
             host,
             port,
+            version,
             query,
             queries_file,
             args,
-        } => run_client(name, host, port, query, queries_file, args),
+        } => run_client(name, host, port, version, query, queries_file, args),
         LocalCommands::Server { command } => run_server_commands(command, json).await,
         LocalCommands::Postgres { command } => postgres::run(command, json).await,
     }
@@ -259,6 +260,7 @@ fn run_client(
     name: Option<String>,
     host: Option<String>,
     port: Option<u16>,
+    version_spec: Option<ClientVersionArg>,
     query: Option<String>,
     queries_file: Option<String>,
     args: Vec<String>,
@@ -268,7 +270,7 @@ fn run_client(
     let (resolved_host, tcp_port, version) = if host.is_some() || port.is_some() {
         let h = host.unwrap_or_else(|| "localhost".to_string());
         let p = port.unwrap_or(9000);
-        let v = version_manager::get_default_version()?;
+        let v = resolve_direct_client_version(version_spec)?;
         (h, p, v)
     } else {
         let server_name = name.as_deref().unwrap_or("default");
@@ -315,6 +317,28 @@ fn run_client(
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
+}
+
+fn resolve_direct_client_version(version_spec: Option<ClientVersionArg>) -> Result<String> {
+    if let Some(version_spec) = version_spec {
+        let spec = version_spec.into_spec();
+        return version_manager::resolve::try_resolve_local(&spec)
+            .ok_or_else(|| Error::ClientVersionNotInstalled(spec.to_string()));
+    }
+
+    match version_manager::get_default_version() {
+        Ok(version) => Ok(version),
+        Err(Error::NoDefaultVersion) => {
+            let installed = version_manager::list_installed_versions()?;
+            match installed.as_slice() {
+                [] => Err(Error::NoClientVersionInstalled),
+                [version] => Ok(version.clone()),
+                _ => Err(Error::AmbiguousClientVersion),
+            }
+        }
+        Err(Error::VersionNotFound(version)) => Err(Error::StaleDefaultVersion(version)),
+        Err(error) => Err(error),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -322,7 +322,7 @@ fn run_client(
 fn resolve_direct_client_version(version_spec: Option<ClientVersionArg>) -> Result<String> {
     if let Some(version_spec) = version_spec {
         let spec = version_spec.into_spec();
-        return version_manager::resolve::try_resolve_local(&spec)
+        return version_manager::resolve::try_resolve_local(&spec)?
             .ok_or_else(|| Error::ClientVersionNotInstalled(spec.to_string()));
     }
 

--- a/crates/clickhousectl/src/version_manager/install.rs
+++ b/crates/clickhousectl/src/version_manager/install.rs
@@ -23,7 +23,7 @@ pub async fn install_local_first(
     platform: &Platform,
     force: bool,
 ) -> Result<String> {
-    if !force && let Some(local) = try_resolve_local(spec) {
+    if !force && let Some(local) = try_resolve_local(spec)? {
         eprintln!("ClickHouse {} is already installed as {}", spec, local);
         eprintln!("Use --force to re-download the latest build");
         return Ok(local);
@@ -40,7 +40,7 @@ pub async fn ensure_installed_local_first(
     spec: &VersionSpec,
     platform: &Platform,
 ) -> Result<String> {
-    if let Some(local) = try_resolve_local(spec) {
+    if let Some(local) = try_resolve_local(spec)? {
         return Ok(local);
     }
 

--- a/crates/clickhousectl/src/version_manager/resolve.rs
+++ b/crates/clickhousectl/src/version_manager/resolve.rs
@@ -28,12 +28,12 @@ pub struct ResolvedVersion {
 /// Try to satisfy a spec from already-installed versions, without any network call.
 /// Returns `None` for floating specs (`Latest`, `Channel(_)`) — those always need the
 /// remote — or when no installed version matches.
-pub fn try_resolve_local(spec: &VersionSpec) -> Option<String> {
+pub fn try_resolve_local(spec: &VersionSpec) -> Result<Option<String>> {
     match spec {
-        VersionSpec::Latest | VersionSpec::Channel(_) => None,
+        VersionSpec::Latest | VersionSpec::Channel(_) => Ok(None),
         _ => {
-            let installed = list_installed_versions().ok()?;
-            find_local_match(spec, &installed)
+            let installed = list_installed_versions()?;
+            Ok(find_local_match(spec, &installed))
         }
     }
 }

--- a/crates/clickhousectl/tests/local_client_selectors_test.rs
+++ b/crates/clickhousectl/tests/local_client_selectors_test.rs
@@ -1,24 +1,47 @@
-//! Subprocess coverage for local client selector validation and direct-mode defaults.
+//! Subprocess coverage for local client selector and native binary selection.
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-const VERSION: &str = "25.12.9.61";
+const VERSION_A: &str = "25.12.9.61";
+const VERSION_B: &str = "26.8.1.1760";
+const MISSING_VERSION: &str = "27.1.2.3";
 
 fn clickhousectl_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
 }
 
-fn write_arg_printer(path: &Path) {
+fn write_executable(path: &Path, script: &str) {
     std::fs::create_dir_all(path.parent().expect("fake child parent"))
         .expect("create fake child directory");
-    std::fs::write(path, b"#!/bin/sh\nprintf '%s\\n' \"$@\"\n").expect("write fake child");
+    std::fs::write(path, script).expect("write fake child");
     let mut permissions = std::fs::metadata(path)
         .expect("read fake child metadata")
         .permissions();
     permissions.set_mode(0o755);
     std::fs::set_permissions(path, permissions).expect("make fake child executable");
+}
+
+fn write_arg_printer(path: &Path) {
+    write_executable(path, "#!/bin/sh\nprintf '%s\\n' \"$@\"\n");
+}
+
+fn install_fake_clickhouse(home: &Path, version: &str) {
+    let binary = home
+        .join(".clickhouse/versions")
+        .join(version)
+        .join("clickhouse");
+    write_executable(
+        &binary,
+        &format!("#!/bin/sh\nprintf '%s\\n' 'binary:{version}'\nprintf '%s\\n' \"$@\"\n"),
+    );
+}
+
+fn write_default(home: &Path, version: &str) {
+    let path = home.join(".clickhouse/default");
+    std::fs::create_dir_all(path.parent().expect("default parent")).expect("create default parent");
+    std::fs::write(path, version).expect("write default version");
 }
 
 fn run(project: &Path, home: &Path, path: Option<&Path>, args: &[&str]) -> Output {
@@ -43,6 +66,37 @@ fn assert_child_args(output: Output, expected: &[&str]) {
         .lines()
         .collect();
     assert_eq!(args, expected);
+}
+
+fn assert_clickhouse_child(output: Output, version: &str, expected: &[&str]) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "stderr: {stderr}");
+    let lines: Vec<&str> = std::str::from_utf8(&output.stdout)
+        .expect("child output is UTF-8")
+        .lines()
+        .collect();
+    let marker = format!("binary:{version}");
+    assert_eq!(lines.first().copied(), Some(marker.as_str()));
+    assert_eq!(&lines[1..], expected);
+}
+
+fn assert_runtime_error(output: Output, expected: &[&str]) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    for text in expected {
+        assert!(stderr.contains(text), "missing {text:?} in: {stderr}");
+    }
+}
+
+fn assert_default(home: &Path, expected: Option<&str>) {
+    let path = home.join(".clickhouse/default");
+    match expected {
+        Some(version) => assert_eq!(
+            std::fs::read_to_string(path).expect("read default version"),
+            version
+        ),
+        None => assert!(!path.exists(), "client unexpectedly created a default"),
+    }
 }
 
 fn assert_usage_before_resolution(args: &[&str], expected: &[&str]) {
@@ -74,9 +128,14 @@ fn invalid_clickhouse_selectors_fail_before_binary_or_project_resolution() {
         &["local", "client", "--host", "remote", "--name", "dev"],
         &["local", "client", "--name", "dev", "--port", "9000"],
         &["local", "client", "--port", "9000", "--name", "dev"],
+        &["local", "client", "--name", "dev", "--version", VERSION_A],
     ] {
         assert_usage_before_resolution(args, &["--name", "cannot be used"]);
     }
+    assert_usage_before_resolution(
+        &["local", "client", "--version", VERSION_A],
+        &["required arguments", "--host", "--port"],
+    );
     assert_usage_before_resolution(
         &["local", "client", "--port", "0"],
         &["invalid value", "--port"],
@@ -88,38 +147,230 @@ fn invalid_clickhouse_selectors_fail_before_binary_or_project_resolution() {
 }
 
 #[test]
-fn clickhouse_direct_selectors_reach_fake_child_with_documented_defaults() {
+fn clickhouse_direct_default_and_single_installed_selection_reach_fake_child() {
     let project = tempfile::tempdir().expect("create project tempdir");
     let home = tempfile::tempdir().expect("create home tempdir");
-    let binary = home
-        .path()
-        .join(".clickhouse/versions")
-        .join(VERSION)
-        .join("clickhouse");
-    write_arg_printer(&binary);
-    std::fs::write(home.path().join(".clickhouse/default"), VERSION)
-        .expect("write default version");
+    install_fake_clickhouse(home.path(), VERSION_A);
+    install_fake_clickhouse(home.path(), VERSION_B);
+    write_default(home.path(), VERSION_A);
 
-    assert_child_args(
+    assert_clickhouse_child(
         run(
             project.path(),
             home.path(),
             None,
             &["local", "client", "--host", "remote", "--query", "SELECT 1"],
         ),
+        VERSION_A,
         &[
             "client", "--host", "remote", "--port", "9000", "--query", "SELECT 1",
         ],
     );
-    assert_child_args(
+    assert_default(home.path(), Some(VERSION_A));
+
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+    assert_clickhouse_child(
         run(
             project.path(),
             home.path(),
             None,
             &["local", "client", "--port", "65535"],
         ),
+        VERSION_B,
         &["client", "--host", "localhost", "--port", "65535"],
     );
+    assert_default(home.path(), None);
+}
+
+#[test]
+fn clickhouse_direct_without_version_reports_zero_and_multiple_installs() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    assert_runtime_error(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote"],
+        ),
+        &[
+            "No ClickHouse client versions are installed",
+            "clickhousectl local install <version>",
+        ],
+    );
+    assert_default(home.path(), None);
+
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_A);
+    install_fake_clickhouse(home.path(), VERSION_B);
+    assert_runtime_error(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote"],
+        ),
+        &[
+            "Multiple ClickHouse client versions are installed",
+            "--version <version>",
+            "clickhousectl local use <version>",
+        ],
+    );
+    assert_default(home.path(), None);
+}
+
+#[test]
+fn clickhouse_direct_explicit_version_overrides_but_never_changes_default() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local",
+                "client",
+                "--host",
+                "remote",
+                "--version",
+                VERSION_B,
+            ],
+        ),
+        VERSION_B,
+        &["client", "--host", "remote", "--port", "9000"],
+    );
+    assert_default(home.path(), None);
+
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_A);
+    install_fake_clickhouse(home.path(), VERSION_B);
+    write_default(home.path(), VERSION_A);
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote", "--version", "26.8"],
+        ),
+        VERSION_B,
+        &["client", "--host", "remote", "--port", "9000"],
+    );
+    assert_default(home.path(), Some(VERSION_A));
+}
+
+#[test]
+fn clickhouse_direct_reports_stale_default_and_explicit_missing_version() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+    write_default(home.path(), VERSION_A);
+
+    let stale_message = format!("Default ClickHouse version '{VERSION_A}' is not installed");
+    assert_runtime_error(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote"],
+        ),
+        &[
+            &stale_message,
+            "clickhousectl local use <version>",
+            "--version <installed-version>",
+        ],
+    );
+    assert_default(home.path(), Some(VERSION_A));
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local",
+                "client",
+                "--host",
+                "remote",
+                "--version",
+                VERSION_B,
+            ],
+        ),
+        VERSION_B,
+        &["client", "--host", "remote", "--port", "9000"],
+    );
+    assert_default(home.path(), Some(VERSION_A));
+
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_A);
+    write_default(home.path(), VERSION_A);
+    let missing_message = format!("ClickHouse client version '{MISSING_VERSION}' is not installed");
+    let install_message = format!("clickhousectl local install {MISSING_VERSION}");
+    assert_runtime_error(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local",
+                "client",
+                "--host",
+                "remote",
+                "--version",
+                MISSING_VERSION,
+            ],
+        ),
+        &[
+            &missing_message,
+            &install_message,
+            "clickhousectl local list",
+        ],
+    );
+    assert_default(home.path(), Some(VERSION_A));
+}
+
+#[test]
+fn clickhouse_named_mode_uses_server_version_without_a_default() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+
+    let servers = project.path().join(".clickhouse/servers");
+    std::fs::create_dir_all(&servers).expect("create server metadata directory");
+    std::fs::write(
+        servers.join("dev.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "name": "dev",
+            "pid": std::process::id(),
+            "version": VERSION_B,
+            "http_port": 8123,
+            "tcp_port": 19000,
+            "started_at": "test",
+            "cwd": project.path(),
+            "engine": "clickhouse"
+        }))
+        .expect("serialize server metadata"),
+    )
+    .expect("write server metadata");
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--name", "dev"],
+        ),
+        VERSION_B,
+        &["client", "--host", "localhost", "--port", "19000"],
+    );
+    assert_default(home.path(), None);
 }
 
 #[test]

--- a/crates/clickhousectl/tests/local_client_selectors_test.rs
+++ b/crates/clickhousectl/tests/local_client_selectors_test.rs
@@ -337,6 +337,38 @@ fn clickhouse_direct_reports_stale_default_and_explicit_missing_version() {
 }
 
 #[test]
+fn clickhouse_direct_explicit_version_propagates_version_list_io_errors() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    let clickhouse = home.path().join(".clickhouse");
+    std::fs::create_dir_all(&clickhouse).expect("create ClickHouse directory");
+    std::fs::write(clickhouse.join("versions"), "not a directory")
+        .expect("write invalid versions path");
+
+    let output = run(
+        project.path(),
+        home.path(),
+        None,
+        &[
+            "local",
+            "client",
+            "--host",
+            "remote",
+            "--version",
+            VERSION_A,
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr: {stderr}");
+    assert!(stderr.contains("IO error"), "stderr: {stderr}");
+    assert!(stderr.contains("Not a directory"), "stderr: {stderr}");
+    assert!(
+        !stderr.contains("is not installed"),
+        "filesystem error was masked: {stderr}"
+    );
+}
+
+#[test]
 fn clickhouse_named_mode_uses_server_version_without_a_default() {
     let project = tempfile::tempdir().expect("create project tempdir");
     let home = tempfile::tempdir().expect("create home tempdir");

--- a/crates/clickhousectl/tests/local_version_error_test.rs
+++ b/crates/clickhousectl/tests/local_version_error_test.rs
@@ -57,6 +57,17 @@ fn invalid_local_versions_fail_before_dispatch_or_filesystem_setup() {
         &["local", "server", "start", "--version", "25.12.9.61.2"],
         "expected 1-2 or 4 parts",
     );
+    assert_rejected_before_side_effects(
+        &[
+            "local",
+            "client",
+            "--host",
+            "remote",
+            "--version",
+            "25.12.9",
+        ],
+        "3-part version '25.12.9' is not supported",
+    );
 }
 
 #[test]
@@ -68,5 +79,16 @@ fn postgres_install_selector_is_rejected_by_clickhouse_only_commands() {
     assert_rejected_before_side_effects(
         &["local", "server", "start", "--version", "postgres@18"],
         "only supported by `local install`; `local server start --version` requires a ClickHouse version",
+    );
+    assert_rejected_before_side_effects(
+        &[
+            "local",
+            "client",
+            "--host",
+            "remote",
+            "--version",
+            "postgres@18",
+        ],
+        "only supported by `local install`; `local client --version` requires an installed ClickHouse version",
     );
 }


### PR DESCRIPTION
## Summary
- add direct-mode `local client --version` selection for installed ClickHouse binaries without modifying the global default
- intentionally let partial numeric selectors choose the newest installed match, while exact selectors require that installed version
- define actionable zero, one, multiple, stale-default, missing-explicit, and named-mode behavior
- document connection selection versus local binary selection and reject named-mode version overrides during clap parsing
- cover parser behavior and the complete isolated fake-binary subprocess matrix

## Tests
- `cargo test -p clickhousectl`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`
- `cargo fmt --all --check`

Closes #469