### PR TITLE
Make omitted local server selection deliberate

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ clickhousectl local server list
 clickhousectl local server list --global                  # List running ClickHouse servers across all projects
 
 # Stop servers
-clickhousectl local server stop                           # Stop "default"
+clickhousectl local server stop                           # Stop "default", or the sole ClickHouse server
 clickhousectl local server stop dev                       # Stop by name
 clickhousectl local server stop default --global          # Stop from any project
 clickhousectl local server stop default --global --project /path/to/project  # Disambiguate
@@ -271,7 +271,7 @@ clickhousectl local server stop-all                       # Stop all ClickHouse 
 clickhousectl local server stop-all --global              # Stop all ClickHouse servers system-wide
 
 # Remove a stopped server and its data
-clickhousectl local server remove                         # Remove "default"
+clickhousectl local server remove                         # Remove "default" only; never guesses a custom name
 clickhousectl local server remove test                    # Remove by name
 
 # Write connection env vars to .env file
@@ -282,6 +282,8 @@ clickhousectl local server dotenv --local --user default --database mydb  # Incl
 ```
 
 Stopping a server preserves its data and identity metadata, so it remains visible in `server list` with a `stopped` status. Version and ports are shown only while running because they are resolved again on each start. Starting the same name resumes the existing data directory.
+
+Without a name, `server stop` selects an existing `default`, then a sole known ClickHouse server. It succeeds without changing anything when none exist, and requires a name or `server stop-all` when multiple non-default servers exist. Bare `server remove` is deliberately stricter: it removes an existing `default` only and otherwise requires an explicit name, even when there is just one custom server.
 
 **Server naming:** Without a name, the first server is called "default". If "default" is already running, a random name is generated (e.g. "bold-crane"). Pass a name positionally for stable identities you can start/stop repeatedly.
 

--- a/README.md
+++ b/README.md
@@ -979,6 +979,7 @@ The schema and meanings of existing codes are stable. New optional fields or cod
 | Code | Meaning |
 | ---- | ------- |
 | `server_not_found` | The selected local server does not exist |
+| `server_selection_required` | A server name is required because omission is ambiguous or unsafe |
 | `server_not_running` | The selected local server exists but is stopped |
 | `server_running` | The operation requires a stopped server |
 | `invalid_version` | The version selector is invalid |

--- a/crates/clickhousectl/src/error.rs
+++ b/crates/clickhousectl/src/error.rs
@@ -310,6 +310,16 @@ pub enum Error {
     #[error("Server '{0}' not found")]
     ServerNotFound(String),
 
+    #[error(
+        "No server name was provided and multiple non-default ClickHouse servers exist (available: {available}). Pass a name with `clickhousectl local server stop <name>`, or stop every server with `clickhousectl local server stop-all`."
+    )]
+    ServerStopSelectionRequired { available: usize },
+
+    #[error(
+        "No server name was provided and the default ClickHouse server does not exist (custom ClickHouse servers available: {available}). Inspect them with `clickhousectl local server list`; to remove one, pass its name with `clickhousectl local server remove <name>`."
+    )]
+    ServerRemoveSelectionRequired { available: usize },
+
     #[error("Server '{0}' is already running")]
     ServerAlreadyRunning(String),
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -413,8 +413,10 @@ CONTEXT FOR AGENTS:
     /// Stop a running server by name
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Stops a ClickHouse server. The name defaults to \"default\"; pass it positionally to select
-  another server (e.g., `server stop dev`). Use `clickhousectl local server list` to find names.
+  Without a name, stops \"default\" when it exists; otherwise stops the sole known ClickHouse
+  server. With no ClickHouse servers this is a successful no-op. Multiple non-default servers
+  require an explicit name or `clickhousectl local server stop-all`.
+  Pass the name positionally (e.g., `server stop dev`).
   Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
   The server's data and metadata are preserved so it remains visible in `server list`.
   Restart with `clickhousectl local server start <name>`.
@@ -422,7 +424,7 @@ CONTEXT FOR AGENTS:
   An unknown server name still errors so typos are caught.
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
-        /// Name of the server to stop (default: "default")
+        /// Name of the server to stop (auto-selects default or a sole ClickHouse server when omitted)
         #[arg(value_name = "NAME", conflicts_with = "name_flag")]
         name: Option<String>,
 
@@ -459,10 +461,12 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  The name defaults to \"default\"; pass it positionally to select another server.
+  Without a name, removes \"default\" only when it exists. A custom server is never selected
+  implicitly; use `server list`, then pass its name explicitly.
+  Pass the name positionally (e.g., `server remove dev`).
   Related: `clickhousectl local server stop [name]` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
-        /// Name of the server to remove (default: "default")
+        /// Name of the server to remove (only an existing "default" is selected when omitted)
         #[arg(value_name = "NAME", conflicts_with = "name_flag")]
         name: Option<String>,
 

--- a/crates/clickhousectl/src/local/cli.rs
+++ b/crates/clickhousectl/src/local/cli.rs
@@ -413,15 +413,12 @@ CONTEXT FOR AGENTS:
     /// Stop a running server by name
     #[command(after_help = "\
 CONTEXT FOR AGENTS:
-  Without a name, stops \"default\" when it exists; otherwise stops the sole known ClickHouse
-  server. With no ClickHouse servers this is a successful no-op. Multiple non-default servers
-  require an explicit name or `clickhousectl local server stop-all`.
-  Pass the name positionally (e.g., `server stop dev`).
-  Sends SIGTERM first, then SIGKILL if the process doesn't exit gracefully.
+  Stops a ClickHouse server. Without a name, stops \"default\" when it exists, otherwise the sole
+  known ClickHouse server. With no ClickHouse servers this is a successful no-op; with multiple
+  non-default servers, pass a positional name (e.g., `server stop dev`) or use `server stop-all`.
+  Use `clickhousectl local server list` to find names.
   The server's data and metadata are preserved so it remains visible in `server list`.
   Restart with `clickhousectl local server start <name>`.
-  Idempotent: a server that exists but is already stopped exits 0 (no error).
-  An unknown server name still errors so typos are caught.
   Related: `clickhousectl local server list` to see servers.")]
     Stop {
         /// Name of the server to stop (auto-selects default or a sole ClickHouse server when omitted)
@@ -429,7 +426,12 @@ CONTEXT FOR AGENTS:
         name: Option<String>,
 
         /// Compatibility form for the server name; prefer positional NAME
-        #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
+        #[arg(
+            long = "name",
+            value_name = "NAME",
+            conflicts_with = "name",
+            hide = true
+        )]
         name_flag: Option<String>,
 
         /// System-wide maintenance only: stop a server from any project. You almost certainly want the default project-scoped stop instead.
@@ -461,9 +463,8 @@ CONTEXT FOR AGENTS:
 CONTEXT FOR AGENTS:
   Permanently deletes a server's data directory. The server must be stopped first.
   This is irreversible — all data for this server instance will be lost.
-  Without a name, removes \"default\" only when it exists. A custom server is never selected
-  implicitly; use `server list`, then pass its name explicitly.
-  Pass the name positionally (e.g., `server remove dev`).
+  Without a name, removes \"default\" only when it exists. It never guesses a custom server;
+  use `server list`, then pass a custom name positionally.
   Related: `clickhousectl local server stop [name]` to stop first, `clickhousectl local server list` to see servers.")]
     Remove {
         /// Name of the server to remove (only an existing "default" is selected when omitted)
@@ -471,7 +472,12 @@ CONTEXT FOR AGENTS:
         name: Option<String>,
 
         /// Compatibility form for the server name; prefer positional NAME
-        #[arg(long = "name", value_name = "NAME", conflicts_with = "name")]
+        #[arg(
+            long = "name",
+            value_name = "NAME",
+            conflicts_with = "name",
+            hide = true
+        )]
         name_flag: Option<String>,
     },
 
@@ -1559,19 +1565,15 @@ mod tests {
     }
 
     #[test]
-    fn server_teardown_agent_help_only_advertises_positional_names() {
+    fn server_teardown_help_hides_compatibility_name_flags() {
         for command in ["stop", "remove"] {
             let help = Cli::try_parse_from(["clickhousectl", "local", "server", command, "--help"])
                 .err()
                 .expect("help should exit through clap")
                 .to_string();
-            let context = help
-                .split_once("CONTEXT FOR AGENTS:")
-                .expect("agent context")
-                .1;
 
-            assert!(context.contains("positionally"), "{help}");
-            assert!(!context.contains("--name"), "{help}");
+            assert!(!help.contains("--name"), "{help}");
+            assert!(help.contains("Without a name"), "{help}");
         }
     }
 

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -796,50 +796,12 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             name_flag,
             global,
             project,
-        } => {
-            let name = name.or(name_flag).unwrap_or_else(|| "default".to_string());
-            if global {
-                stop_server_global(&name, project.as_deref(), json)
-            } else {
-                server::validate_server_name(&name)?;
-
-                // Recover orphaned servers so we can stop processes
-                // that lost their metadata files.
-                let metadata_lock = server::lock_metadata()?;
-                server::recover_current_project_servers_locked(&metadata_lock)?;
-
-                match classify_stop(
-                    server::is_server_running_locked(&name, &metadata_lock)?,
-                    server::server_data_dir(&name).exists(),
-                ) {
-                    StopOutcome::Stop => {
-                        if !json {
-                            println!("Stopping server '{}'...", name);
-                        }
-                        server::kill_server_locked(&name, &metadata_lock)?;
-                        let out = output::ServerStopOutput {
-                            name,
-                            already_stopped: false,
-                        };
-                        output::print_output(&out, json);
-                        Ok(())
-                    }
-                    StopOutcome::AlreadyStopped => {
-                        // Server exists on disk but isn't running. `stop` is
-                        // idempotent: this is the desired end state, so succeed
-                        // instead of erroring.
-                        let out = output::ServerStopOutput {
-                            name,
-                            already_stopped: true,
-                        };
-                        output::print_output(&out, json);
-                        Ok(())
-                    }
-                    // No such server in this project — surface the typo.
-                    StopOutcome::NotFound => Err(Error::ServerNotFound(name)),
-                }
-            }
-        }
+        } => stop_server(
+            ServerNameInput::from_args(name, name_flag),
+            global,
+            project,
+            json,
+        ),
         ServerCommands::StopAll { global } => {
             if global {
                 stop_all_servers_global(json)
@@ -855,30 +817,165 @@ async fn run_server_commands(command: ServerCommands, json: bool) -> Result<()> 
             database,
         } => dotenv_server(name.as_deref(), local, user, password, database, json),
         ServerCommands::Remove { name, name_flag } => {
-            let name = name.or(name_flag).unwrap_or_else(|| "default".to_string());
-            server::validate_server_name(&name)?;
+            remove_server(ServerNameInput::from_args(name, name_flag), json)
+        }
+    }
+}
 
-            // Recover orphaned servers so we correctly detect a running
-            // process even when its metadata file is missing.
-            let metadata_lock = server::lock_metadata()?;
-            server::recover_current_project_servers_locked(&metadata_lock)?;
+#[derive(Debug, PartialEq, Eq)]
+enum ServerNameInput {
+    Omitted,
+    Positional(String),
+    NameFlag(String),
+}
 
-            if server::is_server_running_locked(&name, &metadata_lock)? {
-                return Err(Error::ServerRunningCannotRemove(name));
+impl ServerNameInput {
+    fn from_args(positional: Option<String>, name_flag: Option<String>) -> Self {
+        match (positional, name_flag) {
+            (Some(name), None) => Self::Positional(name),
+            (None, Some(name)) => Self::NameFlag(name),
+            (None, None) => Self::Omitted,
+            (Some(_), Some(_)) => unreachable!("clap rejects conflicting server name forms"),
+        }
+    }
+}
+
+fn stop_server(
+    name_input: ServerNameInput,
+    global: bool,
+    project: Option<String>,
+    json: bool,
+) -> Result<()> {
+    if global {
+        return stop_server_global(name_input, project.as_deref(), json);
+    }
+
+    let explicit_name = match &name_input {
+        ServerNameInput::Omitted => None,
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => Some(name),
+    };
+    if let Some(name) = explicit_name {
+        server::validate_server_name(name)?;
+    }
+
+    // Recover orphaned servers so we can stop processes
+    // that lost their metadata files.
+    let metadata_lock = server::lock_metadata()?;
+    server::recover_current_project_servers_locked(&metadata_lock)?;
+    let (name, selection, known) = match name_input {
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => {
+            (name, output::ServerSelection::Explicit, false)
+        }
+        ServerNameInput::Omitted => {
+            let names = server::list_clickhouse_server_names_locked(&metadata_lock)?;
+            if names.iter().any(|name| name == "default") {
+                (
+                    "default".to_string(),
+                    output::ServerSelection::Implicit,
+                    true,
+                )
+            } else {
+                match names.as_slice() {
+                    [] => {
+                        let out = output::ServerStopNoopOutput {
+                            stopped: false,
+                            selection: output::ServerSelection::Implicit,
+                            reason: "no_clickhouse_servers",
+                        };
+                        output::print_output(&out, json);
+                        return Ok(());
+                    }
+                    [name] => (name.clone(), output::ServerSelection::Implicit, true),
+                    names => {
+                        return Err(Error::ServerStopSelectionRequired {
+                            available: names.len(),
+                        });
+                    }
+                }
             }
-            let data_dir = server::server_data_dir(&name);
-            if !data_dir.exists() {
-                return Err(Error::ServerNotFound(name));
+        }
+    };
+
+    match classify_stop(
+        server::is_server_running_locked(&name, &metadata_lock)?,
+        known || server::server_data_dir(&name).exists(),
+    ) {
+        StopOutcome::Stop => {
+            if !json {
+                println!("Stopping server '{}'...", name);
             }
-            // Remove the whole server directory (parent of data/)
-            let server_dir = data_dir.parent().unwrap();
-            std::fs::remove_dir_all(server_dir)?;
-            server::try_remove_server_info_locked(&name, &metadata_lock)?;
-            let out = output::ServerRemoveOutput { name };
+            server::kill_server_locked(&name, &metadata_lock)?;
+            let out = output::ServerStopOutput {
+                name,
+                already_stopped: false,
+                selection: Some(selection),
+            };
             output::print_output(&out, json);
             Ok(())
         }
+        StopOutcome::AlreadyStopped => {
+            // Server exists on disk but isn't running. `stop` is
+            // idempotent: this is the desired end state, so succeed
+            // instead of erroring.
+            let out = output::ServerStopOutput {
+                name,
+                already_stopped: true,
+                selection: Some(selection),
+            };
+            output::print_output(&out, json);
+            Ok(())
+        }
+        // No such server in this project — surface the typo.
+        StopOutcome::NotFound => Err(Error::ServerNotFound(name)),
     }
+}
+
+fn remove_server(name_input: ServerNameInput, json: bool) -> Result<()> {
+    let explicit_name = match &name_input {
+        ServerNameInput::Omitted => None,
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => Some(name),
+    };
+    if let Some(name) = explicit_name {
+        server::validate_server_name(name)?;
+    }
+
+    // Recover orphaned servers so we correctly detect a running
+    // process even when its metadata file is missing.
+    let metadata_lock = server::lock_metadata()?;
+    server::recover_current_project_servers_locked(&metadata_lock)?;
+    let (name, selection) = match name_input {
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => {
+            (name, output::ServerSelection::Explicit)
+        }
+        ServerNameInput::Omitted => {
+            let names = server::list_clickhouse_server_names_locked(&metadata_lock)?;
+            if names.iter().any(|name| name == "default") {
+                ("default".to_string(), output::ServerSelection::Implicit)
+            } else {
+                return Err(Error::ServerRemoveSelectionRequired {
+                    available: names.len(),
+                });
+            }
+        }
+    };
+
+    if server::is_server_running_locked(&name, &metadata_lock)? {
+        return Err(Error::ServerRunningCannotRemove(name));
+    }
+    let data_dir = server::server_data_dir(&name);
+    if !data_dir.exists() {
+        return Err(Error::ServerNotFound(name));
+    }
+    // Remove the whole server directory (parent of data/)
+    let server_dir = data_dir.parent().unwrap();
+    std::fs::remove_dir_all(server_dir)?;
+    server::try_remove_server_info_locked(&name, &metadata_lock)?;
+    let out = output::ServerRemoveOutput {
+        name,
+        selection: Some(selection),
+    };
+    output::print_output(&out, json);
+    Ok(())
 }
 
 /// What a project-scoped `server stop <name>` should do, given whether the
@@ -1010,16 +1107,52 @@ fn list_servers_global(json: bool) -> Result<()> {
     Ok(())
 }
 
-fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<()> {
+fn stop_server_global(
+    name_input: ServerNameInput,
+    project: Option<&str>,
+    json: bool,
+) -> Result<()> {
     let all = server::list_all_servers_global();
-    let mut matches: Vec<_> = all.iter().filter(|e| e.name == name).collect();
-
-    if let Some(proj) = project {
-        matches.retain(|e| e.project == proj);
-    }
+    let candidates: Vec<_> = all
+        .iter()
+        .filter(|entry| project.is_none_or(|project| entry.project == project))
+        .collect();
+    let (name, selection) = match name_input {
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => {
+            server::validate_server_name(&name)?;
+            (name, output::ServerSelection::Explicit)
+        }
+        ServerNameInput::Omitted => {
+            if candidates.iter().any(|entry| entry.name == "default") {
+                ("default".to_string(), output::ServerSelection::Implicit)
+            } else {
+                match candidates.as_slice() {
+                    [] => {
+                        let out = output::ServerStopNoopOutput {
+                            stopped: false,
+                            selection: output::ServerSelection::Implicit,
+                            reason: "no_clickhouse_servers",
+                        };
+                        output::print_output(&out, json);
+                        return Ok(());
+                    }
+                    [entry] => (entry.name.clone(), output::ServerSelection::Implicit),
+                    entries => {
+                        return Err(Error::ServerStopSelectionRequired {
+                            available: entries.len(),
+                        });
+                    }
+                }
+            }
+        }
+    };
+    let matches: Vec<_> = candidates
+        .into_iter()
+        .filter(|entry| entry.name == name)
+        .collect();
 
     if matches.is_empty() {
-        return Err(Error::ServerNotFound(name.to_string()));
+        return Err(Error::ServerNotFound(name));
     }
 
     if matches.len() > 1 {
@@ -1037,8 +1170,9 @@ fn stop_server_global(name: &str, project: Option<&str>, json: bool) -> Result<(
     }
     server::kill_server_by_pid(entry.pid)?;
     let out = output::ServerStopOutput {
-        name: name.to_string(),
+        name,
         already_stopped: false,
+        selection: Some(selection),
     };
     output::print_output(&out, json);
     Ok(())
@@ -1204,6 +1338,22 @@ mod tests {
     #[test]
     fn classify_stop_unknown_name_is_not_found() {
         assert_eq!(classify_stop(false, false), StopOutcome::NotFound);
+    }
+
+    #[test]
+    fn server_name_input_preserves_cli_source() {
+        assert_eq!(
+            ServerNameInput::from_args(None, None),
+            ServerNameInput::Omitted
+        );
+        assert_eq!(
+            ServerNameInput::from_args(Some("positional".into()), None),
+            ServerNameInput::Positional("positional".into())
+        );
+        assert_eq!(
+            ServerNameInput::from_args(None, Some("flagged".into())),
+            ServerNameInput::NameFlag("flagged".into())
+        );
     }
 
     #[test]

--- a/crates/clickhousectl/src/local/mod.rs
+++ b/crates/clickhousectl/src/local/mod.rs
@@ -1113,42 +1113,11 @@ fn stop_server_global(
     json: bool,
 ) -> Result<()> {
     let all = server::list_all_servers_global();
-    let candidates: Vec<_> = all
+    let (name, selection) = global_stop_target(name_input)?;
+    let matches: Vec<_> = all
         .iter()
-        .filter(|entry| project.is_none_or(|project| entry.project == project))
-        .collect();
-    let (name, selection) = match name_input {
-        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => {
-            server::validate_server_name(&name)?;
-            (name, output::ServerSelection::Explicit)
-        }
-        ServerNameInput::Omitted => {
-            if candidates.iter().any(|entry| entry.name == "default") {
-                ("default".to_string(), output::ServerSelection::Implicit)
-            } else {
-                match candidates.as_slice() {
-                    [] => {
-                        let out = output::ServerStopNoopOutput {
-                            stopped: false,
-                            selection: output::ServerSelection::Implicit,
-                            reason: "no_clickhouse_servers",
-                        };
-                        output::print_output(&out, json);
-                        return Ok(());
-                    }
-                    [entry] => (entry.name.clone(), output::ServerSelection::Implicit),
-                    entries => {
-                        return Err(Error::ServerStopSelectionRequired {
-                            available: entries.len(),
-                        });
-                    }
-                }
-            }
-        }
-    };
-    let matches: Vec<_> = candidates
-        .into_iter()
         .filter(|entry| entry.name == name)
+        .filter(|entry| project.is_none_or(|project| entry.project == project))
         .collect();
 
     if matches.is_empty() {
@@ -1176,6 +1145,16 @@ fn stop_server_global(
     };
     output::print_output(&out, json);
     Ok(())
+}
+
+fn global_stop_target(name_input: ServerNameInput) -> Result<(String, output::ServerSelection)> {
+    match name_input {
+        ServerNameInput::Positional(name) | ServerNameInput::NameFlag(name) => {
+            server::validate_server_name(&name)?;
+            Ok((name, output::ServerSelection::Explicit))
+        }
+        ServerNameInput::Omitted => Ok(("default".to_string(), output::ServerSelection::Implicit)),
+    }
 }
 
 fn stop_all_servers_local(json: bool) -> Result<()> {
@@ -1353,6 +1332,14 @@ mod tests {
         assert_eq!(
             ServerNameInput::from_args(None, Some("flagged".into())),
             ServerNameInput::NameFlag("flagged".into())
+        );
+    }
+
+    #[test]
+    fn omitted_global_stop_keeps_the_literal_default_target() {
+        assert_eq!(
+            global_stop_target(ServerNameInput::Omitted).unwrap(),
+            ("default".to_string(), output::ServerSelection::Implicit)
         );
     }
 

--- a/crates/clickhousectl/src/local/output.rs
+++ b/crates/clickhousectl/src/local/output.rs
@@ -15,6 +15,7 @@ use tabled::{Table, Tabled, settings::Style};
 #[serde(rename_all = "snake_case")]
 enum LocalErrorCode {
     ServerNotFound,
+    ServerSelectionRequired,
     ServerNotRunning,
     ServerRunning,
     InvalidVersion,
@@ -46,6 +47,20 @@ impl LocalErrorOutput {
             Error::ServerNotFound(name) => LocalErrorDetail {
                 code: LocalErrorCode::ServerNotFound,
                 message: format!("Server '{name}' not found"),
+                command: Some("clickhousectl local server list"),
+            },
+            Error::ServerStopSelectionRequired { available } => LocalErrorDetail {
+                code: LocalErrorCode::ServerSelectionRequired,
+                message: format!(
+                    "Multiple non-default ClickHouse servers exist (available: {available}); specify a name or use stop-all"
+                ),
+                command: Some("clickhousectl local server list"),
+            },
+            Error::ServerRemoveSelectionRequired { available } => LocalErrorDetail {
+                code: LocalErrorCode::ServerSelectionRequired,
+                message: format!(
+                    "The default ClickHouse server does not exist (custom ClickHouse servers available: {available}); no server was removed"
+                ),
                 command: Some("clickhousectl local server list"),
             },
             Error::ServerNotRunning(name) => LocalErrorDetail {
@@ -635,20 +650,46 @@ impl fmt::Display for PostgresDotenvOutput {
 
 // ── server stop ─────────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ServerSelection {
+    Explicit,
+    Implicit,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ServerStopOutput {
     pub name: String,
     /// True when the server existed but was already stopped (idempotent noop).
     pub already_stopped: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection: Option<ServerSelection>,
 }
 
 impl fmt::Display for ServerStopOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.already_stopped {
-            write!(f, "Server '{}' is already stopped", self.name)
+            write!(f, "Server '{}' is already stopped", self.name)?;
         } else {
-            write!(f, "Server '{}' stopped", self.name)
+            write!(f, "Server '{}' stopped", self.name)?;
         }
+        if self.selection == Some(ServerSelection::Implicit) {
+            write!(f, " (selected automatically)")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ServerStopNoopOutput {
+    pub stopped: bool,
+    pub selection: ServerSelection,
+    pub reason: &'static str,
+}
+
+impl fmt::Display for ServerStopNoopOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "No ClickHouse servers found; nothing to stop")
     }
 }
 
@@ -704,11 +745,17 @@ impl fmt::Display for ServerStopAllOutput {
 #[derive(Debug, Clone, Serialize)]
 pub struct ServerRemoveOutput {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection: Option<ServerSelection>,
 }
 
 impl fmt::Display for ServerRemoveOutput {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Server '{}' removed", self.name)
+        write!(f, "Server '{}' removed", self.name)?;
+        if self.selection == Some(ServerSelection::Implicit) {
+            write!(f, " (selected automatically)")?;
+        }
+        Ok(())
     }
 }
 
@@ -763,6 +810,10 @@ mod tests {
     fn local_error_codes_cover_the_stable_vocabulary() {
         let cases = [
             (Error::ServerNotFound("default".into()), "server_not_found"),
+            (
+                Error::ServerStopSelectionRequired { available: 2 },
+                "server_selection_required",
+            ),
             (
                 Error::ServerNotRunning("default".into()),
                 "server_not_running",
@@ -1059,12 +1110,14 @@ mod tests {
         let output = ServerStopOutput {
             name: "default".to_string(),
             already_stopped: false,
+            selection: Some(ServerSelection::Explicit),
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
         assert_eq!(json["name"], "default");
         assert_eq!(json["already_stopped"], false);
+        assert_eq!(json["selection"], "explicit");
     }
 
     #[test]
@@ -1072,8 +1125,12 @@ mod tests {
         let output = ServerStopOutput {
             name: "default".to_string(),
             already_stopped: true,
+            selection: Some(ServerSelection::Implicit),
         };
-        assert_eq!(output.to_string(), "Server 'default' is already stopped");
+        assert_eq!(
+            output.to_string(),
+            "Server 'default' is already stopped (selected automatically)"
+        );
 
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
@@ -1164,11 +1221,13 @@ mod tests {
     fn server_remove_json() {
         let output = ServerRemoveOutput {
             name: "test".to_string(),
+            selection: Some(ServerSelection::Explicit),
         };
         let json: serde_json::Value =
             serde_json::from_str(&serde_json::to_string_pretty(&output).unwrap()).unwrap();
 
         assert_eq!(json["name"], "test");
+        assert_eq!(json["selection"], "explicit");
     }
 
     // ── Display (human-readable) tests ──────────────────────────────────
@@ -1388,6 +1447,7 @@ mod tests {
         let output = ServerStopOutput {
             name: "default".to_string(),
             already_stopped: false,
+            selection: Some(ServerSelection::Explicit),
         };
         assert_eq!(output.to_string(), "Server 'default' stopped");
     }
@@ -1432,6 +1492,7 @@ mod tests {
     fn server_remove_display() {
         let output = ServerRemoveOutput {
             name: "test".to_string(),
+            selection: Some(ServerSelection::Explicit),
         };
         assert_eq!(output.to_string(), "Server 'test' removed");
     }

--- a/crates/clickhousectl/src/local/postgres.rs
+++ b/crates/clickhousectl/src/local/postgres.rs
@@ -969,6 +969,7 @@ async fn stop(name: &str, version: Option<&str>, json: bool) -> Result<()> {
     let out = output::ServerStopOutput {
         name: user_name_from_key(&target.name).to_string(),
         already_stopped: false,
+        selection: None,
     };
     output::print_output(&out, json);
     Ok(())
@@ -1022,6 +1023,7 @@ fn remove(name: &str, version: Option<&str>, json: bool) -> Result<()> {
     server::try_remove_server_info_locked(&key, &metadata_lock)?;
     let out = output::ServerRemoveOutput {
         name: name.to_string(),
+        selection: None,
     };
     output::print_output(&out, json);
     Ok(())

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -174,6 +174,12 @@ pub fn pg_instance_key(name: &str, major: &str) -> String {
     format!("{}-pg{}", name, major)
 }
 
+fn is_pg_instance_key(name: &str) -> bool {
+    name.rsplit_once("-pg").is_some_and(|(name, major)| {
+        !name.is_empty() && !major.is_empty() && major.chars().all(|c| c.is_ascii_digit())
+    })
+}
+
 /// Join a child name onto the servers directory. Exposed so handlers can
 /// remove a whole `<key>/` wrapper without poking at internals.
 pub fn servers_dir_join(child: &str) -> PathBuf {
@@ -502,6 +508,7 @@ pub(crate) fn list_clickhouse_server_names_locked(lock: &MetadataLock) -> Result
             continue;
         };
         if validate_server_name(&name).is_err()
+            || is_pg_instance_key(&name)
             || entries.iter().any(|entry| {
                 entry.name == name
                     && entry

--- a/crates/clickhousectl/src/local/server.rs
+++ b/crates/clickhousectl/src/local/server.rs
@@ -478,6 +478,48 @@ fn list_all_servers_locked_inner(
     Ok(entries)
 }
 
+/// List persisted ClickHouse identities, including legacy stopped servers that
+/// have a data directory but predate retained metadata.
+pub(crate) fn list_clickhouse_server_names_locked(lock: &MetadataLock) -> Result<Vec<String>> {
+    let entries = list_all_servers_locked(lock)?;
+    let mut names: Vec<_> = entries
+        .iter()
+        .filter(|entry| {
+            entry
+                .info
+                .as_ref()
+                .is_some_and(|info| info.engine == Engine::Clickhouse)
+        })
+        .map(|entry| entry.name.clone())
+        .collect();
+
+    for directory in std::fs::read_dir(&lock.dir)? {
+        let directory = directory?;
+        if !directory.file_type()?.is_dir() || !directory.path().join("data").is_dir() {
+            continue;
+        }
+        let Ok(name) = directory.file_name().into_string() else {
+            continue;
+        };
+        if validate_server_name(&name).is_err()
+            || entries.iter().any(|entry| {
+                entry.name == name
+                    && entry
+                        .info
+                        .as_ref()
+                        .is_some_and(|info| info.engine == Engine::Postgres)
+            })
+        {
+            continue;
+        }
+        names.push(name);
+    }
+
+    names.sort();
+    names.dedup();
+    Ok(names)
+}
+
 pub(crate) fn server_entry_locked(name: &str, lock: &MetadataLock) -> Result<Option<ServerEntry>> {
     server_entry_locked_with(name, lock, || {})
 }

--- a/crates/clickhousectl/tests/local_postgres_readiness_test.rs
+++ b/crates/clickhousectl/tests/local_postgres_readiness_test.rs
@@ -851,7 +851,7 @@ fn immediate_exit_redacts_bounded_logs_without_setup_success_or_telemetry_noise(
 }
 
 #[test]
-fn failed_fresh_start_preserves_preexisting_data_and_recovery_metadata() {
+fn failed_fresh_start_preserves_postgres_identity_without_polluting_clickhouse_selection() {
     let (output, requests, project) = run_start(
         DockerScenario {
             existing: false,
@@ -897,6 +897,30 @@ fn failed_fresh_start_preserves_preexisting_data_and_recovery_metadata() {
             .count(),
         1
     );
+
+    let clickhouse_data = project.path().join(".clickhouse/servers/dev/data");
+    std::fs::create_dir_all(&clickhouse_data).expect("create ClickHouse data directory");
+    let home = tempfile::tempdir().expect("create selection home");
+    let stop = Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home.path())
+        .env("PATH", "/usr/bin:/bin")
+        .current_dir(project.path())
+        .args(["local", "--json", "server", "stop"])
+        .output()
+        .expect("run omitted ClickHouse stop");
+
+    assert!(
+        stop.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&stop.stderr)
+    );
+    let result: serde_json::Value = serde_json::from_slice(&stop.stdout).expect("stop JSON");
+    assert_eq!(result["name"], "dev");
+    assert_eq!(result["already_stopped"], true);
+    assert_eq!(result["selection"], "implicit");
+    assert!(clickhouse_data.is_dir());
 }
 
 #[test]

--- a/crates/clickhousectl/tests/local_server_name_compatibility_test.rs
+++ b/crates/clickhousectl/tests/local_server_name_compatibility_test.rs
@@ -47,6 +47,14 @@ fn assert_stop_dispatch(name_args: &[&str], expected: &str) {
     let body: Value = serde_json::from_slice(&output.stdout).expect("parse stop JSON");
     assert_eq!(body["name"], expected);
     assert_eq!(body["already_stopped"], true);
+    assert_eq!(
+        body["selection"],
+        if name_args.is_empty() {
+            "implicit"
+        } else {
+            "explicit"
+        }
+    );
     assert!(decoy.exists());
 }
 
@@ -64,6 +72,14 @@ fn assert_remove_dispatch(name_args: &[&str], expected: &str) {
     assert_success(&output);
     let body: Value = serde_json::from_slice(&output.stdout).expect("parse remove JSON");
     assert_eq!(body["name"], expected);
+    assert_eq!(
+        body["selection"],
+        if name_args.is_empty() {
+            "implicit"
+        } else {
+            "explicit"
+        }
+    );
     assert!(!selected.exists());
     assert!(decoy.exists());
 }
@@ -81,7 +97,7 @@ fn remove_dispatches_positional_and_compatibility_names_exactly() {
 }
 
 #[test]
-fn omitted_names_keep_the_current_default_runtime_behavior() {
+fn omitted_names_select_an_existing_default_implicitly() {
     assert_stop_dispatch(&[], "default");
     assert_remove_dispatch(&[], "default");
 }

--- a/crates/clickhousectl/tests/local_server_selection_test.rs
+++ b/crates/clickhousectl/tests/local_server_selection_test.rs
@@ -1,0 +1,353 @@
+//! Isolated subprocess coverage for deliberate omitted server selection.
+
+use serde_json::{Value, json};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const VERSION: &str = "25.12.9.61";
+
+fn clickhousectl_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_clickhousectl"))
+}
+
+fn run(project: &Path, home: &Path, args: &[&str]) -> Output {
+    Command::new(clickhousectl_binary())
+        .env_clear()
+        .env("DO_NOT_TRACK", "1")
+        .env("HOME", home)
+        .env("PATH", "/usr/bin:/bin")
+        .current_dir(project)
+        .args(args)
+        .output()
+        .expect("run clickhousectl")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn body(output: &Output) -> Value {
+    serde_json::from_slice(&output.stdout).expect("parse JSON output")
+}
+
+fn create_stopped_server(project: &Path, name: &str) -> PathBuf {
+    let servers = project.join(".clickhouse/servers");
+    let directory = servers.join(name);
+    std::fs::create_dir_all(directory.join("data")).expect("create server data directory");
+    std::fs::write(
+        servers.join(format!("{name}.json")),
+        serde_json::to_vec_pretty(&json!({
+            "name": name,
+            "pid": 0,
+            "version": "",
+            "http_port": 0,
+            "tcp_port": 0,
+            "started_at": "1700000000",
+            "cwd": project.display().to_string(),
+            "engine": "clickhouse"
+        }))
+        .unwrap(),
+    )
+    .expect("write stopped server metadata");
+    directory
+}
+
+fn install_fake_clickhouse(home: &Path) {
+    let binary = home.join(format!(".clickhouse/versions/{VERSION}/clickhouse"));
+    std::fs::create_dir_all(binary.parent().unwrap()).expect("create fake version directory");
+    std::fs::write(
+        &binary,
+        b"#!/bin/sh\ntrap 'exit 0' TERM INT\nwhile :; do sleep 1; done\n",
+    )
+    .expect("write fake ClickHouse");
+    std::fs::set_permissions(&binary, std::fs::Permissions::from_mode(0o755))
+        .expect("make fake ClickHouse executable");
+}
+
+fn unused_port() -> u16 {
+    std::net::TcpListener::bind(("127.0.0.1", 0))
+        .expect("bind temporary port")
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+struct ProcessGuard {
+    pid: u32,
+    active: bool,
+}
+
+impl Drop for ProcessGuard {
+    fn drop(&mut self) {
+        if self.active {
+            unsafe {
+                libc::kill(self.pid as i32, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[test]
+fn omitted_stop_is_a_human_and_json_noop_with_zero_servers() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+
+    let json_output = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert_success(&json_output);
+    assert_eq!(
+        body(&json_output),
+        json!({
+            "stopped": false,
+            "selection": "implicit",
+            "reason": "no_clickhouse_servers"
+        })
+    );
+
+    let human = run(project.path(), home.path(), &["local", "server", "stop"]);
+    assert_success(&human);
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout),
+        "No ClickHouse servers found; nothing to stop\n"
+    );
+    assert!(human.stderr.is_empty());
+}
+
+#[test]
+fn omitted_stop_selects_the_sole_running_then_stopped_custom_server() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    install_fake_clickhouse(home.path());
+    let http_port = unused_port().to_string();
+    let tcp_port = unused_port().to_string();
+
+    let start = run(
+        project.path(),
+        home.path(),
+        &[
+            "local",
+            "--json",
+            "server",
+            "start",
+            "dev",
+            "--version",
+            VERSION,
+            "--http-port",
+            &http_port,
+            "--tcp-port",
+            &tcp_port,
+            "--no-wait",
+        ],
+    );
+    assert_success(&start);
+    let pid = body(&start)["pid"].as_u64().expect("server PID") as u32;
+    let mut process = ProcessGuard { pid, active: true };
+
+    let stop = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert_success(&stop);
+    process.active = false;
+    let stop_body = body(&stop);
+    assert_eq!(stop_body["name"], "dev");
+    assert_eq!(stop_body["already_stopped"], false);
+    assert_eq!(stop_body["selection"], "implicit");
+
+    let metadata = project.path().join(".clickhouse/servers/dev.json");
+    let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
+    assert_eq!(saved["pid"], 0);
+    assert_eq!(saved["version"], "");
+    assert!(project.path().join(".clickhouse/servers/dev/data").is_dir());
+
+    let second = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert_success(&second);
+    let second_body = body(&second);
+    assert_eq!(second_body["name"], "dev");
+    assert_eq!(second_body["already_stopped"], true);
+    assert_eq!(second_body["selection"], "implicit");
+    assert!(metadata.exists(), "idempotent stop must retain identity");
+}
+
+#[test]
+fn omitted_stop_recognizes_a_sole_legacy_stopped_data_directory() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let legacy = project.path().join(".clickhouse/servers/legacy/data");
+    std::fs::create_dir_all(&legacy).expect("create legacy data directory");
+
+    let stop = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+
+    assert_success(&stop);
+    let stop_body = body(&stop);
+    assert_eq!(stop_body["name"], "legacy");
+    assert_eq!(stop_body["already_stopped"], true);
+    assert_eq!(stop_body["selection"], "implicit");
+    assert!(legacy.is_dir());
+    assert!(
+        !project
+            .path()
+            .join(".clickhouse/servers/legacy.json")
+            .exists()
+    );
+}
+
+#[test]
+fn omitted_commands_prefer_default_without_touching_custom_servers() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let default = create_stopped_server(project.path(), "default");
+    let custom = create_stopped_server(project.path(), "dev");
+
+    let stop = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert_success(&stop);
+    assert_eq!(body(&stop)["name"], "default");
+    assert_eq!(body(&stop)["selection"], "implicit");
+    assert!(default.exists());
+    assert!(custom.exists());
+
+    let remove = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "remove"],
+    );
+    assert_success(&remove);
+    assert_eq!(body(&remove)["name"], "default");
+    assert_eq!(body(&remove)["selection"], "implicit");
+    assert!(!default.exists());
+    assert!(
+        !project
+            .path()
+            .join(".clickhouse/servers/default.json")
+            .exists()
+    );
+    assert!(custom.exists());
+    assert!(project.path().join(".clickhouse/servers/dev.json").exists());
+}
+
+#[test]
+fn omitted_stop_requires_a_name_or_stop_all_for_many_non_default_servers() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let alpha = create_stopped_server(project.path(), "alpha");
+    let beta = create_stopped_server(project.path(), "beta");
+
+    let ambiguous = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+    assert_eq!(ambiguous.status.code(), Some(1));
+    assert!(ambiguous.stdout.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<Value>(&ambiguous.stderr).unwrap(),
+        json!({
+            "error": {
+                "code": "server_selection_required",
+                "message": "Multiple non-default ClickHouse servers exist (available: 2); specify a name or use stop-all",
+                "command": "clickhousectl local server list"
+            }
+        })
+    );
+
+    let human = run(project.path(), home.path(), &["local", "server", "stop"]);
+    assert_eq!(human.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&human.stderr);
+    assert!(stderr.contains("multiple non-default ClickHouse servers exist (available: 2)"));
+    assert!(stderr.contains("clickhousectl local server stop <name>"));
+    assert!(stderr.contains("clickhousectl local server stop-all"));
+    assert!(alpha.exists());
+    assert!(beta.exists());
+
+    for command in ["stop", "remove"] {
+        let explicit_unknown = run(
+            project.path(),
+            home.path(),
+            &["local", "--json", "server", command, "missing"],
+        );
+        assert_eq!(explicit_unknown.status.code(), Some(1));
+        let error: Value = serde_json::from_slice(&explicit_unknown.stderr).unwrap();
+        assert_eq!(error["error"]["code"], "server_not_found");
+        assert_eq!(error["error"]["message"], "Server 'missing' not found");
+    }
+}
+
+#[test]
+fn omitted_remove_never_selects_custom_servers() {
+    for names in [&[][..], &["dev"][..], &["alpha", "beta"][..]] {
+        let project = tempfile::tempdir().expect("create project");
+        let home = tempfile::tempdir().expect("create home");
+        for name in names {
+            create_stopped_server(project.path(), name);
+        }
+
+        let remove = run(
+            project.path(),
+            home.path(),
+            &["local", "--json", "server", "remove"],
+        );
+        assert_eq!(remove.status.code(), Some(1));
+        assert!(remove.stdout.is_empty());
+        let error: Value = serde_json::from_slice(&remove.stderr).unwrap();
+        assert_eq!(error["error"]["code"], "server_selection_required");
+        assert_eq!(
+            error["error"]["message"],
+            format!(
+                "The default ClickHouse server does not exist (custom ClickHouse servers available: {}); no server was removed",
+                names.len()
+            )
+        );
+        assert_eq!(error["error"]["command"], "clickhousectl local server list");
+        for name in names {
+            assert!(
+                project
+                    .path()
+                    .join(".clickhouse/servers")
+                    .join(name)
+                    .exists()
+            );
+        }
+    }
+
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let custom = create_stopped_server(project.path(), "dev");
+    let human = run(project.path(), home.path(), &["local", "server", "remove"]);
+    assert_eq!(human.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&human.stderr);
+    assert!(stderr.contains("custom ClickHouse servers available: 1"));
+    assert!(stderr.contains("clickhousectl local server list"));
+    assert!(stderr.contains("clickhousectl local server remove <name>"));
+    assert!(custom.exists());
+
+    let explicit = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "remove", "--name", "dev"],
+    );
+    assert_success(&explicit);
+    assert_eq!(body(&explicit)["name"], "dev");
+    assert_eq!(body(&explicit)["selection"], "explicit");
+    assert!(!custom.exists());
+}

--- a/crates/clickhousectl/tests/local_server_selection_test.rs
+++ b/crates/clickhousectl/tests/local_server_selection_test.rs
@@ -122,6 +122,33 @@ fn omitted_stop_is_a_human_and_json_noop_with_zero_servers() {
 }
 
 #[test]
+fn omitted_stop_is_a_noop_with_only_a_postgres_data_remnant() {
+    let project = tempfile::tempdir().expect("create project");
+    let home = tempfile::tempdir().expect("create home");
+    let postgres_data = project
+        .path()
+        .join(".clickhouse/servers/analytics-pg18/data");
+    std::fs::create_dir_all(&postgres_data).expect("create Postgres data remnant");
+
+    let stop = run(
+        project.path(),
+        home.path(),
+        &["local", "--json", "server", "stop"],
+    );
+
+    assert_success(&stop);
+    assert_eq!(
+        body(&stop),
+        json!({
+            "stopped": false,
+            "selection": "implicit",
+            "reason": "no_clickhouse_servers"
+        })
+    );
+    assert!(postgres_data.is_dir());
+}
+
+#[test]
 fn omitted_stop_selects_the_sole_running_then_stopped_custom_server() {
     let project = tempfile::tempdir().expect("create project");
     let home = tempfile::tempdir().expect("create home");

--- a/crates/clickhousectl/tests/local_server_stopped_test.rs
+++ b/crates/clickhousectl/tests/local_server_stopped_test.rs
@@ -142,6 +142,7 @@ fn stopping_clickhouse_retains_metadata_and_lists_it_as_stopped() {
     let body: Value = serde_json::from_slice(&stop.stdout).expect("parse stop JSON");
     assert_eq!(body["name"], "default");
     assert_eq!(body["already_stopped"], false);
+    assert_eq!(body["selection"], "implicit");
 
     let saved: Value = serde_json::from_slice(&std::fs::read(&metadata).unwrap()).unwrap();
     assert_eq!(saved["pid"], 0);

--- a/crates/clickhousectl/tests/local_structured_errors_test.rs
+++ b/crates/clickhousectl/tests/local_structured_errors_test.rs
@@ -106,7 +106,7 @@ fn fresh_home_json_error_defers_telemetry_notice_to_human_mode() {
     };
 
     let output = fresh_home_command()
-        .args(["local", "--json", "server", "stop"])
+        .args(["local", "--json", "server", "stop", "missing"])
         .output()
         .expect("run structured failure");
     assert_eq!(output.status.code(), Some(1));
@@ -120,14 +120,14 @@ fn fresh_home_json_error_defers_telemetry_notice_to_human_mode() {
     );
 
     let output = fresh_home_command()
-        .args(["local", "server", "stop"])
+        .args(["local", "server", "stop", "missing"])
         .output()
         .expect("run human failure");
     assert_eq!(output.status.code(), Some(1));
     assert!(output.stdout.is_empty());
     let stderr = String::from_utf8(output.stderr).expect("human stderr is UTF-8");
     assert!(
-        stderr.contains("Error: Server 'default' not found"),
+        stderr.contains("Error: Server 'missing' not found"),
         "{stderr}"
     );
     assert!(stderr.contains("anonymous usage data"), "{stderr}");
@@ -146,7 +146,7 @@ fn telemetry_debug_does_not_append_to_a_structured_error() {
     let output = command(project.path(), home.path())
         .env_remove("DO_NOT_TRACK")
         .env("CHCTL_TELEMETRY_DEBUG", "1")
-        .args(["local", "--json", "server", "stop"])
+        .args(["local", "--json", "server", "stop", "missing"])
         .output()
         .expect("run structured failure with telemetry debug");
 
@@ -154,7 +154,7 @@ fn telemetry_debug_does_not_append_to_a_structured_error() {
         &output,
         &expected_error(
             "server_not_found",
-            "Server 'default' not found",
+            "Server 'missing' not found",
             Some("clickhousectl local server list"),
         ),
     );

--- a/crates/clickhousectl/tests/local_structured_errors_test.rs
+++ b/crates/clickhousectl/tests/local_structured_errors_test.rs
@@ -72,20 +72,20 @@ fn explicit_json_and_agent_mode_emit_the_same_exact_server_error() {
     let home = tempfile::tempdir().expect("create home");
     let expected = expected_error(
         "server_not_found",
-        "Server 'default' not found",
+        "Server 'missing' not found",
         Some("clickhousectl local server list"),
     );
 
     let explicit = run(
         project.path(),
         home.path(),
-        &["local", "--json", "server", "stop"],
+        &["local", "--json", "server", "stop", "missing"],
     );
     assert_structured_failure(&explicit, &expected);
 
     let agent = command(project.path(), home.path())
         .env("AGENT", "opencode")
-        .args(["local", "server", "stop"])
+        .args(["local", "server", "stop", "missing"])
         .output()
         .expect("run clickhousectl in agent mode");
     assert_structured_failure(&agent, &expected);
@@ -287,12 +287,16 @@ fn human_and_clap_errors_keep_their_existing_formats() {
     let project = tempfile::tempdir().expect("create project");
     let home = tempfile::tempdir().expect("create home");
 
-    let human = run(project.path(), home.path(), &["local", "server", "stop"]);
+    let human = run(
+        project.path(),
+        home.path(),
+        &["local", "server", "stop", "missing"],
+    );
     assert_eq!(human.status.code(), Some(1));
     assert!(human.stdout.is_empty());
     assert_eq!(
         String::from_utf8_lossy(&human.stderr),
-        "Error: Server 'default' not found\n"
+        "Error: Server 'missing' not found\n"
     );
 
     let clap = run(


### PR DESCRIPTION
## Summary
- select `default` or a sole ClickHouse server deliberately for an omitted project-scoped `server stop` name, while keeping omitted `stop --global` pinned to literal `default`
- keep omitted `server remove` conservative and exclude Postgres metadata and data remnants from ClickHouse selection
- keep compatibility `--name` dispatch hidden from help and preserve positional dispatch
- intentionally include `selection` for both implicit and explicit ClickHouse stop/remove outcomes; Postgres output omits the optional field
- document the selection policy and the `server_selection_required` structured error code

## Tests
- `cargo test -p clickhousectl --test local_server_selection_test`
- `cargo test -p clickhousectl --test local_postgres_readiness_test -- --test-threads=1`
- `cargo test -p clickhousectl --test local_server_name_compatibility_test`
- `cargo test -p clickhousectl --test local_server_stopped_test`
- `cargo test -p clickhousectl --test local_structured_errors_test -- --test-threads=1`
- `cargo test -p clickhousectl -- --test-threads=1`
- `cargo fmt --all --check`
- `cargo check -p clickhousectl --all-targets`
- `cargo clippy -p clickhousectl --all-targets -- -D warnings`

Closes #473