### PR TITLE
Preserve native query and query-file multiplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ clickhousectl local client --name dev                # Connects to "dev" server
 clickhousectl local client --query "SHOW DATABASES"  # Run a query
 clickhousectl local client --query "SELECT 1" --query "SELECT 2" # Run queries in order
 clickhousectl local client --queries-file schema.sql # Run queries from a file
-clickhousectl local client --queries-file schema.sql --queries-file seed.sql # Run files in order
+clickhousectl local client --queries-file schema.sql seed.sql # Run files in order
 clickhousectl local client --host remote-host --port 9000  # Connect to a specific host/port
 clickhousectl local client --host remote-host         # Direct mode; port defaults to 9000
 clickhousectl local client --port 19000               # Direct mode; host defaults to localhost
@@ -237,7 +237,7 @@ In direct mode, `--host` and `--port` select the server connection while `--vers
 
 Without `--version`, direct mode uses the valid default. If no default exists, zero installed versions is an error, one installed version is used without creating a default, and multiple installed versions require either `--version` or `local use`. A default that names a missing binary is an error; repair it with `local use`, or bypass it for one direct connection with `--version`.
 
-`--query` and `--queries-file` can each be repeated; values, including empty strings, are passed to the native client unchanged and in order. They cannot be combined because the native ClickHouse client rejects that combination, so clickhousectl reports a usage error before resolving a binary. Arguments after `--` are appended after all wrapper-generated arguments. Repeatable `--query` requires ClickHouse 23.9.1.1854 or newer, where [ClickHouse added the native behavior](https://github.com/ClickHouse/ClickHouse/blob/8f9a227de1f530cdbda52c145d41a6b0f1d29961/docs/changelogs/archive/v23.9.1.1854-stable.md); clickhousectl checks the selected client version before execution.
+`--query` can be repeated, while each `--queries-file` accepts one or more paths and the flag itself can also be repeated. Values, including empty strings, are passed to the native client unchanged and in order. The two options cannot be combined because the native ClickHouse client rejects that combination, so clickhousectl reports a usage error before resolving a binary. Arguments after `--` are appended after all wrapper-generated arguments. Repeatable `--query` requires ClickHouse 23.9.1.1854 or newer, where [ClickHouse added the native behavior](https://github.com/ClickHouse/ClickHouse/blob/8f9a227de1f530cdbda52c145d41a6b0f1d29961/docs/changelogs/archive/v23.9.1.1854-stable.md); clickhousectl checks the selected client version before execution.
 
 ### Creating and managing ClickHouse servers
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ postgres/
 clickhousectl local client                           # Connects to "default" server
 clickhousectl local client --name dev                # Connects to "dev" server
 clickhousectl local client --query "SHOW DATABASES"  # Run a query
+clickhousectl local client --query "SELECT 1" --query "SELECT 2" # Run queries in order
 clickhousectl local client --queries-file schema.sql # Run queries from a file
+clickhousectl local client --queries-file schema.sql --queries-file seed.sql # Run files in order
 clickhousectl local client --host remote-host --port 9000  # Connect to a specific host/port
 clickhousectl local client --host remote-host         # Direct mode; port defaults to 9000
 clickhousectl local client --port 19000               # Direct mode; host defaults to localhost
@@ -234,6 +236,8 @@ clickhousectl local client --host remote-host --version 26.8.1.1760  # Use an in
 In direct mode, `--host` and `--port` select the server connection while `--version` independently selects an already installed local client binary. Numeric selectors such as `26`, `26.8`, and `26.8.1.1760` select the newest installed match. This does not install a binary or change `~/.clickhouse/default`.
 
 Without `--version`, direct mode uses the valid default. If no default exists, zero installed versions is an error, one installed version is used without creating a default, and multiple installed versions require either `--version` or `local use`. A default that names a missing binary is an error; repair it with `local use`, or bypass it for one direct connection with `--version`.
+
+`--query` and `--queries-file` can each be repeated; values, including empty strings, are passed to the native client unchanged and in order. They cannot be combined because the native ClickHouse client rejects that combination, so clickhousectl reports a usage error before resolving a binary. Arguments after `--` are appended after all wrapper-generated arguments. Repeatable `--query` requires ClickHouse 23.9.1.1854 or newer, where [ClickHouse added the native behavior](https://github.com/ClickHouse/ClickHouse/blob/8f9a227de1f530cdbda52c145d41a6b0f1d29961/docs/changelogs/archive/v23.9.1.1854-stable.md); clickhousectl checks the selected client version before execution.
 
 ### Creating and managing ClickHouse servers
 

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -160,6 +160,14 @@ pub enum Error {
     )]
     ClientVersionNotInstalled(String),
 
+    #[error(
+        "ClickHouse client version '{version}' does not support repeated --query values. Use ClickHouse {minimum} or newer, or send one --query value."
+    )]
+    RepeatedClientQueryUnsupported {
+        version: String,
+        minimum: &'static str,
+    },
+
     #[error("Version {0} is already installed")]
     VersionAlreadyInstalled(String),
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -249,8 +249,9 @@ CONTEXT FOR AGENTS:
   2. Explicit host/port: `clickhousectl local client --host myhost --port 9000` — connects to any
      ClickHouse server directly, bypassing local server lookup. Host-only uses port 9000; port-only
      connects to localhost. Direct selectors cannot be combined with --name.
-  --query and --queries-file are repeatable and preserve every value. ClickHouse rejects using the
-  two options together, so clickhousectl reports that combination as a usage error.
+  Repeat --query to execute multiple inline queries. --queries-file accepts multiple paths after
+  one flag and can also be repeated. ClickHouse rejects combining the two options, so clickhousectl
+  reports that combination as a usage error.
   Additional clickhouse-client args can be passed after --.
   Related: `clickhousectl local server start` to start a local server, `clickhousectl local server list` to see servers."
     )]
@@ -275,12 +276,12 @@ CONTEXT FOR AGENTS:
         #[arg(long, short = 'v', requires = "direct", conflicts_with = "name")]
         version: Option<ClientVersionArg>,
 
-        /// Execute a SQL query (repeatable; requires ClickHouse 23.9.1.1854+ when repeated)
+        /// Execute a SQL query; repeat for multiple queries (requires ClickHouse 23.9.1.1854+)
         #[arg(long, short, conflicts_with = "queries_file")]
         query: Vec<String>,
 
-        /// Execute queries from a SQL file (repeatable; cannot be combined with --query)
-        #[arg(long, conflicts_with = "query")]
+        /// Execute queries from SQL files; accepts multiple paths or repeated flags
+        #[arg(long, num_args = 1.., conflicts_with = "query")]
         queries_file: Vec<String>,
 
         /// Additional arguments to pass to clickhouse-client
@@ -984,10 +985,10 @@ mod tests {
             "client",
             "--queries-file",
             "schema.sql",
-            "--queries-file",
             "seed.sql",
             "--queries-file",
             "",
+            "verify.sql",
             "--",
             "--queries-file",
             "tail.sql",
@@ -996,7 +997,7 @@ mod tests {
             panic!("expected ClickHouse client");
         };
         assert!(query.is_empty());
-        assert_eq!(queries_file, ["schema.sql", "seed.sql", ""]);
+        assert_eq!(queries_file, ["schema.sql", "seed.sql", "", "verify.sql"]);
         assert_eq!(args, ["--queries-file", "tail.sql"]);
     }
 
@@ -1062,6 +1063,21 @@ mod tests {
         ] {
             assert!(help.contains(text), "missing {text:?} in:\n{help}");
         }
+    }
+
+    #[test]
+    fn clickhouse_client_help_describes_query_multiplicity_and_exclusion() {
+        let help = Cli::try_parse_from(["clickhousectl", "local", "client", "--help"])
+            .err()
+            .expect("help should exit through clap")
+            .to_string();
+
+        assert!(help.contains("repeat for multiple queries"), "{help}");
+        assert!(
+            help.contains("accepts multiple paths or repeated flags"),
+            "{help}"
+        );
+        assert!(help.contains("ClickHouse rejects combining"), "{help}");
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -249,7 +249,8 @@ CONTEXT FOR AGENTS:
   2. Explicit host/port: `clickhousectl local client --host myhost --port 9000` — connects to any
      ClickHouse server directly, bypassing local server lookup. Host-only uses port 9000; port-only
      connects to localhost. Direct selectors cannot be combined with --name.
-  --query and --queries-file execute SQL inline or from a file.
+  --query and --queries-file are repeatable and preserve every value. ClickHouse rejects using the
+  two options together, so clickhousectl reports that combination as a usage error.
   Additional clickhouse-client args can be passed after --.
   Related: `clickhousectl local server start` to start a local server, `clickhousectl local server list` to see servers."
     )]
@@ -274,13 +275,13 @@ CONTEXT FOR AGENTS:
         #[arg(long, short = 'v', requires = "direct", conflicts_with = "name")]
         version: Option<ClientVersionArg>,
 
-        /// Execute a SQL query
-        #[arg(long, short)]
-        query: Option<String>,
+        /// Execute a SQL query (repeatable; requires ClickHouse 23.9.1.1854+ when repeated)
+        #[arg(long, short, conflicts_with = "queries_file")]
+        query: Vec<String>,
 
-        /// Execute queries from a SQL file
-        #[arg(long)]
-        queries_file: Option<String>,
+        /// Execute queries from a SQL file (repeatable; cannot be combined with --query)
+        #[arg(long, conflicts_with = "query")]
+        queries_file: Vec<String>,
 
         /// Additional arguments to pass to clickhouse-client
         #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
@@ -937,6 +938,82 @@ mod tests {
             let error = local_parse_error(&["client", "--port", port]);
             assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
             assert!(error.to_string().contains("--port"), "{error}");
+        }
+    }
+
+    #[test]
+    fn clickhouse_client_parses_minimal_and_repeated_query_inputs_in_order() {
+        let LocalCommands::Client {
+            query,
+            queries_file,
+            args,
+            ..
+        } = local_command(&["client"])
+        else {
+            panic!("expected ClickHouse client");
+        };
+        assert!(query.is_empty());
+        assert!(queries_file.is_empty());
+        assert!(args.is_empty());
+
+        let LocalCommands::Client {
+            query,
+            queries_file,
+            args,
+            ..
+        } = local_command(&[
+            "client", "--query", "SELECT 1", "-q", "SELECT 2", "--query", "", "--", "--query",
+            "SELECT 3", "--format", "CSV",
+        ])
+        else {
+            panic!("expected ClickHouse client");
+        };
+        assert_eq!(query, ["SELECT 1", "SELECT 2", ""]);
+        assert!(queries_file.is_empty());
+        assert_eq!(args, ["--query", "SELECT 3", "--format", "CSV"]);
+    }
+
+    #[test]
+    fn clickhouse_client_parses_repeated_query_files_and_empty_values_in_order() {
+        let LocalCommands::Client {
+            query,
+            queries_file,
+            args,
+            ..
+        } = local_command(&[
+            "client",
+            "--queries-file",
+            "schema.sql",
+            "--queries-file",
+            "seed.sql",
+            "--queries-file",
+            "",
+            "--",
+            "--queries-file",
+            "tail.sql",
+        ])
+        else {
+            panic!("expected ClickHouse client");
+        };
+        assert!(query.is_empty());
+        assert_eq!(queries_file, ["schema.sql", "seed.sql", ""]);
+        assert_eq!(args, ["--queries-file", "tail.sql"]);
+    }
+
+    #[test]
+    fn clickhouse_client_rejects_combined_query_sources_in_every_order() {
+        for inputs in [
+            ["--query", "SELECT 1", "--queries-file", "queries.sql"],
+            ["--queries-file", "queries.sql", "--query", "SELECT 1"],
+        ] {
+            let args: Vec<&str> = ["client"].into_iter().chain(inputs).collect();
+            let error = local_parse_error(&args);
+            assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+            assert!(error.to_string().contains("--query <QUERY>"), "{error}");
+            assert!(
+                error.to_string().contains("--queries-file <QUERIES_FILE>"),
+                "{error}"
+            );
         }
     }
 

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -261,8 +261,8 @@ fn run_client(
     host: Option<String>,
     port: Option<u16>,
     version_spec: Option<ClientVersionArg>,
-    query: Option<String>,
-    queries_file: Option<String>,
+    query: Vec<String>,
+    queries_file: Vec<String>,
     args: Vec<String>,
 ) -> Result<()> {
     // If --host or --port is set, connect directly (bypass local server lookup).
@@ -295,6 +295,8 @@ fn run_client(
         return Err(Error::VersionNotFound(version));
     }
 
+    ensure_repeated_query_supported(&version, query.len())?;
+
     let mut cmd = Command::new(&binary);
     cmd.arg("client")
         .arg("--host")
@@ -302,11 +304,11 @@ fn run_client(
         .arg("--port")
         .arg(tcp_port.to_string());
 
-    if let Some(q) = &query {
+    for q in &query {
         cmd.arg("--query").arg(q);
     }
 
-    if let Some(f) = &queries_file {
+    for f in &queries_file {
         cmd.arg("--queries-file").arg(f);
     }
 
@@ -317,6 +319,21 @@ fn run_client(
     crate::telemetry::finalize_before_exec();
     let err = cmd.exec();
     Err(Error::Exec(err.to_string()))
+}
+
+const REPEATED_QUERY_MIN_VERSION: &str = "23.9.1.1854";
+
+fn ensure_repeated_query_supported(version: &str, query_count: usize) -> Result<()> {
+    if query_count > 1
+        && version_manager::list::compare_versions(version, REPEATED_QUERY_MIN_VERSION)
+            == std::cmp::Ordering::Less
+    {
+        return Err(Error::RepeatedClientQueryUnsupported {
+            version: version.to_string(),
+            minimum: REPEATED_QUERY_MIN_VERSION,
+        });
+    }
+    Ok(())
 }
 
 fn resolve_direct_client_version(version_spec: Option<ClientVersionArg>) -> Result<String> {
@@ -1103,6 +1120,17 @@ fn stop_all_servers_global(json: bool) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn repeated_query_support_matches_the_native_client_contract() {
+        // ClickHouse introduced repeatable --query in v23.9.1.1854. The pinned
+        // release evidence is linked from README.md; these tests need no live binary.
+        assert!(ensure_repeated_query_supported("23.8.1.2992", 1).is_ok());
+        assert!(ensure_repeated_query_supported("23.9.1.1853", 2).is_err());
+        assert!(ensure_repeated_query_supported(REPEATED_QUERY_MIN_VERSION, 2).is_ok());
+        assert!(ensure_repeated_query_supported("25.12.9.61", 3).is_ok());
+        assert!(ensure_repeated_query_supported("26.8.1.1760", usize::MAX).is_ok());
+    }
 
     fn server_info(name: &str, engine: server::Engine, version: &str) -> server::ServerInfo {
         server::ServerInfo {

--- a/crates/clickhousectl/tests/local_client_selectors_test.rs
+++ b/crates/clickhousectl/tests/local_client_selectors_test.rs
@@ -256,7 +256,7 @@ fn clickhouse_client_preserves_repeated_query_order_empty_values_and_passthrough
 }
 
 #[test]
-fn clickhouse_client_preserves_repeated_query_file_order_empty_values_and_passthrough() {
+fn clickhouse_client_preserves_multi_value_and_repeated_query_file_order() {
     let project = tempfile::tempdir().expect("create project tempdir");
     let home = tempfile::tempdir().expect("create home tempdir");
     // Repeated --queries-file already existed before repeated --query landed.
@@ -274,10 +274,10 @@ fn clickhouse_client_preserves_repeated_query_file_order_empty_values_and_passth
                 "19000",
                 "--queries-file",
                 "schema.sql",
+                "seed.sql",
                 "--queries-file",
                 "",
-                "--queries-file",
-                "seed.sql",
+                "verify.sql",
                 "--",
                 "--queries-file",
                 "tail.sql",
@@ -295,9 +295,11 @@ fn clickhouse_client_preserves_repeated_query_file_order_empty_values_and_passth
             "--queries-file",
             "schema.sql",
             "--queries-file",
+            "seed.sql",
+            "--queries-file",
             "",
             "--queries-file",
-            "seed.sql",
+            "verify.sql",
             "--queries-file",
             "tail.sql",
             "--format",

--- a/crates/clickhousectl/tests/local_client_selectors_test.rs
+++ b/crates/clickhousectl/tests/local_client_selectors_test.rs
@@ -6,6 +6,7 @@ use std::process::{Command, Output};
 
 const VERSION_A: &str = "25.12.9.61";
 const VERSION_B: &str = "26.8.1.1760";
+const VERSION_BEFORE_REPEATED_QUERY: &str = "23.8.1.2992";
 const MISSING_VERSION: &str = "27.1.2.3";
 
 fn clickhousectl_binary() -> PathBuf {
@@ -182,6 +183,186 @@ fn clickhouse_direct_default_and_single_installed_selection_reach_fake_child() {
         &["client", "--host", "localhost", "--port", "65535"],
     );
     assert_default(home.path(), None);
+}
+
+#[test]
+fn clickhouse_client_preserves_minimal_query_and_query_file_argv() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote", "--query", "SELECT 1"],
+        ),
+        VERSION_B,
+        &[
+            "client", "--host", "remote", "--port", "9000", "--query", "SELECT 1",
+        ],
+    );
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local",
+                "client",
+                "--host",
+                "remote",
+                "--queries-file",
+                "queries.sql",
+            ],
+        ),
+        VERSION_B,
+        &[
+            "client",
+            "--host",
+            "remote",
+            "--port",
+            "9000",
+            "--queries-file",
+            "queries.sql",
+        ],
+    );
+}
+
+#[test]
+fn clickhouse_client_preserves_repeated_query_order_empty_values_and_passthrough() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local", "client", "--host", "remote", "--query", "SELECT 1", "-q", "", "--query",
+                "SELECT 2", "--", "--query", "SELECT 3", "--format", "CSV",
+            ],
+        ),
+        VERSION_B,
+        &[
+            "client", "--host", "remote", "--port", "9000", "--query", "SELECT 1", "--query", "",
+            "--query", "SELECT 2", "--query", "SELECT 3", "--format", "CSV",
+        ],
+    );
+}
+
+#[test]
+fn clickhouse_client_preserves_repeated_query_file_order_empty_values_and_passthrough() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    // Repeated --queries-file already existed before repeated --query landed.
+    install_fake_clickhouse(home.path(), VERSION_BEFORE_REPEATED_QUERY);
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &[
+                "local",
+                "client",
+                "--port",
+                "19000",
+                "--queries-file",
+                "schema.sql",
+                "--queries-file",
+                "",
+                "--queries-file",
+                "seed.sql",
+                "--",
+                "--queries-file",
+                "tail.sql",
+                "--format",
+                "CSV",
+            ],
+        ),
+        VERSION_BEFORE_REPEATED_QUERY,
+        &[
+            "client",
+            "--host",
+            "localhost",
+            "--port",
+            "19000",
+            "--queries-file",
+            "schema.sql",
+            "--queries-file",
+            "",
+            "--queries-file",
+            "seed.sql",
+            "--queries-file",
+            "tail.sql",
+            "--format",
+            "CSV",
+        ],
+    );
+}
+
+#[test]
+fn clickhouse_client_rejects_combined_query_sources_before_the_fake_child_in_every_order() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_B);
+    write_default(home.path(), VERSION_B);
+
+    for inputs in [
+        ["--query", "SELECT 1", "--queries-file", "queries.sql"],
+        ["--queries-file", "queries.sql", "--query", "SELECT 1"],
+    ] {
+        let args: Vec<&str> = ["local", "client"].into_iter().chain(inputs).collect();
+        let output = run(project.path(), home.path(), None, &args);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(output.status.code(), Some(2), "stderr: {stderr}");
+        assert!(stderr.contains("--query <QUERY>"), "{stderr}");
+        assert!(stderr.contains("--queries-file <QUERIES_FILE>"), "{stderr}");
+        assert!(output.stdout.is_empty(), "fake child unexpectedly ran");
+    }
+}
+
+#[test]
+fn clickhouse_client_checks_native_repeated_query_version_support() {
+    let project = tempfile::tempdir().expect("create project tempdir");
+    let home = tempfile::tempdir().expect("create home tempdir");
+    install_fake_clickhouse(home.path(), VERSION_BEFORE_REPEATED_QUERY);
+    write_default(home.path(), VERSION_BEFORE_REPEATED_QUERY);
+
+    assert_clickhouse_child(
+        run(
+            project.path(),
+            home.path(),
+            None,
+            &["local", "client", "--host", "remote", "--query", "SELECT 1"],
+        ),
+        VERSION_BEFORE_REPEATED_QUERY,
+        &[
+            "client", "--host", "remote", "--port", "9000", "--query", "SELECT 1",
+        ],
+    );
+
+    let output = run(
+        project.path(),
+        home.path(),
+        None,
+        &[
+            "local", "client", "--host", "remote", "--query", "SELECT 1", "--query", "SELECT 2",
+        ],
+    );
+    assert_runtime_error(
+        output,
+        &[
+            "does not support repeated --query values",
+            VERSION_BEFORE_REPEATED_QUERY,
+            "23.9.1.1854 or newer",
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- preserve repeatable `--query` plus multi-path and repeated `--queries-file` values in native client argv order
- reject mixed inline/file sources at clap time and guard repeated queries on pre-23.9 clients
- document the native contract and cover help text, empty values, multi-path files, and `--` pass-through with fake children

## Tests
- `cargo test -p clickhousectl clickhouse_client`
- `cargo test -p clickhousectl --test local_client_selectors_test`
- `cargo test -p clickhousectl`
- `cargo fmt --all --check`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #470